### PR TITLE
Change the name of the production database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,6 @@ test:
 #
 production:
   <<: *default
-  database: content-performance-manager_production
-  username: content-performance-manager
+  database: content_performance_manager_production
+  username: content_performance_manager
   password: <%= ENV['CONTENT-PERFORMANCE-MANAGER_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
Puppet does not handle having hypens in names, so the database name and user has
been changed to using underscores instead.