### PR TITLE
Remove RSpec deprecation when using `stub`

### DIFF
--- a/spec/decorators/content_items_decorator_spec.rb
+++ b/spec/decorators/content_items_decorator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ContentItemsDecorator, type: :decorator do
 
   context 'without organisation' do
     it 'renders the default page title' do
-      helpers.stub(params: {})
+      allow(helpers).to receive(:params).and_return({})
       content_items = [build(:content_item)]
       subject = ContentItemsDecorator.new(content_items)
 
@@ -17,7 +17,7 @@ RSpec.describe ContentItemsDecorator, type: :decorator do
     let(:organisation) { create(:organisation, title: 'Organisation title', slug: 'the-slug') }
 
     it 'renders the organisation title as page title' do
-      helpers.stub(params: { organisation_slug: 'the-slug' })
+      allow(helpers).to receive(:params).and_return(organisation_slug: 'the-slug')
       content_items = [build(:content_item, organisations: [organisation])]
       subject = ContentItemsDecorator.new(content_items)
 


### PR DESCRIPTION
Removes the following deprecation warning:

```terminal
Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling
the syntax is deprecated. Use the new `:expect` syntax or explicitly enable
`:should` instead. Called from /spec/decorators/content_items_decorator_spec.rb:20:
in `block (3 levels) in <top (required)>'.
```