### PR TITLE
Remove nested resource for Organisations Content Items 

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -18,6 +18,6 @@ class ContentItemsController < ApplicationController
 private
 
   def set_organisation
-    @organisation = Organisation.find_by_slug(params[:organisation_slug]) if params[:organisation_slug]
+    @organisation = Organisation.find_by(slug: params[:organisation_slug]) if params[:organisation_slug]
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,7 +1,7 @@
 module OrganisationsHelper
   def stringify_organisations(organisations)
     names = organisations.collect do |organisation|
-      link_to(organisation.title, organisation_content_items_path(organisation_slug: organisation.slug))
+      link_to(organisation.title, content_items_path(organisation_slug: organisation.slug))
     end
 
     names.join(', ').html_safe

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -6,7 +6,7 @@ module TableHelper
   class SortTable
     attr_accessor :view, :heading, :attribute_name
 
-    delegate :content_tag, :params, :link_to, :content_items_path, :content_items_path, to: :view
+    delegate :content_tag, :params, :link_to, :content_items_path, to: :view
 
     def initialize(view, heading, attribute_name)
       @view = view

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -6,7 +6,7 @@ module TableHelper
   class SortTable
     attr_accessor :view, :heading, :attribute_name
 
-    delegate :content_tag, :params, :link_to, :organisation_content_items_path, :content_items_path, to: :view
+    delegate :content_tag, :params, :link_to, :content_items_path, :content_items_path, to: :view
 
     def initialize(view, heading, attribute_name)
       @view = view
@@ -24,7 +24,7 @@ module TableHelper
 
     def link(label, order)
       if view.instance_variable_get(:@organisation).present?
-        link_to organisation_content_items_path(organisation_slug: view.instance_variable_get(:@organisation).slug, sort: attribute_name, order: order, query: params[:query]) do
+        link_to content_items_path(organisation_slug: view.instance_variable_get(:@organisation).slug, sort: attribute_name, order: order, query: params[:query]) do
           "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
         end
       else

--- a/app/views/organisations/_organisation.html.erb
+++ b/app/views/organisations/_organisation.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <td><%= link_to organisation.title, organisation_content_items_path(organisation_slug: organisation.slug) %></td>
+  <td><%= link_to organisation.title, content_items_path(organisation_slug: organisation.slug) %></td>
   <td><%= organisation.content_items.count %></td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %w(index)
 
-  resources :content_items
+  resources :content_items, only: %w(index show)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
-  resources :organisations, only: %w(index), param: :slug do
-    resources :content_items, only: %w(index)
-  end
+  resources :organisations, only: %w(index)
 
   resources :content_items
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -2,58 +2,37 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
   describe "GET #index" do
-    it "returns the content items filtered by text" do
-      expect(ContentItemsQuery).to receive(:build).with(hash_including(query: 'a title')).and_return(:the_results)
+    it "returns http success" do
+      get :index
 
-      get :index, params: { query: 'a title' }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns list of content items" do
+      expect(ContentItemsQuery).to receive(:build).and_return(:the_results)
+      get :index
+
       expect(assigns(:content_items)).to eq(:the_results)
     end
 
-    context "unfiltered" do
-      let(:content_items) { create_list(:content_item_with_organisations, 3) }
+    it "build the query with the expected params" do
+      expected_params = { sort: 'title', order: 'asc', page: '1', organisation: nil, query: 'a title' }
+      expect(ContentItemsQuery).to receive(:build).with(expected_params).and_return(:the_results)
 
-      before do
-        get :index
-      end
-
-      it "returns http success" do
-        expect(response).to have_http_status(:success)
-      end
-
-      it "assigns list of content items" do
-        expect(assigns(:content_items)).to eq(content_items)
-      end
-
-      it "renders the :index template" do
-        expect(subject).to render_template(:index)
-      end
+      get :index, params: expected_params
     end
 
-    context "find by organisation" do
-      let(:organisation) { create(:organisation) }
+    it "assigns the organisation provided the slug" do
+      create(:organisation, slug: 'the-slug')
 
-      before do
-        get :index, params: { organisation_slug: organisation.slug }
-      end
-
-      it "returns http success" do
-        expect(response).to have_http_status(:success)
-      end
-
-      it "assigns current organisation" do
-        expect(assigns(:organisation)).to eq(organisation)
-      end
-
-      it "renders the :index template" do
-        expect(subject).to render_template(:index)
-      end
+      get :index, params: { organisation_slug: 'the-slug' }
+      expect(assigns(:organisation).slug).to eq('the-slug')
     end
 
-    context "content items fetched via ContentItemQuery" do
-      it "returns a list of content items" do
-        allow(ContentItemsQuery).to receive(:build).and_return(:content_items)
-        expect(ContentItemsQuery.build({})).to eq(:content_items)
-      end
+    it "renders the :index template" do
+      get :index
+
+      expect(subject).to render_template(:index)
     end
   end
 

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -3,10 +3,9 @@ require 'features/pagination_spec_helper'
 
 RSpec.feature "Content Item Details", type: :feature do
   scenario "the user clicks on the view content item link and is redirected to the content item show page" do
-    organisation = create :organisation, slug: "the-slug"
-    create :content_item, id: 1, title: "content item title", organisations: [organisation]
+    create :content_item, id: 1, title: "content item title"
 
-    visit "organisations/the-slug/content_items"
+    visit "/content_items"
     click_on "content item title"
 
     expected_path = "/content_items/1"

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -15,9 +15,9 @@ RSpec.feature "Content Item Details", type: :feature do
 
   describe 'The user can navigate paged lists of content items' do
     before do
-      create :organisation_with_content_items, slug: "the-slug", content_items_count: 3
+      create_list :content_item, 3
     end
 
-    it_behaves_like "a paginated list", "organisations/the-slug/content_items"
+    it_behaves_like "a paginated list", "/content_items"
   end
 end

--- a/spec/features/content_items_spec.rb
+++ b/spec/features/content_items_spec.rb
@@ -17,17 +17,4 @@ RSpec.feature "Content Items List", type: :feature do
       it_behaves_like 'a paginated list', 'content_items'
     end
   end
-
-  context "navigation to organisation pages" do
-    scenario "clicks through to an organisation" do
-      first_content_item = @content_items.first
-      first_content_item.organisations << create(:organisation, title: 'the-organisation-title', slug: 'organisation-slug')
-
-      visit 'content_items'
-      click_on 'the-organisation-title'
-
-      expected_path = "/organisations/organisation-slug/content_items"
-      expect(current_path).to eq(expected_path)
-    end
-  end
 end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature "Organisations list", type: :feature do
     visit organisations_path
     click_on "organisation title"
 
-    expected_path = "/organisations/the-slug/content_items"
-    expect(current_path).to eq(expected_path)
+    expected_path = "/content_items?organisation_slug=the-slug"
+    expect(current_url).to include(expected_path)
   end
 
   describe 'The user can navigate paged lists of organisations' do

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OrganisationsHelper, type: :helper do
       subject { helper.stringify_organisations(organisations) }
 
       it "turns each organisation name into a link" do
-        link_href = organisation_content_items_path(organisation_slug: organisations[0].slug)
+        link_href = content_items_path(organisation_slug: organisations[0].slug)
 
         expect(subject).to have_link(href: link_href)
       end

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe TableHelper, type: :helper do
     describe 'Sorting' do
       context 'When the column is unsorted' do
         it 'has a link to sort asc' do
-          link_href = organisation_content_items_path(params_asc)
+          link_href = content_items_path(params_asc)
 
           expect(subject).to have_link(href: link_href)
         end
@@ -62,7 +62,7 @@ RSpec.describe TableHelper, type: :helper do
         before { controller.params = params_asc }
 
         it 'has a link to sort desc' do
-          link_href = organisation_content_items_path(params_desc)
+          link_href = content_items_path(params_desc)
 
           expect(subject).to have_link(href: link_href)
         end
@@ -72,7 +72,7 @@ RSpec.describe TableHelper, type: :helper do
         before { controller.params = params_desc }
 
         it 'has a link to sort asc' do
-          link_href = organisation_content_items_path(params_asc)
+          link_href = content_items_path(params_asc)
 
           expect(subject).to have_link(href: link_href)
         end
@@ -82,7 +82,7 @@ RSpec.describe TableHelper, type: :helper do
         before { controller.params = params_desc.merge(query: 'a query value') }
 
         it 'has a link with the query string' do
-          link_href = organisation_content_items_path(params_asc.merge!(query: 'a query value'))
+          link_href = content_items_path(params_asc.merge!(query: 'a query value'))
 
           expect(subject).to have_link(href: link_href)
         end

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -2,27 +2,13 @@ require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :routing do
   describe 'routing' do
-    context 'with organisation slug' do
-      it 'routes to #index' do
-        expect(get: organisation_content_items_path('a-slug')).to be_routable
-        expect(get: organisation_content_items_path('a-slug'))
-          .to route_to(
-            controller: 'content_items',
-            action: 'index',
-            organisation_slug: 'a-slug'
-          )
-      end
-    end
-
-    context 'without organisation slug' do
-      it 'routes to #index' do
-        expect(get: content_items_path).to be_routable
-        expect(get: content_items_path)
-          .to route_to(
-            controller: 'content_items',
-            action: 'index'
-          )
-      end
+    it 'routes to #index' do
+      expect(get: content_items_path).to be_routable
+      expect(get: content_items_path)
+        .to route_to(
+          controller: 'content_items',
+          action: 'index'
+        )
     end
 
     it 'routes to #show' do

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
       it 'contains a descending and ascending links in table heading' do
         render
-        href = organisation_content_items_path(organisation.slug, order: :asc, sort: :public_updated_at)
+        href = content_items_path(organisation_slug: organisation.slug, order: :asc, sort: :public_updated_at)
 
         expect(rendered).to have_link('Last Updated', href: href)
       end

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'organisations/index.html.erb', type: :view do
     it "should render a link for each organisation" do
       organisations.first.title = "Organisation 1"
       organisations.first.slug = "the-slug"
-      organisation_link = organisation_content_items_path(organisation_slug: "the-slug")
+      organisation_link = content_items_path(organisation_slug: "the-slug")
       render
 
       expect(rendered).to have_selector("a[href='#{organisation_link}']", text: "Organisation 1")


### PR DESCRIPTION
[Trello card](https://trello.com/c/1Cq3XX3B/185-dev-sessions-remove-nested-resource-for-organisations)

There is no need to have a nested resource, as Content Items are also being accessed and searched by Taxonomy, or by ID directly.

The new route has the following format:
![image](https://cloud.githubusercontent.com/assets/227328/23747494/c4943310-04b7-11e7-8e5e-dbbd4f097b13.png)


paired: @theleebriggs @chao-xian @ikennaokpala 