### PR TITLE
Change UPV duration to one month ago

### DIFF
--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -6,7 +6,10 @@ class GoogleAnalyticsService
   def page_views(base_paths)
     raise "base_paths isn't an array" unless base_paths.is_a?(Array)
 
-    request = GoogleAnalytics::Requests::PageViewsRequest.new.build(base_paths)
+    request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
+      base_paths,
+      start_date: 1.month.ago.strftime("%Y-%m-%d")
+    )
     response = client.batch_get_reports(request)
     GoogleAnalytics::Responses::PageViewsResponse.new.parse(response)
   end

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -4,7 +4,7 @@
     <tr class="table-header">
       <%= sort_table_header "Title", "title" %>
       <%= sort_table_header "Type of Document", "document_type" %>
-      <%= sort_table_header "Unique page views (last 7 days)", "unique_page_views" %>
+      <%= sort_table_header "Unique page views (last 1 month)", "unique_page_views" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>
     </tr>
   </thead>

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
     expect(rendered).to have_selector('table thead', text: 'Title')
     expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Unique page views (last 7 days)')
+    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Unique page views (last 1 month)')
     expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Last Updated')
   end
 


### PR DESCRIPTION
Based on feedback from user research session content designers have
highlighted that the previous 7 days unique page view isn’t enough
data.

Here I have changed the start date to always use the date from one month
ago.

This change makes for little need to change the existing code and tests.

**NB:**

I have changed this to only pull data for one month.

This is because google analytics failed (i.e request timeout) when requests for a year were sent.


See [1] and [2]


[1] https://github.com/google/google-api-ruby-client/blob/27f13663bf79e69ea073cd31040a13e1b310cdaf/lib/google/apis/core/base_service.rb

[2] https://github.com/google/google-api-ruby-client/blob/e13da8e05e2368421519e49d2c03ee7e69f3faaa/lib/google/apis/options.rb

See the following log messages

```
rake "import:number_of_views_by_organisation[public-health-england]"
rake aborted!
Google::Apis::ServerError: Server error
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:214:in `check_status'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/api_command.rb:104:in `check_status'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:179:in `process_response'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:286:in `execute_once'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:107:in `block (2 levels) in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:104:in `block in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:96:in `execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/base_service.rb:351:in `execute_or_queue_command'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/generated/google/apis/analyticsreporting_v4/service.rb:76:in `batch_get_reports'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/services/google_analytics_service.rb:13:in `page_views'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/models/importers/number_of_views_by_organisation.rb:8:in `run'
/Users/ikennaokpala/repo/govuk/content-performance-manager/lib/tasks/import.rake:18:in `block (2 levels) in <top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `eval'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => import:number_of_views_by_organisation
(See full trace by running task with --trace)
➜  content-performance-manager git:(upv-one-year-ago) ✗ rails c
Running via Spring preloader in process 18152
Loading development environment (Rails 5.0.1)
2.3.1 :001 > require 'google/apis/analyticsreporting_v4'
 => true
2.3.1 :002 > include Google::Apis::AnalyticsreportingV4
 => Object
2.3.1 :003 > AnalyticsReportingService.new
 => #<Google::Apis::AnalyticsreportingV4::AnalyticsReportingService:0x007ff609c7d420 @root_url="https://analyticsreporting.googleapis.com/", @base_path="", @upload_path="upload/", @batch_path="batch", @client_options=#<struct Google::Apis::ClientOptions application_name="unknown", application_version="0.0.0", proxy_url=nil, use_net_http=false>, @request_options=#<struct Google::Apis::RequestOptions authorization=nil, retries=0, header=nil, timeout_sec=nil, open_timeout_sec=20>>
2.3.1 :004 > exit
➜  content-performance-manager git:(upv-one-year-ago) ✗ rake "import:number_of_views_by_organisation[public-health-england]"
➜  content-performance-manager git:(upv-one-year-ago) ✗ rake "import:number_of_views_by_organisation[public-health-england]"
rake aborted!
Google::Apis::TransmissionError: execution expired
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/ssl_socket.rb:62:in `gets'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:805:in `block in parse_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:801:in `parse_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:784:in `read_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:561:in `get_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1299:in `do_get_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1245:in `do_get_block'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1019:in `block in do_request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1014:in `do_request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:856:in `request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:17:in `block in call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:252:in `initialize'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:16:in `new'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:16:in `call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:122:in `call_with_redirects'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:89:in `call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:71:in `post'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:272:in `execute_once'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:107:in `block (2 levels) in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:104:in `block in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:96:in `execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/base_service.rb:351:in `execute_or_queue_command'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/generated/google/apis/analyticsreporting_v4/service.rb:76:in `batch_get_reports'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/services/google_analytics_service.rb:13:in `page_views'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/models/importers/number_of_views_by_organisation.rb:8:in `run'
/Users/ikennaokpala/repo/govuk/content-performance-manager/lib/tasks/import.rake:18:in `block (2 levels) in <top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `eval'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `<main>'
Hurley::Timeout: execution expired
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/ssl_socket.rb:62:in `gets'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:805:in `block in parse_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:801:in `parse_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:784:in `read_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:561:in `get_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1299:in `do_get_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1245:in `do_get_block'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1019:in `block in do_request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1014:in `do_request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:856:in `request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:17:in `block in call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:252:in `initialize'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:16:in `new'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:16:in `call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:122:in `call_with_redirects'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:89:in `call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:71:in `post'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:272:in `execute_once'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:107:in `block (2 levels) in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:104:in `block in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:96:in `execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/base_service.rb:351:in `execute_or_queue_command'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/generated/google/apis/analyticsreporting_v4/service.rb:76:in `batch_get_reports'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/services/google_analytics_service.rb:13:in `page_views'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/models/importers/number_of_views_by_organisation.rb:8:in `run'
/Users/ikennaokpala/repo/govuk/content-performance-manager/lib/tasks/import.rake:18:in `block (2 levels) in <top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `eval'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `<main>'
HTTPClient::ReceiveTimeoutError: execution expired
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/ssl_socket.rb:62:in `gets'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:805:in `block in parse_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:801:in `parse_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:784:in `read_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient/session.rb:561:in `get_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1299:in `do_get_header'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1245:in `do_get_block'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1019:in `block in do_request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:1014:in `do_request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/httpclient-2.8.3/lib/httpclient.rb:856:in `request'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:17:in `block in call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:252:in `initialize'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:16:in `new'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_client_adapter.rb:16:in `call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:122:in `call_with_redirects'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:89:in `call'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/hurley-0.2/lib/hurley/client.rb:71:in `post'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:272:in `execute_once'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:107:in `block (2 levels) in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:104:in `block in execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/http_command.rb:96:in `execute'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google-api-client-0.9.20/lib/google/apis/core/base_service.rb:351:in `execute_or_queue_command'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/google


Change UPV duration to one year ago
-api-client-0.9.20/generated/google/apis/analyticsreporting_v4/service.rb:76:in `batch_get_reports'
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/services/google_analytics_service.rb:13:in `page_views'


Change UPV duration to one month ago
/Users/ikennaokpala/repo/govuk/content-performance-manager/app/models/importers/number_of_views_by_organisation.rb:8:in `run'
/Users/ikennaokpala/repo/govuk/content-performance-manager/lib/tasks/import.rake:18:in `block (2 levels) in <top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `eval'
/Users/ikennaokpala/.rvm/gems/ruby-2.3.1@content-performance-manager/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => import:number_of_views_by_organisation
(See full trace by running task with --trace)
```


