### PR TITLE
Fix spring.version in Spring stub

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -8,8 +8,8 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring_detected = lockfile.specs.detect { |spec| spec.name == "spring" }
-  if spring_detected
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'


### PR DESCRIPTION
In #74 the extract-variable refactor wasn’t complete, and introduced
a bug that caused issues when opening the Rails console.