### PR TITLE
Update an organisation or a content item if they already exist

### DIFF
--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -9,7 +9,10 @@ class Importers::Organisation
   end
 
   def run
-    @organisation = ::Organisation.create!(slug: slug)
+    @organisation = ::Organisation.find_by(slug: slug)
+    if @organisation.blank?
+      @organisation = ::Organisation.create!(slug: slug)
+    end
 
     loop do
       result = search_content_items_for_organisation

--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -29,9 +29,16 @@ class Importers::Organisation
 
         if content_id.present?
           content_store_item = content_item_store(link)
+
           attributes = content_item_attributes.slice(*CONTENT_ITEM_FIELDS)
             .merge(content_store_item.slice(*CONTENT_STORE_FIELDS))
-          @organisation.content_items << ContentItem.new(attributes)
+          
+          content_item = @organisation.content_items.find_by(content_id: content_id)
+          if content_item.blank?
+            @organisation.content_items << ContentItem.new(attributes)
+          else
+            content_item.update!(attributes)
+          end
         else
           log("There is not content_id for #{slug}")
         end

--- a/db/migrate/20161212124434_add_index_to_content_items.rb
+++ b/db/migrate/20161212124434_add_index_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddIndexToContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_index :content_items, :content_id, unique: true
+  end
+end

--- a/db/migrate/20161212124642_add_index_to_organisations.rb
+++ b/db/migrate/20161212124642_add_index_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddIndexToOrganisations < ActiveRecord::Migration[5.0]
+  def change
+    add_index :organisations, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20161215145222) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "title"
+    t.index ["slug"], name: "index_organisations_on_slug", unique: true, using: :btree
   end
 
   add_foreign_key "content_items", "organisations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20161215145222) do
     t.string   "link"
     t.string   "title"
     t.string   "document_type"
+    t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["organisation_id"], name: "index_content_items_on_organisation_id", using: :btree
   end
 

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe Importers::Organisation do
 
       Importers::Organisation.new('a-slug').run
     end
+    
+    it 'does not add a new organisation if the organisation already exists' do
+      allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(one_content_item_response)
+      allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response)
+
+      slug = 'department-for-education'
+      # The first time the import runs for a slug, a new organisation should be created.
+      expect { Importers::Organisation.new(slug).run }.to change { Organisation.count }.by(1)
+      expect(Organisation.first.slug).to eq(slug)
+
+      # The second time the import runs for a slug, a new organisation should not be created.
+      Importers::Organisation.new(slug).run
+      expect(Organisation.count).to eq(1)
+    end
   end
 
   describe 'Content Items' do

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Importers::Organisation do
 
       Importers::Organisation.new('a-slug').run
     end
-    
+
     it 'does not add a new organisation if the organisation already exists' do
       allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(one_content_item_response)
       allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response)
@@ -168,6 +168,44 @@ RSpec.describe Importers::Organisation do
       Importers::Organisation.new('a-slug').run
       organisation = Organisation.find_by(slug: 'a-slug')
       expect(organisation.content_items.count).to eq(1)
+    end
+
+    it 'does not add a new content item if the content item already exists' do
+      allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(two_content_items_response)
+
+      # The first time the import runs, two content items should be created.
+      Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
+      expect(organisation.content_items.count).to eq(2)
+
+      # The second time the import runs, no new content items should be created.
+      Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
+      expect(organisation.content_items.count).to eq(2)
+    end
+
+    it 'does update content item attributes if they have changed' do
+      allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(one_content_item_response)
+      Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
+      expect(organisation.content_items.count).to eq(1)
+
+      content_item = organisation.content_items.first
+      expect(content_item.title).to eq('title-1')
+
+      updated_one_content_item_response = {
+        content_id: 'content-id-1',
+        link: '/item/1/path',
+        title: 'updated-title-1',
+        organisations: [],
+      }
+
+      allow(HTTParty).to receive(:get).with(search_api_url_pattern).and_return(build_search_api_response([updated_one_content_item_response]))
+
+      Importers::Organisation.new('a-slug').run
+      organisation = Organisation.find_by(slug: 'a-slug')
+      content_item = organisation.content_items.first
+      expect(content_item.title).to eq('updated-title-1')
     end
 
     describe 'Fields ' do
@@ -221,7 +259,13 @@ RSpec.describe Importers::Organisation do
     before { allow(HTTParty).to receive(:get).with(content_items_api_url_pattern).and_return(content_item_response) }
 
     it 'paginates through all the content items for an organisation' do
-      expect(HTTParty).to receive(:get).twice.with(search_api_url_pattern).and_return(two_content_items_response, one_content_item_response)
+      another_content_item = {
+        content_id: 'content-id-3',
+        link: '/item/3/path',
+        title: 'title-3',
+        organisations: [],
+      }
+      expect(HTTParty).to receive(:get).twice.with(search_api_url_pattern).and_return(two_content_items_response, build_search_api_response([another_content_item]))
 
       Importers::Organisation.new('a-slug', batch: 2).run
       organisation = Organisation.find_by(slug: 'a-slug')


### PR DESCRIPTION
Trello card: https://trello.com/c/j7qkEq3Q

## Motivation

The first go at the import task just create new organisations and content items every time it ran. This meant that you could end up with the same organisation being stored in the database multiple times. 

If we load the same organisation twice, then we should have no duplications in the database. Instead, what we would need to do is to update the attributes of a Content Item if it already exists.

## Expected changes

Each organisation should only appear once on the `organisations` page, regardless of how many times it has been imported.