### PR TITLE
Add rake tasks to deploy to Heroku

### DIFF
--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -3,4 +3,9 @@ namespace :heroku do
   task :prepare do |_task|
     Kernel.system 'git remote add heroku https://git.heroku.com/content-performance-manager.git'
   end
+
+  desc 'Deploys the application to Heroku'
+  task :deploy do |_task|
+    Kernel.system 'git push heroku master'
+  end
 end

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,0 +1,6 @@
+namespace :heroku do
+  desc 'Configure the environment to do Heroku deployments'
+  task :prepare do |_task|
+    Kernel.system 'git remote add heroku https://git.heroku.com/content-performance-manager.git'
+  end
+end

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -8,4 +8,11 @@ namespace :heroku do
   task :deploy do |_task|
     Kernel.system 'git push heroku master'
   end
+
+  namespace :db do
+    desc 'Run pending migrations in Heroku'
+    task :migrate do
+      Kernel.system 'heroku rake db:migrate'
+    end
+  end
 end

--- a/spec/lib/tasks/heroku_spec.rb
+++ b/spec/lib/tasks/heroku_spec.rb
@@ -3,41 +3,41 @@ require 'rake'
 
 RSpec.describe 'Import organisation rake task' do
   describe 'heroku:prepare' do
-    before do
-      Rake::Task['heroku:prepare'].reenable
-    end
+    subject { Rake::Task['heroku:prepare'] }
+
+    before { subject.reenable }
 
     it 'adds the remote repo for Heroku' do
-      prepare_command = 'git remote add heroku https://git.heroku.com/content-performance-manager.git'
-      expect(Kernel).to receive(:system).with(prepare_command)
+      command = 'git remote add heroku https://git.heroku.com/content-performance-manager.git'
+      expect(Kernel).to receive(:system).with(command)
 
-      Rake::Task['heroku:prepare'].invoke
+      subject.invoke
     end
   end
 
   describe 'heroku:deploy' do
-    before do
-      Rake::Task['heroku:deploy'].reenable
-    end
+    subject { Rake::Task['heroku:deploy'] }
+
+    before { subject.reenable }
 
     it 'deploys the application to Heroku' do
-      prepare_command = 'git push heroku master'
-      expect(Kernel).to receive(:system).with(prepare_command)
+      command = 'git push heroku master'
+      expect(Kernel).to receive(:system).with(command)
 
-      Rake::Task['heroku:deploy'].invoke
+      subject.invoke
     end
   end
 
   describe 'heroku:db:migrate' do
-    before do
-      Rake::Task['heroku:db:migrate'].reenable
-    end
+    subject { Rake::Task['heroku:db:migrate'] }
+
+    before { subject.reenable }
 
     it 'run pending migrations in Heroku' do
-      prepare_command = 'heroku rake db:migrate'
-      expect(Kernel).to receive(:system).with(prepare_command)
+      command = 'heroku rake db:migrate'
+      expect(Kernel).to receive(:system).with(command)
 
-      Rake::Task['heroku:db:migrate'].invoke
+      subject.invoke
     end
   end
 end

--- a/spec/lib/tasks/heroku_spec.rb
+++ b/spec/lib/tasks/heroku_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe 'Import organisation rake task' do
       Rake::Task['heroku:prepare'].invoke
     end
   end
+
+  describe 'heroku:deploy' do
+    before do
+      Rake::Task['heroku:deploy'].reenable
+    end
+
+    it 'deploys the application to Heroku' do
+      prepare_command = 'git push heroku master'
+      expect(Kernel).to receive(:system).with(prepare_command)
+
+      Rake::Task['heroku:deploy'].invoke
+    end
+  end
 end

--- a/spec/lib/tasks/heroku_spec.rb
+++ b/spec/lib/tasks/heroku_spec.rb
@@ -27,4 +27,17 @@ RSpec.describe 'Import organisation rake task' do
       Rake::Task['heroku:deploy'].invoke
     end
   end
+
+  describe 'heroku:db:migrate' do
+    before do
+      Rake::Task['heroku:db:migrate'].reenable
+    end
+
+    it 'run pending migrations in Heroku' do
+      prepare_command = 'heroku rake db:migrate'
+      expect(Kernel).to receive(:system).with(prepare_command)
+
+      Rake::Task['heroku:db:migrate'].invoke
+    end
+  end
 end

--- a/spec/lib/tasks/heroku_spec.rb
+++ b/spec/lib/tasks/heroku_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'Import organisation rake task' do
+  describe 'heroku:prepare' do
+    before do
+      Rake::Task['heroku:prepare'].reenable
+    end
+
+    it 'adds the remote repo for Heroku' do
+      prepare_command = 'git remote add heroku https://git.heroku.com/content-performance-manager.git'
+      expect(Kernel).to receive(:system).with(prepare_command)
+
+      Rake::Task['heroku:prepare'].invoke
+    end
+  end
+end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -3,10 +3,6 @@ require 'rake'
 
 
 RSpec.describe 'Import organisation rake task' do
-  before(:all) do
-    Rails.application.load_tasks
-  end
-
   describe 'import:organisation' do
     before do
       Rake::Task['import:organisation'].reenable

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:suite) do
+    # Load rake tasks so they can be tested
+    Rails.application.load_tasks
+  end
 end


### PR DESCRIPTION
Adds three rake tasks:

```bash
$ rake -T | grep heroku                                                                                                                                      
rake heroku:db:migrate  # Run pending migrations in Heroku
rake heroku:deploy         # Deploys the application to Heroku
rake heroku:prepare       # Configure the environment to do Heroku deployments
```

## Note

Deploying to Heroku is the temporary solution we have chosen while
a more robust solution is set up for our app.

I have created an application in Heroku: `content-performance-manager` 
and I have given permissions to all developers. 

In another story, we will reuse the GDS heroku account.