### PR TITLE
Move gems to test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,16 +51,16 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'timecop'
   gem 'webmock'
+  gem 'govuk-lint'
+  gem 'listen', '~> 3.0.5'
 end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
-  gem 'listen', '~> 3.0.5'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'govuk-lint'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
Jenkins does not install any gems that are in the `development` group, so the
master branch was failing to build because the linter and listen gems were
missing.

Moving these two gems has fixed the problem.