### PR TITLE
Render all items

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,10 +1,22 @@
 class ContentItemsController < ApplicationController
+  before_action :set_organisation, only: :index
+
   def index
-    @organisation = Organisation.find_by_slug(params[:organisation_slug])
-    @content_items = @organisation.content_items.order("#{params[:sort]} #{params[:order]}").page(params[:page])
+    @content_items = ContentItemsQuery.build(
+      sort: params[:sort],
+      order: params[:order],
+      page: params[:page],
+      organisation: @organisation
+    )
   end
 
   def show
     @content_item = ContentItem.find(params[:id])
+  end
+
+private
+
+  def set_organisation
+    @organisation = Organisation.find_by_slug(params[:organisation_slug]) if params[:organisation_slug]
   end
 end

--- a/app/helpers/content_items_helper.rb
+++ b/app/helpers/content_items_helper.rb
@@ -1,0 +1,9 @@
+module ContentItemsHelper
+  def content_items_header
+    if @organisation.present?
+      @organisation.title
+    else
+      'GOV.UK'
+    end
+  end
+end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,13 +1,9 @@
 module OrganisationsHelper
-  def stringify_organisations(organisations, options = {})
-    organisation_titles = if options[:linkify]
-                            organisations.collect do |organisation|
-                              link_to(organisation.title, organisation_content_items_path(organisation_slug: organisation.slug))
-                            end
-                          else
-                            organisations.collect(&:title)
-                          end
+  def stringify_organisations(organisations)
+    names = organisations.collect do |organisation|
+      link_to(organisation.title, organisation_content_items_path(organisation_slug: organisation.slug))
+    end
 
-    organisation_titles.join(', ').html_safe
+    names.join(', ').html_safe
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,5 +1,13 @@
 module OrganisationsHelper
-  def stringify_organisations(organisations)
-    organisations.collect(&:title).join(', ').html_safe
+  def stringify_organisations(organisations, options = {})
+    organisation_titles = if options[:linkify]
+                            organisations.collect do |organisation|
+                              link_to(organisation.title, organisation_content_items_path(organisation_slug: organisation.slug))
+                            end
+                          else
+                            organisations.collect(&:title)
+                          end
+
+    organisation_titles.join(', ').html_safe
   end
 end

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -6,7 +6,7 @@ module TableHelper
   class SortTable
     attr_accessor :view, :heading, :attribute_name
 
-    delegate :content_tag, :params, :link_to, :organisation_content_items_path, to: :view
+    delegate :content_tag, :params, :link_to, :organisation_content_items_path, :content_items_path, to: :view
 
     def initialize(view, heading, attribute_name)
       @view = view
@@ -23,8 +23,14 @@ module TableHelper
   private
 
     def link(label, order)
-      link_to organisation_content_items_path(organisation_slug: view.instance_variable_get(:@organisation).slug, sort: attribute_name, order: order) do
-        "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
+      if view.instance_variable_get(:@organisation).present?
+        link_to organisation_content_items_path(organisation_slug: view.instance_variable_get(:@organisation).slug, sort: attribute_name, order: order) do
+          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
+        end
+      else
+        link_to content_items_path(sort: attribute_name, order: order) do
+          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
+        end
       end
     end
 

--- a/app/queries/content_items_query.rb
+++ b/app/queries/content_items_query.rb
@@ -1,0 +1,17 @@
+class ContentItemsQuery
+  def self.build(options)
+    ContentItemsQuery.new.results(options)
+  end
+
+  def results(options = {})
+    relation = if options[:organisation]
+                 options[:organisation].content_items
+               else
+                 ContentItem.all
+               end
+
+    relation
+      .order("#{options[:sort]} #{options[:order]}")
+      .page(options[:page])
+  end
+end

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,5 +1,12 @@
 <tr>
   <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
+  <% if @organisation.blank? %>
+    <td>
+      <% content_item.organisations.each do |organisation| %>
+        <%= link_to organisation.title, organisation_content_items_path(organisation_slug: organisation.slug) %>
+      <% end %>
+    </td>
+  <% end %>
   <td><%= content_item.document_type %></td>
   <td><%= content_item.unique_page_views %></td>
   <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -2,9 +2,7 @@
   <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
   <% if @organisation.blank? %>
     <td>
-      <% content_item.organisations.each do |organisation| %>
-        <%= link_to organisation.title, organisation_content_items_path(organisation_slug: organisation.slug) %>
-      <% end %>
+      <%= stringify_organisations content_item.organisations %>
     </td>
   <% end %>
   <td><%= content_item.document_type %></td>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -1,8 +1,11 @@
-<h1><%= @organisation.title %></h1>
+<h1><%= @title %></h1>
 <table class="table table-bordered table-hover">
   <thead>
     <tr class="table-header">
       <%= sort_table_header "Title", "title" %>
+      <% if @organisation.blank? %>
+        <th>Organisation</th>
+      <% end %>
       <%= sort_table_header "Type of Document", "document_type" %>
       <%= sort_table_header "Unique page views (last 1 month)", "unique_page_views" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -1,4 +1,5 @@
-<h1><%= @title %></h1>
+<h1><%= content_items_header %></h1>
+
 <table class="table table-bordered table-hover">
   <thead>
     <tr class="table-header">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,4 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  content_items:
-    index:
-      title: "GOV.UK"
+  hello: "Hello world"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,6 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  content_items:
+    index:
+      title: "GOV.UK"

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -2,56 +2,50 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
   describe "GET #index" do
+    context "unfiltered" do
+      let(:content_items) { create_list(:content_item_with_organisations, 3) }
 
-    before { allow(ContentItemsQuery).to receive(:build).and_return(:the_content_items) }
-
-    it "returns http success" do
-      get :index
-
-      expect(response).to have_http_status(:success)
-    end
-
-    it "assigns list of content items" do
-      get :index
-
-      expect(assigns(:content_items)).to eq(:the_content_items)
-    end
-
-    it "renders the :index template" do
-      get :index
-
-      expect(subject).to render_template(:index)
-    end
-
-    describe "Query filter" do
-      it "filters by organisation" do
-        organisation = create(:organisation, slug: 'organisation-slug')
-
-        get :index, params: { organisation_slug: 'organisation-slug' }
-
-        expect(ContentItemsQuery).to have_received(:build).with(hash_including(organisation: organisation))
+      before do
+        get :index
       end
 
-      it "paginates the results" do
-        get :index, params: { page: 10 }
-
-        expect(ContentItemsQuery).to have_received(:build).with(hash_including(page: "10"))
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
       end
 
-      it "sorts the results" do
-        get :index, params: { order: 'attribute', sort: 'asc' }
+      it "assigns list of content items" do
+        expect(assigns(:content_items)).to eq(content_items)
+      end
 
-        expect(ContentItemsQuery).to have_received(:build).with(hash_including(order: 'attribute', sort: 'asc'))
+      it "renders the :index template" do
+        expect(subject).to render_template(:index)
       end
     end
 
-    context "when organisation slug is present" do
-      let!(:organisation) { create(:organisation, slug: 'organisation-slug') }
+    context "find by organisation" do
+      let(:organisation) { create(:organisation) }
+
+      before do
+        get :index, params: { organisation_slug: organisation.slug }
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
 
       it "assigns current organisation" do
-        get :index, params: { organisation_slug: 'organisation-slug' }
-
         expect(assigns(:organisation)).to eq(organisation)
+      end
+
+      it "renders the :index template" do
+        expect(subject).to render_template(:index)
+      end
+    end
+
+    context "content items fetched via ContentItemQuery" do
+      it "returns a list of content items" do
+        allow(ContentItemsQuery).to receive(:build).and_return(:content_items)
+        expect(ContentItemsQuery.build({})).to eq(:content_items)
       end
     end
   end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -2,53 +2,56 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
   describe "GET #index" do
-    context "find by organisation" do
-      let(:organisation) { create(:organisation_with_content_items, content_items_count: 2) }
 
-      before do
-        get :index, params: { organisation_slug: organisation.slug }
+    before { allow(ContentItemsQuery).to receive(:build).and_return(:the_content_items) }
+
+    it "returns http success" do
+      get :index
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns list of content items" do
+      get :index
+
+      expect(assigns(:content_items)).to eq(:the_content_items)
+    end
+
+    it "renders the :index template" do
+      get :index
+
+      expect(subject).to render_template(:index)
+    end
+
+    describe "Query filter" do
+      it "filters by organisation" do
+        organisation = create(:organisation, slug: 'organisation-slug')
+
+        get :index, params: { organisation_slug: 'organisation-slug' }
+
+        expect(ContentItemsQuery).to have_received(:build).with(hash_including(organisation: organisation))
       end
 
-      it "returns http success" do
-        expect(response).to have_http_status(:success)
+      it "paginates the results" do
+        get :index, params: { page: 10 }
+
+        expect(ContentItemsQuery).to have_received(:build).with(hash_including(page: "10"))
       end
 
-      it "assigns current organisation" do
-        expect(assigns(:organisation)).to eq(organisation)
-      end
+      it "sorts the results" do
+        get :index, params: { order: 'attribute', sort: 'asc' }
 
-      it "assigns list of content items" do
-        expect(assigns(:content_items)).to eq(organisation.content_items)
-      end
-
-      it "renders the :index template" do
-        expect(subject).to render_template(:index)
+        expect(ContentItemsQuery).to have_received(:build).with(hash_including(order: 'attribute', sort: 'asc'))
       end
     end
 
-    context "sorts with parameters" do
-      let(:content_items) do
-        [
-          build(:content_item, id: 1, public_updated_at: Time.parse("2016-12-09")),
-          build(:content_item, id: 2, public_updated_at: Time.parse("2015-12-09"))
-        ]
-      end
-      let(:organisation) { create(:organisation, content_items: content_items) }
+    context "when organisation slug is present" do
+      let!(:organisation) { create(:organisation, slug: 'organisation-slug') }
 
-      context "in ascending order" do
-        it "returns content_items based on supplied params" do
-          get :index, params: { organisation_slug: organisation.slug, order: :asc, sort: :public_updated_at }
+      it "assigns current organisation" do
+        get :index, params: { organisation_slug: 'organisation-slug' }
 
-          expect(assigns(:content_items).pluck(:id)).to match_array([2, 1])
-        end
-      end
-
-      context "in descending order" do
-        it "returns content_items based on supplied params" do
-          get :index, params: { organisation_slug: organisation.slug, order: :desc, sort: :public_updated_at }
-
-          expect(assigns(:content_items).pluck(:id)).to match_array([1, 2])
-        end
+        expect(assigns(:organisation)).to eq(organisation)
       end
     end
   end

--- a/spec/factories/content_items_factory.rb
+++ b/spec/factories/content_items_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :content_item do
     sequence(:id) { |index| index }
     sequence(:content_id) { |index| "content-id-#{index}" }
-    sequence(:title) { |index| "title-#{index}" }
+    sequence(:title) { |index| "content-item-title-#{index}" }
     sequence(:document_type) { |index| "document_type-#{index}" }
     base_path "api/content/item/path"
     public_updated_at { Time.now }

--- a/spec/factories/organisations_factory.rb
+++ b/spec/factories/organisations_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :organisation do
     sequence(:id) { |index| index }
     sequence(:slug) { |index| "slug-#{index}" }
-    sequence(:title) { |index| "title-#{index}" }
+    sequence(:title) { |index| "organisation-title-#{index}" }
 
     factory :organisation_with_content_items do
       transient do

--- a/spec/features/content_items_spec.rb
+++ b/spec/features/content_items_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'features/pagination_spec_helper'
+
+RSpec.feature "Content Items List", type: :feature do
+  background do
+    @content_items = create_list :content_item, 3
+  end
+
+  context "list the content items" do
+    scenario "the user sees a list of all unfiltered content items" do
+      visit 'content_items'
+
+      expect(page).to have_css('table tbody tr', count: 3)
+    end
+
+    describe "user can navigate paged lists of content items" do
+      it_behaves_like 'a paginated list', 'content_items'
+    end
+  end
+
+  context "navigation to organisation pages" do
+    scenario "clicks through to an organisation" do
+      first_content_item = @content_items.first
+      first_content_item.organisations << create(:organisation, title: 'the-organisation-title', slug: 'organisation-slug')
+
+      visit 'content_items'
+      click_on 'the-organisation-title'
+
+      expected_path = "/organisations/organisation-slug/content_items"
+      expect(current_path).to eq(expected_path)
+    end
+  end
+end

--- a/spec/helpers/content_items_helper_spec.rb
+++ b/spec/helpers/content_items_helper_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ContentItemsHelper, type: :helper do
+  describe '#content_items_header', :content_items_header do
+    context 'without organisation' do
+      it 'renders the default page title' do
+        expect(helper.content_items_header).to eq('GOV.UK')
+      end
+    end
+
+    context 'with organisation filter' do
+      let(:organisation) { build(:organisation) }
+
+      before do
+        assign(:organisation, organisation)
+        organisation.title = 'Organisation title'
+      end
+
+      it 'renders the organisation title as page title' do
+        expect(helper.content_items_header).to eq('Organisation title')
+      end
+    end
+  end
+end

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -14,5 +14,15 @@ RSpec.describe OrganisationsHelper, type: :helper do
     it 'has a comma between names' do
       expect(subject).to have_text('An Organisation, Another Organisation')
     end
+
+    context 'linkify organisations' do
+      subject { helper.stringify_organisations(organisations, linkify: true) }
+
+      it "turns each organisation name into a link" do
+        link_href = organisation_content_items_path(organisation_slug: organisations[0].slug)
+
+        expect(subject).to have_link(href: link_href)
+      end
+    end
   end
 end

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OrganisationsHelper, type: :helper do
     end
 
     context 'linkify organisations' do
-      subject { helper.stringify_organisations(organisations, linkify: true) }
+      subject { helper.stringify_organisations(organisations) }
 
       it "turns each organisation name into a link" do
         link_href = organisation_content_items_path(organisation_slug: organisations[0].slug)

--- a/spec/queries/content_items_query_spec.rb
+++ b/spec/queries/content_items_query_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ContentItemsQuery, type: :query do
+  subject { described_class }
+
+  context "sorts with parameters" do
+    let!(:content_items) do
+      [
+        create(:content_item, id: 1, public_updated_at: Time.parse("2016-12-09")),
+        create(:content_item, id: 2, public_updated_at: Time.parse("2015-12-09"))
+      ]
+    end
+
+    context "in ascending order" do
+      it "returns content_items" do
+        results = subject.build(sort: :public_updated_at, order: :asc)
+
+        expect(results.pluck(:id)).to eq([2, 1])
+      end
+    end
+
+    context "in descending order" do
+      it "returns content_items" do
+        results = subject.build(sort: :public_updated_at, order: :desc)
+
+        expect(results.pluck(:id)).to eq([1, 2])
+      end
+    end
+
+    describe "filtering by organisation" do
+      let(:organisation) { create(:organisation, content_items: content_items) }
+
+      it 'returns the content items belonging to the organisation' do
+        create(:content_item)
+        results = subject.build(organisation: organisation)
+
+        expect(results).to match_array(content_items)
+      end
+    end
+  end
+end

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -2,14 +2,27 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :routing do
   describe 'routing' do
-    it 'routes to #index' do
-      expect(get: organisation_content_items_path('a-slug')).to be_routable
-      expect(get: organisation_content_items_path('a-slug'))
-        .to route_to(
-          controller: 'content_items',
-          action: 'index',
-          organisation_slug: 'a-slug'
-        )
+    context 'with organisation slug' do
+      it 'routes to #index' do
+        expect(get: organisation_content_items_path('a-slug')).to be_routable
+        expect(get: organisation_content_items_path('a-slug'))
+          .to route_to(
+            controller: 'content_items',
+            action: 'index',
+            organisation_slug: 'a-slug'
+          )
+      end
+    end
+
+    context 'without organisation slug' do
+      it 'routes to #index' do
+        expect(get: content_items_path).to be_routable
+        expect(get: content_items_path)
+          .to route_to(
+            controller: 'content_items',
+            action: 'index'
+          )
+      end
     end
 
     it 'routes to #show' do

--- a/spec/routes/root_spec.rb
+++ b/spec/routes/root_spec.rb
@@ -5,5 +5,9 @@ RSpec.describe OrganisationsController, type: :routing do
     it 'routes to organisations#index' do
       expect(get: '/').to route_to('organisations#index')
     end
+
+    it 'routes to content_items#index' do
+      expect(get: '/content_items').to route_to('content_items#index')
+    end
   end
 end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       assign(:content_items, content_items)
     end
 
+    it 'renders a page title' do
+      render
+
+      expect(rendered).to have_selector('h1', text: 'GOV.UK')
+    end
+
     it 'renders the table header with the right headings' do
       render
 
@@ -48,7 +54,6 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
     it 'renders the title of the organisation' do
       allow(organisation).to receive(:title).and_return('A Title')
-      assign(:title, organisation.title)
       render
 
       expect(rendered).to have_selector('h1', text: 'A Title')

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -1,74 +1,114 @@
 require 'rails_helper'
 
 RSpec.describe 'content_items/index.html.erb', type: :view do
-  let(:organisation) { build(:organisation) }
-  let(:content_items) { build_list(:content_item, 2) }
+  context 'unfiltered' do
+    let(:content_items) { build_list(:content_item, 2) }
 
-  before do
-    allow(view).to receive(:paginate)
-    allow(view).to receive(:page_entries_info)
-    assign(:content_items, content_items)
-    assign(:organisation, organisation)
-  end
+    before do
+      allow(view).to receive(:paginate)
+      assign(:content_items, content_items)
+    end
 
-  it 'renders the title of the organisation' do
-    allow(organisation).to receive(:title).and_return('A Title')
-    render
-
-    expect(rendered).to have_selector('h1', text: 'A Title')
-  end
-
-  it 'renders the table header with the right headings' do
-    render
-
-    expect(rendered).to have_selector('table thead', text: 'Title')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Unique page views (last 1 month)')
-    expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Last Updated')
-  end
-
-  it 'renders a row per Content Item' do
-    render
-
-    expect(rendered).to have_selector('table tbody tr', count: 2)
-  end
-
-  describe 'Kaminari' do
-    it 'uses Kaminari to paginate the pages' do
-      expect(view).to receive(:paginate)
+    it 'renders the table header with the right headings' do
       render
+
+      expect(rendered).to have_selector('table thead', text: 'Title')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Organisation')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Type of Document')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Unique page views (last 1 month)')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(5)', text: 'Last Updated')
+    end
+
+    it 'renders a row per Content Item' do
+      render
+
+      expect(rendered).to have_selector('table tbody tr', count: 2)
+    end
+
+    describe 'row content' do
+      it 'items depict the Organisations they each belong to' do
+        content_items[0].organisations.build(title: 'An organisation', slug: 'organisation-slug ')
+        render
+
+        expect(rendered).to have_text('An organisation')
+      end
+    end
+  end
+
+  context "filter by org" do
+    let(:organisation) { build(:organisation) }
+    let(:content_items) { build_list(:content_item, 2) }
+
+    before do
+      allow(view).to receive(:paginate)
+      allow(view).to receive(:page_entries_info)
+      assign(:content_items, content_items)
+      assign(:organisation, organisation)
+    end
+
+    it 'renders the title of the organisation' do
+      allow(organisation).to receive(:title).and_return('A Title')
+      assign(:title, organisation.title)
+      render
+
+      expect(rendered).to have_selector('h1', text: 'A Title')
+    end
+
+    it 'renders the table header with the right headings' do
+      render
+
+      expect(rendered).to have_selector('table thead', text: 'Title')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Unique page views (last 1 month)')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Last Updated')
+    end
+
+    it 'renders a row per Content Item' do
+      render
+
+      expect(rendered).to have_link(content_items.first.title, href: content_item_path(id: content_items.first.id))
     end
 
     it 'returns the max page size number of content items per page' do
       render
-      expect(rendered).to have_selector("table tbody tr", count: 2)
-    end
-  end
-
-  describe 'row content' do
-    it 'includes the content item title' do
-      content_items[0].title = 'a-title'
-      render
-
-      expect(rendered).to have_link('a-title', href: content_item_path(
-        id: content_items.first.id,
-        ))
+      expect(rendered).to have_selector('table tbody tr', count: 2)
     end
 
-    it 'includes the last time the content was updated' do
-      Timecop.freeze(Time.parse('2016-3-20')) do
-        content_items[0].public_updated_at = Time.parse('2016-1-20')
+    describe 'Kaminari' do
+      it 'uses Kaminari to paginate the pages' do
+        expect(view).to receive(:paginate)
         render
+      end
 
-        expect(rendered).to have_selector('table tbody tr td', text: '2 months ago')
+      it 'returns the max page size number of content items per page' do
+        render
+        expect(rendered).to have_selector("table tbody tr", count: 2)
       end
     end
 
-    it 'contains a descending and ascending links in table heading' do
-      render
-      href = organisation_content_items_path(organisation.slug, order: :asc, sort: :public_updated_at)
+    describe 'row content' do
+      it 'includes the content item title' do
+        content_items[0].title = 'a-title'
+        render
 
-      expect(rendered).to have_link('Last Updated', href: href)
+        expect(rendered).to have_link('a-title', href: content_item_path(id: content_items.first.id))
+      end
+
+      it 'includes the last time the content was updated' do
+        Timecop.freeze(Time.parse('2016-3-20')) do
+          content_items[0].public_updated_at = Time.parse('2016-1-20')
+          render
+
+          expect(rendered).to have_selector('table tbody tr td', text: '2 months ago')
+        end
+      end
+
+      it 'contains a descending and ascending links in table heading' do
+        render
+        href = organisation_content_items_path(organisation.slug, order: :asc, sort: :public_updated_at)
+
+        expect(rendered).to have_link('Last Updated', href: href)
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/QWhNMeyr)

## Description

We need to be able to see content items without a filter. This adds a view and controller methods to do that, however we've also refactored to introduce a new page title helper and a ContentItemsQuery.

The unfiltered view is at URL:

```
<app_root>/content_items/
```

while the filtered by organisation view remains at:

```
<app_root>/<organisation-slug>/content_items
```

Both of these routes are mapped to `ContentItemsController#index`

This PR also depended on #67 