### PR TITLE
Update page views label

### DIFF
--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -21,7 +21,7 @@
       <td><%= @content_item.document_type %></td>
     </tr>
     <tr>
-      <td>Unique page views (last 7 days)</td>
+      <td>Unique page views (last 1 month)</td>
       <td><%= @content_item.unique_page_views %></td>
     </tr>
     <tr>

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     content_item.unique_page_views = 10
     render
 
-    expect(rendered).to have_selector('td', text: 'Unique page views (last 7 days)')
+    expect(rendered).to have_selector('td', text: 'Unique page views (last 1 month)')
     expect(rendered).to have_selector('td + td', 'text': 10)
   end
 


### PR DESCRIPTION
### Motivation

The app now contains data for unique page views over a time scale of `last 1 month`, rather than the previous range of `last 7 days`, this change makes the `content item` detail page consistent with the data in the app.