### PR TITLE
Content item detail styles

### DIFF
--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,6 +1,5 @@
 <tr>
-  <td><%= link_to content_item.title, content_item.url %></td>
+  <td><%= link_to content_item.title, organisation_content_item_path(organisation_slug: @organisation.slug, id: content_item.id) %></td>
   <td><%= content_item.document_type %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
-  <td><%= link_to "View detail", organisation_content_item_path(organisation_slug: @organisation.slug, id: content_item.id) %>
 </tr>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -5,7 +5,6 @@
       <%= sort_table_header "Title", "title" %>
       <%= sort_table_header "Type of Document", "document_type" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>
-      <th></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -1,35 +1,32 @@
 <h1><%= @content_item.title %></h1>
 
-<div class="data">
-   <span class="data-item bold-medium">Description</span>
-   <span class="data-item font-medium"><%= @content_item.description %></span>
-</div>
-
-<div class="data">
-   <span class="data-item bold-medium">Page on GOV.UK</span>
-   <span class="data-item font-medium"><%= link_to @content_item.url, @content_item.url %></span>
-</div>
-
-<p>
-<div class="grid-row">
-  <div class="column-one-half">
-    <div class="data">
-       <span class="data-item bold-medium">Document type</span>
-       <span class="data-item font-large"><%= @content_item.document_type %></span>
-    </div>
-  </div>
-  <div class="column-one-half">
-    <div class="data">
-     <span class="data-item bold-medium">Last updated</span>
-     <span class="data-item font-large"><%= time_ago_in_words(@content_item.public_updated_at) %> ago</span>
-    </div>
-  </div>
-</div>
-<div class="grid-row">
-  <div class="column-one-half">
-    <div class="data">
-      <span class="data-item bold-medium">Organisation</span>
-      <span class="data-item font-large"><%= @organisation.title %></span>
-    </div>
-  </div>
-</div>
+<table>
+  <thead>
+    <tr>
+      <th>Content item attribute</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Description</td>
+      <td><%= @content_item.description %></td>
+    </tr>
+    <tr>
+      <td>Page on GOV.UK</td>
+      <td><%= link_to @content_item.title, @content_item.url %></td>
+    </tr>
+    <tr>
+      <td>Document type</td>
+      <td><%= @content_item.document_type %></td>
+    </tr>
+    <tr>
+      <td>Last updated</td>
+      <td><%= time_ago_in_words(@content_item.public_updated_at) %> ago</td>
+    </tr>
+    <tr>
+      <td>Organisation</td>
+      <td><%= @organisation.title %></td>
+    </tr>
+  </tbody>
+</table>

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Content Item Details", type: :feature do
 
   scenario "the user clicks on the view content item link and is redirected to the content item show page" do
     visit "organisations/#{organisation.slug}/content_items"
-    click_on "View detail"
+    click_on organisation.content_items.first.title
 
     expected_path = "/organisations/#{organisation.slug}/content_items/#{organisation.content_items.first.id}"
 

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -46,11 +46,13 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
   describe 'row content' do
     it 'includes the content item title' do
-      content_items[0].base_path = '/content/1/path'
       content_items[0].title = 'a-title'
       render
 
-      expect(rendered).to have_link('a-title', href: 'https://gov.uk/content/1/path')
+      expect(rendered).to have_link('a-title', href: organisation_content_item_path(
+        organisation_slug: organisation.slug,
+        id: content_items.first.id,
+        ))
     end
 
     it 'includes the last time the content was updated' do
@@ -67,15 +69,6 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       href = organisation_content_items_path(organisation.slug, order: :asc, sort: :public_updated_at)
 
       expect(rendered).to have_link('Last Updated', href: href)
-    end
-
-    it 'has a link to the content item details page' do
-      render
-
-      expect(rendered).to have_link('View detail', href: organisation_content_item_path(
-        organisation_slug: organisation.slug,
-        id: content_items.first.id,
-        ))
     end
   end
 end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     assign(:organisation, organisation)
   end
 
+  it 'renders the table header with the right headings' do
+    render
+
+    expect(rendered).to have_selector('table th:first-child', text: 'Content item attribute')
+    expect(rendered).to have_selector('table th:nth(2)', text: 'Value')
+  end
+
   it 'renders the title' do
     content_item.title = 'A Title'
     render
@@ -18,18 +25,19 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
 
   it 'renders the url' do
     content_item.base_path = '/content/1/path'
+    content_item.title = 'A Title'
     render
 
-    expect(rendered).to have_text('Page on GOV.UK')
-    expect(rendered).to have_link('https://gov.uk/content/1/path', href: 'https://gov.uk/content/1/path')
+    expect(rendered).to have_selector('td', text: 'Page on GOV.UK')
+    expect(rendered).to have_selector('td + td a[href="https://gov.uk/content/1/path"]', text: 'A Title')
   end
 
   it 'renders the document type' do
     content_item.document_type = 'guidance'
     render
 
-    expect(rendered).to have_text('Document type')
-    expect(rendered).to have_text('guidance')
+    expect(rendered).to have_selector('td', text: 'Document type')
+    expect(rendered).to have_selector('td + td', 'text': 'guidance')
   end
 
   it 'renders the last updated date' do
@@ -38,23 +46,23 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
       render
     end
 
-    expect(rendered).to have_text('Last updated')
-    expect(rendered).to have_text('2 months ago')
+    expect(rendered).to have_selector('td', text: 'Last updated')
+    expect(rendered).to have_selector('td + td', text: '2 months ago')
   end
 
   it 'renders the organisation name' do
     organisation.title = 'An Organisation'
     render
 
-    expect(rendered).to have_text('Organisation')
-    expect(rendered).to have_text('An Organisation')
+    expect(rendered).to have_selector('td', text: 'Organisation')
+    expect(rendered).to have_selector('td + td', text: 'An Organisation')
   end
 
   it 'renders the description of the content item' do
     content_item.description = 'The description of a content item'
     render
 
-    expect(rendered).to have_text('Description')
-    expect(rendered).to have_text('The description of a content item')
+    expect(rendered).to have_selector('td', text: 'Description')
+    expect(rendered).to have_selector('td + td', text: 'The description of a content item')
   end
 end


### PR DESCRIPTION
# Trello

https://trello.com/c/X0EjB4DS/107-3-style-content-item-details-page

# Description

Apply simple html markup to the content item detail view. This PR strips out previous markup in favour of a simple table.

Also simplifies the content item index view table to more sensibly link to the detail page.

# Old

<img width="975" alt="previous" src="https://cloud.githubusercontent.com/assets/6338228/21806889/da18293c-d733-11e6-9bb8-d1078bec92b7.png">

# New

<img width="995" alt="now" src="https://cloud.githubusercontent.com/assets/6338228/21806896/e20e3b9a-d733-11e6-922c-024fe412b0e5.png">
