### PR TITLE
Renames app to content-performance-manager

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  ComPrototype
+  ContentPerformanceManager
 <% end %>
 
 <% content_for :head do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module ComPrototype
+module ContentPerformanceManager
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: com-prototype_development
+  database: content-performance-manager_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: com-prototype
+  #username: content-performance-manager
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: com-prototype_test
+  database: content-performance-manager_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,6 +80,6 @@ test:
 #
 production:
   <<: *default
-  database: com-prototype_production
-  username: com-prototype
-  password: <%= ENV['COM-PROTOTYPE_DATABASE_PASSWORD'] %>
+  database: content-performance-manager_production
+  username: content-performance-manager
+  password: <%= ENV['CONTENT-PERFORMANCE-MANAGER_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "com-prototype_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "content-performance-manager_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_com-prototype_session'
+Rails.application.config.session_store :cookie_store, key: '_content-performance-manager_session'


### PR DESCRIPTION
[Trello card](https://trello.com/c/qaa2kDvO/80-rename-repo-to-content-performance-manager)

A few weeks ago, when we set up the Repo in Github is wasn’t 
clear to us what the name of the application were going to be, 
so we decided to go with a temporary one: com-prototype.

But, we have finally agreed to name it `content-performance-manager`, 
so it is time to update the name across the Rails app.

This PR updates all references to the old name (com-prototype) 
across the codebase:

- Layout
- Application config
- Database names
- Session info