### PR TITLE
Count the number of PDFs attached to a content item

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -4,4 +4,14 @@ class ContentItem < ApplicationRecord
   def url
     "https://gov.uk#{base_path}"
   end
+
+  def self.create_or_update!(attributes, organisation)
+    content_id = attributes.fetch(:content_id)
+    content_item = self.find_or_create_by(content_id: content_id)
+
+    attributes = attributes.slice(*content_item.attributes.symbolize_keys.keys)
+
+    content_item.update!(attributes)
+    content_item.organisations << organisation unless content_item.organisations.include?(organisation)
+  end
 end

--- a/app/models/importers/content_items_by_organisation.rb
+++ b/app/models/importers/content_items_by_organisation.rb
@@ -1,9 +1,16 @@
 module Importers
   class ContentItemsByOrganisation
+    attr_accessor :metric_builder
+
+    def initialize
+      @metric_builder = MetricBuilder.new
+    end
+
     def run(slug)
       organisation = Organisation.find_by(slug: slug)
-      ContentItemsService.new.find_each(slug) do |attributes|
-        create_or_update!(attributes, organisation)
+      ContentItemsService.new.find_each(slug) do |content_item_attributes|
+        metric_builder.run_all(content_item_attributes)
+        create_or_update!(content_item_attributes, organisation)
       end
     end
 

--- a/app/models/importers/content_items_by_organisation.rb
+++ b/app/models/importers/content_items_by_organisation.rb
@@ -1,16 +1,17 @@
 module Importers
   class ContentItemsByOrganisation
-    attr_accessor :metric_builder
+    attr_accessor :metric_builder, :content_items_service
 
     def initialize
       @metric_builder = MetricBuilder.new
+      @content_items_service = ContentItemsService.new
     end
 
     def run(slug)
       organisation = Organisation.find_by(slug: slug)
-      ContentItemsService.new.find_each(slug) do |content_item_attributes|
-        metric_builder.run_all(content_item_attributes)
-        ContentItem.create_or_update!(content_item_attributes, organisation)
+      content_items_service.find_each(slug) do |content_item_attributes|
+        metrics = metric_builder.run_all(content_item_attributes)
+        ContentItem.create_or_update!(metrics.merge(content_item_attributes), organisation)
       end
     end
   end

--- a/app/models/importers/content_items_by_organisation.rb
+++ b/app/models/importers/content_items_by_organisation.rb
@@ -10,18 +10,8 @@ module Importers
       organisation = Organisation.find_by(slug: slug)
       ContentItemsService.new.find_each(slug) do |content_item_attributes|
         metric_builder.run_all(content_item_attributes)
-        create_or_update!(content_item_attributes, organisation)
+        ContentItem.create_or_update!(content_item_attributes, organisation)
       end
-    end
-
-  private
-
-    def create_or_update!(attributes, organisation)
-      content_id = attributes.fetch(:content_id)
-      content_item = ContentItem.find_or_create_by(content_id: content_id)
-
-      content_item.update!(attributes)
-      content_item.organisations << organisation unless content_item.organisations.include?(organisation)
     end
   end
 end

--- a/app/services/content_items_service.rb
+++ b/app/services/content_items_service.rb
@@ -15,6 +15,6 @@ class ContentItemsService
 private
 
   def attribute_names
-    @names ||= %i(content_id description title public_updated_at document_type base_path)
+    @names ||= %i(content_id description title public_updated_at document_type base_path details)
   end
 end

--- a/app/services/metric_builder.rb
+++ b/app/services/metric_builder.rb
@@ -1,0 +1,4 @@
+class MetricBuilder
+  def run_all(content_item_attributes)
+  end
+end

--- a/app/services/metric_builder.rb
+++ b/app/services/metric_builder.rb
@@ -1,4 +1,16 @@
 class MetricBuilder
   def run_all(content_item_attributes)
+    metrics = all_metrics.map do |metric_klass|
+      metric_klass.new(content_item_attributes).run
+    end
+    metrics.reduce(:merge)
+  end
+
+private
+
+  def all_metrics
+    [
+      Metrics::NumberOfPdfsMetric
+    ]
   end
 end

--- a/app/services/metrics/number_of_pdfs_metric.rb
+++ b/app/services/metrics/number_of_pdfs_metric.rb
@@ -2,11 +2,40 @@ module Metrics
   class NumberOfPdfsMetric
     attr_accessor :content_item
 
+    PDF_XPATH = "//*[contains(@class, 'attachment-details')]//a[contains(@href, '.pdf')]".freeze
+
     def initialize(content_item)
       @content_item = content_item
     end
 
     def run
+      documents_string = extract_documents
+      documents = parse documents_string
+      { number_of_pdfs: number_of_pdfs(documents) }
+    end
+
+  private
+
+    def extract_documents
+      if content_item[:details].is_a?(Hash)
+        details = content_item[:details].symbolize_keys
+        documents = document_keys.map do |k|
+          details.fetch(k, nil)
+        end
+        documents.join('')
+      end
+    end
+
+    def document_keys
+      %i(documents final_outcome_documents)
+    end
+
+    def parse(string)
+      Nokogiri::HTML(string)
+    end
+
+    def number_of_pdfs(html_fragment)
+      html_fragment.xpath(PDF_XPATH).length
     end
   end
 end

--- a/app/services/metrics/number_of_pdfs_metric.rb
+++ b/app/services/metrics/number_of_pdfs_metric.rb
@@ -1,0 +1,12 @@
+module Metrics
+  class NumberOfPdfsMetric
+    attr_accessor :content_item
+
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def run
+    end
+  end
+end

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -40,5 +40,9 @@
         <%= stringify_organisations @content_item.organisations %>
       </td>
     </tr>
+    <tr>
+      <td>Number of pdfs</td>
+      <td><%= @content_item.number_of_pdfs %></td>
+    </tr>
   </tbody>
 </table>

--- a/db/migrate/20170227153415_add_pdf_count_to_content_item.rb
+++ b/db/migrate/20170227153415_add_pdf_count_to_content_item.rb
@@ -1,0 +1,5 @@
+class AddPdfCountToContentItem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :number_of_pdfs, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20170307151842) do
     t.string   "document_type"
     t.string   "description"
     t.integer  "unique_page_views", default: 0
+    t.integer  "number_of_pdfs",    default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["title"], name: "index_content_items_on_title", using: :btree
   end

--- a/spec/features/importers/content_items_by_organisation_spec.rb
+++ b/spec/features/importers/content_items_by_organisation_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'rake import:content_items_by_organisation[{department-slug}]', type: :feature do
   let(:search_api_response) { { results: [{ link: '/link-1' }, { link: '/link-2' }] }.to_json }
-  let(:content_item_1) { attributes_for(:content_item, base_path: '/link-1').to_json }
-  let(:content_item_2) { attributes_for(:content_item, base_path: '/link-2').to_json }
+  let(:content_item_1) { attributes_for(:content_item, base_path: '/link-1', details: {}).to_json }
+  let(:content_item_2) { attributes_for(:content_item, base_path: '/link-2', details: {}).to_json }
 
   before do
     Rake::Task['import:content_items_by_organisation'].reenable

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,12 +1,45 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ContentItem, type: :model do
   it { should have_and_belong_to_many(:organisations) }
 
-  describe '#url' do
-    it 'returns a url to a content item on gov.uk' do
-      content_item = build(:content_item, base_path: '/api/content/item/path/1')
-      expect(content_item.url).to eq('https://gov.uk/api/content/item/path/1')
+  describe "#url" do
+    it "returns a url to a content item on gov.uk" do
+      content_item = build(:content_item, base_path: "/api/content/item/path/1")
+      expect(content_item.url).to eq("https://gov.uk/api/content/item/path/1")
+    end
+  end
+
+  describe "#create_or_update" do
+    let(:content_item_1) { { content_id: "first_id" } }
+    let(:content_item_2) { { content_id: "second_id" } }
+    let(:organisation) { build(:organisation, slug: "the-organisation") }
+
+    before do
+      create(:content_item, content_id: "first_id", title: "the title")
+    end
+
+    it "creates a content item if it does not exist" do
+      expect { ContentItem.create_or_update!(content_item_2, organisation) }.to change { ContentItem.count }.by(1)
+    end
+
+    it "updates a content item if it already exists" do
+      content_item_1[:title] = "a new title"
+
+      expect { ContentItem.create_or_update!(content_item_1, organisation) }.to change { ContentItem.count }.by(0)
+      expect(ContentItem.find_by(content_id: "first_id").title).to eq("a new title")
+    end
+
+    it "creates a content item when the content item has attributes that don't exist on the model" do
+      content_item_with_extra = { content_id: "with_extra", extra: "an extra attribute" }
+
+      expect { ContentItem.create_or_update!(content_item_with_extra, organisation) }.to change { ContentItem.count }.by(1)
+    end
+
+    it "adds the organisation to the content item" do
+      ContentItem.create_or_update!(content_item_2, organisation)
+      organisations = ContentItem.find_by(content_id: "second_id").organisations
+      expect(organisations).to eq([organisation])
     end
   end
 end

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -9,14 +9,21 @@ RSpec.describe Importers::ContentItemsByOrganisation do
       it 'creates a content item per attribute group' do
         attrs1 = attributes_for(:content_item)
         attrs2 = attributes_for(:content_item)
+        subject.metric_builder = double()
+
         allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
+        allow(subject.metric_builder).to receive(:run_all).and_return({})
 
         expect { subject.run('the-slug') }.to change { ContentItem.count }.by(2)
       end
 
       it 'updates the attributes' do
         attrs1 = attributes_for(:content_item, base_path: 'the-link-value', title: 'the-title')
+        subject.metric_builder = double()
+
         allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attrs1)
+        allow(subject.metric_builder).to receive(:run_all).and_return({})
+
         subject.run('the-slug')
 
         attributes = ContentItem.find_by(base_path: 'the-link-value').attributes.symbolize_keys
@@ -29,7 +36,10 @@ RSpec.describe Importers::ContentItemsByOrganisation do
 
       it 'does not create a new one' do
         attributes = { content_id: content_item.content_id, base_path: 'the-link' }
+        subject.metric_builder = double()
+
         allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attributes)
+        allow(subject.metric_builder).to receive(:run_all).and_return({})
 
         expect { subject.run('the-slug') }.to change { ContentItem.count }.by(0)
       end
@@ -37,7 +47,10 @@ RSpec.describe Importers::ContentItemsByOrganisation do
       it 'updates the attributes' do
         content_item.update(title: 'old-title')
         attributes = { content_id: content_item.content_id, title: 'the-new-title', base_path: 'the-link' }
+        subject.metric_builder = double()
+
         allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attributes)
+        allow(subject.metric_builder).to receive(:run_all).and_return({})
 
         subject.run('the-slug')
 
@@ -53,7 +66,8 @@ RSpec.describe Importers::ContentItemsByOrganisation do
       subject.metric_builder = double()
 
       allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
-
+      allow(subject.metric_builder).to receive(:run_all).and_return({})
+      
       expect(subject.metric_builder).to receive(:run_all).twice
 
       subject.run('the-slug')

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -44,5 +44,19 @@ RSpec.describe Importers::ContentItemsByOrganisation do
         expect(ContentItem.first.title).to eq('the-new-title')
       end
     end
+
+
+
+    it 'calls the metric builder for each content item' do
+      attrs1 = attributes_for(:content_item)
+      attrs2 = attributes_for(:content_item)
+      subject.metric_builder = double()
+
+      allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
+
+      expect(subject.metric_builder).to receive(:run_all).twice
+
+      subject.run('the-slug')
+    end
   end
 end

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -5,26 +5,25 @@ RSpec.describe Importers::ContentItemsByOrganisation do
     let!(:organisation) { create(:organisation, slug: 'the-slug') }
     let!(:content_item) { create(:content_item, content_id: 'the-content-id', organisations: [organisation]) }
 
-    it 'creates or update all the content items' do
-      subject.metric_builder = double(run_all: {})
+    it 'update the metrics of the content item' do
+      subject.metric_builder = double(run_all: { number_of_pdfs: 10 })
+      subject.content_items_service = double
       attrs1 = { content_id: 'the-content-id' }
-      attrs2 = { content_id: 'the-content-id2' }
-      allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
-
-      expect { subject.run('the-slug') }.to change { ContentItem.count }.by(1)
-    end
-
-    it 'calls the metric builder for each content item' do
-      attrs1 = attributes_for(:content_item)
-      attrs2 = attributes_for(:content_item)
-      subject.metric_builder = double()
-
-      allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
-      allow(subject.metric_builder).to receive(:run_all).and_return({})
-      
-      expect(subject.metric_builder).to receive(:run_all).twice
+      allow(subject.content_items_service).to receive(:find_each).with('the-slug').and_yield(attrs1)
 
       subject.run('the-slug')
+
+      expect(content_item.reload.number_of_pdfs).to eq(10)
+    end
+
+    it 'creates a new content item and updates an existing one in the same import' do
+      subject.metric_builder = double(run_all: {})
+      subject.content_items_service = double
+      attrs1 = { content_id: 'the-content-id' }
+      attrs2 = { content_id: 'the-content-id2' }
+      allow(subject.content_items_service).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
+
+      expect { subject.run('the-slug') }.to change { ContentItem.count }.by(1)
     end
   end
 end

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -3,62 +3,16 @@ require 'rails_helper'
 RSpec.describe Importers::ContentItemsByOrganisation do
   describe '#run' do
     let!(:organisation) { create(:organisation, slug: 'the-slug') }
-    let(:content_item) { create(:content_item, base_path: 'the-link', organisations: [organisation]) }
+    let!(:content_item) { create(:content_item, content_id: 'the-content-id', organisations: [organisation]) }
 
-    context 'when the content item does not exist' do
-      it 'creates a content item per attribute group' do
-        attrs1 = attributes_for(:content_item)
-        attrs2 = attributes_for(:content_item)
-        subject.metric_builder = double()
+    it 'creates or update all the content items' do
+      subject.metric_builder = double(run_all: {})
+      attrs1 = { content_id: 'the-content-id' }
+      attrs2 = { content_id: 'the-content-id2' }
+      allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
 
-        allow_any_instance_of(ContentItemsService).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
-        allow(subject.metric_builder).to receive(:run_all).and_return({})
-
-        expect { subject.run('the-slug') }.to change { ContentItem.count }.by(2)
-      end
-
-      it 'updates the attributes' do
-        attrs1 = attributes_for(:content_item, base_path: 'the-link-value', title: 'the-title')
-        subject.metric_builder = double()
-
-        allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attrs1)
-        allow(subject.metric_builder).to receive(:run_all).and_return({})
-
-        subject.run('the-slug')
-
-        attributes = ContentItem.find_by(base_path: 'the-link-value').attributes.symbolize_keys
-        expect(attributes).to include(title: 'the-title')
-      end
+      expect { subject.run('the-slug') }.to change { ContentItem.count }.by(1)
     end
-
-    context 'when the content item already exists' do
-      let(:content_item) { create(:content_item, base_path: 'the-link', organisations: [organisation]) }
-
-      it 'does not create a new one' do
-        attributes = { content_id: content_item.content_id, base_path: 'the-link' }
-        subject.metric_builder = double()
-
-        allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attributes)
-        allow(subject.metric_builder).to receive(:run_all).and_return({})
-
-        expect { subject.run('the-slug') }.to change { ContentItem.count }.by(0)
-      end
-
-      it 'updates the attributes' do
-        content_item.update(title: 'old-title')
-        attributes = { content_id: content_item.content_id, title: 'the-new-title', base_path: 'the-link' }
-        subject.metric_builder = double()
-
-        allow_any_instance_of(ContentItemsService).to receive(:find_each).and_yield(attributes)
-        allow(subject.metric_builder).to receive(:run_all).and_return({})
-
-        subject.run('the-slug')
-
-        expect(ContentItem.first.title).to eq('the-new-title')
-      end
-    end
-
-
 
     it 'calls the metric builder for each content item' do
       attrs1 = attributes_for(:content_item)

--- a/spec/services/metric_builder_spec.rb
+++ b/spec/services/metric_builder_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe MetricBuilder do
+  describe "#run_all" do
+    let(:metrics) { { m1: 1 } }
+
+    it "calls each metric class once" do
+      expect_any_instance_of(Metrics::NumberOfPdfsMetric).to receive(:run).exactly(1).times
+
+      subject.run_all({})
+    end
+  end
+end

--- a/spec/services/metrics/number_of_pdfs_metric_spec.rb
+++ b/spec/services/metrics/number_of_pdfs_metric_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::NumberOfPdfsMetric do
+  subject { Metrics::NumberOfPdfsMetric }
+
+  let(:content_with_pdfs) {
+    {
+      details: {
+        documents: [
+          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
+          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>'
+        ],
+        final_outcome_documents: [
+          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>'
+        ]
+      }
+    }
+  }
+  let(:content_without_pdfs) {
+    {
+      details: {
+        "documents" => ['<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>']
+      }
+    }
+  }
+  let(:content_without_document_keys) { { details: {} } }
+  let(:content_without_details_key) { {} }
+
+  it "returns the number of pdfs present" do
+    expect(subject.new(content_with_pdfs).run).to eq(number_of_pdfs: 3)
+  end
+
+  it "returns 0 if no pdfs are present" do
+    expect(subject.new(content_without_pdfs).run).to eq(number_of_pdfs: 0)
+  end
+
+  it "returns 0 if no document keys are present" do
+    expect(subject.new(content_without_document_keys).run).to eq(number_of_pdfs: 0)
+  end
+
+  it "returns 0 if the 'details' key is not present" do
+    expect(subject.new(content_without_details_key).run).to eq(number_of_pdfs: 0)
+  end
+end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_selector('td + td', text: 'The description of a content item')
   end
 
+  it 'renders the number of pdfs the content item has' do
+    content_item.number_of_pdfs = 10
+    render
+
+    expect(rendered).to have_selector('td', text: 'Number of pdfs')
+    expect(rendered).to have_selector('td + td', text: 10)
+  end
+
   context "content items belong to multiple organisations" do
     let(:content_item) { create(:content_item_with_organisations, organisations_count: 2) }
 


### PR DESCRIPTION
### Motivation
Going forward it will be useful to not only highlight content items with large numbers of PDFs attached, but also give a sense of the total number of PDFs found across gov.uk

### Description
This PR grabs an additional field (`details`) from the content store - this field contains chunks of html representing attached documents, these chunks can be parsed to count the number of pdf documents found. This figure is then stored in each `ContentItem` under a new field `number_of_pdfs`.

### Before
<img width="1176" alt="screen shot 2017-03-01 at 17 44 04" src="https://cloud.githubusercontent.com/assets/6338228/23473671/f97c6ad0-fea8-11e6-9fb6-b01f5374a6c5.png">

### After
<img width="1163" alt="screen shot 2017-03-01 at 17 43 23" src="https://cloud.githubusercontent.com/assets/6338228/23473684/0547b39c-fea9-11e6-9919-52a64dcd582b.png">

