### PR TITLE
Switch sort arrows

### DIFF
--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -23,12 +23,12 @@
 
 [aria-sort=descending] > * {
   &:after {
-    content: '\25B2'; // Up arrow
+    content: '\25BC'; // Down arrow
   }
 }
 
 [aria-sort=ascending] > * {
   &:after {
-    content: '\25BC'; // Down arrow
+    content: '\25B2'; // Up arrow
   }
 }


### PR DESCRIPTION
### Motivation
The sort `desc` and `asc` arrows were the wrong way round. This meant that a `down arrow` was shown for `order=asc` and an `up arrow` for `order=desc`.

This PR switches this - it is a css only change.

### Before
<img width="1178" alt="screen shot 2017-03-01 at 12 43 06" src="https://cloud.githubusercontent.com/assets/6338228/23460385/0b4ddb62-fe7d-11e6-9beb-94c1166f68d2.png">

### After
<img width="1174" alt="screen shot 2017-03-01 at 12 43 23" src="https://cloud.githubusercontent.com/assets/6338228/23460394/16e5e2d0-fe7d-11e6-9c92-8f587afa95d6.png">


