### PR TITLE
Import Google Analytics data in batches

### DIFF
--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -2,13 +2,16 @@ module Importers
   class NumberOfViewsByOrganisation
     def run(slug)
       organisation = Organisation.find_by(slug: slug)
+      google_analytics_service = GoogleAnalyticsService.new
 
-      base_paths = organisation.content_items.pluck(:base_path)
+      organisation.content_items.find_in_batches(batch_size: 1) do |content_items|
+        base_paths = content_items.pluck(:base_path)
 
-      results = GoogleAnalyticsService.new.page_views(base_paths)
-      results.each do |result|
-        content_item = ContentItem.find_by(base_path: result[:base_path])
-        content_item.update!(unique_page_views: result[:page_views])
+        results = google_analytics_service.page_views(base_paths)
+        results.each do |result|
+          content_item = ContentItem.find_by(base_path: result[:base_path])
+          content_item.update!(unique_page_views: result[:page_views])
+        end
       end
     end
   end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -1,10 +1,12 @@
 module Importers
   class NumberOfViewsByOrganisation
+    BATCH_SIZE = 3000
+
     def run(slug)
       organisation = Organisation.find_by(slug: slug)
       google_analytics_service = GoogleAnalyticsService.new
 
-      organisation.content_items.find_in_batches(batch_size: 1) do |content_items|
+      organisation.content_items.find_in_batches(batch_size: BATCH_SIZE) do |content_items|
         base_paths = content_items.pluck(:base_path)
 
         results = google_analytics_service.page_views(base_paths)

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
           },
         ]
       )
+
+      stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 1)
+
       subject.run('the-slug')
 
       content_item_one = ContentItem.find_by(base_path: 'the-link/first')
@@ -28,10 +31,22 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
       expect(content_item_two.unique_page_views).to eq(2)
     end
 
-    it "perform the requests in batches" do
-      expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).twice.and_return([])
+    context "performs the request to google api in batches" do
+      it "makes two requests when the batch size is one" do
+        expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).twice.and_return([])
 
-      subject.run('the-slug')
+        stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 1)
+
+        subject.run('the-slug')
+      end
+
+      it "makes one request when the batch size is two" do
+        expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).once.and_return([])
+
+        stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 2)
+
+        subject.run('the-slug')
+      end
     end
   end
 end

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
     let!(:content_item_first) { create(:content_item, base_path: 'the-link/first', organisations: [organisation]) }
     let!(:content_item_second) { create(:content_item, base_path: 'the-link/second', organisations: [organisation]) }
 
-    before do
+    it "updates the number of views for all content items" do
       allow_any_instance_of(GoogleAnalyticsService).to receive(:page_views).and_return(
         [
           {
@@ -19,11 +19,6 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
           },
         ]
       )
-    end
-
-    it "updates the number of views for all content items" do
-      organisation.content_items = [content_item_first, content_item_second]
-
       subject.run('the-slug')
 
       content_item_one = ContentItem.find_by(base_path: 'the-link/first')
@@ -31,6 +26,12 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
 
       expect(content_item_one.unique_page_views).to eq(3)
       expect(content_item_two.unique_page_views).to eq(2)
+    end
+
+    it "perform the requests in batches" do
+      expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).twice.and_return([])
+
+      subject.run('the-slug')
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/AuddFX1d

## Motivation

We are not using batches to retrieve ContentItems from the Database, so while we are able to retrieve GA data for small departments, large organisations like HMRC time out waiting for Google Analytics to respond.

## Changes 

Modify the import to request data from Google Analytics in batches of 3000.