### PR TITLE
Show sort arrow always fix to the right hand side.

### DIFF
--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -1,4 +1,5 @@
 [aria-sort] > * {
+  display: inline-block;
   position: relative;
 
   &:after {


### PR DESCRIPTION
# Description
Quick fix for sortable header text + arrow.
When text wraps in sortable table headers the up/down arrow positioning was off, this correctly positions them on the righthand side of the header.

# Before
<img width="632" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/22023305/8c01bcce-dcbd-11e6-9471-270216418945.png">

# Now
<img width="666" alt="now" src="https://cloud.githubusercontent.com/assets/6338228/22023309/92fbb7d2-dcbd-11e6-8b0b-feeb57058bf7.png">


