### PR TITLE
Story: add 'Document type' to the content items of the organisation.

### DIFF
--- a/app/models/importers/organisation.rb
+++ b/app/models/importers/organisation.rb
@@ -19,7 +19,7 @@ class Importers::Organisation
         if content_id.present?
           content_store_item = content_item_store(link)
           attributes = content_item_attributes.slice(*CONTENT_ITEM_FIELDS)
-            .merge(content_store_item.slice('public_updated_at'))
+            .merge(content_store_item.slice(*CONTENT_STORE_FIELDS))
           organisation.content_items << ContentItem.new(attributes)
         else
           log("There is not content_id for #{slug}")
@@ -36,6 +36,7 @@ class Importers::Organisation
 private
 
   CONTENT_ITEM_FIELDS = %w(content_id link title).freeze
+  CONTENT_STORE_FIELDS = %w(public_updated_at document_type).freeze
 
   private_constant :CONTENT_ITEM_FIELDS
 

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,4 +1,5 @@
 <tr>
   <td><%= link_to content_item.title, content_item.url %></td>
+  <td><%= content_item.document_type %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
 </tr>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -3,6 +3,7 @@
   <thead>
     <tr>
       <th>Title</th>
+      <th>Type of Document</th>
       <th><%= order_link "Last Updated", :public_updated_at, params[:order] %></th>
     </tr>
   </thead>

--- a/db/migrate/20161215145222_add_document_type_to_content_items.rb
+++ b/db/migrate/20161215145222_add_document_type_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddDocumentTypeToContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :document_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161130153206) do
+ActiveRecord::Schema.define(version: 20161215145222) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "content_items", force: :cascade do |t|
     t.string   "content_id"
     t.integer  "organisation_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.datetime "public_updated_at"
     t.string   "link"
     t.string   "title"
-    t.datetime "public_updated_at"
+    t.string   "document_type"
     t.index ["organisation_id"], name: "index_content_items_on_organisation_id", using: :btree
   end
 

--- a/spec/models/importers/organisation_spec.rb
+++ b/spec/models/importers/organisation_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Importers::Organisation do
     double(
       body: {
         public_updated_at: "2016-11-01 11:20:45.481868000 +0000",
+        document_type: "guidance",
       }.to_json
     )
   }
@@ -141,6 +142,14 @@ RSpec.describe Importers::Organisation do
 
         expect(content_item.content_id).to eq('content-id-1')
         expect(content_item.public_updated_at).to eq(Time.parse('2016-11-01 11:20:45.481868'))
+      end
+
+      it 'imports a `document_type` for every content item' do
+        Importers::Organisation.new('a-slug').run
+        content_items = Organisation.find_by(slug: 'a-slug').content_items
+        document_type = content_items.pluck(:document_type).first
+
+        expect(document_type).to eq('guidance')
       end
     end
   end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
     render
 
     expect(rendered).to have_selector('table thead', text: 'Title')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Last Updated')
+    expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
+    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Last Updated')
   end
 
   it 'renders a row per Content Item' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/XOEuihPj/88-5-story-add-document-type-to-the-content-items-of-the-organisation)

## Description 

For every content item, content designers want to see the type of document a
content item is belonging to an organisation.

Here a new column/attribute (i.e `document_type`) has been added to the
content_item(s).

The `document_type` attribute’s value is obtained from the content item
store [1].

The content item end point provides access to the document_type JSON property

For obtaining the document type a piece of content_item, this endpoint [1] is queried
with the base_path supplied.

This PR also updates the content items view table to show the document type.


[1] /api/content/:content_item_base_path