### PR TITLE
Add content item details page

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -6,5 +6,6 @@ class ContentItemsController < ApplicationController
 
   def show
     @content_item = ContentItem.find(params[:id])
+    @organisation = Organisation.find(params[:organisation_id])
   end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -5,6 +5,6 @@ class ContentItemsController < ApplicationController
   end
 
   def show
-    head :ok
+    @content_item = ContentItem.find(params[:id])
   end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -3,4 +3,8 @@ class ContentItemsController < ApplicationController
     @organisation = Organisation.find(params[:organisation_id])
     @content_items = @organisation.content_items.order("#{params[:sort]} #{params[:order]}").page(params[:page])
   end
+
+  def show
+    head :ok
+  end
 end

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -2,4 +2,5 @@
   <td><%= link_to content_item.title, content_item.url %></td>
   <td><%= content_item.document_type %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
+  <td><%= link_to "View detail", organisation_content_item_path(organisation_id: @organisation.id, id: content_item.id) %>
 </tr>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -5,6 +5,7 @@
       <th>Title</th>
       <th>Type of Document</th>
       <th><%= order_link "Last Updated", :public_updated_at, params[:order] %></th>
+      <th></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @content_item.title %></h1>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -20,3 +20,11 @@
     </div>
   </div>
 </div>
+<div class="grid-row">
+  <div class="column-one-half">
+    <div class="data">
+      <span class="data-item bold-medium">Organisation</span>
+      <span class="data-item font-large"><%= @organisation.title %></span>
+    </div>
+  </div>
+</div>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -1,3 +1,5 @@
 <h1><%= @content_item.title %></h1>
 
 <%= link_to "Page on GOV.UK", @content_item.url %>
+<br>
+Document type: <%= @content_item.document_type %>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -1,7 +1,22 @@
 <h1><%= @content_item.title %></h1>
 
-<%= link_to "Page on GOV.UK", @content_item.url %>
-<br>
-Document type: <%= @content_item.document_type %>
-<br>
-Last updated:  <%= time_ago_in_words(@content_item.public_updated_at) %> ago
+<div class="data">
+   <span class="data-item bold-medium">Page on GOV.UK</span>
+   <span class="data-item font-medium"><%= link_to @content_item.url, @content_item.url %></span>
+</div>
+
+<p>
+<div class="grid-row">
+  <div class="column-one-half">
+    <div class="data">
+       <span class="data-item bold-medium">Document type</span>
+       <span class="data-item font-large"><%= @content_item.document_type %></span>
+    </div>
+  </div>
+  <div class="column-one-half">
+    <div class="data">
+     <span class="data-item bold-medium">Last updated</span>
+     <span class="data-item font-large"><%= time_ago_in_words(@content_item.public_updated_at) %> ago</span>
+    </div>
+  </div>
+</div>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -1,1 +1,3 @@
 <h1><%= @content_item.title %></h1>
+
+<%= link_to "Page on GOV.UK", @content_item.url %>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -3,3 +3,5 @@
 <%= link_to "Page on GOV.UK", @content_item.url %>
 <br>
 Document type: <%= @content_item.document_type %>
+<br>
+Last updated:  <%= time_ago_in_words(@content_item.public_updated_at) %> ago

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   root to: 'organisations#index'
 
   resources :organisations, only: %w(index) do
-    resources :content_items, only: %w(index)
+    resources :content_items, only: %w(index show)
   end
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -56,13 +56,22 @@ RSpec.describe ContentItemsController, type: :controller do
 
   describe "GET #show" do
     context "find by content item" do
-      let(:organisation) { create(:organisation_with_content_items, content_items_count: 2) }
-      let(:content_item) { build(:content_item, id: 1) }
+      let(:organisation) { create(:organisation_with_content_items, content_items_count: 1) }
+
+      before do
+        get :show, params: { organisation_id: organisation, id: organisation.content_items.first.id }
+      end
 
       it "returns http success" do
-        get :show, params: { organisation_id: organisation, id: content_item.id }
-
         expect(response).to have_http_status(:success)
+      end
+
+      it "assigns current content item" do
+        expect(assigns(:content_item)).to eq(organisation.content_items.first)
+      end
+
+      it "renders the :show template" do
+        expect(subject).to render_template(:show)
       end
     end
   end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -53,4 +53,17 @@ RSpec.describe ContentItemsController, type: :controller do
       end
     end
   end
+
+  describe "GET #show" do
+    context "find by content item" do
+      let(:organisation) { create(:organisation_with_content_items, content_items_count: 2) }
+      let(:content_item) { build(:content_item, id: 1) }
+
+      it "returns http success" do
+        get :show, params: { organisation_id: organisation, id: content_item.id }
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe ContentItemsController, type: :controller do
         expect(assigns(:content_item)).to eq(organisation.content_items.first)
       end
 
+      it "assigns current organisation" do
+        expect(assigns(:organisation)).to eq(organisation)
+      end
+
       it "renders the :show template" do
         expect(subject).to render_template(:show)
       end

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :content_item do
+    sequence(:id) { |index| index }
     sequence(:content_id) { |index| "7776ddf3-f918-5f32-bf18-dc1ced2eeeb#{index}" }
     link "api/content/item/path"
     public_updated_at { Time.now }

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature "Content Item Details", type: :feature do
   let(:organisation) { create(:organisation_with_content_items, content_items_count: 1) }
 
-  xscenario "the user clicks on the view content item link and is redirected to the content item show page" do
+  scenario "the user clicks on the view content item link and is redirected to the content item show page" do
     visit "organisations/#{organisation.id}/content_items"
     click_on "View detail"
 

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature "Content Item Details", type: :feature do
+  let(:organisation) { create(:organisation_with_content_items, content_items_count: 1) }
+
+  xscenario "the user clicks on the view content item link and is redirected to the content item show page" do
+    visit "organisations/#{organisation.id}/content_items"
+    click_on "View detail"
+
+    expected_path = "/organisations/#{organisation.id}/content_items/#{organisation.content_items.first.id}"
+
+    expect(current_path).to eq(expected_path)
+  end
+end

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -11,5 +11,16 @@ RSpec.describe ContentItemsController, type: :routing do
           organisation_id: '1'
         )
     end
+
+    it 'routes to #show' do
+      expect(get: organisation_content_item_path(organisation_id: 1, id: 1)).to be_routable
+      expect(get: organisation_content_item_path(organisation_id: 1, id: 1))
+        .to route_to(
+          controller: 'content_items',
+          action: 'show',
+          organisation_id: '1',
+          id: '1',
+        )
+    end
   end
 end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -68,5 +68,14 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
       expect(rendered).to have_link('Last Updated', href: href)
     end
+
+    it 'has a link to the content item details page' do
+      render
+
+      expect(rendered).to have_link('View detail', href: organisation_content_item_path(
+        organisation_id: organisation.id,
+        id: content_items.first.id,
+        ))
+    end
   end
 end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'content_items/show.html.erb', type: :view do
   let(:content_item) { build(:content_item) }
+  let(:organisation) { build(:organisation) }
 
   before do
     assign(:content_item, content_item)
+    assign(:organisation, organisation)
   end
 
   it 'renders the title' do
@@ -38,5 +40,13 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
 
     expect(rendered).to have_text('Last updated')
     expect(rendered).to have_text('2 months ago')
+  end
+
+  it 'renders the organisation name' do
+    organisation.title = 'An Organisation'
+    render
+
+    expect(rendered).to have_text('Organisation')
+    expect(rendered).to have_text('An Organisation')
   end
 end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     content_item.link = '/content/1/path'
     render
 
-    expect(rendered).to have_link("Page on GOV.UK", href: 'https://gov.uk/content/1/path')
+    expect(rendered).to have_text('Page on GOV.UK')
+    expect(rendered).to have_link('https://gov.uk/content/1/path', href: 'https://gov.uk/content/1/path')
   end
 
   it 'renders the document type' do

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -21,7 +21,13 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_link("Page on GOV.UK", href: 'https://gov.uk/content/1/path')
   end
 
-  xit 'renders the document type'
+  it 'renders the document type' do
+    content_item.document_type = 'guidance'
+    render
+
+    expect(rendered).to have_text('Document type')
+    expect(rendered).to have_text('guidance')
+  end
 
   xit 'renders the last updated date'
 end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'content_items/show.html.erb', type: :view do
+  let(:content_item) { build(:content_item) }
+
+  it 'renders the title' do
+    content_item.title = 'A Title'
+    assign(:content_item, content_item)
+    render
+
+    expect(rendered).to have_selector('h1', text: 'A Title')
+  end
+
+  xit 'renders the url'
+
+  xit 'renders the document type'
+
+  xit 'renders the last updated date'
+end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -29,5 +29,13 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_text('guidance')
   end
 
-  xit 'renders the last updated date'
+  it 'renders the last updated date' do
+    Timecop.freeze('2016-3-20') do
+      content_item.public_updated_at = Date.parse('2016-1-20')
+      render
+    end
+
+    expect(rendered).to have_text('Last updated')
+    expect(rendered).to have_text('2 months ago')
+  end
 end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -3,15 +3,23 @@ require 'rails_helper'
 RSpec.describe 'content_items/show.html.erb', type: :view do
   let(:content_item) { build(:content_item) }
 
+  before do
+    assign(:content_item, content_item)
+  end
+
   it 'renders the title' do
     content_item.title = 'A Title'
-    assign(:content_item, content_item)
     render
 
     expect(rendered).to have_selector('h1', text: 'A Title')
   end
 
-  xit 'renders the url'
+  it 'renders the url' do
+    content_item.link = '/content/1/path'
+    render
+
+    expect(rendered).to have_link("Page on GOV.UK", href: 'https://gov.uk/content/1/path')
+  end
 
   xit 'renders the document type'
 


### PR DESCRIPTION
Trello card: https://trello.com/c/dZNJBYlc

## Details

Add a new page that shows all of the details for a single content item.

Currently that is limited to the information that already appears in the content item list:

* Title
* URL on GOV.UK
* Document type
* Last updated date
* Organisation name

## Expected Changes
### Before

![screen shot 2016-12-21 at 12 13 44](https://cloud.githubusercontent.com/assets/5793815/21388958/f28f7a64-c776-11e6-8a64-81c63c54eb6d.png)

### After
![contentperformancemanager](https://cloud.githubusercontent.com/assets/5793815/21389053/838c1bc6-c777-11e6-8f91-8197acbe7712.png)

![screen shot 2016-12-21 at 12 18 19](https://cloud.githubusercontent.com/assets/5793815/21389064/936bd4c8-c777-11e6-9552-36028c74a709.png)
