### PR TITLE
ManytoMany: ContentItems<=>Organisations

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,5 @@
 class ContentItem < ApplicationRecord
-  belongs_to :organisation
+  has_and_belongs_to_many :organisations
 
   def url
     "https://gov.uk#{base_path}"

--- a/app/models/importers/content_items_by_organisation.rb
+++ b/app/models/importers/content_items_by_organisation.rb
@@ -11,9 +11,10 @@ module Importers
 
     def create_or_update!(attributes, organisation)
       content_id = attributes.fetch(:content_id)
-      content_item = organisation.content_items.find_or_create_by(content_id: content_id)
+      content_item = ContentItem.find_or_create_by(content_id: content_id)
 
       content_item.update!(attributes)
+      content_item.organisations << organisation unless content_item.organisations.include?(organisation)
     end
   end
 end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -3,8 +3,7 @@ module Importers
     def run(slug)
       organisation = ::Organisation.find_by(slug: slug)
 
-      content_items = ::ContentItem.where(organisation_id: organisation.id)
-      base_paths = content_items.pluck(:base_path)
+      base_paths = organisation.content_items.pluck(:base_path)
 
       results = GoogleAnalyticsService.new.page_views(base_paths)
       results.each do |result|

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,3 +1,3 @@
 class Organisation < ApplicationRecord
-  has_many :content_items
+  has_and_belongs_to_many :content_items
 end

--- a/db/migrate/20170203113501_create_content_items_organisations_join_table.rb
+++ b/db/migrate/20170203113501_create_content_items_organisations_join_table.rb
@@ -1,0 +1,5 @@
+class CreateContentItemsOrganisationsJoinTable < ActiveRecord::Migration[5.0]
+  def change
+    create_join_table :content_items, :organisations
+  end
+end

--- a/db/migrate/20170206153248_migrate_many_to_many_content_items_organisation.rb
+++ b/db/migrate/20170206153248_migrate_many_to_many_content_items_organisation.rb
@@ -1,0 +1,12 @@
+class MigrateManyToManyContentItemsOrganisation < ActiveRecord::Migration[5.0]
+  class ContentItem < ActiveRecord::Base
+    belongs_to :organisation
+    has_and_belongs_to_many :organisations
+  end
+
+  def change
+    MigrateManyToManyContentItemsOrganisation::ContentItem.find_each do |content_item|
+      content_item.organisations << content_item.organisation
+    end
+  end
+end

--- a/db/migrate/20170206153437_remove_organisation_reference_from_content_items.rb
+++ b/db/migrate/20170206153437_remove_organisation_reference_from_content_items.rb
@@ -1,0 +1,5 @@
+class RemoveOrganisationReferenceFromContentItems < ActiveRecord::Migration[5.0]
+  def change
+    remove_reference :content_items, :organisation, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170117171347) do
+ActiveRecord::Schema.define(version: 20170206153437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "content_items", force: :cascade do |t|
     t.string   "content_id"
-    t.integer  "organisation_id"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.datetime "public_updated_at"
@@ -27,7 +26,11 @@ ActiveRecord::Schema.define(version: 20170117171347) do
     t.string   "description"
     t.integer  "unique_page_views", default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
-    t.index ["organisation_id"], name: "index_content_items_on_organisation_id", using: :btree
+  end
+
+  create_table "content_items_organisations", id: false, force: :cascade do |t|
+    t.integer "content_item_id", null: false
+    t.integer "organisation_id", null: false
   end
 
   create_table "organisations", force: :cascade do |t|
@@ -38,5 +41,4 @@ ActiveRecord::Schema.define(version: 20170117171347) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true, using: :btree
   end
 
-  add_foreign_key "content_items", "organisations"
 end

--- a/spec/factories/organisations_factory.rb
+++ b/spec/factories/organisations_factory.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
         content_items_count 1
       end
       after(:create) do |organisation, evaluator|
-        create_list(:content_item, evaluator.content_items_count, organisation: organisation)
+        create_list(:content_item, evaluator.content_items_count, organisations: [organisation])
       end
     end
   end

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -4,7 +4,7 @@ require 'features/pagination_spec_helper'
 RSpec.feature "Content Item Details", type: :feature do
   scenario "the user clicks on the view content item link and is redirected to the content item show page" do
     organisation = create :organisation, slug: "the-slug"
-    create :content_item, id: 1, title: "content item title", organisation: organisation
+    create :content_item, id: 1, title: "content item title", organisations: [organisation]
 
     visit "organisations/the-slug/content_items"
     click_on "content item title"

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ContentItem, type: :model do
-  it { should belong_to(:organisation) }
+  it { should have_and_belong_to_many(:organisations) }
 
   describe '#url' do
     it 'returns a url to a content item on gov.uk' do

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Importers::ContentItemsByOrganisation do
   describe '#run' do
     let!(:organisation) { create(:organisation, slug: 'the-slug') }
-    let(:content_item) { create(:content_item, base_path: 'the-link', organisation: organisation) }
+    let(:content_item) { create(:content_item, base_path: 'the-link', organisations: [organisation]) }
 
     context 'when the content item does not exist' do
       it 'creates a content item per attribute group' do
@@ -25,7 +25,7 @@ RSpec.describe Importers::ContentItemsByOrganisation do
     end
 
     context 'when the content item already exists' do
-      let(:content_item) { create(:content_item, base_path: 'the-link', organisation: organisation) }
+      let(:content_item) { create(:content_item, base_path: 'the-link', organisations: [organisation]) }
 
       it 'does not create a new one' do
         attributes = { content_id: content_item.content_id, base_path: 'the-link' }

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe Importers::NumberOfViewsByOrganisation do
   describe '#run' do
     let!(:organisation) { create(:organisation, slug: 'the-slug') }
-    let!(:content_item_first) { create(:content_item, base_path: 'the-link/first', organisation: organisation) }
-    let!(:content_item_second) { create(:content_item, base_path: 'the-link/second', organisation: organisation) }
+    let!(:content_item_first) { create(:content_item, base_path: 'the-link/first', organisations: [organisation]) }
+    let!(:content_item_second) { create(:content_item, base_path: 'the-link/second', organisations: [organisation]) }
 
     before do
       allow_any_instance_of(GoogleAnalyticsService).to receive(:page_views).and_return(

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
-  it { should have_many(:content_items) }
+  it { should have_and_belong_to_many(:content_items) }
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/pLg019CM/109-5-create-a-many-to-many-association-between-contentitem-and-organisations)

## Description 

The import fails when a content item appears to belong to more than one
organisations.

This commit seeks to re-defines the association between ContenItems and the
respective Organisations to a ManytoMany association.

This allows for content items to be associated with the relevant
organisations (i.e more than one organisation).

As a result of this re-definition of association some tests have failed,
requiring the updates to factory girl’s definition of organisation and
also similar updates to some tests and concrete code.

I have updated factory girl organisation_with_content_items. This has been
done to fix failing tests and provide insight on the nature of the relationship
between content item and organisation from a factory girl point.

This references [1].

[1] http://www.rubydoc.info/gems/factory_girl/file/GETTING_STARTED.md#Associations