### PR TITLE
Remove factorygirl prefix

### DIFF
--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
   describe "GET #index" do
-    let(:organisation) { FactoryGirl.create(:organisation_with_content_items) }
+    let(:organisation) { create(:organisation_with_content_items) }
 
     before do
       get :index, params: { organisation_id: organisation }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Organisation, type: :model do
 
   describe '#total_content_items' do
     it 'returns the total content items' do
-      organisation = FactoryGirl.create(:organisation_with_content_items, slug: 'a_slug', content_items_count: 2)
+      organisation = create(:organisation_with_content_items, slug: 'a_slug', content_items_count: 2)
 
       expect(organisation.total_content_items).to eq(2)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'support/factory_girl'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Organisations', type: :request do
     end
 
     it 'returns a JSON with the ids of the organisation and the number of content_items' do
-      FactoryGirl.create(:organisation_with_content_items, slug: 'a_slug', content_items_count: 2)
+      create(:organisation_with_content_items, slug: 'a_slug', content_items_count: 2)
 
       get organisations_path
       expect(response.body).to eq([{ slug: 'a_slug', total_content_items: 2 }].to_json)

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'content_items/index.html.erb', type: :view do
-  let(:content_items) { FactoryGirl.build_list(:content_item, 2) }
+  let(:content_items) { build_list(:content_item, 2) }
 
   before { assign(:content_items, content_items) }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/HHOll3yN/82-remove-factorygirl-prefix-in-our-tests)

Our tests are calling FactoryGirl methods as:

```ruby
FactoryGirl.create(...)
```

but this can be configured so that we can drop the prefix and simply call:

```ruby
create(...)
```

This PR adds the configuration and tidies up the tests.