### PR TITLE
Remove nested show for content item

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -6,6 +6,5 @@ class ContentItemsController < ApplicationController
 
   def show
     @content_item = ContentItem.find(params[:id])
-    @organisation = Organisation.find_by_slug(params[:organisation_slug])
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,0 +1,5 @@
+module OrganisationsHelper
+  def stringify_organisations(organisations)
+    organisations.collect(&:title).join(', ').html_safe
+  end
+end

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to content_item.title, organisation_content_item_path(organisation_slug: @organisation.slug, id: content_item.id) %></td>
+  <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
   <td><%= content_item.document_type %></td>
   <td><%= content_item.unique_page_views %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -30,7 +30,9 @@
     </tr>
     <tr>
       <td>Organisation</td>
-      <td><%= @organisation.title %></td>
+      <td>
+        <%= stringify_organisations @content_item.organisations %>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root to: 'organisations#index'
 
   resources :organisations, only: %w(index), param: :slug do
-    resources :content_items, only: %w(index show)
+    resources :content_items, only: %w(index)
   end
+
+  resources :content_items
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -69,10 +69,6 @@ RSpec.describe ContentItemsController, type: :controller do
         expect(assigns(:content_item)).to eq(organisation.content_items.first)
       end
 
-      it "assigns current organisation" do
-        expect(assigns(:organisation)).to eq(organisation)
-      end
-
       it "renders the :show template" do
         expect(subject).to render_template(:show)
       end

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -6,5 +6,14 @@ FactoryGirl.define do
     sequence(:document_type) { |index| "document_type-#{index}" }
     base_path "api/content/item/path"
     public_updated_at { Time.now }
+
+    factory :content_item_with_organisations do
+      transient do
+        organisations_count 1
+      end
+      after(:create) do |content_item, evaluator|
+        create_list(:organisation, evaluator.organisations_count, content_items: [content_item])
+      end
+    end
   end
 end

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Content Item Details", type: :feature do
     visit "organisations/the-slug/content_items"
     click_on "content item title"
 
-    expected_path = "/organisations/the-slug/content_items/1"
+    expected_path = "/content_items/1"
     expect(current_path).to eq(expected_path)
   end
 

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe OrganisationsHelper, type: :helper do
+  describe '#stringify_organisations', :stringify_organisations do
+    let(:organisations) { build_list(:organisation, 2) }
+    before do
+      assign(:organisations, organisations)
+      organisations[0].title = 'An Organisation'
+      organisations[1].title = 'Another Organisation'
+    end
+
+    subject { helper.stringify_organisations(organisations) }
+
+    it 'has a comma between names' do
+      expect(subject).to have_text('An Organisation, Another Organisation')
+    end
+  end
+end

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -13,12 +13,11 @@ RSpec.describe ContentItemsController, type: :routing do
     end
 
     it 'routes to #show' do
-      expect(get: organisation_content_item_path(organisation_slug: 'a-slug', id: 1)).to be_routable
-      expect(get: organisation_content_item_path(organisation_slug: 'a-slug', id: 1))
+      expect(get: content_item_path(id: 1)).to be_routable
+      expect(get: content_item_path(id: 1))
         .to route_to(
           controller: 'content_items',
           action: 'show',
-          organisation_slug: 'a-slug',
           id: '1',
         )
     end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       content_items[0].title = 'a-title'
       render
 
-      expect(rendered).to have_link('a-title', href: organisation_content_item_path(
-        organisation_slug: organisation.slug,
+      expect(rendered).to have_link('a-title', href: content_item_path(
         id: content_items.first.id,
         ))
     end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
   before do
     assign(:content_item, content_item)
     assign(:organisation, organisation)
+    content_item.organisations << organisation
   end
 
   it 'renders the table header with the right headings' do
@@ -58,19 +59,24 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_selector('td + td', text: '2 months ago')
   end
 
-  it 'renders the organisation name' do
-    organisation.title = 'An Organisation'
-    render
-
-    expect(rendered).to have_selector('td', text: 'Organisation')
-    expect(rendered).to have_selector('td + td', text: 'An Organisation')
-  end
-
   it 'renders the description of the content item' do
     content_item.description = 'The description of a content item'
     render
 
     expect(rendered).to have_selector('td', text: 'Description')
     expect(rendered).to have_selector('td + td', text: 'The description of a content item')
+  end
+
+  context "content items belong to multiple organisations" do
+    let(:content_item) { create(:content_item_with_organisations, organisations_count: 2) }
+
+    it 'renders the organisations names' do
+      content_item.organisations[0].title = 'An Organisation'
+      content_item.organisations[1].title = 'Another Organisation'
+      render
+
+      expect(rendered).to have_selector('td', text: 'Organisation')
+      expect(rendered).to have_selector('td + td', text: 'An Organisation, Another Organisation')
+    end
   end
 end


### PR DESCRIPTION
Since we reworked the model to be many to many between organisations and content items, the view for a single item within an organisation does not need to be at a nested route. As in:

`/organisations/hm-revenue-customs/content_items/30339`

can just be

`/content_items/30339`

as that content item might also belong to another org at:

`/organisations/public-health-england/content_items/30339`

This change also displays the multiple organisations that an item belongs to in the `content_items#show` view.

This change is also in preparation for https://trello.com/c/QWhNMeyr