### PR TITLE
Handle ordering of content items by attribute in ascending or descending order

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,6 +1,6 @@
 class ContentItemsController < ApplicationController
   def index
     @organisation = Organisation.find(params[:organisation_id])
-    @content_items = @organisation.content_items.first(25)
+    @content_items = @organisation.content_items.order("#{params[:sort]} #{params[:order]}").first(25)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def order_link(heading, content_item_attribute)
+    link_to heading, organisation_content_items_path(
+      organisation_id: @organisation.id,
+      sort: content_item_attribute,
+      order: params.present? && params[:order] == "asc" ? :desc : :asc
+    )
+  end
 end

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -3,7 +3,7 @@
   <thead>
     <tr>
       <th>Title</th>
-      <th>Last Updated</th>
+      <th><%= order_link "Last Updated", :public_updated_at %></th>
     </tr>
   </thead>
   <tbody>

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -2,26 +2,85 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
   describe "GET #index" do
-    let(:organisation) { create(:organisation_with_content_items) }
+    context "find by organisation" do
+      let(:organisation) { create(:organisation_with_content_items, content_items_count: 2) }
 
-    before do
-      get :index, params: { organisation_id: organisation }
+      before do
+        get :index, params: { organisation_id: organisation }
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "assigns current organisation" do
+        expect(assigns(:organisation)).to eq(organisation)
+      end
+
+      it "assigns list of content items" do
+        expect(assigns(:content_items)).to eq(organisation.content_items)
+      end
+
+      it "renders the :index template" do
+        expect(subject).to render_template(:index)
+      end
     end
 
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
-    end
+    context "sorts with parameters" do
+      let(:content_items) do
+        [
+          build(:content_item, id: 1, public_updated_at: Time.parse("2016-12-09")),
+          build(:content_item, id: 2, public_updated_at: Time.parse("2015-12-09"))
+        ]
+      end
+      let(:organisation) { create(:organisation, content_items: content_items) }
 
-    it "assigns list of content items" do
-      expect(assigns(:content_items)).to eq(organisation.content_items)
-    end
+      context "in ascending order" do
+        before do
+          get :index, params: { organisation_id: organisation, order: :asc, sort: :public_updated_at }
+        end
 
-    it "assigns the organisation" do
-      expect(assigns(:organisation)).to eq(organisation)
-    end
+        it "uses order, sort, organisation_id, controller and action params" do
+          expect(request.params.keys).to eq(%w(order sort organisation_id controller action))
+        end
 
-    it "renders the :index template" do
-      expect(subject).to render_template(:index)
+        it "uses asc as the order" do
+          expect(request.params[:order]).to eq("asc")
+        end
+
+        it "sorts by a valid content item attribute" do
+          content_item = build(:content_item)
+          expect(content_item.attributes).to have_key(request.params[:sort])
+        end
+
+        it "returns content_items based on supplied params" do
+          expect(assigns(:content_items).pluck(:id)).to eq([2, 1])
+        end
+      end
+
+      context "in descending order" do
+        before do
+          get :index, params: { organisation_id: organisation, order: :desc, sort: :public_updated_at }
+        end
+
+        it "uses order, sort, organisation_id, controller and action params" do
+          expect(request.params.keys).to eq(%w(order sort organisation_id controller action))
+          expect(request.params[:order]).to eq("desc")
+        end
+
+        it "uses desc as the order" do
+          expect(request.params[:order]).to eq("desc")
+        end
+
+        it "sorts by a valid content item attribute" do
+          content_item = build(:content_item)
+          expect(content_item.attributes).to have_key(request.params[:sort])
+        end
+
+        it "returns content_items based on supplied params" do
+          expect(assigns(:content_items).pluck(:id)).to eq([1, 2])
+        end
+      end
     end
   end
 end

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :content_item do
     sequence(:content_id) { |index| "7776ddf3-f918-5f32-bf18-dc1ced2eeeb#{index}" }
     link "api/content/item/path"
-    public_updated_at Time.parse("2016-11-01 11:20:45.481868")
+    public_updated_at { Time.now }
   end
 end

--- a/spec/factories/organisations_factory.rb
+++ b/spec/factories/organisations_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :organisation do
+    sequence(:id) { |index| index }
     sequence(:slug) { |index| "slug-#{index}" }
 
     factory :organisation_with_content_items do

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
     render
 
     expect(rendered).to have_selector('table thead', text: 'Title')
-    expect(rendered).to have_selector('table thead', text: 'Last Updated')
+    expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Last Updated')
   end
 
   it 'renders a row per Content Item' do
@@ -45,6 +45,13 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
         expect(rendered).to have_selector('table tbody tr td', text: '2 months ago')
       end
+    end
+
+    it 'contains a descending and ascending links in table heading' do
+      render
+      href = organisation_content_items_path(organisation, order: :asc, sort: :public_updated_at)
+
+      expect(rendered).to have_link('Last Updated', href: href)
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/jGICn84K/65-story-list-the-pages-that-have-not-been-updated-in-order-bigger-gap-first)

## Description 

As a content designer, when I click on the last_update_at column I change the ordering of the column (ascending and descending).

When a user clicks on the last update table column the ordering of the column changes to
ascending or descending.

Here two links have been included to help with sorting the column by the last updated time.

We cater for the order and sort params that come through and are used to sort the content items by `public_updated_at` in ascending and descending order.

The ordering format is as follows `order('<attribute> (ASC|DESC)')`.

This has not been hard coded and can be reused by any other content item
attribute.


Following the conversations below.. we have agreed to park 6f501c34d3dd3505f8bbb134e069a8a90385a2dd to [story/handle-content-ordering-cntd](https://github.com/alphagov/content-performance-manager/commits/story/handle-content-ordering-cntd), to be revisited in the coming sprints.