### PR TITLE
Remove logging configuration from importing file

### DIFF
--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -1,11 +1,13 @@
 class Importers::Organisation
   attr_reader :slug, :batch, :start
   attr_writer :start
+  attr_accessor :logger
 
-  def initialize(slug, batch: 10, start: 0)
+  def initialize(slug, batch: 10, start: 0, logger: Rails.logger)
     @slug = slug
     @batch = batch
     @start = start
+    @logger = logger
   end
 
   def run
@@ -22,7 +24,7 @@ class Importers::Organisation
             .merge(content_store_item.slice('public_updated_at'))
           organisation.content_items << ContentItem.new(attributes)
         else
-          log("There is not content_id for #{slug}")
+          logger.warn("There is not content_id for #{slug}")
         end
       end
 
@@ -67,6 +69,6 @@ private
   end
 
   def log(message)
-    Rails.logger.warn(message)
+    @logger.warn(message)
   end
 end

--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -67,8 +67,6 @@ private
   end
 
   def log(message)
-    unless Rails.env.test?
-      Logger.new(STDOUT).warn(message)
-    end
+    Rails.logger.warn(message)
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -2,9 +2,9 @@ namespace :import do
   desc 'Import an organisation\'s details and content items'
   task :organisation, [:slug] => :environment do |_, args|
     raise 'Missing slug parameter' unless args.slug
-    Rails.logger = Logger.new(STDOUT)
-    Rails.logger.level = Logger::INFO
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::INFO
 
-    Importers::Organisation.new(args.slug).run
+    Importers::Organisation.new(args.slug, logger: logger).run
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -2,6 +2,8 @@ namespace :import do
   desc 'Import an organisation\'s details and content items'
   task :organisation, [:slug] => :environment do |_, args|
     raise 'Missing slug parameter' unless args.slug
+    Rails.logger = Logger.new(STDOUT)
+    Rails.logger.level = Logger::INFO
 
     Importers::Organisation.new(args.slug).run
   end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe 'Import organisation rake task' do
       Rake::Task['import:organisation'].reenable
     end
 
+    let(:importer) { double('importer') }
+
     it 'runs the process to import the organisations' do
-      importer = double('importer')
-      expect(Importers::Organisation).to receive(:new).with('a_slug').and_return(importer)
+      expect(Importers::Organisation).to receive(:new).with('a_slug', anything).and_return(importer)
       expect(importer).to receive(:run)
 
       Rake::Task['import:organisation'].invoke('a_slug')
+    end
+
+    it 'pass the logger to the importer' do
+      expect(Importers::Organisation).to receive(:new).with(anything, hash_including(logger: instance_of(Logger))).and_return(importer)
+      allow(importer).to receive(:run)
+
+      Rake::Task['import:organisation'].invoke('a-string')
     end
 
     it 'raises an error if a slug parameter is not present' do

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -1,31 +1,38 @@
 require 'rails_helper'
 require 'rake'
 
-
 RSpec.describe 'Import organisation rake task' do
   describe 'import:organisation' do
     before do
       Rake::Task['import:organisation'].reenable
     end
 
-    let(:importer) { double('importer') }
-
     it 'runs the process to import the organisations' do
-      expect(Importers::Organisation).to receive(:new).with('a_slug', anything).and_return(importer)
-      expect(importer).to receive(:run)
+      expect_any_instance_of(Importers::Organisation).to receive(:run)
 
       Rake::Task['import:organisation'].invoke('a_slug')
     end
 
-    it 'pass the logger to the importer' do
-      expect(Importers::Organisation).to receive(:new).with(anything, hash_including(logger: instance_of(Logger))).and_return(importer)
-      allow(importer).to receive(:run)
+    describe 'Importer parameters' do
+      let(:importer) { instance_double(Importers::Organisation, run: nil) }
 
-      Rake::Task['import:organisation'].invoke('a-string')
-    end
+      it 'raises an error if a slug parameter is not present' do
+        expect { Rake::Task['import:organisation'].invoke }.to raise_error('Missing slug parameter')
+      end
 
-    it 'raises an error if a slug parameter is not present' do
-      expect { Rake::Task['import:organisation'].invoke }.to raise_error('Missing slug parameter')
+      it 'receives the slug' do
+        expected = 'a-slug'
+        expect(Importers::Organisation).to receive(:new).with(expected, anything).and_return(importer)
+
+        Rake::Task['import:organisation'].invoke('a-slug')
+      end
+
+      it 'receives the logger' do
+        expected = hash_including(logger: instance_of(Logger))
+        expect(Importers::Organisation).to receive(:new).with(anything, expected).and_return(importer)
+
+        Rake::Task['import:organisation'].invoke('a-string')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR intends to remove environment-dependent code

### Background

The rake task outputs content to STDOUT, but if we use it from `Rails console` we would like to use the defaults configured in `config/environments/development.rb`.
Likewise, if we are in  production, we would like to use the configuration specified in `config/environments/production.rb`.

To summarise it, we want to get rid of any configuration code related to the the current environment.

We can configure logging per environment in the files:
- config/environments/test.rb
- config/environments/development.rb
- config/environments/production.rb

## Developer note:

If the logging information is valuable for the script user we will store it in a more reliable place (Database, filesytem...) We have chosen a quick way to get feedback from the rake task
until we have a better picture about all the issues we have when parsing the data.