### PR TITLE
Get the organisation title from search-api

### DIFF
--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -14,10 +14,7 @@ class Importers::Organisation
     loop do
       result = search_content_items_for_organisation
 
-      organisation_titles = result.map do |item|
-        organisations = item['organisations'].first
-        organisations['title'] if organisations.present?
-      end
+      organisation_titles = get_organisation_titles(result)
 
       if organisation_titles.any? && organisation_titles.first && @organisation.title.blank?
         add_organisation_title(organisation_titles.first)
@@ -87,5 +84,13 @@ private
     unless Rails.env.test?
       Logger.new(STDOUT).warn(message)
     end
+  end
+
+  def get_organisation_titles(content_items)
+    titles = content_items.map do |content_item|
+      organisations = content_item['organisations'].first
+      organisations['title'] if organisations.present?
+    end
+    titles
   end
 end

--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -13,6 +13,11 @@ class Importers::Organisation
     loop do
       result = search_content_items_for_organisation
       result.each do |content_item_attributes|
+        content_item_organisations = content_item_attributes['organisations']
+        if content_item_organisations.present?
+          organisation.update!(title: content_item_organisations.first['title'])
+        end
+
         content_id = content_item_attributes['content_id']
         link = content_item_attributes['link']
 
@@ -37,8 +42,9 @@ private
 
   CONTENT_ITEM_FIELDS = %w(content_id link title).freeze
   CONTENT_STORE_FIELDS = %w(public_updated_at document_type).freeze
+  SEARCH_API_FIELDS = CONTENT_ITEM_FIELDS + %w(organisations)
 
-  private_constant :CONTENT_ITEM_FIELDS
+  private_constant :CONTENT_ITEM_FIELDS, :SEARCH_API_FIELDS
 
   def last_page?(results)
     results.length < batch
@@ -54,7 +60,7 @@ private
   end
 
   def search_api_end_point
-    "https://www.gov.uk/api/search.json?filter_organisations=#{slug}&count=#{batch}&fields=#{CONTENT_ITEM_FIELDS.join(',')}&start=#{start}"
+    "https://www.gov.uk/api/search.json?filter_organisations=#{slug}&count=#{batch}&fields=#{SEARCH_API_FIELDS.join(',')}&start=#{start}"
   end
 
   def content_item_store(base_path)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,8 +4,4 @@ class Organisation < ApplicationRecord
   def total_content_items
     content_items.length
   end
-
-  def name
-    slug.tr('-', ' ').titleize
-  end
 end

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= @organisation.name %></h1>
+<h1><%= @organisation.title %></h1>
 <table>
   <thead>
     <tr>

--- a/db/migrate/20161214104355_add_title_to_organisation.rb
+++ b/db/migrate/20161214104355_add_title_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddTitleToOrganisation < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organisations, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20161215145222) do
     t.string   "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "title"
   end
 
   add_foreign_key "content_items", "organisations"

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Importers::Organisation do
         content_id: 'content-id-1',
         link: '/item/1/path',
         title: 'title-1',
+        organisations: [],
       }
     ]
   }
@@ -20,11 +21,13 @@ RSpec.describe Importers::Organisation do
         content_id: 'content-id-1',
         link: '/item/1/path',
         title: 'title-1',
+        organisations: [],
       },
       {
         content_id: 'content-id-2',
         link: '/item/2/path',
-        title: 'title-2'
+        title: 'title-2',
+        organisations: [],
       }
     ]
   }
@@ -93,6 +96,32 @@ RSpec.describe Importers::Organisation do
       organisation = Organisation.find_by(slug: 'a-slug')
       expect(organisation.title).to eq('An organisation title')
     end
+
+    it 'only imports the organisation title once' do
+      allow(HTTParty).to receive(:get).and_return(build_search_api_response([
+        {
+          content_id: 'content-id-1',
+          link: '/item/1/path',
+          title: 'title-1',
+          organisations: [{
+            title: 'An organisation title',
+            slug: 'a-slug'
+          }]
+        },
+        {
+          content_id: 'content-id-2',
+          link: '/item/2/path',
+          title: 'title-2',
+          organisations: [{
+            title: 'An organisation title',
+            slug: 'a-slug'
+          }]
+        }.with_indifferent_access
+      ]))
+      expect_any_instance_of(Importers::Organisation).to receive(:add_organisation_title).once
+
+      Importers::Organisation.new('a-slug').run
+    end
   end
 
   describe 'Content Items' do
@@ -112,11 +141,13 @@ RSpec.describe Importers::Organisation do
           content_id: 'content-id',
           link: '/item/1/path',
           title: 'title-1',
+          organisations: [],
         },
         {
           content_id: '',
           link: '/item/2/path',
           title: 'title-2',
+          organisations: [],
         }
       ]))
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -10,10 +10,4 @@ RSpec.describe Organisation, type: :model do
       expect(organisation.total_content_items).to eq(2)
     end
   end
-
-  it 'returns the organisation name' do
-    organisation = build(:organisation, slug: 'a-name')
-
-    expect(organisation.name).to eq('A Name')
-  end
 end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
     assign(:organisation, organisation)
   end
 
-  it 'renders the name of the organisation from the slug' do
-    allow(organisation).to receive(:name).and_return('A Name')
+  it 'renders the title of the organisation' do
+    allow(organisation).to receive(:title).and_return('A Title')
     render
 
-    expect(rendered).to have_selector('h1', text: 'A Name')
+    expect(rendered).to have_selector('h1', text: 'A Title')
   end
 
   it 'renders the table header with the right headings' do


### PR DESCRIPTION
Trello card: https://trello.com/c/rfRIShPe

## Motivation

The title of the organisations that a piece of content "belongs" to can be retrieved from the search api by requesting the organisations field. Getting the organisation title from the search-api means that if there are any organisation titles that don't quite match their slugs, the application won't be affected.

An example of an organisation title not matching the slug is `hm-revenue-customs`. The title for this organisation is `HM Revenue & Customs`.