### PR TITLE
Do not pass a slug to import rake task

### DIFF
--- a/spec/features/importers/all_organisations_spec.rb
+++ b/spec/features/importers/all_organisations_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'rake import:all_organisations', type: :feature do
   end
 
   it 'creates all organisations' do
-    expect { Rake::Task['import:all_organisations'].invoke('a_slug') }.to change { Organisation.count }.by(2)
+    expect { Rake::Task['import:all_organisations'].invoke }.to change { Organisation.count }.by(2)
   end
 
   it 'saves an organisation attributes' do


### PR DESCRIPTION
The import:all_organisations doesn't take any parameters. By default it fetchs
the basic details of all organisations from the search_api, so there is no need
to pass it a slug in the feature tests.