### PR TITLE
Paginate content items for an Organisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'govuk_elements_rails'
 # gem 'capistrano-rails', group: :development
 
 gem 'httparty'
+gem 'kaminari', '~> 0.17.0'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -238,6 +241,7 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari (~> 0.17.0)
   listen (~> 3.0.5)
   pg (~> 0.18)
   puma (~> 3.0)
@@ -253,6 +257,9 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.13.6

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,6 +1,6 @@
 class ContentItemsController < ApplicationController
   def index
     @organisation = Organisation.find(params[:organisation_id])
-    @content_items = @organisation.content_items.order("#{params[:sort]} #{params[:order]}").first(25)
+    @content_items = @organisation.content_items.order("#{params[:sort]} #{params[:order]}").page(params[:page])
   end
 end

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -10,3 +10,4 @@
     <%= render @content_items %>
   </tbody>
 </table>
+<%= paginate @content_items %>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -10,4 +10,5 @@
     <%= render @content_items %>
   </tbody>
 </table>
+<div id="total-content-items"> <%= page_entries_info @content_items %> </div>
 <%= paginate @content_items %>

--- a/spec/features/pagination_spec.rb
+++ b/spec/features/pagination_spec.rb
@@ -47,5 +47,9 @@ RSpec.feature "Content Item's Pagination", type: :feature do
     end
   end
 
-  xscenario "sees the total number of pages"
+  scenario "The user can see information about the total number of content items" do
+    visit "organisations/#{organisation.id}/content_items"
+
+    expect(page).to have_selector('div#total-content-items', text: 'Displaying content items 1 - 2 of 3 in total')
+  end
 end

--- a/spec/features/pagination_spec.rb
+++ b/spec/features/pagination_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature "Content Item's Pagination", type: :feature do
+  let(:organisation) { create(:organisation_with_content_items, content_items_count: 3) }
+
+  before do
+    Kaminari.configure do |config|
+      @default_per_page = config.default_per_page
+      config.default_per_page = 2
+    end
+  end
+
+  after do
+    Kaminari.configure do |config|
+      config.default_per_page = @default_per_page
+    end
+  end
+
+  context "When user navigates to" do
+    scenario "the first page, the current page number is 1" do
+      visit "organisations/#{organisation.id}/content_items"
+
+      expect(page).to have_selector('nav.pagination .current', text: 1)
+    end
+
+    scenario "the previous page from page 2, the current page number is 1" do
+      visit "organisations/#{organisation.id}/content_items?page=2"
+      click_on "Prev"
+
+      expect(page).to have_selector('nav.pagination .current', text: 1)
+    end
+
+    scenario "the last page, the current page number is 2" do
+      visit "organisations/#{organisation.id}/content_items"
+      within("nav.pagination") do
+        click_on "Last"
+      end
+
+      expect(page).to have_selector('nav.pagination .current', text: 2)
+    end
+
+    scenario "the next page, the current page number is 2" do
+      visit "organisations/#{organisation.id}/content_items"
+      click_on "Next"
+
+      expect(page).to have_selector('nav.pagination .current', text: 2)
+    end
+  end
+
+  xscenario "sees the total number of pages"
+end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   let(:content_items) { build_list(:content_item, 2) }
 
   before do
+    allow(view).to receive(:paginate)
     assign(:content_items, content_items)
     assign(:organisation, organisation)
   end
@@ -27,6 +28,18 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
     render
 
     expect(rendered).to have_selector('table tbody tr', count: 2)
+  end
+
+  describe 'Kaminari' do
+    it 'uses Kaminari to paginate the pages' do
+      expect(view).to receive(:paginate)
+      render
+    end
+
+    it 'returns the max page size number of content items per page' do
+      render
+      expect(rendered).to have_selector("table tbody tr", count: 2)
+    end
   end
 
   describe 'row content' do

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
   before do
     allow(view).to receive(:paginate)
+    allow(view).to receive(:page_entries_info)
     assign(:content_items, content_items)
     assign(:organisation, organisation)
   end


### PR DESCRIPTION
Trello card: https://trello.com/c/zRpELgGi

## Motivation

Some organisations own thousands content items. To make it easier to load them on the page, restrict the maximum number of content items that can be viewed on a page to 25.

## Expected changes

### Before
![screen shot 2016-12-13 at 18 13 48](https://cloud.githubusercontent.com/assets/5793815/21152838/f6ea49c6-c15f-11e6-995e-67a3a8e9c132.png)

### After
![screen shot 2016-12-14 at 10 22 56](https://cloud.githubusercontent.com/assets/84896/21178402/59765648-c1e7-11e6-9a46-04c6d7dfa6bc.png)


![screen shot 2016-12-13 at 18 16 19](https://cloud.githubusercontent.com/assets/5793815/21152929/4c41e47e-c160-11e6-992f-51ec8fe561b8.png)

