### PR TITLE
prepend bundle exec to startup script for local dev

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -2,4 +2,4 @@
 
 bundle install
 
-rails s -b 0.0.0.0 -p 3206
+bundle exec rails s -b 0.0.0.0 -p 3206


### PR DESCRIPTION
`startup.sh` was running `rails s ...` previously, and could not find the `rails` executable.

