### PR TITLE
Filter content items by departments

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -15,6 +15,10 @@ class ContentItemsController < ApplicationController
     @content_item = ContentItem.find(params[:id]).decorate
   end
 
+  def filter
+    @organisations = Organisation.all
+  end
+
 private
 
   def set_organisation

--- a/app/views/content_items/filter.html.erb
+++ b/app/views/content_items/filter.html.erb
@@ -1,0 +1,13 @@
+<%= form_tag content_items_path, method: :get, class: 'form-horizontal' do %>
+  <div class="form-group">
+    <label for="organisation_slug" class="col-sm-2 control-label"></label>
+    <div class="col-sm-10">
+      <%= select_tag :organisation_slug, options_from_collection_for_select(@organisations, :slug, :title), class: "form-control" %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <%= submit_tag "Filter", class: "btn btn-default btn-lg", name: nil %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %w(index)
 
-  resources :content_items, only: %w(index show)
+  resources :content_items, only: %w(index show) do
+    collection { get :filter }
+  end
 end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -57,4 +57,26 @@ RSpec.describe ContentItemsController, type: :controller do
       end
     end
   end
+
+  describe "GET #filter" do
+    it "returns http success" do
+      get :filter
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns a list of organisations" do
+      organisations = [build(:organisation), build(:organisation)]
+      allow(Organisation).to receive(:all).and_return(organisations)
+      get :filter
+
+      expect(assigns(:organisations)).to match_array(organisations)
+    end
+
+    it "renders the filter template" do
+      get :filter
+      
+      expect(response).to render_template("filter")
+    end
+  end
 end

--- a/spec/features/content_items_spec.rb
+++ b/spec/features/content_items_spec.rb
@@ -17,4 +17,19 @@ RSpec.feature "Content Items List", type: :feature do
       it_behaves_like 'a paginated list', 'content_items'
     end
   end
+
+  context "Filtering content items by organisation" do
+    scenario "the user selects an organisation from the organisations select box, clicks the filter button and retrieves a filtered list of the organisation's content items" do
+      create :organisation, slug: "the-slug-1", title: "title 1"
+      create :organisation, slug: "the-slug-2", title: "title 2"
+
+      visit "/content_items/filter"
+      select "title 2", from: "organisation_slug"
+      click_on "Filter"
+
+      expected_path = URI.escape "/content_items?utf8=✓&organisation_slug=the-slug-2"
+
+      expect(current_url).to include(expected_path)
+    end
+  end
 end

--- a/spec/routes/content_item_spec.rb
+++ b/spec/routes/content_item_spec.rb
@@ -20,5 +20,14 @@ RSpec.describe ContentItemsController, type: :routing do
           id: '1',
         )
     end
+
+    it 'routes to #filter' do
+      expect(get: filter_content_items_path).to be_routable
+      expect(get: filter_content_items_path)
+        .to route_to(
+          controller: 'content_items',
+          action: 'filter'
+        )
+    end
   end
 end

--- a/spec/views/content_items/filter.html.erb_spec.rb
+++ b/spec/views/content_items/filter.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "content_items/filter.html.erb", type: :view do
+  describe "Form for filtering content items" do
+    it "will render an empty select box if supplied with no organisation" do
+      assign(:organisations, [])
+      render
+
+      expect(rendered).to have_selector("form select[name=organisation_slug]")
+      expect(rendered).to have_selector('form select option', count: 0)
+    end
+
+    it "will render a select box with organisations if supplied a list of organisations" do
+      organisations = [build(:organisation), build(:organisation)]
+      assign(:organisations, organisations)
+      render
+
+      expect(rendered).to have_selector('form select option', count: 2)
+    end
+
+    it "renders a button with the value of 'Filter' for executing the form action" do
+      assign(:organisations, [])
+      render
+
+      expect(rendered).to have_selector("form input[type=submit][value=Filter]")
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/oVP2S6GC/172-5-filter-department)

## Description 

As a content designer I want to filter by departments so that I can see
the content that is most relevant to me.

Here, updates have been made to present a content items filter form with a
select box containing a list of the existing organisations, hence making
it possible to filter content items by an organisation.

This is presented on the "/content_items/filter" path. This is understood to
be the temporary and will change. This also reflects certain placements of
the tests within related content items files, these are also temporary and
will be moved once much progress is made.

Controller, feature, route and view specs have been added to further
describe the expected behaviour.

Bootstrap [1] form css classes / layout have been used to give some
initial presentation context to the filtering form.

[1] http://getbootstrap.com/css/#forms