### PR TITLE
Use SQL count instead of Array#length

### DIFF
--- a/app/views/organisations/_organisation.html.erb
+++ b/app/views/organisations/_organisation.html.erb
@@ -1,4 +1,4 @@
 <tr>
   <td><%= link_to organisation.title, organisation_content_items_path(organisation_slug: organisation.slug) %></td>
-  <td><%= organisation.content_items.length %></td>
+  <td><%= organisation.content_items.count %></td>
 </tr>


### PR DESCRIPTION
Fix memory issue when all ContentItems were retrieved into memory to be
counted.   

The memory peak could be reproduced by hitting many times the home
page where organisations are being displayed along with the number of 
content items for each one; we need, though, a bit organisation with many
Content Items like HMRC

```sql
SELECT "content_items".* FROM "content_items" 
INNER JOIN "content_items_organisations" ON "content_items"."id" = "content_items_organisations"."content_item_id" 
WHERE "content_items_organisations"."organisation_id" = $1  [["organisation_id", 25]]
```

Updated to:

```sql
SELECT COUNT(*) FROM "content_items" 
INNER JOIN "content_items_organisations" ON "content_items"."id" = "content_items_organisations"."content_item_id" 
WHERE "content_items_organisations"."organisation_id" = $1  [["organisation_id", 25]]
```