### PR TITLE
Add 1 month and 6 months UPVs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Use delayed_job as backend for ActiveJob
+gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
+    delayed_job (4.1.2)
+      activesupport (>= 3.0, < 5.1)
+    delayed_job_active_record (4.1.1)
+      activerecord (>= 3.0, < 5.1)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
@@ -356,6 +361,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  delayed_job_active_record
   draper (= 3.0.0.pre1)
   factory_girl_rails
   gds-api-adapters (~> 38.1.0)

--- a/app/jobs/import_pageviews_job.rb
+++ b/app/jobs/import_pageviews_job.rb
@@ -1,0 +1,20 @@
+class ImportPageviewsJob < ApplicationJob
+  queue_as :default
+  attr_accessor :google_analytics_service
+
+  def initialize(*)
+    super
+    self.google_analytics_service = GoogleAnalyticsService.new
+  end
+
+  def perform(*args)
+    content_items = args[0]
+    base_paths = content_items.pluck(:base_path)
+
+    results = google_analytics_service.page_views(base_paths)
+    results.each do |result|
+      content_item = ContentItem.find_by(base_path: result[:base_path])
+      content_item.update!(result.slice(:one_month_page_views, :six_months_page_views))
+    end
+  end
+end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -1,19 +1,16 @@
 module Importers
   class NumberOfViewsByOrganisation
-    BATCH_SIZE = 3000
+    attr_accessor :batch_size
+
+    def initialize
+      self.batch_size = 500
+    end
 
     def run(slug)
       organisation = Organisation.find_by(slug: slug)
-      google_analytics_service = GoogleAnalyticsService.new
 
-      organisation.content_items.find_in_batches(batch_size: BATCH_SIZE) do |content_items|
-        base_paths = content_items.pluck(:base_path)
-
-        results = google_analytics_service.page_views(base_paths)
-        results.each do |result|
-          content_item = ContentItem.find_by(base_path: result[:base_path])
-          content_item.update!(one_month_page_views: result[:page_views][:one_month])
-        end
+      organisation.content_items.find_in_batches(batch_size: batch_size) do |content_items|
+        ImportPageviewsJob.perform_later(content_items)
       end
     end
   end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -12,7 +12,7 @@ module Importers
         results = google_analytics_service.page_views(base_paths)
         results.each do |result|
           content_item = ContentItem.find_by(base_path: result[:base_path])
-          content_item.update!(unique_page_views: result[:page_views])
+          content_item.update!(unique_page_views: result[:page_views][:one_month])
         end
       end
     end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -12,7 +12,7 @@ module Importers
         results = google_analytics_service.page_views(base_paths)
         results.each do |result|
           content_item = ContentItem.find_by(base_path: result[:base_path])
-          content_item.update!(unique_page_views: result[:page_views][:one_month])
+          content_item.update!(one_month_page_views: result[:page_views][:one_month])
         end
       end
     end

--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -6,15 +6,16 @@ module GoogleAnalytics
     class PageViewsRequest
       include Google::Apis::AnalyticsreportingV4
 
-      def build(base_paths, start_dates: ["7daysAgo"], end_date: "today")
+      def build(args = {})
+        end_date = args[:end_date] || "today"
         GetReportsRequest.new.tap do |reports|
           reports.report_requests = Array.new.push(
             ReportRequest.new.tap do |request|
               request.metrics = metrics(unique_page_views)
               request.view_id = view_id
-              request.dimension_filter_clauses = filters(base_paths, page_path)
+              request.dimension_filter_clauses = filters(args[:base_paths], page_path)
               request.dimensions = dimensions(page_path)
-              request.date_ranges = date_ranges(start_dates, end_date)
+              request.date_ranges = date_ranges(args[:start_dates], end_date)
             end
           )
         end

--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -6,7 +6,7 @@ module GoogleAnalytics
     class PageViewsRequest
       include Google::Apis::AnalyticsreportingV4
 
-      def build(base_paths, start_date: "7daysAgo", end_date: "today")
+      def build(base_paths, start_dates: ["7daysAgo"], end_date: "today")
         GetReportsRequest.new.tap do |reports|
           reports.report_requests = Array.new.push(
             ReportRequest.new.tap do |request|
@@ -14,7 +14,7 @@ module GoogleAnalytics
               request.view_id = view_id
               request.dimension_filter_clauses = filters(base_paths, page_path)
               request.dimensions = dimensions(page_path)
-              request.date_ranges = date_ranges(start_date, end_date)
+              request.date_ranges = date_ranges(start_dates, end_date)
             end
           )
         end
@@ -22,11 +22,14 @@ module GoogleAnalytics
 
     private
 
-      def date_ranges(start_date, end_date)
-        date_range = DateRange.new
-        date_range.start_date = start_date
-        date_range.end_date = end_date
-        [date_range]
+      def date_ranges(start_dates, end_date)
+        date_ranges = start_dates.map do |start_date|
+          date_range = DateRange.new
+          date_range.start_date = start_date
+          date_range.end_date = end_date
+          date_range
+        end
+        date_ranges
       end
 
       def dimensions(name)

--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -12,7 +12,8 @@ module GoogleAnalytics
           {
             base_path: row.dimensions.first,
             page_views: {
-              one_month: row.metrics.first.values.first.to_i
+              one_month: row.metrics.first.values.first.to_i,
+              six_months: row.metrics.second.values.first.to_i
             },
           }
         end

--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -11,10 +11,8 @@ module GoogleAnalytics
         report.data.rows.map do |row|
           {
             base_path: row.dimensions.first,
-            page_views: {
-              one_month: row.metrics.first.values.first.to_i,
-              six_months: row.metrics.second.values.first.to_i
-            },
+            one_month_page_views: row.metrics.first.values.first.to_i,
+            six_months_page_views: row.metrics.second.values.first.to_i
           }
         end
       end

--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -11,7 +11,9 @@ module GoogleAnalytics
         report.data.rows.map do |row|
           {
             base_path: row.dimensions.first,
-            page_views: row.metrics.first.values.first.to_i
+            page_views: {
+              one_month: row.metrics.first.values.first.to_i
+            },
           }
         end
       end

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -8,7 +8,7 @@ class GoogleAnalyticsService
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
       base_paths,
-      start_dates: [1.month.ago.strftime("%Y-%m-%d")]
+      start_dates: [1.month.ago.strftime("%Y-%m-%d"), 6.months.ago.strftime("%Y-%m-%d")]
     )
     response = client.batch_get_reports(request)
     GoogleAnalytics::Responses::PageViewsResponse.new.parse(response)

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -8,7 +8,7 @@ class GoogleAnalyticsService
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
       base_paths,
-      start_date: 1.month.ago.strftime("%Y-%m-%d")
+      start_dates: [1.month.ago.strftime("%Y-%m-%d")]
     )
     response = client.batch_get_reports(request)
     GoogleAnalytics::Responses::PageViewsResponse.new.parse(response)

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -7,7 +7,7 @@ class GoogleAnalyticsService
     raise "base_paths isn't an array" unless base_paths.is_a?(Array)
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
-      base_paths,
+      base_paths: base_paths,
       start_dates: [1.month.ago.strftime("%Y-%m-%d"), 6.months.ago.strftime("%Y-%m-%d")]
     )
     response = client.batch_get_reports(request)

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -6,7 +6,7 @@
     </td>
   <% end %>
   <td><%= content_item.document_type %></td>
-  <td><%= content_item.unique_page_views %></td>
+  <td><%= content_item.one_month_page_views %></td>
   <td>
     <% if content_item.public_updated_at %>
       <%= time_ago_in_words(content_item.public_updated_at) %> ago

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -7,6 +7,7 @@
   <% end %>
   <td><%= content_item.document_type %></td>
   <td><%= content_item.one_month_page_views %></td>
+  <td><%= content_item.six_months_page_views %></td>
   <td>
     <% if content_item.public_updated_at %>
       <%= time_ago_in_words(content_item.public_updated_at) %> ago

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -21,7 +21,7 @@
         <th>Organisation</th>
       <% end %>
       <%= sort_table_header "Type of Document", "document_type" %>
-      <%= sort_table_header "Unique page views (last 1 month)", "unique_page_views" %>
+      <%= sort_table_header "Unique page views (last 1 month)", "one_month_page_views" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>
     </tr>
   </thead>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -22,6 +22,7 @@
       <% end %>
       <%= sort_table_header "Type of Document", "document_type" %>
       <%= sort_table_header "Unique page views (last 1 month)", "one_month_page_views" %>
+      <%= sort_table_header "Unique page views (last 6 months)", "six_months_page_views" %>
       <%= sort_table_header "Last Updated", "public_updated_at" %>
     </tr>
   </thead>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -25,6 +25,10 @@
       <td><%= @content_item.one_month_page_views %></td>
     </tr>
     <tr>
+      <td>Unique page views (last 6 months)</td>
+      <td><%= @content_item.six_months_page_views %></td>
+    </tr>
+    <tr>
       <td>Last updated</td>
       <td>
         <%= @content_item.last_updated %>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -22,7 +22,7 @@
     </tr>
     <tr>
       <td>Unique page views (last 1 month)</td>
-      <td><%= @content_item.unique_page_views %></td>
+      <td><%= @content_item.one_month_page_views %></td>
     </tr>
     <tr>
       <td>Last updated</td>

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,6 @@ module ContentPerformanceManager
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/db/migrate/20170301154536_rename_page_views_to_one_month_page_views.rb
+++ b/db/migrate/20170301154536_rename_page_views_to_one_month_page_views.rb
@@ -1,0 +1,5 @@
+class RenamePageViewsToOneMonthPageViews < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :content_items, :unique_page_views, :one_month_page_views
+  end
+end

--- a/db/migrate/20170301165728_add_six_months_column.rb
+++ b/db/migrate/20170301165728_add_six_months_column.rb
@@ -1,0 +1,5 @@
+class AddSixMonthsColumn < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :six_months_page_views, :integer, default: 0
+  end
+end

--- a/db/migrate/20170308165623_create_delayed_jobs.rb
+++ b/db/migrate/20170308165623_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,14 +17,15 @@ ActiveRecord::Schema.define(version: 20170314110425) do
 
   create_table "content_items", force: :cascade do |t|
     t.string   "content_id"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.datetime "public_updated_at"
     t.string   "base_path"
     t.string   "title"
     t.string   "document_type"
     t.string   "description"
-    t.integer  "one_month_page_views", default: 0
+    t.integer  "one_month_page_views",  default: 0
+    t.integer  "six_months_page_views", default: 0
     t.integer  "number_of_pdfs",    default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["title"], name: "index_content_items_on_title", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,21 @@ ActiveRecord::Schema.define(version: 20170314110425) do
     t.index ["taxonomy_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true, using: :btree
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+  end
+
   create_table "organisations", force: :cascade do |t|
     t.string   "slug"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,14 +17,14 @@ ActiveRecord::Schema.define(version: 20170314110425) do
 
   create_table "content_items", force: :cascade do |t|
     t.string   "content_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.datetime "public_updated_at"
     t.string   "base_path"
     t.string   "title"
     t.string   "document_type"
     t.string   "description"
-    t.integer  "unique_page_views", default: 0
+    t.integer  "one_month_page_views", default: 0
     t.integer  "number_of_pdfs",    default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["title"], name: "index_content_items_on_title", using: :btree

--- a/spec/factories/google_analytics/page_views_response_factory.rb
+++ b/spec/factories/google_analytics/page_views_response_factory.rb
@@ -14,7 +14,7 @@ module GoogleAnalytics
                     metrics: [
                       Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
                         values: [
-                          response.fetch(:page_views)
+                          response.fetch(:page_views, {}).fetch(:one_month, nil)
                         ]
                       )
                     ]

--- a/spec/factories/google_analytics/page_views_response_factory.rb
+++ b/spec/factories/google_analytics/page_views_response_factory.rb
@@ -16,6 +16,11 @@ module GoogleAnalytics
                         values: [
                           response.fetch(:page_views, {}).fetch(:one_month, nil)
                         ]
+                      ),
+                      Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
+                        values: [
+                          response.fetch(:page_views, {}).fetch(:six_months, nil)
+                        ]
                       )
                     ]
                   )

--- a/spec/factories/google_analytics/page_views_response_factory.rb
+++ b/spec/factories/google_analytics/page_views_response_factory.rb
@@ -14,12 +14,12 @@ module GoogleAnalytics
                     metrics: [
                       Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
                         values: [
-                          response.fetch(:page_views, {}).fetch(:one_month, nil)
+                          response.fetch(:one_month_page_views)
                         ]
                       ),
                       Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
                         values: [
-                          response.fetch(:page_views, {}).fetch(:six_months, nil)
+                          response.fetch(:six_months_page_views)
                         ]
                       )
                     ]

--- a/spec/jobs/import_pageviews_job_spec.rb
+++ b/spec/jobs/import_pageviews_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ImportPageviewsJob, type: :job do
+  it "updates the content items with pageviews" do
+    content_item = create(:content_item, base_path: '/the-base-path')
+    service = double(:google_analytics_service)
+    allow(service).to receive(:page_views).with(['/the-base-path']).and_return(
+      [
+        {
+          base_path: '/the-base-path',
+          one_month_page_views: 88,
+          six_months_page_views: 888
+        }
+      ]
+    )
+    subject.google_analytics_service = service
+
+    subject.perform([content_item])
+
+    content_item.reload
+    expect(content_item.one_month_page_views).to eq(88)
+    expect(content_item.six_months_page_views).to eq(888)
+  end
+end

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -11,11 +11,15 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
         [
           {
             base_path: 'the-link/first',
-            page_views: 3,
+            page_views: {
+              one_month: 3,
+            },
           },
           {
             base_path: 'the-link/second',
-            page_views: 2,
+            page_views: {
+              one_month: 2,
+            },
           },
         ]
       )

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -1,56 +1,25 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Importers::NumberOfViewsByOrganisation do
-  describe '#run' do
-    let!(:organisation) { create(:organisation, slug: 'the-slug') }
-    let!(:content_item_first) { create(:content_item, base_path: 'the-link/first', organisations: [organisation]) }
-    let!(:content_item_second) { create(:content_item, base_path: 'the-link/second', organisations: [organisation]) }
+  describe "#run" do
+    let(:organisation) { create(:organisation, slug: "the-slug") }
 
-    it "updates the number of views for all content items" do
-      allow_any_instance_of(GoogleAnalyticsService).to receive(:page_views).and_return(
-        [
-          {
-            base_path: 'the-link/first',
-            page_views: {
-              one_month: 3,
-            },
-          },
-          {
-            base_path: 'the-link/second',
-            page_views: {
-              one_month: 2,
-            },
-          },
-        ]
-      )
+    it "creates a job to import pageviews for content items" do
+      content_items = [create(:content_item)]
+      organisation.content_items << content_items
 
-      stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 1)
+      expect(ImportPageviewsJob).to receive(:perform_later).with(content_items)
 
-      subject.run('the-slug')
-
-      content_item_one = ContentItem.find_by(base_path: 'the-link/first')
-      content_item_two = ContentItem.find_by(base_path: 'the-link/second')
-
-      expect(content_item_one.one_month_page_views).to eq(3)
-      expect(content_item_two.one_month_page_views).to eq(2)
+      subject.run("the-slug")
     end
 
-    context "performs the request to google api in batches" do
-      it "makes two requests when the batch size is one" do
-        expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).twice.and_return([])
+    it "creates a job per batch of content items" do
+      organisation.content_items << create_list(:content_item, 2)
+      subject.batch_size = 1
 
-        stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 1)
+      expect(ImportPageviewsJob).to receive(:perform_later).twice
 
-        subject.run('the-slug')
-      end
-
-      it "makes one request when the batch size is two" do
-        expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).once.and_return([])
-
-        stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 2)
-
-        subject.run('the-slug')
-      end
+      subject.run("the-slug")
     end
   end
 end

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
       content_item_one = ContentItem.find_by(base_path: 'the-link/first')
       content_item_two = ContentItem.find_by(base_path: 'the-link/second')
 
-      expect(content_item_one.unique_page_views).to eq(3)
-      expect(content_item_two.unique_page_views).to eq(2)
+      expect(content_item_one.one_month_page_views).to eq(3)
+      expect(content_item_two.one_month_page_views).to eq(2)
     end
 
     context "performs the request to google api in batches" do

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -63,7 +63,7 @@ module GoogleAnalytics
 
           request = PageViewsRequest.new.build(
             ["/check-uk-visa"],
-            start_date: "2016/11/22",
+            start_dates: ["2016/11/22"],
             end_date: "2016/12/22")
 
           expect(request.as_json).to include(page_views_request)

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -50,21 +50,16 @@ module GoogleAnalytics
           }.deep_stringify_keys!
         end
 
-        it "builds the requests body with default arguments" do
-          request = PageViewsRequest.new.build(["/check-uk-visa"])
-
-          expect(request.as_json).to include(page_views_request)
-        end
-
         it "builds the requests body with supplied arguments" do
           date_range = page_views_request["report_requests"][0]["date_ranges"][0]
           date_range["start_date"] = "2016/11/22"
           date_range["end_date"] = "2016/12/22"
 
           request = PageViewsRequest.new.build(
-            ["/check-uk-visa"],
+            base_paths: ["/check-uk-visa"],
             start_dates: ["2016/11/22"],
-            end_date: "2016/12/22")
+            end_date: "2016/12/22"
+            )
 
           expect(request.as_json).to include(page_views_request)
         end

--- a/spec/services/google_analytics/responses/page_views_response_spec.rb
+++ b/spec/services/google_analytics/responses/page_views_response_spec.rb
@@ -9,12 +9,14 @@ module GoogleAnalytics
             base_path: "/check-uk-visa",
             page_views: {
               one_month: 400,
+              six_months: 4800,
             },
           },
           {
             base_path: "/marriage-abroad",
             page_views: {
               one_month: 500,
+              six_months: 6000,
             },
           }
         ])
@@ -27,12 +29,14 @@ module GoogleAnalytics
             base_path: "/check-uk-visa",
             page_views: {
               one_month: 400,
+              six_months: 4800,
             },
           },
           {
             base_path: "/marriage-abroad",
             page_views: {
               one_month: 500,
+              six_months: 6000,
             },
           }
         ]

--- a/spec/services/google_analytics/responses/page_views_response_spec.rb
+++ b/spec/services/google_analytics/responses/page_views_response_spec.rb
@@ -7,17 +7,13 @@ module GoogleAnalytics
         GoogleAnalytics::PageViewsResponseFactory.build([
           {
             base_path: "/check-uk-visa",
-            page_views: {
-              one_month: 400,
-              six_months: 4800,
-            },
+            one_month_page_views: 400,
+            six_months_page_views: 4800,
           },
           {
             base_path: "/marriage-abroad",
-            page_views: {
-              one_month: 500,
-              six_months: 6000,
-            },
+            one_month_page_views: 500,
+            six_months_page_views: 6000,
           }
         ])
       end
@@ -27,17 +23,13 @@ module GoogleAnalytics
         expected_response = [
           {
             base_path: "/check-uk-visa",
-            page_views: {
-              one_month: 400,
-              six_months: 4800,
-            },
+            one_month_page_views: 400,
+            six_months_page_views: 4800,
           },
           {
             base_path: "/marriage-abroad",
-            page_views: {
-              one_month: 500,
-              six_months: 6000,
-            },
+            one_month_page_views: 500,
+            six_months_page_views: 6000,
           }
         ]
 

--- a/spec/services/google_analytics/responses/page_views_response_spec.rb
+++ b/spec/services/google_analytics/responses/page_views_response_spec.rb
@@ -7,11 +7,15 @@ module GoogleAnalytics
         GoogleAnalytics::PageViewsResponseFactory.build([
           {
             base_path: "/check-uk-visa",
-            page_views: 400
+            page_views: {
+              one_month: 400,
+            },
           },
           {
             base_path: "/marriage-abroad",
-            page_views: 500
+            page_views: {
+              one_month: 500,
+            },
           }
         ])
       end
@@ -21,11 +25,15 @@ module GoogleAnalytics
         expected_response = [
           {
             base_path: "/check-uk-visa",
-            page_views: 400
+            page_views: {
+              one_month: 400,
+            },
           },
           {
             base_path: "/marriage-abroad",
-            page_views: 500
+            page_views: {
+              one_month: 500,
+            },
           }
         ]
 

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe GoogleAnalyticsService do
         [
           {
             base_path: '/path-1',
-            page_views: {
-              one_month: 5,
-              six_months: 60,
-            },
+            one_month_page_views: 5,
+            six_months_page_views: 60,
           }
         ]
       )
@@ -31,10 +29,8 @@ RSpec.describe GoogleAnalyticsService do
       expect(response).to eq([
         {
           base_path: '/path-1',
-          page_views: {
-            one_month: 5,
-            six_months: 60,
-          },
+          one_month_page_views: 5,
+          six_months_page_views: 60,
         }
       ])
     end

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -14,14 +14,25 @@ RSpec.describe GoogleAnalyticsService do
     end
 
     it 'returns a hash containing the page views' do
-      google_response = GoogleAnalytics::PageViewsResponseFactory.build([{ base_path: '/path-1', page_views: 5 }])
+      google_response = GoogleAnalytics::PageViewsResponseFactory.build(
+        [
+          {
+            base_path: '/path-1',
+            page_views: {
+              one_month: 5,
+            },
+          }
+        ]
+      )
       allow(google_client).to receive(:batch_get_reports).and_return(google_response)
 
       response = subject.page_views(%w(/path-1))
       expect(response).to eq([
         {
           base_path: '/path-1',
-          page_views: 5
+          page_views: {
+            one_month: 5,
+          },
         }
       ])
     end

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe GoogleAnalyticsService do
             base_path: '/path-1',
             page_views: {
               one_month: 5,
+              six_months: 60,
             },
           }
         ]
@@ -32,6 +33,7 @@ RSpec.describe GoogleAnalyticsService do
           base_path: '/path-1',
           page_views: {
             one_month: 5,
+            six_months: 60,
           },
         }
       ])

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Organisation')
       expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Type of Document')
       expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Unique page views (last 1 month)')
-      expect(rendered).to have_selector('table thead tr:first-child th:nth(5)', text: 'Last Updated')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(5)', text: 'Unique page views (last 6 months)')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(6)', text: 'Last Updated')
     end
 
     it 'renders a row per Content Item' do
@@ -55,7 +56,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
         content_items[0].public_updated_at = nil
         render
 
-        expect(rendered).to have_selector('table tr td:nth(5)', text: 'Never')
+        expect(rendered).to have_selector('table tr td:nth(6)', text: 'Never')
       end
     end
 
@@ -93,7 +94,8 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
       expect(rendered).to have_selector('table thead', text: 'Title')
       expect(rendered).to have_selector('table thead tr:first-child th:nth(2)', text: 'Type of Document')
       expect(rendered).to have_selector('table thead tr:first-child th:nth(3)', text: 'Unique page views (last 1 month)')
-      expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Last Updated')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(4)', text: 'Unique page views (last 6 months)')
+      expect(rendered).to have_selector('table thead tr:first-child th:nth(5)', text: 'Last Updated')
     end
 
     it 'renders a row per Content Item' do
@@ -148,7 +150,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
           content_items[0].public_updated_at = nil
           render
 
-          expect(rendered).to have_selector('table tr td:nth(4)', text: 'Never')
+          expect(rendered).to have_selector('table tr td:nth(5)', text: 'Never')
         end
       end
     end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -42,12 +42,20 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_selector('td + td', 'text': 'guidance')
   end
 
-  it 'renders the number of views' do
+  it 'renders the number of views for one month' do
     content_item.one_month_page_views = 10
     render
 
     expect(rendered).to have_selector('td', text: 'Unique page views (last 1 month)')
     expect(rendered).to have_selector('td + td', 'text': 10)
+  end
+
+  it 'renders the number of views for six months' do
+    content_item.six_months_page_views = 20
+    render
+
+    expect(rendered).to have_selector('td', text: 'Unique page views (last 6 months)')
+    expect(rendered).to have_selector('td + td', 'text': 20)
   end
 
   it 'renders the last updated date' do
@@ -101,7 +109,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
         content_item.public_updated_at = nil
         render
 
-        expect(rendered).to have_selector('table tbody tr:nth(5) td:nth(2)', text: 'Never')
+        expect(rendered).to have_selector('table tbody tr:nth(6) td:nth(2)', text: 'Never')
       end
     end
   end

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
   end
 
   it 'renders the number of views' do
-    content_item.unique_page_views = 10
+    content_item.one_month_page_views = 10
     render
 
     expect(rendered).to have_selector('td', text: 'Unique page views (last 1 month)')


### PR DESCRIPTION
Supersedes #90

[Trello card](https://trello.com/c/jwrJjjhs)

The original story was to fetch 12 months' worth of pageviews data but this is not possible - other teams have tried and failed. We are instead able to pull in 6 months' worth adequately.

In this PR we are adding `delayed_job_active_record` to queue our batches of requests into background jobs. This helps us to avoid too many timeouts with Google Analytics, speed up the import and also handle re-trying of failed requests.

The calling of the rake task does not change. We will however need to start up a queue when we deploy the app in order for the import to work.

## Expected changes

### Before
![image](https://cloud.githubusercontent.com/assets/424772/23914654/80172e06-08de-11e7-869b-7749ab5edca9.png)
![image](https://cloud.githubusercontent.com/assets/424772/23914666/8853d614-08de-11e7-8aba-49e7f54e628a.png)


### After
![image](https://cloud.githubusercontent.com/assets/424772/23914674/9212811e-08de-11e7-99b2-8c71fd84477b.png)
![image](https://cloud.githubusercontent.com/assets/424772/23914690/9bed1122-08de-11e7-8a48-edf446c1b89c.png)

