### PR TITLE
Handle content store 404s

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
   gem 'timecop'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -211,6 +213,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -258,6 +261,9 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webmock (1.20.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -296,6 +302,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  webmock
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/app/services/clients/content_store.rb
+++ b/app/services/clients/content_store.rb
@@ -3,9 +3,13 @@ module Clients
     class << self
       def find(path, attributes)
         response = HTTParty.get(end_point(path))
-        content_item = JSON.parse(response.body).symbolize_keys
-
-        content_item.slice(*attributes)
+        case response.code
+        when 200
+          content_item = JSON.parse(response.body).symbolize_keys
+          content_item.slice(*attributes)
+        when 404
+          nil
+        end
       end
 
     private

--- a/app/services/content_items_service.rb
+++ b/app/services/content_items_service.rb
@@ -7,8 +7,8 @@ class ContentItemsService
 
     Clients::SearchAPI.find_each(query: query, fields: fields) do |response|
       base_path = response.fetch(:link)
-
-      yield Clients::ContentStore.find(base_path, attribute_names)
+      content_item = Clients::ContentStore.find(base_path, attribute_names)
+      yield content_item if content_item
     end
   end
 

--- a/spec/features/importers/all_organisations_spec.rb
+++ b/spec/features/importers/all_organisations_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'rake import:all_organisations', type: :feature do
 
   before do
     Rake::Task['import:all_organisations'].reenable
-    stub_request(:get, %r{.*}).to_return(:status => 200, :body => two_organisations)
+    stub_request(:get, %r{.*}).to_return(status: 200, body:  two_organisations)
   end
 
   it 'creates all organisations' do

--- a/spec/features/importers/all_organisations_spec.rb
+++ b/spec/features/importers/all_organisations_spec.rb
@@ -2,18 +2,17 @@ require 'rails_helper'
 
 RSpec.feature 'rake import:all_organisations', type: :feature do
   let(:two_organisations) {
-    double(body: {
+    {
       results: [
         { slug: 'slug-1', title: 'title-1' },
         { slug: 'slug-2', title: 'title-2' }
       ]
-    }.to_json)
+    }.to_json
   }
 
   before do
     Rake::Task['import:all_organisations'].reenable
-
-    allow(HTTParty).to receive(:get).and_return(two_organisations)
+    stub_request(:get, %r{.*}).to_return(:status => 200, :body => two_organisations)
   end
 
   it 'creates all organisations' do

--- a/spec/features/importers/content_items_by_organisation_spec.rb
+++ b/spec/features/importers/content_items_by_organisation_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.feature 'rake import:content_items_by_organisation[{department-slug}]', type: :feature do
-  let(:search_api_response) { double(body: { results: [{ link: '/link-1' }, { link: '/link-2' }] }.to_json) }
-  let(:content_item_1) { double(body: attributes_for(:content_item, base_path: '/link-1').to_json) }
-  let(:content_item_2) { double(body: attributes_for(:content_item, base_path: '/link-2').to_json) }
+  let(:search_api_response) { { results: [{ link: '/link-1' }, { link: '/link-2' }] }.to_json }
+  let(:content_item_1) { attributes_for(:content_item, base_path: '/link-1').to_json }
+  let(:content_item_2) { attributes_for(:content_item, base_path: '/link-2').to_json }
 
   before do
     Rake::Task['import:content_items_by_organisation'].reenable
@@ -14,14 +14,22 @@ RSpec.feature 'rake import:content_items_by_organisation[{department-slug}]', ty
   subject { Rake::Task['import:content_items_by_organisation'].invoke('the-organisation-slug') }
 
   it 'creates all the content items belonging to an organisation' do
-    allow(HTTParty).to receive(:get).and_return(search_api_response, content_item_1, content_item_2)
+    stub_request(:get, %r{.*}).to_return(
+      { :status => 200, :body => search_api_response },
+      { :status => 200, :body => content_item_1 },
+      { :status => 200, :body => content_item_2 }      
+    )
 
     expect { subject }.to change { ContentItem.count }.by(2)
   end
 
   it 'saves the content item attributes' do
-    content_item_1 = double(body: attributes_for(:content_item, base_path: '/link-1', title: 'new-title').to_json)
-    allow(HTTParty).to receive(:get).and_return(search_api_response, content_item_1)
+    content_item_1 = attributes_for(:content_item, base_path: '/link-1', title: 'new-title').to_json
+    stub_request(:get, %r{.*}).to_return(
+      { :status => 200, :body => search_api_response },
+      { :status => 200, :body => content_item_1 }
+    )
+
     subject
 
     content_item = ContentItem.find_by(base_path: '/link-1')

--- a/spec/features/importers/content_items_by_organisation_spec.rb
+++ b/spec/features/importers/content_items_by_organisation_spec.rb
@@ -14,21 +14,21 @@ RSpec.feature 'rake import:content_items_by_organisation[{department-slug}]', ty
   subject { Rake::Task['import:content_items_by_organisation'].invoke('the-organisation-slug') }
 
   it 'creates all the content items belonging to an organisation' do
-    stub_request(:get, %r{.*}).to_return(
-      { :status => 200, :body => search_api_response },
-      { :status => 200, :body => content_item_1 },
-      { :status => 200, :body => content_item_2 }      
-    )
+    stub_request(:get, %r{.*}).to_return([
+      { status: 200, body:  search_api_response },
+      { status: 200, body:  content_item_1 },
+      { status: 200, body:  content_item_2 }
+    ])
 
     expect { subject }.to change { ContentItem.count }.by(2)
   end
 
   it 'saves the content item attributes' do
     content_item_1 = attributes_for(:content_item, base_path: '/link-1', title: 'new-title').to_json
-    stub_request(:get, %r{.*}).to_return(
-      { :status => 200, :body => search_api_response },
-      { :status => 200, :body => content_item_1 }
-    )
+    stub_request(:get, %r{.*}).to_return([
+      { status: 200, body:  search_api_response },
+      { status: 200, body:  content_item_1 }
+    ])
 
     subject
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'support/factory_girl'
+require 'webmock/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/clients/content_store_spec.rb
+++ b/spec/services/clients/content_store_spec.rb
@@ -4,16 +4,18 @@ RSpec.describe Clients::ContentStore do
   subject { Clients::ContentStore }
 
   it 'queries the content item API with base path' do
-    response = double(body: {}.to_json)
-    expected_url = 'https://www.gov.uk/api/content/the-path'
-    expect(HTTParty).to receive(:get).with(expected_url).and_return(response)
+    stub_request(:get, %r{/the-path}).to_return(:status => 200, :body => {}.to_json)
 
     subject.find('/the-path', Array.new)
+
+    expect(WebMock).to have_requested(:get, %r{/the-path})
   end
 
   it 'returns the content item attributes' do
-    response = double(body: { param1: :value1, param2: :value2 }.to_json)
-    expect(HTTParty).to receive(:get).and_return(response)
+    stub_request(:get, %r{/the-path}).to_return(
+      :status => 200, 
+      :body => { param1: :value1, param2: :value2 }.to_json
+    )
 
     expect(subject.find('/the-path', %i(param2))).to eq(param2: 'value2')
   end

--- a/spec/services/clients/content_store_spec.rb
+++ b/spec/services/clients/content_store_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Clients::ContentStore do
   subject { Clients::ContentStore }
 
   it 'queries the content item API with base path' do
-    stub_request(:get, %r{/the-path}).to_return(:status => 200, :body => {}.to_json)
+    stub_request(:get, %r{/the-path}).to_return(status: 200, body:  {}.to_json)
 
     subject.find('/the-path', Array.new)
 
@@ -13,10 +13,19 @@ RSpec.describe Clients::ContentStore do
 
   it 'returns the content item attributes' do
     stub_request(:get, %r{/the-path}).to_return(
-      :status => 200, 
-      :body => { param1: :value1, param2: :value2 }.to_json
+      status: 200,
+      body:  { param1: :value1, param2: :value2 }.to_json
     )
 
     expect(subject.find('/the-path', %i(param2))).to eq(param2: 'value2')
+  end
+
+  it "returns nil when a content item is not found" do
+    stub_request(:get, %r{/does-not-exist}).to_return(
+      status: 404,
+      body: "Not Found"
+    )
+
+    expect(subject.find('/does-not-exist', Array.new)).to eq(nil)
   end
 end

--- a/spec/services/clients/search_api_spec.rb
+++ b/spec/services/clients/search_api_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Clients::SearchAPI do
 
   it 'returns symbolized attributes' do
     response = { results: [{ 'title' => 'title-1' }] }.to_json
-    stub_request(:get, %r{.*}).to_return(:status => 200, :body => response)
+    stub_request(:get, %r{.*}).to_return(status: 200, body:  response)
 
     subject.find_each(query: { param: :value1 }, fields: %w(title)) do |attributes|
       expect(attributes).to eq(title: 'title-1')
@@ -24,7 +24,7 @@ RSpec.describe Clients::SearchAPI do
 
   it 'builds the SearchAPI query' do
     stub_request(:get, "https://www.gov.uk/api/search.json?count=1000&fields=field1,field2&param=value1&start=0")
-      .to_return(:status => 200, :body => { results: [] }.to_json)
+      .to_return(status: 200, body:  { results: [] }.to_json)
 
     subject.find_each(query: { param: :value1 }, fields: %w(field1 field2)) {}
 
@@ -35,10 +35,10 @@ RSpec.describe Clients::SearchAPI do
     it 'iterates through the pages' do
       another_content_item = { results: [{ content_id: 'content-id-3' }] }.to_json
 
-      stub_request(:get, %r{.*}).to_return(
-        { :status => 200, :body => two_content_items },
-        { :status => 200, :body => another_content_item }
-      )
+      stub_request(:get, %r{.*}).to_return([
+        { status: 200, body:  two_content_items },
+        { status: 200, body:  another_content_item }
+      ])
 
       allow(subject).to receive(:batch_size).and_return(2)
 
@@ -46,10 +46,10 @@ RSpec.describe Clients::SearchAPI do
     end
 
     it 'does not fail when last page size is equal to batch size' do
-      stub_request(:get, %r{.*}).to_return(
-        { :status => 200, :body => one_content_item },
-        { :status => 200, :body => empty_response }
-      )
+      stub_request(:get, %r{.*}).to_return([
+        { status: 200, body:  one_content_item },
+        { status: 200, body:  empty_response }
+      ])
 
       allow(subject).to receive(:batch_size).and_return(1)
 

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe ContentItemsService do
       expect(result).to match_array([:a])
     end
 
+    it "does not yield nil responses from the content store" do
+      result = []
+      allow(Clients::SearchAPI).to receive(:find_each).and_yield(link: :link1)
+      allow(Clients::ContentStore).to receive(:find).and_return(nil)
+      subject.find_each('organisation-slug') { |value| result << value }
+
+      expect(result).to match_array([])
+    end
+
+
     it 'raises an exception if no block is passed' do
       expect { subject.find_each('organisation-slug') }.to raise_exception('missing block!')
     end


### PR DESCRIPTION
# Trello
https://trello.com/c/wyB5V6m0/108-a-content-item-on-gov-uk-is-causing-import-task-import-content-items-by-organisation-to-fail

# Description
Some content items found using the search api may not have a corresponding entry in the content store API - these will return a 404 which in turn will stop the import of an organisations content items at that point.

This PR adds 404 logic to the content store service as well as an overhaul of the http request mocking in the test suite, adding in WebMock rather than hijacking HTTParty. By doing this the tests remain http client agnostic.
