### PR TITLE
Show URL for a departments content item

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,3 +1,7 @@
 class ContentItem < ApplicationRecord
   belongs_to :organisation
+
+  def url
+    "https://gov.uk#{self.link}"
+  end
 end

--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -13,7 +13,7 @@ class Importers::Organisation
     loop do
       result = search_content_items_for_organisation
       result.each do |content_item_attributes|
-        attributes = content_item_attributes.slice('content_id')
+        attributes = content_item_attributes.slice('content_id', 'link')
         organisation.content_items << ContentItem.new(attributes)
       end
 
@@ -40,6 +40,6 @@ private
   end
 
   def search_api_end_point
-    "https://www.gov.uk/api/search.json?filter_organisations=#{slug}&count=#{batch}&fields=content_id&start=#{start}"
+    "https://www.gov.uk/api/search.json?filter_organisations=#{slug}&count=#{batch}&fields=content_id,link&start=#{start}"
   end
 end

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -3,12 +3,14 @@
   <thead>
     <tr>
       <th>Content Ids</th>
+      <th>Content URL</th>
     </tr>
   </thead>
   <tbody>
     <% @content_items.each do |content_item| %>
       <tr>
         <td><%= content_item.content_id %></td>
+        <td><a href="<%= content_item.url %>"> <%= content_item.url %> </a></td>
       </tr>
     <% end %>
   </tbody>

--- a/db/migrate/20161201111152_add_link_to_content_items.rb
+++ b/db/migrate/20161201111152_add_link_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddLinkToContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123141301) do
+ActiveRecord::Schema.define(version: 20161201111152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20161123141301) do
     t.integer  "organisation_id"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.string   "link"
     t.index ["organisation_id"], name: "index_content_items_on_organisation_id", using: :btree
   end
 

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :content_item do
     sequence(:content_id) { |index| "7776ddf3-f918-5f32-bf18-dc1ced2eeeb#{index}" }
+    link "api/content/item/path"
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -2,4 +2,11 @@ require 'rails_helper'
 
 RSpec.describe ContentItem, type: :model do
   it { should belong_to(:organisation) }
+
+  describe '#url' do
+    it 'returns a url to a content item on gov.uk' do
+      content_item = build(:content_item, link: '/api/content/item/path/1')
+      expect(content_item.url).to eq('https://gov.uk/api/content/item/path/1')
+    end
+  end
 end

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -31,28 +31,22 @@ RSpec.describe Importers::Organisation do
   end
 
   context 'Content Items' do
-    it 'imports all content items for the organisation' do
-      allow(HTTParty).to receive(:get).and_return(two_content_items_response)
-      Importers::Organisation.new('a-slug').run
-      organisation = Organisation.find_by(slug: 'a-slug')
+    before { allow(HTTParty).to receive(:get).and_return(two_content_items_response) }
+    let(:organisation) { Organisation.find_by(slug: 'a-slug') }
 
+    it 'imports all content items for the organisation' do
+      Importers::Organisation.new('a-slug').run
       expect(organisation.content_items.count).to eq(2)
     end
 
     it 'imports a `content_id` for every content item' do
-      allow(HTTParty).to receive(:get).and_return(two_content_items_response)
       Importers::Organisation.new('a-slug').run
-      organisation = Organisation.find_by(slug: 'a-slug')
-
       content_ids = organisation.content_items.pluck(:content_id)
       expect(content_ids).to eq(%w(content-id-1 content-id-2))
     end
 
     it 'imports a `link` for every content item' do
-      allow(HTTParty).to receive(:get).and_return(two_content_items_response)
       Importers::Organisation.new('a-slug').run
-      organisation = Organisation.find_by(slug: 'a-slug')
-
       links = organisation.content_items.pluck(:link)
       expect(links).to eq(%w(content/1/path content/2/path))
     end

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Importers::Organisation do
   let(:one_content_item_response) { build_seach_api_response [content_id: 'content-id-1'] }
-  let(:two_content_items_response) { build_seach_api_response [{ content_id: 'content-id-1' }, { content_id: 'content-id-2' }] }
+  let(:two_content_items_response) { build_seach_api_response [{ content_id: 'content-id-1', link: 'content/1/path' }, { content_id: 'content-id-2', link: 'content/2/path' }] }
 
   it "queries the search API with the organisation's slug" do
-    expected_url = 'https://www.gov.uk/api/search.json?filter_organisations=MY-SLUG&count=99&fields=content_id&start=0'
+    expected_url = 'https://www.gov.uk/api/search.json?filter_organisations=MY-SLUG&count=99&fields=content_id,link&start=0'
     expect(HTTParty).to receive(:get).with(expected_url).and_return(one_content_item_response)
 
     Importers::Organisation.new('MY-SLUG', batch: 99).run
@@ -46,6 +46,15 @@ RSpec.describe Importers::Organisation do
 
       content_ids = organisation.content_items.pluck(:content_id)
       expect(content_ids).to eq(%w(content-id-1 content-id-2))
+    end
+
+    it 'imports a `link` for every content item' do
+      allow(HTTParty).to receive(:get).and_return(two_content_items_response)
+      Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
+
+      links = organisation.content_items.pluck(:link)
+      expect(links).to eq(%w(content/1/path content/2/path))
     end
   end
 

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
   before { assign(:content_items, content_items) }
 
-  it 'render the table header' do
+  it 'renders the table header with the right headings' do
     render
 
-    expect(rendered).to have_selector('table thead', text: 'Content Ids')
+    expect(rendered).to have_selector('table thead tr:first-child', text: 'Content Ids')
+    expect(rendered).to have_selector('table thead tr:nth(1)', text: 'Content URL')
   end
 
   it 'renders a row per Content Item' do
@@ -18,11 +19,18 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   end
 
   describe 'row content' do
-    it 'includes the content-id' do
+    it 'contains the content-id in the first column' do
       content_items[0].content_id = 'a-content-id'
       render
 
-      expect(rendered).to have_selector('table tbody tr td', text: 'a-content-id')
+      expect(rendered).to have_selector('table tbody tr:first-child td', text: 'a-content-id')
+    end
+
+    it 'contains the content\'s url in the second column' do
+      content_items[0].link = '/content/1/path'
+      render
+
+      expect(rendered).to have_selector('table tbody tr:first-child td:nth(2) a', text: 'https://gov.uk/content/1/path')
     end
   end
 end


### PR DESCRIPTION
Related #13 

[Trello card](https://trello.com/c/SgGrXnx9/71-collect-url-for-a-departments-content)

## Description 

For each department’s content item, content designers want to visit the url of a
content item.

The link column/attribute has been added to the content_item(s).
This attribute’s value is obtained via this request to the search api.

A new method (i.e url) has been introduced that concatenates https://gov.uk and
the content item’s path.

This is then used to populate a Content URL column.
