### PR TITLE
Add last-update-time to the content items of an organisation

### DIFF
--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -13,8 +13,14 @@ class Importers::Organisation
     loop do
       result = search_content_items_for_organisation
       result.each do |content_item_attributes|
-        attributes = content_item_attributes.slice(*CONTENT_ITEM_FIELDS)
-        organisation.content_items << ContentItem.new(attributes)
+        content_id = content_item_attributes['content_id']
+
+        if content_id.present?
+          attributes = content_item_attributes.slice(*CONTENT_ITEM_FIELDS)
+          organisation.content_items << ContentItem.new(attributes)
+        else
+          log("There is not content_id for #{slug}")
+        end
       end
 
       break if last_page?(result)
@@ -45,5 +51,11 @@ private
 
   def search_api_end_point
     "https://www.gov.uk/api/search.json?filter_organisations=#{slug}&count=#{batch}&fields=#{CONTENT_ITEM_FIELDS.join(',')}&start=#{start}"
+  end
+
+  def log(message)
+    unless Rails.env.test?
+      Logger.new(STDOUT).warn(message)
+    end
   end
 end

--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -14,9 +14,12 @@ class Importers::Organisation
       result = search_content_items_for_organisation
       result.each do |content_item_attributes|
         content_id = content_item_attributes['content_id']
+        link = content_item_attributes['link']
 
         if content_id.present?
+          content_store_item = content_item_store(link)
           attributes = content_item_attributes.slice(*CONTENT_ITEM_FIELDS)
+            .merge(content_store_item.slice('public_updated_at'))
           organisation.content_items << ContentItem.new(attributes)
         else
           log("There is not content_id for #{slug}")
@@ -51,6 +54,16 @@ private
 
   def search_api_end_point
     "https://www.gov.uk/api/search.json?filter_organisations=#{slug}&count=#{batch}&fields=#{CONTENT_ITEM_FIELDS.join(',')}&start=#{start}"
+  end
+
+  def content_item_store(base_path)
+    endpoint = content_item_end_point(base_path)
+    response = HTTParty.get(endpoint)
+    JSON.parse(response.body)
+  end
+
+  def content_item_end_point(base_path)
+    "https://www.gov.uk/api/content#{base_path}"
   end
 
   def log(message)

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -5,6 +5,7 @@
       <th>Content Ids</th>
       <th>Content URL</th>
       <th>Title</th>
+      <th>Last Updated</th>
     </tr>
   </thead>
   <tbody>
@@ -13,6 +14,7 @@
         <td><%= content_item.content_id %></td>
         <td><a href="<%= content_item.url %>"> <%= content_item.url %> </a></td>
         <td><%= content_item.title %></td>
+        <td><%= content_item.public_updated_at %></td>
       </tr>
     <% end %>
   </tbody>

--- a/db/migrate/20161130153206_add_public_updated_at_to_content_items.rb
+++ b/db/migrate/20161130153206_add_public_updated_at_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddPublicUpdatedAtToContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :public_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202101420) do
-
+ActiveRecord::Schema.define(version: 20161130153206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +21,7 @@ ActiveRecord::Schema.define(version: 20161202101420) do
     t.datetime "updated_at",      null: false
     t.string   "link"
     t.string   "title"
+    t.datetime "public_updated_at"
     t.index ["organisation_id"], name: "index_content_items_on_organisation_id", using: :btree
   end
 

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :content_item do
     sequence(:content_id) { |index| "7776ddf3-f918-5f32-bf18-dc1ced2eeeb#{index}" }
     link "api/content/item/path"
+    public_updated_at Time.parse("2016-11-01 11:20:45.481868")
   end
 end

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Importers::Organisation do
+  let(:search_api_url_pattern) { /^https:\/\/www.gov.uk\/api\/search\.json\?.*$/ }
+  let(:content_items_api_url_pattern) { /^https:\/\/www.gov.uk\/api\/content\/.*$/ }
+
   let(:one_content_item_response) {
     build_search_api_response [
       {
@@ -33,41 +36,54 @@ RSpec.describe Importers::Organisation do
     )
   }
 
-  it "queries the search API with the organisation's slug" do
-    expected_url = 'https://www.gov.uk/api/search.json?filter_organisations=MY-SLUG&count=99&fields=content_id,link,title&start=0'
-    expected_content_url = 'https://www.gov.uk/api/content/item/1/path'
+  describe 'making API calls with HTTParty' do
+    it 'queries the search API with the organisation\'s slug' do
+      expected_url = 'https://www.gov.uk/api/search.json?filter_organisations=MY-SLUG&count=99&fields=content_id,link,title&start=0'
+      allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response)
+      expect(HTTParty).to receive(:get).once.with(expected_url).and_return(two_content_items_response)
 
-    expect(HTTParty).to receive(:get).once.with(expected_url).and_return(one_content_item_response)
-    allow(HTTParty).to receive(:get).once.with(expected_content_url).and_return(content_item_response)
+      Importers::Organisation.new('MY-SLUG', batch: 99).run
+    end
 
-    Importers::Organisation.new('MY-SLUG', batch: 99).run
+    it 'queries the content item API with base path' do
+      content_api_url_with_base_path_1 = 'https://www.gov.uk/api/content/item/1/path'
+      content_api_url_with_base_path_2 = 'https://www.gov.uk/api/content/item/2/path'
+
+      allow(HTTParty).to receive(:get).once.with(search_api_url_pattern).and_return(two_content_items_response)
+
+      expect(HTTParty).to receive(:get).once.with(content_api_url_with_base_path_1).and_return(content_item_response)
+      expect(HTTParty).to receive(:get).once.with(content_api_url_with_base_path_2).and_return(content_item_response)
+
+      Importers::Organisation.new('MY-SLUG', batch: 99).run
+    end
   end
 
   context 'Organisation' do
     it 'imports an organisation with the provided slug' do
-      allow(HTTParty).to receive(:get).and_return(one_content_item_response)
+      allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(one_content_item_response)
+      allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response)
 
       slug = 'hm-revenue-customs'
-      Importers::Organisation.new(slug).run
-
-      expect(Organisation.count).to eq(1)
+      expect { Importers::Organisation.new(slug).run }.to change { Organisation.count }.by(1)
       expect(Organisation.first.slug).to eq(slug)
     end
 
     it 'raises an exception with an organisation that does not exist' do
       response = double(body: { results: [] }.to_json)
-      allow(HTTParty).to receive(:get).and_return(response)
+      allow(HTTParty).to receive(:get).once.with(search_api_url_pattern).and_return(response)
 
       expect { Importers::Organisation.new('none-existing-org').run }.to raise_error('No result for slug')
     end
   end
 
-  context 'Content Items' do
-    before { allow(HTTParty).to receive(:get).and_return(two_content_items_response) }
-    let(:organisation) { Organisation.find_by(slug: 'a-slug') }
+  describe 'Content Items' do
+    before { allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response) }
 
     it 'imports all content items for the organisation' do
+      allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(two_content_items_response)
+
       Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
       expect(organisation.content_items.count).to eq(2)
     end
 
@@ -86,54 +102,55 @@ RSpec.describe Importers::Organisation do
       ]))
 
       Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
       expect(organisation.content_items.count).to eq(1)
     end
 
-    it 'imports a `content_id` for every content item' do
-      Importers::Organisation.new('a-slug').run
-      content_ids = organisation.content_items.pluck(:content_id)
-      expect(content_ids).to eq(%w(content-id-1 content-id-2))
-    end
+    describe 'Fields ' do
+      before { allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(one_content_item_response) }
 
-    it 'imports a `link` for every content item' do
-      Importers::Organisation.new('a-slug').run
-      links = organisation.content_items.pluck(:link)
-      expect(links).to eq(%w(/item/1/path /item/2/path))
-    end
+      it 'imports a `content_id` for every content item' do
+        Importers::Organisation.new('a-slug').run
+        organisation = Organisation.find_by(slug: 'a-slug')
 
-    it 'imports a `title` for every content item' do
-      allow(HTTParty).to receive(:get).and_return(two_content_items_response)
-      Importers::Organisation.new('a-slug').run
+        content_ids = organisation.content_items.pluck(:content_id)
+        expect(content_ids).to eq(%w(content-id-1))
+      end
 
-      organisation = Organisation.find_by(slug: 'a-slug')
-      titles = organisation.content_items.pluck(:title)
+      it 'imports a `link` for every content item' do
+        Importers::Organisation.new('a-slug').run
+        organisation = Organisation.find_by(slug: 'a-slug')
+        links = organisation.content_items.pluck(:link)
+        expect(links).to eq(%w(/item/1/path))
+      end
 
-      expect(titles).to eq(%w(title-1 title-2))
-    end
+      it 'imports a `title` for every content item' do
+        Importers::Organisation.new('a-slug').run
 
-    it 'imports a `public_updated_at` for each content item' do
-      search_url = "https://www.gov.uk/api/search.json?filter_organisations=a-slug&count=10&fields=content_id,link&start=0"
-      content_base_path_1 = "https://www.gov.uk/api/content/item/1/path"
-      content_base_path_2 = "https://www.gov.uk/api/content/item/2/path"
+        organisation = Organisation.find_by(slug: 'a-slug')
+        titles = organisation.content_items.pluck(:title)
 
-      allow(HTTParty).to receive(:get).once.with(search_url).and_return(two_content_items_response)
-      allow(HTTParty).to receive(:get).once.with(content_base_path_1).and_return(content_item_response)
-      allow(HTTParty).to receive(:get).once.with(content_base_path_2).and_return(content_item_response)
+        expect(titles).to eq(%w(title-1))
+      end
 
-      Importers::Organisation.new('a-slug').run
-      organisation = Organisation.find_by(slug: 'a-slug')
+      it 'imports a `public_updated_at` for each content item' do
+        Importers::Organisation.new('a-slug').run
+        organisation = Organisation.find_by(slug: 'a-slug')
 
-      content_id = organisation.content_items.pluck(:content_id).first
-      public_update = organisation.content_items.pluck(:public_updated_at).first
+        content_item = organisation.content_items.first
 
-      expect(content_id).to eq('content-id-1')
-      expect(public_update).to eq(Time.parse('2016-11-01 11:20:45.481868'))
+        expect(content_item.content_id).to eq('content-id-1')
+        expect(content_item.public_updated_at).to eq(Time.parse('2016-11-01 11:20:45.481868'))
+      end
     end
   end
 
   context 'Pagination' do
+    before { allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response) }
+
     it 'paginates through all the content items for an organisation' do
-      expect(HTTParty).to receive(:get).exactly(5).times.and_return(two_content_items_response, one_content_item_response)
+      expect(HTTParty).to receive(:get).twice.with(search_api_url_pattern).and_return(two_content_items_response, one_content_item_response)
+
       Importers::Organisation.new('a-slug', batch: 2).run
       organisation = Organisation.find_by(slug: 'a-slug')
 

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -1,26 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe Importers::Organisation do
-  let(:one_content_item_response) { build_search_api_response [content_id: 'content-id-1'] }
+  let(:one_content_item_response) {
+    build_search_api_response [
+      {
+        content_id: 'content-id-1',
+        link: '/item/1/path',
+        title: 'title-1',
+      }
+    ]
+  }
 
   let(:two_content_items_response) {
     build_search_api_response [
       {
         content_id: 'content-id-1',
-        link: 'content/1/path',
+        link: '/item/1/path',
         title: 'title-1',
       },
       {
         content_id: 'content-id-2',
-        link: 'content/2/path',
+        link: '/item/2/path',
         title: 'title-2'
       }
     ]
   }
+  let(:content_item_response) {
+    double(
+      body: {
+        public_updated_at: "2016-11-01 11:20:45.481868000 +0000",
+      }.to_json
+    )
+  }
 
   it "queries the search API with the organisation's slug" do
     expected_url = 'https://www.gov.uk/api/search.json?filter_organisations=MY-SLUG&count=99&fields=content_id,link,title&start=0'
-    expect(HTTParty).to receive(:get).with(expected_url).and_return(one_content_item_response)
+    expected_content_url = 'https://www.gov.uk/api/content/item/1/path'
+
+    expect(HTTParty).to receive(:get).once.with(expected_url).and_return(one_content_item_response)
+    allow(HTTParty).to receive(:get).once.with(expected_content_url).and_return(content_item_response)
 
     Importers::Organisation.new('MY-SLUG', batch: 99).run
   end
@@ -80,7 +98,7 @@ RSpec.describe Importers::Organisation do
     it 'imports a `link` for every content item' do
       Importers::Organisation.new('a-slug').run
       links = organisation.content_items.pluck(:link)
-      expect(links).to eq(%w(content/1/path content/2/path))
+      expect(links).to eq(%w(/item/1/path /item/2/path))
     end
 
     it 'imports a `title` for every content item' do
@@ -92,19 +110,38 @@ RSpec.describe Importers::Organisation do
 
       expect(titles).to eq(%w(title-1 title-2))
     end
+
+    it 'imports a `public_updated_at` for each content item' do
+      search_url = "https://www.gov.uk/api/search.json?filter_organisations=a-slug&count=10&fields=content_id,link&start=0"
+      content_base_path_1 = "https://www.gov.uk/api/content/item/1/path"
+      content_base_path_2 = "https://www.gov.uk/api/content/item/2/path"
+
+      allow(HTTParty).to receive(:get).once.with(search_url).and_return(two_content_items_response)
+      allow(HTTParty).to receive(:get).once.with(content_base_path_1).and_return(content_item_response)
+      allow(HTTParty).to receive(:get).once.with(content_base_path_2).and_return(content_item_response)
+
+      Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
+
+      content_id = organisation.content_items.pluck(:content_id).first
+      public_update = organisation.content_items.pluck(:public_updated_at).first
+
+      expect(content_id).to eq('content-id-1')
+      expect(public_update).to eq(Time.parse('2016-11-01 11:20:45.481868'))
+    end
   end
 
   context 'Pagination' do
     it 'paginates through all the content items for an organisation' do
-      expect(HTTParty).to receive(:get).twice.and_return(two_content_items_response, one_content_item_response)
+      expect(HTTParty).to receive(:get).exactly(5).times.and_return(two_content_items_response, one_content_item_response)
       Importers::Organisation.new('a-slug', batch: 2).run
       organisation = Organisation.find_by(slug: 'a-slug')
 
       expect(organisation.content_items.count).to eq(3)
     end
 
-    it 'handles last page with 0 results' do
-      expect(HTTParty).to receive(:get).twice.and_return(one_content_item_response, build_search_api_response([]))
+    it 'handles last page with 0 results when organisation already has content items' do
+      expect(HTTParty).to receive(:get).exactly(3).times.and_return(one_content_item_response, build_search_api_response([]))
       Importers::Organisation.new('a-slug', batch: 1).run
       organisation = Organisation.find_by(slug: 'a-slug')
 

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe Importers::Organisation do
       expect(organisation.content_items.count).to eq(2)
     end
 
+    it 'imports only content items where content_id is present' do
+      allow(HTTParty).to receive(:get).and_return(build_search_api_response([
+        {
+          content_id: 'content-id',
+          link: '/item/1/path',
+          title: 'title-1',
+        },
+        {
+          content_id: '',
+          link: '/item/2/path',
+          title: 'title-2',
+        }
+      ]))
+
+      Importers::Organisation.new('a-slug').run
+      expect(organisation.content_items.count).to eq(1)
+    end
+
     it 'imports a `content_id` for every content item' do
       Importers::Organisation.new('a-slug').run
       content_ids = organisation.content_items.pluck(:content_id)

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
     expect(rendered).to have_selector('table thead tr:first-child', text: 'Content Ids')
     expect(rendered).to have_selector('table thead tr:nth(1)', text: 'Content URL')
     expect(rendered).to have_selector('table thead', text: 'Title')
+    expect(rendered).to have_selector('table thead', text: 'Last Updated')
   end
 
   it 'renders a row per Content Item' do
@@ -39,6 +40,12 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       render
 
       expect(rendered).to have_selector('table tbody tr td', text: 'a-title')
+    end
+
+    it 'includes the last time the content was updated' do
+      render
+
+      expect(rendered).to have_selector('table tbody tr td', text: '2016-11-01 11:20:45 UTC')
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/7swQPTrR/63-story-add-last-update-time-to-the-content-items-of-an-organisation)

## Description 
For every content item, content designers want to see the last time a
content item was updated for an organisation.

Here a new column/attribute (i.e `last_updated_at`) has been added to the content_item(s).

The `last_updated_at` attribute’s value is obtained via from the publishing api [1] via
the gds-api-adapters gem.

The gds-api-adapters gem provides access to the publishing_api endpoints

For obtaining the last time a piece of content_item was updated, this endpoint [1] is 
queried with the content_id supplied.

All organisation importer tests have been affected and a before hook introduced to
stub calls to get_content.

***NB:***

Kindly take note that publishing api can only be access via the dev VM [2]. 



[1] /v2/content/:content_id
[2] http://publishing-api.dev.gov.uk/v2/content/:content_id