### PR TITLE
Show first (25) Content Items for an Organisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~>3.5'
+  gem 'rails-controller-testing', '~>1.0.1'
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~>3.5'
   gem 'rails-controller-testing', '~>1.0.1'
+  gem 'capybara'
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -224,6 +228,7 @@ DEPENDENCIES
   pg (~> 0.18)
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing (~> 1.0.1)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   shoulda-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,10 +38,19 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     ast (2.3.0)
     builder (3.2.2)
     byebug (9.0.6)
+    capybara (2.10.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -106,6 +115,7 @@ GEM
       ast (~> 2.2)
     pg (0.19.0)
     powerpack (0.1.1)
+    public_suffix (2.0.4)
     puma (3.6.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -209,12 +219,15 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
+  capybara
   coffee-rails (~> 4.2)
   factory_girl_rails
   govuk-lint

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,0 +1,5 @@
+class ContentItemsController < ApplicationController
+  def index
+    head :ok
+  end
+end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,5 +1,6 @@
 class ContentItemsController < ApplicationController
   def index
-    head :ok
+    organisation = Organisation.find(params[:organisation_id])
+    @content_items = organisation.content_items.first(25)
   end
 end

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -1,0 +1,15 @@
+<h1>List Content Items</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Content Ids</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @content_items.each do |content_item| %>
+      <tr>
+        <td><%= content_item.content_id %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
-  resources :organisations, only: %w(index)
+  resources :organisations, only: %w(index) do
+    resources :content_items, only: %w(index)
+  end
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -2,9 +2,18 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
   describe "GET #index" do
+    let(:organisation) { FactoryGirl.create(:organisation_with_content_items) }
+
+    before do
+      get :index, params: { organisation_id: organisation }
+    end
+
     it "returns http success" do
-      get :index, organisation_id: 1
       expect(response).to have_http_status(:success)
+    end
+
+    it "assigns list of content items" do
+      expect(assigns(:content_items)).to eq(organisation.content_items)
     end
   end
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ContentItemsController, type: :controller do
+  describe "GET #index" do
+    it "returns http success" do
+      get :index, organisation_id: 1
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -15,5 +15,9 @@ RSpec.describe ContentItemsController, type: :controller do
     it "assigns list of content items" do
       expect(assigns(:content_items)).to eq(organisation.content_items)
     end
+
+    it "renders the :index template" do
+      expect(subject).to render_template(:index)
+    end
   end
 end

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :content_item do
+    sequence(:content_id) { |index| "7776ddf3-f918-5f32-bf18-dc1ced2eeeb#{index}" }
   end
 end

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ContentItemsController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: organisation_content_items_path(1)).to be_routable
+      expect(get: organisation_content_items_path(1))
+        .to route_to(
+          controller: 'content_items',
+          action: 'index',
+          organisation_id: '1'
+        )
+    end
+  end
+end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'content_items/index.html.erb', type: :view do
+  let(:content_items) { FactoryGirl.build_list(:content_item, 2) }
+
+  before { assign(:content_items, content_items) }
+
+  it 'render the table header' do
+    render
+
+    expect(rendered).to have_selector('table thead', text: 'Content Ids')
+  end
+
+  it 'renders a row per Content Item' do
+    render
+
+    expect(rendered).to have_selector('table tbody tr', count: 2)
+  end
+
+  describe 'row content' do
+    it 'includes the content-id' do
+      content_items[0].content_id = 'a-content-id'
+      render
+
+      expect(rendered).to have_selector('table tbody tr td', text: 'a-content-id')
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/XwH3123y/60-story-show-first-25-content-items-for-an-organisation)

## Description 

This PR covers this [card](https://trello.com/c/XwH3123y/60-story-show-first-25-content-items-for-an-organisation), with the intention to fetch an organisation's content items (i.e given the organisation’s id) and renders the content items in a HTML table.

1. Defines `/organisations/organisation_id/content_items` endpoint
2. Gets the first 25 content items belonging to an organisation.
3. Renders the content items ids in a html table.

### NB: 

The following gems have been added as required.

- rails-controller-testing: Providing methods/matchers like `assigns`, `render_template ` etc
- capybara: Providing matchers like have_selector that help inspect the rendered page

