### PR TITLE
Run the database migration in same rake task as the deployment to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-### Important
-
-The name of this repo is temporary, and will change in a few weeks.
-
-
-
 ### App development
 
 * [GOVUK-LINT-RUBY](doc/govuk-lint.md)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+
+### Deployment to Heroku
+
+1\. Setup the environment to deploy to Heroku
+
+```bash
+$ rake heroku:prepare # Only need to be done once
+````
+
+2\. Deploy to Heroku
+
+```bash
+$ rake heroku:deploy
+```
+
 ### App development
 
 * [GOVUK-LINT-RUBY](doc/govuk-lint.md)

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -6,13 +6,7 @@ namespace :heroku do
 
   desc 'Deploys the application to Heroku'
   task :deploy do |_task|
+    Bundler.with_clean_env { Kernel.system 'heroku rake db:migrate' }
     Kernel.system 'git push heroku master'
-  end
-
-  namespace :db do
-    desc 'Run pending migrations in Heroku'
-    task :migrate do
-      Kernel.system 'heroku rake db:migrate'
-    end
   end
 end

--- a/spec/lib/tasks/heroku_spec.rb
+++ b/spec/lib/tasks/heroku_spec.rb
@@ -21,21 +21,8 @@ RSpec.describe 'Import organisation rake task' do
     before { subject.reenable }
 
     it 'deploys the application to Heroku' do
-      command = 'git push heroku master'
-      expect(Kernel).to receive(:system).with(command)
-
-      subject.invoke
-    end
-  end
-
-  describe 'heroku:db:migrate' do
-    subject { Rake::Task['heroku:db:migrate'] }
-
-    before { subject.reenable }
-
-    it 'run pending migrations in Heroku' do
-      command = 'heroku rake db:migrate'
-      expect(Kernel).to receive(:system).with(command)
+      expect(Kernel).to receive(:system).with('heroku rake db:migrate')
+      expect(Kernel).to receive(:system).with('git push heroku master')
 
       subject.invoke
     end


### PR DESCRIPTION
It feels more convenient for a developer not to have to run the 
database migration each time he needs to do a deployment.

For this reason, I am including the migration task within the deployment
task.

As a side note, I had to add the `Bundler.with_clean_env` to run the 
migrations because Heroku was picking up the wrong version of ruby.
See suggested solution in StackOverflow[1] and explanation in:

[1]: http://stackoverflow.com/questions/12995271/rails-server-error-ruby-version-is-1-8-7-but-your-gemfile-specified-1-9-3