### PR TITLE
Show content item taxonomies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'draper', '3.0.0.pre1'
 
 gem 'unicorn', '~> 5.1.0'
 
+gem 'gds-api-adapters', '~> 38.1.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     actioncable (5.0.1)
       actionpack (= 5.0.1)
       nio4r (~> 1.2)
@@ -74,6 +75,8 @@ GEM
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
     draper (3.0.0.pre1)
       actionpack (~> 5.0)
       activemodel (~> 5.0)
@@ -91,6 +94,13 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.17)
     formatador (0.2.5)
+    gds-api-adapters (38.1.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     google-api-client (0.9.20)
@@ -132,6 +142,8 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.2)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
@@ -149,6 +161,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.10.0)
+    link_header (0.0.8)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -158,6 +171,8 @@ GEM
       multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     lumberjack (1.0.11)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
@@ -172,16 +187,19 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
+    netrc (0.11.0)
     nio4r (1.2.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    null_logger (0.0.1)
     os (0.9.6)
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
+    plek (1.12.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -190,6 +208,8 @@ GEM
     public_suffix (2.0.5)
     puma (3.6.2)
     rack (2.0.1)
+    rack-cache (1.7.0)
+      rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.1)
@@ -228,6 +248,10 @@ GEM
     representable (2.3.0)
       uber (~> 0.0.7)
     request_store (1.3.2)
+    rest-client (2.0.1)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (2.1.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -303,6 +327,9 @@ GEM
     uber (0.0.15)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicode-display_width (1.1.1)
     unicorn (5.1.0)
       kgio (~> 2.6)
@@ -331,6 +358,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   draper (= 3.0.0.pre1)
   factory_girl_rails
+  gds-api-adapters (~> 38.1.0)
   google-api-client (~> 0.9)
   govuk-lint
   govuk_admin_template (~> 5.0)
@@ -362,4 +390,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.14.5

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -16,4 +16,8 @@ class ContentItemDecorator < Draper::Decorator
 
     names.join(', ').html_safe
   end
+
+  def taxons_as_string
+    object.taxonomies.map(&:title).join(', ')
+  end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -10,9 +10,25 @@ class ContentItem < ApplicationRecord
     content_id = attributes.fetch(:content_id)
     content_item = self.find_or_create_by(content_id: content_id)
 
-    attributes = attributes.slice(*content_item.attributes.symbolize_keys.keys)
+    content_item.add_organisation(organisation)
+    content_item.add_taxonomies(attributes.fetch(:taxons))
 
+    attributes = content_item.existing_attributes(attributes)
     content_item.update!(attributes)
-    content_item.organisations << organisation unless content_item.organisations.include?(organisation)
+  end
+
+  def add_organisation(organisation)
+    self.organisations << organisation unless self.organisations.include?(organisation)
+  end
+
+  def add_taxonomies(taxon_ids)
+    taxon_ids.each do |taxon_id|
+      taxon = Taxonomy.find_by(content_id: taxon_id)
+      taxonomies << taxon unless taxon.nil? || taxonomies.include?(taxon)
+    end
+  end
+
+  def existing_attributes(attributes)
+    attributes.slice(*self.attributes.symbolize_keys.keys)
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,6 @@
 class ContentItem < ApplicationRecord
   has_and_belongs_to_many :organisations
+  has_and_belongs_to_many :taxonomies
 
   def url
     "https://gov.uk#{base_path}"

--- a/app/models/importers/all_taxons.rb
+++ b/app/models/importers/all_taxons.rb
@@ -1,0 +1,6 @@
+module Importers
+  class AllTaxons
+    def run
+    end
+  end
+end

--- a/app/models/importers/all_taxons.rb
+++ b/app/models/importers/all_taxons.rb
@@ -1,6 +1,17 @@
 module Importers
   class AllTaxons
+    attr_accessor :taxonomies_service
+
+    def initialize
+      @taxonomies_service = TaxonomiesService.new
+    end
+
     def run
+      taxonomies_service.find_each do |attributes|
+        content_id = attributes.fetch(:content_id)
+        taxonomy = Taxonomy.find_or_create_by(content_id: content_id)
+        taxonomy.update!(attributes.slice(:title, :content_id))
+      end
     end
   end
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,0 +1,2 @@
+class Taxonomy < ApplicationRecord
+end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,2 +1,3 @@
 class Taxonomy < ApplicationRecord
+  has_and_belongs_to_many :content_items
 end

--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -1,6 +1,45 @@
+require 'gds_api/publishing_api_v2'
+
 module Clients
   class PublishingAPI
+    attr_accessor :publishing_api, :per_page
+
+    def initialize
+      @publishing_api = GdsApi::PublishingApiV2.new(
+        Plek.new.find('publishing-api'),
+        disable_cache: true,
+        bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+      )
+      @per_page = 100
+    end
+
     def find_each(fields)
+      current_page = 1
+      loop do
+        response = publishing_api.get_content_items(
+          document_type: 'taxon',
+          order: '-public_updated_at',
+          q: '',
+          page: current_page,
+          per_page: per_page,
+          states: ['published'],
+        )
+
+        taxonomies = map_taxon_results(response['results'], fields)
+        taxonomies.each { |taxon| yield taxon }
+        break if last_page?(response)
+        current_page = response["current_page"] + 1
+      end
+    end
+
+  private
+
+    def last_page?(response)
+      response["pages"] == response["current_page"]
+    end
+
+    def map_taxon_results(taxon_results, fields)
+      taxon_results.map { |taxon_hash| taxon_hash.symbolize_keys.slice(*fields) }
     end
   end
 end

--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -1,0 +1,6 @@
+module Clients
+  class PublishingAPI
+    def find_each(fields)
+    end
+  end
+end

--- a/app/services/content_items_service.rb
+++ b/app/services/content_items_service.rb
@@ -8,13 +8,16 @@ class ContentItemsService
     Clients::SearchAPI.find_each(query: query, fields: fields) do |response|
       base_path = response.fetch(:link)
       content_item = Clients::ContentStore.find(base_path, attribute_names)
-      yield content_item if content_item
+      if content_item
+        content_item[:taxons] = TaxonomyParser.parse(content_item)
+        yield content_item
+      end
     end
   end
 
 private
 
   def attribute_names
-    @names ||= %i(content_id description title public_updated_at document_type base_path details)
+    @names ||= %i(content_id description title public_updated_at document_type base_path details links)
   end
 end

--- a/app/services/taxonomies_service.rb
+++ b/app/services/taxonomies_service.rb
@@ -1,0 +1,4 @@
+class TaxonomiesService
+  def find_each
+  end
+end

--- a/app/services/taxonomies_service.rb
+++ b/app/services/taxonomies_service.rb
@@ -1,4 +1,19 @@
 class TaxonomiesService
+  attr_accessor :publishing_api
+
+  def initialize
+    @publishing_api = Clients::PublishingAPI.new
+  end
+
   def find_each
+    publishing_api.find_each(attribute_names) do |taxonomy|
+      yield taxonomy
+    end
+  end
+
+private
+
+  def attribute_names
+    @names ||= %i(content_id title)
   end
 end

--- a/app/services/taxonomy_parser.rb
+++ b/app/services/taxonomy_parser.rb
@@ -1,0 +1,12 @@
+class TaxonomyParser
+  def self.parse(content_item)
+    if content_item[:links].is_a?(Hash)
+      links = content_item[:links].deep_symbolize_keys
+      links.fetch(:taxons, []).map do |taxon|
+        taxon.fetch(:content_id)
+      end
+    else
+      []
+    end
+  end
+end

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -40,5 +40,8 @@
       <td>Number of pdfs</td>
       <td><%= @content_item.number_of_pdfs %></td>
     </tr>
+      <td>Taxonomies</td>
+      <td><%= @content_item.taxons_as_string %></td>
+    </tr>
   </tbody>
 </table>

--- a/db/migrate/20170221150721_create_taxonomies.rb
+++ b/db/migrate/20170221150721_create_taxonomies.rb
@@ -1,0 +1,10 @@
+class CreateTaxonomies < ActiveRecord::Migration[5.0]
+  def change
+    create_table :taxonomies do |t|
+      t.string :content_id
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170314110425_create_join_table_content_item_taxonomy.rb
+++ b/db/migrate/20170314110425_create_join_table_content_item_taxonomy.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableContentItemTaxonomy < ActiveRecord::Migration[5.0]
+  def change
+    create_join_table :content_items, :taxonomies do |t|
+      t.index [:content_item_id]
+      t.index [:taxonomy_id, :content_item_id], name: "index_content_item_taxonomies", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,4 +43,11 @@ ActiveRecord::Schema.define(version: 20170307151842) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true, using: :btree
   end
 
+  create_table "taxonomies", force: :cascade do |t|
+    t.string   "content_id"
+    t.string   "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170307151842) do
+ActiveRecord::Schema.define(version: 20170314110425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,13 @@ ActiveRecord::Schema.define(version: 20170307151842) do
   create_table "content_items_organisations", id: false, force: :cascade do |t|
     t.integer "content_item_id", null: false
     t.integer "organisation_id", null: false
+  end
+
+  create_table "content_items_taxonomies", id: false, force: :cascade do |t|
+    t.integer "content_item_id", null: false
+    t.integer "taxonomy_id",     null: false
+    t.index ["content_item_id"], name: "index_content_items_taxonomies_on_content_item_id", using: :btree
+    t.index ["taxonomy_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true, using: :btree
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/doc/importing_data.md
+++ b/doc/importing_data.md
@@ -8,6 +8,12 @@
 $ rake import:all_organisations
 ```
 
+* To import all taxonomies:
+
+```bash
+$ rake import:all_taxons
+```
+
 * To create or update the content items for an existing organisation:
 
 ```bash
@@ -39,6 +45,7 @@ There is a Jenkins job, `Run rake task` that can be used to import data.
   * MACHINE_CLASS: `backend`
   * RAKE_TASK:
      * `import:all_organisations`
+     * `import:all_taxons`
      * `import:content_items_by_organisation[{department-slug}]`
      * `import:all_content_items`
      * `import:number_of_views_by_organisation[{department-slug}]`

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -16,6 +16,11 @@ namespace :import do
     Importers::AllContentItems.new.run
   end
 
+  desc 'Import all taxons (without content items)'
+  task all_taxons: :environment do
+    Importers::AllTaxons.new.run
+  end
+
   desc 'Update the number of page views for all content items belonging to an organisation'
   task :number_of_views_by_organisation, [:slug] => :environment do |_, args|
     raise 'Missing slug parameter' unless args.slug

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe ContentItemsController, type: :controller do
         expect(assigns(:content_item)).to eq(organisation.content_items.first)
       end
 
+      it "decorates the content item" do
+        expect(assigns(:content_item)).to be_decorated
+      end
+
       it "renders the :show template" do
         expect(subject).to render_template(:show)
       end

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe ContentItemDecorator, type: :decorator do
       expect(organisation_links).to include(%{<a href=\"/content_items?organisation_slug=slug-2\">title-2</a>})
     end
   end
+
+  describe "#list_taxons" do
+    let(:taxonomies) { [build(:taxonomy, title: 'taxon 1'), build(:taxonomy, title: 'taxon 2')] }
+    let(:content_item) { build(:content_item, taxonomies: taxonomies).decorate }
+
+    it "returns a string of taxons separated by a comma" do
+      taxons = content_item.taxons_as_string
+      expect(taxons).to eq("taxon 1, taxon 2")
+    end
+  end
 end

--- a/spec/factories/taxonomies_factory.rb
+++ b/spec/factories/taxonomies_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :taxonomy do
+    sequence(:content_id) { |index| "content-id-#{index}" }
+    sequence(:title) { |index| "title-#{index}" }
+  end
+end

--- a/spec/features/importers/content_items_by_organisation_spec.rb
+++ b/spec/features/importers/content_items_by_organisation_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'rake import:content_items_by_organisation[{department-slug}]', type: :feature do
   let(:search_api_response) { { results: [{ link: '/link-1' }, { link: '/link-2' }] }.to_json }
-  let(:content_item_1) { attributes_for(:content_item, base_path: '/link-1', details: {}).to_json }
-  let(:content_item_2) { attributes_for(:content_item, base_path: '/link-2', details: {}).to_json }
+  let(:content_item_1) { attributes_for(:content_item, base_path: '/link-1', details: {}, links: {}).to_json }
+  let(:content_item_2) { attributes_for(:content_item, base_path: '/link-2', details: {}, links: {}).to_json }
 
   before do
     Rake::Task['import:content_items_by_organisation'].reenable
@@ -24,7 +24,7 @@ RSpec.feature 'rake import:content_items_by_organisation[{department-slug}]', ty
   end
 
   it 'saves the content item attributes' do
-    content_item_1 = attributes_for(:content_item, base_path: '/link-1', title: 'new-title').to_json
+    content_item_1 = attributes_for(:content_item, base_path: '/link-1', title: 'new-title', links: {}).to_json
     stub_request(:get, %r{.*}).to_return([
       { status: 200, body:  search_api_response },
       { status: 200, body:  content_item_1 }

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe 'Import organisation rake task' do
     end
   end
 
+  describe 'import:all_taxons' do
+    before do
+      Rake::Task['import:all_taxons'].reenable
+    end
+
+    it 'runs the process to import all taxons' do
+      expect_any_instance_of(Importers::AllTaxons).to receive(:run)
+
+      Rake::Task['import:all_taxons'].invoke
+    end
+  end
+
   describe 'import:number_of_views_by_organisation' do
     before do
       Rake::Task['import:number_of_views_by_organisation'].reenable

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ContentItem, type: :model do
   it { should have_and_belong_to_many(:organisations) }
 
+  it { should have_and_belong_to_many(:taxonomies) }
+
   describe "#url" do
     it "returns a url to a content item on gov.uk" do
       content_item = build(:content_item, base_path: "/api/content/item/path/1")

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -13,35 +13,92 @@ RSpec.describe ContentItem, type: :model do
   end
 
   describe "#create_or_update" do
-    let(:content_item_1) { { content_id: "first_id" } }
-    let(:content_item_2) { { content_id: "second_id" } }
-    let(:organisation) { build(:organisation, slug: "the-organisation") }
-
-    before do
-      create(:content_item, content_id: "first_id", title: "the title")
-    end
-
     it "creates a content item if it does not exist" do
-      expect { ContentItem.create_or_update!(content_item_2, organisation) }.to change { ContentItem.count }.by(1)
+      content_item = { content_id: "second_id", taxons: [] }
+      organisation = build(:organisation, slug: "the-organisation")
+      expect { ContentItem.create_or_update!(content_item, organisation) }.to change { ContentItem.count }.by(1)
     end
 
     it "updates a content item if it already exists" do
-      content_item_1[:title] = "a new title"
+      create(:content_item, content_id: "the_id", title: "the title")
+      organisation = build(:organisation, slug: "the-organisation")
 
-      expect { ContentItem.create_or_update!(content_item_1, organisation) }.to change { ContentItem.count }.by(0)
-      expect(ContentItem.find_by(content_id: "first_id").title).to eq("a new title")
+      content_item = { content_id: "the_id", title: "a new title", taxons: [] }
+
+      expect { ContentItem.create_or_update!(content_item, organisation) }.to change { ContentItem.count }.by(0)
+      expect(ContentItem.find_by(content_id: "the_id").title).to eq("a new title")
     end
 
     it "creates a content item when the content item has attributes that don't exist on the model" do
-      content_item_with_extra = { content_id: "with_extra", extra: "an extra attribute" }
+      content_item = { content_id: "the_id", extra_attr: "extra", taxons: [] }
+      organisation = build(:organisation, slug: "the-organisation")
 
-      expect { ContentItem.create_or_update!(content_item_with_extra, organisation) }.to change { ContentItem.count }.by(1)
+      expect { ContentItem.create_or_update!(content_item, organisation) }.to change { ContentItem.count }.by(1)
     end
 
     it "adds the organisation to the content item" do
-      ContentItem.create_or_update!(content_item_2, organisation)
-      organisations = ContentItem.find_by(content_id: "second_id").organisations
+      content_item = { content_id: "the_id", taxons: [] }
+      organisation = build(:organisation, slug: "the-organisation")
+
+      ContentItem.create_or_update!(content_item, organisation)
+
+      organisations = ContentItem.find_by(content_id: "the_id").organisations
       expect(organisations).to eq([organisation])
+    end
+
+    it "adds the taxonomies to the content item" do
+      create(:taxonomy, content_id: "taxon_1")
+      create(:taxonomy, content_id: "taxon_2")
+      content_item = { content_id: "the_id", taxons: %w(taxon_1 taxon_2) }
+      organisation = build(:organisation, slug: "the-organisation")
+
+      ContentItem.create_or_update!(content_item, organisation)
+
+      taxonomies = ContentItem.find_by(content_id: "the_id").taxonomies
+      expect(taxonomies.count).to eq(2)
+    end
+  end
+
+  describe "#add_organisation" do
+    it "adds an organisation to the content item" do
+      organisation = build(:organisation, slug: "the-organisation")
+      content_item = create(:content_item, content_id: "the_id", title: "the title")
+
+      content_item.add_organisation(organisation)
+
+      expect(content_item.organisations.count).to eq(1)
+    end
+
+    it "does not add an organisation that is already associated with the content item" do
+      organisation = build(:organisation, slug: "the-organisation")
+      content_item = create(:content_item, content_id: "the_id", title: "the title")
+      content_item.organisations << organisation
+
+      content_item.add_organisation(organisation)
+
+      expect(content_item.organisations.count).to eq(1)
+    end
+  end
+
+  describe "#add_taxonomies" do
+    it "adds taxonomies to the content item by taxon content_id" do
+      content_item = create(:content_item, content_id: "the_id", title: "the title")
+      create(:taxonomy, content_id: "taxon_1")
+      create(:taxonomy, content_id: "taxon_2")
+
+      content_item.add_taxonomies(%w(taxon_1 taxon_2))
+
+      expect(content_item.taxonomies.count).to eq(2)
+    end
+
+    it "does not add taxonomies already associated with the content item" do
+      content_item = create(:content_item, content_id: "the_id", title: "the title")
+      taxon = create(:taxonomy, content_id: "taxon_1")
+      content_item.taxonomies << taxon
+
+      content_item.add_taxonomies(%w(taxon_1))
+
+      expect(content_item.taxonomies.count).to eq(1)
     end
   end
 end

--- a/spec/models/importers/all_taxons_spec.rb
+++ b/spec/models/importers/all_taxons_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Importers::AllTaxons do
       attrs1 = { content_id: 'a-content-item_-1', title: 'a-title-1' }
       attrs2 = { content_id: 'a-content-item_-2', title: 'a-title-2' }
       subject.taxonomies_service = double
-      
+
       allow(subject.taxonomies_service).to receive(:find_each).and_yield(attrs1).and_yield(attrs2)
 
       expect { subject.run }.to change { Taxonomy.count }.by(2)
@@ -20,7 +20,7 @@ RSpec.describe Importers::AllTaxons do
         subject.taxonomies_service = double
 
         allow(subject.taxonomies_service).to receive(:find_each).and_yield(attrs1)
-        
+
         subject.run
 
         taxon = Taxonomy.find_by(content_id: 'a-content-id-1')

--- a/spec/models/importers/all_taxons_spec.rb
+++ b/spec/models/importers/all_taxons_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Importers::AllTaxons do
+  describe '#run' do
+    it 'import all taxons'
+  end
+end

--- a/spec/models/importers/all_taxons_spec.rb
+++ b/spec/models/importers/all_taxons_spec.rb
@@ -2,6 +2,30 @@ require 'rails_helper'
 
 RSpec.describe Importers::AllTaxons do
   describe '#run' do
-    it 'import all taxons'
+    it 'creates a new Taxonomy if not present' do
+      attrs1 = { content_id: 'a-content-item_-1', title: 'a-title-1' }
+      attrs2 = { content_id: 'a-content-item_-2', title: 'a-title-2' }
+      subject.taxonomies_service = double
+      
+      allow(subject.taxonomies_service).to receive(:find_each).and_yield(attrs1).and_yield(attrs2)
+
+      expect { subject.run }.to change { Taxonomy.count }.by(2)
+    end
+
+    context 'when the taxonomy exists' do
+      before { create :taxonomy, title: 'old-title' }
+
+      it 'updates the attributes' do
+        attrs1 = { content_id: 'a-content-id-1', title: 'a-title-1' }
+        subject.taxonomies_service = double
+
+        allow(subject.taxonomies_service).to receive(:find_each).and_yield(attrs1)
+        
+        subject.run
+
+        taxon = Taxonomy.find_by(content_id: 'a-content-id-1')
+        expect(taxon.title).to eq('a-title-1')
+      end
+    end
   end
 end

--- a/spec/models/importers/content_items_by_organisation_spec.rb
+++ b/spec/models/importers/content_items_by_organisation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Importers::ContentItemsByOrganisation do
     it 'update the metrics of the content item' do
       subject.metric_builder = double(run_all: { number_of_pdfs: 10 })
       subject.content_items_service = double
-      attrs1 = { content_id: 'the-content-id' }
+      attrs1 = { content_id: 'the-content-id', taxons: [] }
       allow(subject.content_items_service).to receive(:find_each).with('the-slug').and_yield(attrs1)
 
       subject.run('the-slug')
@@ -19,8 +19,8 @@ RSpec.describe Importers::ContentItemsByOrganisation do
     it 'creates a new content item and updates an existing one in the same import' do
       subject.metric_builder = double(run_all: {})
       subject.content_items_service = double
-      attrs1 = { content_id: 'the-content-id' }
-      attrs2 = { content_id: 'the-content-id2' }
+      attrs1 = { content_id: 'the-content-id', taxons: [] }
+      attrs2 = { content_id: 'the-content-id2', taxons: [] }
       allow(subject.content_items_service).to receive(:find_each).with('the-slug').and_yield(attrs1).and_yield(attrs2)
 
       expect { subject.run('the-slug') }.to change { ContentItem.count }.by(1)

--- a/spec/models/taxonomy_spec.rb
+++ b/spec/models/taxonomy_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy, type: :model do
+  it { should have_and_belong_to_many(:content_items) }
+end

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Clients::PublishingAPI do
+  subject { Clients::PublishingAPI.new }
+
+  it "loops through paged results from the gds publishing api" do
+    subject.publishing_api = double
+    page_1 = { "results" => [], "pages" => 2, "current_page" => 1 }
+    page_2 = { "results" => [], "pages" => 2, "current_page" => 2 }
+
+    expect(subject.publishing_api).to receive(:get_content_items).exactly(2).times.and_return(page_1, page_2)
+
+    subject.find_each([]) {}
+  end
+
+  it "yields the taxon fields that were requested" do
+    yielded = []
+    subject.publishing_api = double
+    results = { "results" => ["content_id" => "an_id", "another" => "field"], "pages" => 1, "current_page" => 1 }
+    allow(subject.publishing_api).to receive(:get_content_items).and_return(results)
+
+    subject.find_each(%i(content_id)) { |x| yielded << x }
+
+    expect(yielded).to eq([{ content_id: "an_id" }])
+  end
+end

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe ContentItemsService do
     it 'yields the response' do
       result = []
       allow(Clients::SearchAPI).to receive(:find_each).and_yield(link: :link1)
-      allow(Clients::ContentStore).to receive(:find).and_return(:a)
+      allow(Clients::ContentStore).to receive(:find).and_return({})
       subject.find_each('organisation-slug') { |value| result << value }
 
-      expect(result).to match_array([:a])
+      expect(result).to match_array([{ taxons: [] }])
     end
 
     it "does not yield nil responses from the content store" do

--- a/spec/services/taxonomies_service_spec.rb
+++ b/spec/services/taxonomies_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe TaxonomiesService do
+  describe '#find_each' do
+    it 'queries the publishing API for the given fields' do
+      subject.publishing_api = double
+      expected_params = %i(content_id title)
+
+      expect(subject.publishing_api).to receive(:find_each).with(expected_params)
+
+      subject.find_each {}
+    end
+  end
+end

--- a/spec/services/taxonomy_parser_spec.rb
+++ b/spec/services/taxonomy_parser_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe TaxonomyParser do
+  describe "#parse" do
+    it 'returns an array of taxons ID' do
+      content_item = {
+        links: {
+          taxons: [{ content_id: 1 }, { content_id: 2 }]
+        }
+      }
+      taxons = TaxonomyParser.parse(content_item)
+      expect(taxons.length).to eq(2)
+    end
+
+    it 'returns an empty array when no taxons are present' do
+      content_item = { links: {} }
+      taxons = TaxonomyParser.parse(content_item)
+      expect(taxons.length).to eq(0)
+    end
+
+    it 'returns an empty array when no links are present' do
+      content_item = {}
+      taxons = TaxonomyParser.parse(content_item)
+      expect(taxons.length).to eq(0)
+    end
+  end
+end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'content_items/show.html.erb', type: :view do
   let(:content_item) { build(:content_item).decorate }
   let(:organisation) { build(:organisation) }
+  let(:taxonomy) { build(:taxonomy, title: "taxon title") }
 
   before do
     assign(:content_item, content_item)
@@ -73,6 +74,14 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
 
     expect(rendered).to have_selector('td', text: 'Number of pdfs')
     expect(rendered).to have_selector('td + td', text: 10)
+  end
+
+  it 'renders the taxonomies' do
+    content_item.taxonomies = [taxonomy]
+    render
+
+    expect(rendered).to have_selector('td', text: 'Taxonomies')
+    expect(rendered).to have_selector('td + td', text: "taxon title")
   end
 
   context "content items belong to multiple organisations" do


### PR DESCRIPTION
### Trello
[https://trello.com/c/pdFxztlt/150-8-show-the-taxonomies-of-a-content-item](https://trello.com/c/pdFxztlt/150-8-show-the-taxonomies-of-a-content-item)

### Motivation
As a Content Designer I want to see the taxonomies tagged to a Content Item in the details page so I know how a Content Item is tagged within GOV.UK

### Description
This PR adds a few key things:

* `rake` task to import all taxonomies known to the publishing api
* Many 2 many relationship of `ContentItem` 2 `Taxonomy`
* Update to the creation of content items to add taxonomies to them
* Render content item taxonomies in the content item detail view

**Note: only "education" as a theme has had taxonomies created for it, so to see this new info view content items filtered by "Department of Education"**

### Before
<img width="1167" alt="screen shot 2017-03-09 at 17 33 39" src="https://cloud.githubusercontent.com/assets/6338228/23763117/5352578e-04f0-11e7-946f-910b84df56bc.png">

### After
<img width="1165" alt="screen shot 2017-03-09 at 17 32 34" src="https://cloud.githubusercontent.com/assets/6338228/23763114/519f6bde-04f0-11e7-991e-0a8dec996136.png">



