### PR TITLE
Switch id param for slug

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,11 +1,11 @@
 class ContentItemsController < ApplicationController
   def index
-    @organisation = Organisation.find(params[:organisation_id])
+    @organisation = Organisation.find_by_slug(params[:organisation_slug])
     @content_items = @organisation.content_items.order("#{params[:sort]} #{params[:order]}").page(params[:page])
   end
 
   def show
     @content_item = ContentItem.find(params[:id])
-    @organisation = Organisation.find(params[:organisation_id])
+    @organisation = Organisation.find_by_slug(params[:organisation_slug])
   end
 end

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -23,7 +23,7 @@ module TableHelper
   private
 
     def link(label, order)
-      link_to organisation_content_items_path(organisation_id: view.instance_variable_get(:@organisation), sort: attribute_name, order: order) do
+      link_to organisation_content_items_path(organisation_slug: view.instance_variable_get(:@organisation).slug, sort: attribute_name, order: order) do
         "#{heading}#{content_tag :span, label, class: 'visually-hidden'}".html_safe
       end
     end

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -2,5 +2,5 @@
   <td><%= link_to content_item.title, content_item.url %></td>
   <td><%= content_item.document_type %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
-  <td><%= link_to "View detail", organisation_content_item_path(organisation_id: @organisation.id, id: content_item.id) %>
+  <td><%= link_to "View detail", organisation_content_item_path(organisation_slug: @organisation.slug, id: content_item.id) %>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
-  resources :organisations, only: %w(index) do
+  resources :organisations, only: %w(index), param: :slug do
     resources :content_items, only: %w(index show)
   end
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ContentItemsController, type: :controller do
       let(:organisation) { create(:organisation_with_content_items, content_items_count: 2) }
 
       before do
-        get :index, params: { organisation_id: organisation }
+        get :index, params: { organisation_slug: organisation.slug }
       end
 
       it "returns http success" do
@@ -37,7 +37,7 @@ RSpec.describe ContentItemsController, type: :controller do
 
       context "in ascending order" do
         it "returns content_items based on supplied params" do
-          get :index, params: { organisation_id: organisation, order: :asc, sort: :public_updated_at }
+          get :index, params: { organisation_slug: organisation.slug, order: :asc, sort: :public_updated_at }
 
           expect(assigns(:content_items).pluck(:id)).to match_array([2, 1])
         end
@@ -47,7 +47,7 @@ RSpec.describe ContentItemsController, type: :controller do
       end
 
       it "returns content_items based on supplied params" do
-        get :index, params: { organisation_id: organisation, order: :desc, sort: :public_updated_at }
+        get :index, params: { organisation_slug: organisation.slug, order: :desc, sort: :public_updated_at }
 
         expect(assigns(:content_items).pluck(:id)).to match_array([1, 2])
       end
@@ -59,7 +59,7 @@ RSpec.describe ContentItemsController, type: :controller do
       let(:organisation) { create(:organisation_with_content_items, content_items_count: 1) }
 
       before do
-        get :show, params: { organisation_id: organisation, id: organisation.content_items.first.id }
+        get :show, params: { organisation_slug: organisation.slug, id: organisation.content_items.first.id }
       end
 
       it "returns http success" do

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -4,10 +4,10 @@ RSpec.feature "Content Item Details", type: :feature do
   let(:organisation) { create(:organisation_with_content_items, content_items_count: 1) }
 
   scenario "the user clicks on the view content item link and is redirected to the content item show page" do
-    visit "organisations/#{organisation.id}/content_items"
+    visit "organisations/#{organisation.slug}/content_items"
     click_on "View detail"
 
-    expected_path = "/organisations/#{organisation.id}/content_items/#{organisation.content_items.first.id}"
+    expected_path = "/organisations/#{organisation.slug}/content_items/#{organisation.content_items.first.id}"
 
     expect(current_path).to eq(expected_path)
   end

--- a/spec/features/pagination_spec.rb
+++ b/spec/features/pagination_spec.rb
@@ -18,20 +18,20 @@ RSpec.feature "Content Item's Pagination", type: :feature do
 
   context "When user navigates to" do
     scenario "the first page, the current page number is 1" do
-      visit "organisations/#{organisation.id}/content_items"
+      visit "organisations/#{organisation.slug}/content_items"
 
       expect(page).to have_selector('nav.pagination .current', text: 1)
     end
 
     scenario "the previous page from page 2, the current page number is 1" do
-      visit "organisations/#{organisation.id}/content_items?page=2"
+      visit "organisations/#{organisation.slug}/content_items?page=2"
       click_on "Prev"
 
       expect(page).to have_selector('nav.pagination .current', text: 1)
     end
 
     scenario "the last page, the current page number is 2" do
-      visit "organisations/#{organisation.id}/content_items"
+      visit "organisations/#{organisation.slug}/content_items"
       within("nav.pagination") do
         click_on "Last"
       end
@@ -40,7 +40,7 @@ RSpec.feature "Content Item's Pagination", type: :feature do
     end
 
     scenario "the next page, the current page number is 2" do
-      visit "organisations/#{organisation.id}/content_items"
+      visit "organisations/#{organisation.slug}/content_items"
       click_on "Next"
 
       expect(page).to have_selector('nav.pagination .current', text: 2)
@@ -48,7 +48,7 @@ RSpec.feature "Content Item's Pagination", type: :feature do
   end
 
   scenario "The user can see information about the total number of content items" do
-    visit "organisations/#{organisation.id}/content_items"
+    visit "organisations/#{organisation.slug}/content_items"
 
     expect(page).to have_selector('div#total-content-items', text: 'Displaying content items 1 - 2 of 3 in total')
   end

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe TableHelper, type: :helper do
     let(:organisation) { build(:organisation) }
     before { assign(:organisation, organisation) }
 
-    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_id: organisation } }
-    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_id: organisation } }
+    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_slug: organisation.slug } }
+    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_slug: organisation.slug } }
 
     let(:heading) { 'Last Updated' }
     let(:attribute_name) { 'public_updated_at' }

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 RSpec.describe ContentItemsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: organisation_content_items_path(1)).to be_routable
-      expect(get: organisation_content_items_path(1))
+      expect(get: organisation_content_items_path('a-slug')).to be_routable
+      expect(get: organisation_content_items_path('a-slug'))
         .to route_to(
           controller: 'content_items',
           action: 'index',
-          organisation_id: '1'
+          organisation_slug: 'a-slug'
         )
     end
 
     it 'routes to #show' do
-      expect(get: organisation_content_item_path(organisation_id: 1, id: 1)).to be_routable
-      expect(get: organisation_content_item_path(organisation_id: 1, id: 1))
+      expect(get: organisation_content_item_path(organisation_slug: 'a-slug', id: 1)).to be_routable
+      expect(get: organisation_content_item_path(organisation_slug: 'a-slug', id: 1))
         .to route_to(
           controller: 'content_items',
           action: 'show',
-          organisation_id: '1',
+          organisation_slug: 'a-slug',
           id: '1',
         )
     end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
     it 'contains a descending and ascending links in table heading' do
       render
-      href = organisation_content_items_path(organisation, order: :asc, sort: :public_updated_at)
+      href = organisation_content_items_path(organisation.slug, order: :asc, sort: :public_updated_at)
 
       expect(rendered).to have_link('Last Updated', href: href)
     end
@@ -73,7 +73,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       render
 
       expect(rendered).to have_link('View detail', href: organisation_content_item_path(
-        organisation_id: organisation.id,
+        organisation_slug: organisation.slug,
         id: content_items.first.id,
         ))
     end


### PR DESCRIPTION
## Trello card
https://trello.com/c/nycgDoG5

## Changes

The URL for accessing content items for an organisation, for example:
```
http://{{app.root}}/organisations/24/content_items
```
is hard to remember, difficult to find and sometimes changes when we clean and re-import the data for orgs into the database.

Use the slug of an organisation as the parameter in the URL when viewing an org and its content items, and when viewing a specific content item for an org:

```
http://{{app.root}}/organisations/{organisation-slug}/content_items
http://{{app.root}}/organisations/{organisation-slug}/content_items/{content-item-id}
```