### PR TITLE
Fix display for no last updated at

### DIFF
--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -7,5 +7,11 @@
   <% end %>
   <td><%= content_item.document_type %></td>
   <td><%= content_item.unique_page_views %></td>
-  <td><%= time_ago_in_words(content_item.public_updated_at) %> ago</td>
+  <td>
+    <% if content_item.public_updated_at %>
+      <%= time_ago_in_words(content_item.public_updated_at) %> ago
+    <% else %>
+      Never
+    <% end %>
+  </td>
 </tr>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -26,7 +26,13 @@
     </tr>
     <tr>
       <td>Last updated</td>
-      <td><%= time_ago_in_words(@content_item.public_updated_at) %> ago</td>
+      <td>
+        <% if @content_item.public_updated_at %>
+          <%= time_ago_in_words(@content_item.public_updated_at) %> ago
+        <% else %>
+          Never
+        <% end %>
+      </td>
     </tr>
     <tr>
       <td>Organisation</td>

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       expect(rendered).to have_selector('table tbody tr', count: 2)
     end
 
+    context 'items that have never been published' do
+      it 'renders for no last updated value' do
+        content_items[0].public_updated_at = nil
+        render
+
+        expect(rendered).to have_selector('table tr td:nth(5)', text: 'Never')
+      end
+    end
+
     describe 'row content' do
       it 'items depict the Organisations they each belong to' do
         content_items[0].organisations.build(title: 'An organisation', slug: 'organisation-slug ')
@@ -113,6 +122,15 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
         href = organisation_content_items_path(organisation.slug, order: :asc, sort: :public_updated_at)
 
         expect(rendered).to have_link('Last Updated', href: href)
+      end
+
+      context 'items that have never been published' do
+        it 'renders for no last updated value' do
+          content_items[0].public_updated_at = nil
+          render
+
+          expect(rendered).to have_selector('table tr td:nth(4)', text: 'Never')
+        end
       end
     end
   end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -78,5 +78,14 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
       expect(rendered).to have_selector('td', text: 'Organisation')
       expect(rendered).to have_selector('td + td', text: 'An Organisation, Another Organisation')
     end
+
+    context 'item has never been published' do
+      it 'renders for no last updated value' do
+        content_item.public_updated_at = nil
+        render
+
+        expect(rendered).to have_selector('table tbody tr:nth(5) td:nth(2)', text: 'Never')
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/o48vQ12o)

Where we have content items that have never been published, we are
attempting to apply a helper to nil values in the view, which is causing
server errors. To fix this we need to check in the view before attempting
to output anything for that field.

Includes a test that replicates the bug.