### PR TITLE
Case insensitive search

### DIFF
--- a/app/queries/content_items_query.rb
+++ b/app/queries/content_items_query.rb
@@ -9,7 +9,7 @@ class ContentItemsQuery
                else
                  ContentItem.all
                end
-    relation = relation.where('title like ?', "%#{options[:query]}%") if options[:query].present?
+    relation = relation.where('title ilike ?', "%#{options[:query]}%") if options[:query].present?
     relation
       .order("#{options[:sort]} #{options[:order]}")
       .page(options[:page])

--- a/spec/queries/content_items_query_spec.rb
+++ b/spec/queries/content_items_query_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe ContentItemsQuery, type: :query do
       ]
     end
 
-    it "returns content_items" do
-      results = subject.build(query: 'title 1')
+    it "returns content_items case insensitively" do
+      results = subject.build(query: 'TITLE 1')
 
       expect(results.count).to eq(1)
       expect(results.first.title).to eq('title 1')


### PR DESCRIPTION
### Motivation

The first iteration of the search by title functionality was case sensitive, ideally users should not have to know the capitalisation of the content item titles to search for them.

### Description
Simple change to downcase the search term and the model field when querying.