### PR TITLE
Make labels consistent

### DIFF
--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -17,11 +17,11 @@
       <td><%= link_to @content_item.title, @content_item.url %></td>
     </tr>
     <tr>
-      <td>Document type</td>
+      <td>Type of document</td>
       <td><%= @content_item.document_type %></td>
     </tr>
     <tr>
-      <td>Number of unique views</td>
+      <td>Unique page views (last 7 days)</td>
       <td><%= @content_item.unique_page_views %></td>
     </tr>
     <tr>

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     content_item.document_type = 'guidance'
     render
 
-    expect(rendered).to have_selector('td', text: 'Document type')
+    expect(rendered).to have_selector('td', text: 'Type of document')
     expect(rendered).to have_selector('td + td', 'text': 'guidance')
   end
 
@@ -44,7 +44,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     content_item.unique_page_views = 10
     render
 
-    expect(rendered).to have_selector('td', text: 'Number of unique views')
+    expect(rendered).to have_selector('td', text: 'Unique page views (last 7 days)')
     expect(rendered).to have_selector('td + td', 'text': 10)
   end
 


### PR DESCRIPTION
The details page did not include the context of a time frame for the unique page views as the listings page did. The wording for this label and for document type was also inconsistent. I have addressed these minor issues in this small PR.