### PR TITLE
Move WebMock into test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,12 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_girl_rails'
   gem 'timecop'
-  gem 'webmock'
   gem 'govuk-lint'
   gem 'listen', '~> 3.0.5'
+end
+
+group :test do
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,8 +310,5 @@ DEPENDENCIES
   web-console
   webmock
 
-RUBY VERSION
-   ruby 2.3.1p112
-
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
The WebMock gem was also being used in the development group but should only be available for test.