### PR TITLE
Improve the information displayed in the content items table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'capybara'
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timecop (0.8.1)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -247,6 +248,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,0 +1,4 @@
+<tr>
+  <td><%= link_to content_item.title, content_item.url %></td>
+  <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
+</tr>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -14,7 +14,7 @@
         <td><%= content_item.content_id %></td>
         <td><a href="<%= content_item.url %>"> <%= content_item.url %> </a></td>
         <td><%= content_item.title %></td>
-        <td><%= content_item.public_updated_at %></td>
+        <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -2,7 +2,6 @@
 <table>
   <thead>
     <tr>
-      <th>Content Ids</th>
       <th>Content URL</th>
       <th>Title</th>
       <th>Last Updated</th>
@@ -11,7 +10,6 @@
   <tbody>
     <% @content_items.each do |content_item| %>
       <tr>
-        <td><%= content_item.content_id %></td>
         <td><a href="<%= content_item.url %>"> <%= content_item.url %> </a></td>
         <td><%= content_item.title %></td>
         <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -2,7 +2,6 @@
 <table>
   <thead>
     <tr>
-      <th>Content URL</th>
       <th>Title</th>
       <th>Last Updated</th>
     </tr>
@@ -10,8 +9,7 @@
   <tbody>
     <% @content_items.each do |content_item| %>
       <tr>
-        <td><a href="<%= content_item.url %>"> <%= content_item.url %> </a></td>
-        <td><%= content_item.title %></td>
+        <td><a href="<%= content_item.url %>"> <%= content_item.title %> </a></td>
         <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
       </tr>
     <% end %>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -9,7 +9,7 @@
   <tbody>
     <% @content_items.each do |content_item| %>
       <tr>
-        <td><a href="<%= content_item.url %>"> <%= content_item.title %> </a></td>
+        <td><%= link_to content_item.title, content_item.url %></td>
         <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
       </tr>
     <% end %>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -7,11 +7,6 @@
     </tr>
   </thead>
   <tbody>
-    <% @content_items.each do |content_item| %>
-      <tr>
-        <td><%= link_to content_item.title, content_item.url %></td>
-        <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
-      </tr>
-    <% end %>
+    <%= render @content_items %>
   </tbody>
 </table>

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   it 'renders the table header with the right headings' do
     render
 
-    expect(rendered).to have_selector('table thead tr:first-child', text: 'Content Ids')
-    expect(rendered).to have_selector('table thead tr:nth(1)', text: 'Content URL')
+    expect(rendered).to have_selector('table thead', text: 'Content URL')
     expect(rendered).to have_selector('table thead', text: 'Title')
     expect(rendered).to have_selector('table thead', text: 'Last Updated')
   end
@@ -21,18 +20,11 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   end
 
   describe 'row content' do
-    it 'contains the content-id in the first column' do
-      content_items[0].content_id = 'a-content-id'
-      render
-
-      expect(rendered).to have_selector('table tbody tr:first-child td', text: 'a-content-id')
-    end
-
-    it 'contains the content\'s url in the second column' do
+    it 'contains the content\'s url' do
       content_items[0].link = '/content/1/path'
       render
 
-      expect(rendered).to have_selector('table tbody tr:first-child td:nth(2) a', text: 'https://gov.uk/content/1/path')
+      expect(rendered).to have_selector('table tbody td a', text: 'https://gov.uk/content/1/path')
     end
 
     it 'includes the content item title' do

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   it 'renders the table header with the right headings' do
     render
 
-    expect(rendered).to have_selector('table thead', text: 'Content URL')
     expect(rendered).to have_selector('table thead', text: 'Title')
     expect(rendered).to have_selector('table thead', text: 'Last Updated')
   end
@@ -20,18 +19,12 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   end
 
   describe 'row content' do
-    it 'contains the content\'s url' do
-      content_items[0].link = '/content/1/path'
-      render
-
-      expect(rendered).to have_selector('table tbody td a', text: 'https://gov.uk/content/1/path')
-    end
-
     it 'includes the content item title' do
+      content_items[0].link = '/content/1/path'
       content_items[0].title = 'a-title'
       render
 
-      expect(rendered).to have_selector('table tbody tr td', text: 'a-title')
+      expect(rendered).to have_link('a-title', href: 'https://gov.uk/content/1/path')
     end
 
     it 'includes the last time the content was updated' do

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -43,9 +43,12 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
     end
 
     it 'includes the last time the content was updated' do
-      render
+      Timecop.freeze(Time.parse('2016-3-20')) do
+        content_items[0].public_updated_at = Time.parse('2016-1-20')
+        render
 
-      expect(rendered).to have_selector('table tbody tr td', text: '2016-11-01 11:20:45 UTC')
+        expect(rendered).to have_selector('table tbody tr td', text: '2 months ago')
+      end
     end
   end
 end


### PR DESCRIPTION
Include a few improvements for our first story:

1. Removes the column with the content item id
2. Uses the content item title for the link text
3. Open the Content Item link in a new Tab
4. Another minor refactoring

### Before
![image](https://cloud.githubusercontent.com/assets/227328/21004820/3080abb0-bd2a-11e6-974f-885da69d4525.png)

### After
![image](https://cloud.githubusercontent.com/assets/227328/21004793/0e4bbd78-bd2a-11e6-9f47-83f14c726d07.png)
