### PR TITLE
Set up Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,52 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'content-performance-manager'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage('Checkout') {
+      checkout scm
+    }
+
+    stage('Clean') {
+      govuk.cleanupGit()
+      govuk.mergeMasterBranch()
+    }
+
+    stage('Bundle') {
+      govuk.bundleApp()
+    }
+
+    stage('Linter') {
+      govuk.rubyLinter()
+    }
+
+    stage('Database') {
+      govuk.setupDb()
+    }
+
+    stage('Tests') {
+      govuk.setEnvar('RAILS_ENV', 'test')
+      govuk.runTests()
+    }
+
+    stage('Push release tag') {
+      govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
+    }
+
+    stage('Deploy to Integration') {
+      // Deploy on Integration (only master)
+      govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
+    }
+
+  } catch (e) {
+    currentBuild.result = 'FAILED'
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -x
-
-set -e
-
-bundle exec govuk-lint-ruby --format clang
-
-RAILS_ENV=test TEST_COVERAGE=true bundle exec rake test
-
-bundle exec rake assets:precompile


### PR DESCRIPTION
The continuous integration environment is switching to Jenkins 2.
As content-performance-manager is a brand new app we should start by
creating a properly configured `Jenkinsfile`, rather than just one that
points to the old style `jenkins.sh`