### PR TITLE
Change the content item `link` to `base_path`

### DIFF
--- a/app/lib/collectors/content_items.rb
+++ b/app/lib/collectors/content_items.rb
@@ -7,10 +7,10 @@ module Collectors
       fields = %w(link)
 
       Clients::SearchAPI.find_each(query_params, fields) do |attributes|
-        link = attributes.fetch(:link)
-        content_item_attributes = %i(content_id description title public_updated_at document_type link)
+        base_path = attributes.fetch(:link)
+        content_item_attributes = %i(content_id description title public_updated_at document_type base_path)
 
-        yield Clients::ContentStore.find(link, content_item_attributes)
+        yield Clients::ContentStore.find(base_path, content_item_attributes)
       end
     end
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -2,6 +2,6 @@ class ContentItem < ApplicationRecord
   belongs_to :organisation
 
   def url
-    "https://gov.uk#{self.link}"
+    "https://gov.uk#{self.base_path}"
   end
 end

--- a/app/services/content_items_service.rb
+++ b/app/services/content_items_service.rb
@@ -6,15 +6,15 @@ class ContentItemsService
     fields = %w(link)
 
     Clients::SearchAPI.find_each(query: query, fields: fields) do |response|
-      link = response.fetch(:link)
+      base_path = response.fetch(:link)
 
-      yield Clients::ContentStore.find(link, attribute_names)
+      yield Clients::ContentStore.find(base_path, attribute_names)
     end
   end
 
 private
 
   def attribute_names
-    @names ||= %i(content_id description title public_updated_at document_type link)
+    @names ||= %i(content_id description title public_updated_at document_type base_path)
   end
 end

--- a/db/migrate/20170111104312_rename_link_to_base_path.rb
+++ b/db/migrate/20170111104312_rename_link_to_base_path.rb
@@ -1,0 +1,5 @@
+class RenameLinkToBasePath < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :content_items, :link, :base_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161221134137) do
+ActiveRecord::Schema.define(version: 20170111104312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20161221134137) do
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
     t.datetime "public_updated_at"
-    t.string   "link"
+    t.string   "base_path"
     t.string   "title"
     t.string   "document_type"
     t.string   "description"

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     sequence(:content_id) { |index| "content-id-#{index}" }
     sequence(:title) { |index| "title-#{index}" }
     sequence(:document_type) { |index| "document_type-#{index}" }
-    link "api/content/item/path"
+    base_path "api/content/item/path"
     public_updated_at { Time.now }
   end
 end

--- a/spec/features/importers/content_items_by_organisation_spec.rb
+++ b/spec/features/importers/content_items_by_organisation_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'rake import:organisation[{department-slug}]', type: :feature do
   let(:search_api_response) { double(body: { results: [{ link: '/link-1' }, { link: '/link-2' }] }.to_json) }
-  let(:content_item_1) { double(body: attributes_for(:content_item, link: '/link-1').to_json) }
-  let(:content_item_2) { double(body: attributes_for(:content_item, link: '/link-2').to_json) }
+  let(:content_item_1) { double(body: attributes_for(:content_item, base_path: '/link-1').to_json) }
+  let(:content_item_2) { double(body: attributes_for(:content_item, base_path: '/link-2').to_json) }
 
   before do
     Rake::Task['import:content_items_by_organisation'].reenable
@@ -20,11 +20,11 @@ RSpec.feature 'rake import:organisation[{department-slug}]', type: :feature do
   end
 
   it 'saves the content item attributes' do
-    content_item_1 = double(body: attributes_for(:content_item, link: '/link-1', title: 'new-title').to_json)
+    content_item_1 = double(body: attributes_for(:content_item, base_path: '/link-1', title: 'new-title').to_json)
     allow(HTTParty).to receive(:get).and_return(search_api_response, content_item_1)
     subject
 
-    content_item = ContentItem.find_by(link: '/link-1')
+    content_item = ContentItem.find_by(base_path: '/link-1')
     expect(content_item.title).to include('new-title')
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ContentItem, type: :model do
 
   describe '#url' do
     it 'returns a url to a content item on gov.uk' do
-      content_item = build(:content_item, link: '/api/content/item/path/1')
+      content_item = build(:content_item, base_path: '/api/content/item/path/1')
       expect(content_item.url).to eq('https://gov.uk/api/content/item/path/1')
     end
   end

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -14,20 +14,20 @@ RSpec.describe Importers::ContentItemsByOrganisation do
       end
 
       it 'updates the attributes' do
-        attrs1 = attributes_for(:content_item, link: 'the-link-value', title: 'the-title')
+        attrs1 = attributes_for(:content_item, base_path: 'the-link-value', title: 'the-title')
         allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attrs1)
         subject.run('the-slug')
 
-        attributes = ContentItem.find_by(link: 'the-link-value').attributes.symbolize_keys
+        attributes = ContentItem.find_by(base_path: 'the-link-value').attributes.symbolize_keys
         expect(attributes).to include(title: 'the-title')
       end
     end
 
     context 'when the content item already exists' do
-      let(:content_item) { create(:content_item, link: 'the-link', organisation: organisation) }
+      let(:content_item) { create(:content_item, base_path: 'the-link', organisation: organisation) }
 
       it 'does not create a new one' do
-        attributes = { content_id: content_item.content_id, link: 'the-link' }
+        attributes = { content_id: content_item.content_id, base_path: 'the-link' }
         allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attributes)
 
         expect { subject.run('the-slug') }.to change { ContentItem.count }.by(0)

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
   describe 'row content' do
     it 'includes the content item title' do
-      content_items[0].link = '/content/1/path'
+      content_items[0].base_path = '/content/1/path'
       content_items[0].title = 'a-title'
       render
 

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
   end
 
   it 'renders the url' do
-    content_item.link = '/content/1/path'
+    content_item.base_path = '/content/1/path'
     render
 
     expect(rendered).to have_text('Page on GOV.UK')


### PR DESCRIPTION
Before PR #39, when we were getting the content item details from the 
search_api, the url to the page on GOV.UK was being returned as `link`.

PR #39 changed the import task to get content item details from the 
Content Store. In the Content Store, the url to the page on GOV.UK is 
returned as `base_path`.

This has caused parts of the `content_items_by_organisation` rake task
to fail.

To make things consistent with the content store, change all references
to `link` in the content item and content item related services to 
`base_path`.

The `link` is still referred to as `link` in organisations to keep it
consistent with the search api.