### PR TITLE
Set up Errbit error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'httparty'
 gem 'kaminari', '~> 0.17.0'
 gem 'google-api-client', '~> 0.9'
 
+gem 'airbrake', '4.3.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    airbrake (4.3.1)
+      builder
+      multi_json
     arel (7.1.4)
     ast (2.3.0)
     builder (3.2.2)
@@ -268,6 +271,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 4.3.1)
   byebug
   capybara
   coffee-rails (~> 4.2)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV["ERRBIT_API_KEY"].present?
+  errbit_uri = Plek.find_uri("errbit")
+
+  Airbrake.configure do |config|
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == "https"
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/cXXXWGXG

Using an older version of the airbrake because after version 5, the
view tests fail with the following error:

```
Failure/Error: <%= sort_table_header "Title", "title" %>
     
ActionView::Template::Error:
  undefined method `sort_table_header' for #<#<Class:0x007fe658b743f0>:0x007fe6508420b8>
```

The Airbrake gem was re-written when it moved to version 5 and split
into two gems: `airbrake` and `airbrake-ruby`. Some investigation will
need to be done to determine why version 5 is not compatible with the
`sort_table_header` used to order the columns in the table on the
content items page.

Using config recommended in: https://github.gds/pages/gds/opsmanual/infrastructure/howto/setting-up-new-rails-app.html#configuring-errbit