### PR TITLE
Change to unique page views

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -2,6 +2,6 @@ class ContentItem < ApplicationRecord
   belongs_to :organisation
 
   def url
-    "https://gov.uk#{self.base_path}"
+    "https://gov.uk#{base_path}"
   end
 end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -9,7 +9,7 @@ module Importers
       results = GoogleAnalyticsService.new.page_views(base_paths)
       results.each do |result|
         content_item = ::ContentItem.find_by(base_path: result[:base_path])
-        content_item.update!(number_of_views: result[:page_views])
+        content_item.update!(unique_page_views: result[:page_views])
       end
     end
   end

--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -10,7 +10,7 @@ module GoogleAnalytics
         GetReportsRequest.new.tap do |reports|
           reports.report_requests = Array.new.push(
             ReportRequest.new.tap do |request|
-              request.metrics = metrics(page_views)
+              request.metrics = metrics(unique_page_views)
               request.view_id = view_id
               request.dimension_filter_clauses = filters(base_paths, page_path)
               request.dimensions = dimensions(page_path)
@@ -61,8 +61,8 @@ module GoogleAnalytics
         "ga:pagePath"
       end
 
-      def page_views
-        "ga:pageViews"
+      def unique_page_views
+        "ga:uniquePageviews"
       end
 
       def view_id

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= link_to content_item.title, organisation_content_item_path(organisation_slug: @organisation.slug, id: content_item.id) %></td>
   <td><%= content_item.document_type %></td>
-  <td><%= content_item.number_of_views %></td>
+  <td><%= content_item.unique_page_views %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
 </tr>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -4,7 +4,7 @@
     <tr>
       <%= sort_table_header "Title", "title" %>
       <%= sort_table_header "Type of Document", "document_type" %>
-      <%= sort_table_header "Number of Views", "number_of_views" %>
+      <%= sort_table_header "Unique page views (last 7 days)", "unique_page_views" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>
     </tr>
   </thead>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -21,8 +21,8 @@
       <td><%= @content_item.document_type %></td>
     </tr>
     <tr>
-      <td>Number of views</td>
-      <td><%= @content_item.number_of_views %></td>
+      <td>Number of unique views</td>
+      <td><%= @content_item.unique_page_views %></td>
     </tr>
     <tr>
       <td>Last updated</td>

--- a/db/migrate/20170117171347_rename_pageviews_to_uniquepageviews.rb
+++ b/db/migrate/20170117171347_rename_pageviews_to_uniquepageviews.rb
@@ -1,0 +1,5 @@
+class RenamePageviewsToUniquepageviews < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :content_items, :number_of_views, :unique_page_views
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170112173524) do
+ActiveRecord::Schema.define(version: 20170117171347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20170112173524) do
     t.string   "title"
     t.string   "document_type"
     t.string   "description"
-    t.integer  "number_of_views",   default: 0
+    t.integer  "unique_page_views", default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["organisation_id"], name: "index_content_items_on_organisation_id", using: :btree
   end

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
       content_item_one = ContentItem.find_by(base_path: 'the-link/first')
       content_item_two = ContentItem.find_by(base_path: 'the-link/second')
 
-      expect(content_item_one.number_of_views).to eq(3)
-      expect(content_item_two.number_of_views).to eq(2)
+      expect(content_item_one.unique_page_views).to eq(3)
+      expect(content_item_two.unique_page_views).to eq(2)
     end
   end
 end

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -19,7 +19,7 @@ module GoogleAnalytics
               {
                 metrics: [
                   {
-                    expression: "ga:pageViews"
+                    expression: "ga:uniquePageviews"
                   }
                 ],
                 view_id: "12345678",

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
     expect(rendered).to have_selector('table thead', text: 'Title')
     expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Number of Views')
+    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Unique page views (last 7 days)')
     expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Last Updated')
   end
 

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
   end
 
   it 'renders the number of views' do
-    content_item.number_of_views = 10
+    content_item.unique_page_views = 10
     render
 
-    expect(rendered).to have_selector('td', text: 'Number of views')
+    expect(rendered).to have_selector('td', text: 'Number of unique views')
     expect(rendered).to have_selector('td + td', 'text': 10)
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/AbEpIghY

## Motivation
The query to Google Analytics passes `ga:pageviews` as the metric expression. 

From [pageviews vs unique_views](https://support.google.com/analytics/answer/1257084#pageviews_vs_unique_views):

A pageview is defined as a view of a page on your site that is being tracked by the Analytics tracking code. If a user clicks reload after reaching the page, this is counted as an additional pageview. If a user navigates to a different page and then returns to the original page, a second pageview is recorded as well.

A unique pageview, as seen in the Content Overview report, aggregates pageviews that are generated by the same user during the same session. A unique pageview represents the number of sessions during which that page was viewed one or more times.

## Changes
Change to using unique pageviews because it is a better metric to discover the number of unique users visiting the page.