### PR TITLE
[DO NOT MERGE] Content item attachment class

### DIFF
--- a/app/lib/content_item_attachments.rb
+++ b/app/lib/content_item_attachments.rb
@@ -1,0 +1,20 @@
+class ContentItemAttachments
+  class << self
+    PDF_THRESHOLD = 1
+    PDF_XPATH = "//*[contains(@class, 'attachment-details')]//a[contains(@href, '.pdf')]".freeze
+
+    def pdfs?(html_string)
+      pdfs(parse(html_string)).length >= PDF_THRESHOLD
+    end
+
+  private
+
+    def parse(html_string)
+      Nokogiri::HTML(html_string)
+    end
+
+    def pdfs(html_fragment)
+      html_fragment.xpath(PDF_XPATH)
+    end
+  end
+end

--- a/spec/services/content_item_attachments_spec.rb
+++ b/spec/services/content_item_attachments_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ContentItemAttachments do
+  subject { ContentItemAttachments }
+
+  let(:fragment_with_pdfs) {
+    '<div class=\"attachment-details\">\n
+    <a href=\"link.pdf\">1</a>\n\n\n\n</div>'
+  }
+
+  let(:fragment_without_pdfs) {
+    '<div class=\"attachment-details\">\n
+    <a href=\"link.txt\">1</a>\n\n\n\n</div>'
+  }
+
+  it "returns true is pdfs are present" do
+    expect(subject.pdfs?(fragment_with_pdfs)).to be(true)
+  end
+
+  it "returns false if pdfs are not present" do
+    expect(subject.pdfs?(fragment_without_pdfs)).to be(false)
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/8qSDBmiM

Used to extra get info from content_item[“documents”]. content_item[“documents”] is an escaped html string returned from the content store.

Can tell whether a set of attachments contain PDFs.