### PR TITLE
Page views content item detail

### DIFF
--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -4,7 +4,7 @@
     <tr>
       <%= sort_table_header "Title", "title" %>
       <%= sort_table_header "Type of Document", "document_type" %>
-      <%= sort_table_header "Page Views", "number_of_views" %>
+      <%= sort_table_header "Number of Views", "number_of_views" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>
     </tr>
   </thead>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -21,6 +21,10 @@
       <td><%= @content_item.document_type %></td>
     </tr>
     <tr>
+      <td>Number of views</td>
+      <td><%= @content_item.number_of_views %></td>
+    </tr>
+    <tr>
       <td>Last updated</td>
       <td><%= time_ago_in_words(@content_item.public_updated_at) %> ago</td>
     </tr>

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
     expect(rendered).to have_selector('table thead', text: 'Title')
     expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Page Views')
+    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Number of Views')
     expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Last Updated')
   end
 

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_selector('td + td', 'text': 'guidance')
   end
 
+  it 'renders the number of views' do
+    content_item.number_of_views = 10
+    render
+
+    expect(rendered).to have_selector('td', text: 'Number of views')
+    expect(rendered).to have_selector('td + td', 'text': 10)
+  end
+
   it 'renders the last updated date' do
     Timecop.freeze('2016-3-20') do
       content_item.public_updated_at = Date.parse('2016-1-20')


### PR DESCRIPTION
# Trello
https://trello.com/c/icZa2lmE/91-1-add-number-of-views-to-content-item-detail-page

# Description
Add the new `number_of_views` per content item into the content item details view

# Looks like

<img width="1002" alt="screen shot 2017-01-17 at 12 02 14" src="https://cloud.githubusercontent.com/assets/6338228/22019786/d46b8992-dcac-11e6-98b4-b2385b30428e.png">
