### PR TITLE
Add Endpoints to show and create Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ In the browser navigate to: http://localhost:3206
 * [On the local environment](doc/importing_data.md#Local_environment)
 * [On GOV.UK environments](doc/importing_data.md#jenkins)
 
+### API 
+
+* [Configuration](doc/api.md#set_up_api)
+* [Samples](doc/api.md#samples)
+
 ### Deploying the application
 * [Heroku](doc/deploying.md#heroku)
 * [Integration](doc/deploying.md#integration)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,4 +4,20 @@ class GroupsController < ApplicationController
   def show
     @group = Group.find(params[:id])
   end
+
+  def create
+    @group = Group.new(group_params)
+
+    if @group.save
+      render :show, status: :created
+    else
+      render json: @group.errors, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def group_params
+    params.require(:group).permit(:slug, :name, :parent_group_slug, :group_type)
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,8 @@
 class GroupsController < ApplicationController
   protect_from_forgery unless: -> { request.format.json? }
 
+  before_action :set_parent_group, only: :create
+
   def show
     @group = Group.find(params[:id])
   end
@@ -17,7 +19,15 @@ class GroupsController < ApplicationController
 
 private
 
+  def set_parent_group
+    parent_group_slug = params[:group][:parent_group_slug]
+    if parent_group_slug
+      parent = Group.find_by(slug: parent_group_slug)
+      params[:group][:parent_group_id] = parent.id
+    end
+  end
+
   def group_params
-    params.require(:group).permit(:slug, :name, :parent_group_slug, :group_type, content_item_ids: [])
+    params.require(:group).permit(:slug, :name, :parent_group_id, :group_type, content_item_ids: [])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,7 @@
+class GroupsController < ApplicationController
+  protect_from_forgery unless: -> { request.format.json? }
+
+  def show
+    @group = Group.find(params[:id])
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,6 +18,6 @@ class GroupsController < ApplicationController
 private
 
   def group_params
-    params.require(:group).permit(:slug, :name, :parent_group_slug, :group_type)
+    params.require(:group).permit(:slug, :name, :parent_group_slug, :group_type, content_item_ids: [])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
   protect_from_forgery unless: -> { request.format.json? }
 
+  before_action :ensure_valid_token
   before_action :set_parent_group, only: :create
 
   def show
@@ -29,5 +30,11 @@ private
 
   def group_params
     params.require(:group).permit(:slug, :name, :parent_group_id, :group_type, content_item_ids: [])
+  end
+
+  def ensure_valid_token
+    expected_token = ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN']
+
+    head 401 unless expected_token.present? && expected_token == params[:api_token]
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
   before_action :set_parent_group, only: :create
 
   def show
-    @group = Group.find(params[:id])
+    @group = Group.find_by(slug: params[:slug])
   end
 
   def create

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,7 @@
+class Group < ApplicationRecord
+  validates :slug, uniqueness: true
+  validates :slug, :name, :group_type, presence: true
+
+  belongs_to :parent, class_name: 'Group', foreign_key: :parent_group_id, optional: true
+  has_many :children, class_name: 'Group', foreign_key: :parent_group_id
+end

--- a/app/views/groups/_group.json.jbuilder
+++ b/app/views/groups/_group.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! group, :id, :slug, :name, :group_type, :created_at, :updated_at
+json.url group_url(group, format: :json)

--- a/app/views/groups/show.json.jbuilder
+++ b/app/views/groups/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "groups/group", group: @group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
+  resources :groups, only: %w(show)
+
   resources :organisations, only: %w(index)
 
   resources :content_items, only: %w(index show) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
-  resources :groups, only: %w(show)
+  resources :groups, only: %w(show create)
 
   resources :organisations, only: %w(index)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
-  resources :groups, only: %w(show create)
+  resources :groups, only: %w(show create), param: "slug"
 
   resources :organisations, only: %w(index)
 

--- a/db/migrate/20170316110649_create_groups.rb
+++ b/db/migrate/20170316110649_create_groups.rb
@@ -1,0 +1,12 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :slug
+      t.string :name
+      t.string :group_type
+      t.integer :parent_group_id, foreign_key: true, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170318110819_add_content_ids_to_groups.rb
+++ b/db/migrate/20170318110819_add_content_ids_to_groups.rb
@@ -1,0 +1,5 @@
+class AddContentIdsToGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :groups, :content_item_ids, :text, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170314110425) do
+ActiveRecord::Schema.define(version: 20170316163752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,15 @@ ActiveRecord::Schema.define(version: 20170314110425) do
     t.integer "taxonomy_id",     null: false
     t.index ["content_item_id"], name: "index_content_items_taxonomies_on_content_item_id", using: :btree
     t.index ["taxonomy_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true, using: :btree
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string   "slug"
+    t.string   "name"
+    t.string   "group_type"
+    t.integer  "parent_group_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170316163752) do
+ActiveRecord::Schema.define(version: 20170318110819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,8 +47,9 @@ ActiveRecord::Schema.define(version: 20170316163752) do
     t.string   "name"
     t.string   "group_type"
     t.integer  "parent_group_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.text     "content_item_ids", default: [],              array: true
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,44 @@
+# Set up API
+
+To be able to use the API a few environment variables need to be set.
+
+1) Create file `config/local_env.yml` (if the file does not exist yet)
+
+2) Add an entry to `config/local_env.yml` for: `CONTENT-PERFORMANCE-MANAGER-TOKEN`
+
+e.g.
+
+```bash
+CONTENT-PERFORMANCE-MANAGER-TOKEN: "1234567"
+```
+
+Use this the token value in any API request
+
+# Samples
+
+* Create a group
+
+```terminal
+curl -X "POST" "http://content-performance-manager.dev.gov.uk/groups.json" \
+     -H "Content-Type: application/json" \
+     -d $'{
+  "group": {
+    "slug": "the-slug",
+    "group_type": "the-group-type",
+    "name": "the-name",
+    "content_item_ids": [
+      "content-id-1",
+      "content-id-2"
+    ],
+    "parent_group_slug": "firstname49"
+  },
+  "api_token": "1234567"
+}'
+```
+
+* Show a group
+
+```terminal
+curl "http://content-performance-manager.dev.gov.uk/groups/3.json?api_token=1234567" \
+     -H "Content-Type: application/json"
+```

--- a/doc/api.md
+++ b/doc/api.md
@@ -39,6 +39,6 @@ curl -X "POST" "http://content-performance-manager.dev.gov.uk/groups.json" \
 * Show a group
 
 ```terminal
-curl "http://content-performance-manager.dev.gov.uk/groups/3.json?api_token=1234567" \
+curl "http://content-performance-manager.dev.gov.uk/groups/the-slug.json?api_token=1234567" \
      -H "Content-Type: application/json"
 ```

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe GroupsController, type: :controller do
   describe "Authorisation" do
     context "When no API token is provided" do
       it "returns 401 status code" do
-        group = create :group
-        get :show, params: { id: group.to_param }, format: :json
+        create :group, slug: "the-slug"
+        get :show, params: { slug: "the-slug" }, format: :json
 
         expect(response.status).to eq(401)
       end
@@ -21,8 +21,8 @@ RSpec.describe GroupsController, type: :controller do
 
   describe "GET #show" do
     it "assigns the requested group as @group" do
-      group = create :group
-      get :show, format: :json, params: { id: group.to_param, api_token: 'a-token' }
+      group = create :group, slug: "the-slug"
+      get :show, format: :json, params: { slug: "the-slug", api_token: 'a-token' }
 
       expect(assigns(:group)).to eq(group)
     end
@@ -45,7 +45,7 @@ RSpec.describe GroupsController, type: :controller do
         expect(assigns(:group)).to be_persisted
       end
 
-      it "redirects to the created group" do
+      it "assigns :created (201) status code" do
         post :create, format: :json, params: { group: valid_attributes, api_token: 'a-token' }
         expect(response.status).to eq(201)
       end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe GroupsController, type: :controller do
+  describe "GET #show" do
+    it "assigns the requested group as @group" do
+      group = create :group
+      get :show, format: :json, params: { id: group.to_param }
+
+      expect(assigns(:group)).to eq(group)
+    end
+  end
+end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -9,4 +9,37 @@ RSpec.describe GroupsController, type: :controller do
       expect(assigns(:group)).to eq(group)
     end
   end
+
+  describe "POST #create" do
+    let(:valid_attributes) { attributes_for(:group) }
+    let(:invalid_attributes) { { name: 'a-name', group_type: 'a-type' } }
+
+    context "with valid params" do
+      it "creates a new Group" do
+        expect {
+          post :create, format: :json, params: { group: valid_attributes }
+        }.to change(Group, :count).by(1)
+      end
+
+      it "assigns a newly created group as @group" do
+        post :create, format: :json, params: { group: valid_attributes }
+        expect(assigns(:group)).to be_a(Group)
+        expect(assigns(:group)).to be_persisted
+      end
+
+      it "assigns :created (201) status code" do
+        post :create, format: :json, params: { group: valid_attributes }
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "with invalid params" do
+      it "assigns a newly created but unsaved group as @group" do
+        post :create, format: :json, params: { group: invalid_attributes }
+
+        expect(assigns(:group)).to be_a_new(Group)
+        expect(assigns(:group).errors).to_not be_empty
+      end
+    end
+  end
 end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,10 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe GroupsController, type: :controller do
+  before do
+    @old_content_performance_manager_token = ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN']
+    ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN'] = 'a-token'
+  end
+
+  after { ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN'] = @old_content_performance_manager_token }
+
+  describe "Authorisation" do
+    context "When no API token is provided" do
+      it "returns 401 status code" do
+        group = create :group
+        get :show, params: { id: group.to_param }, format: :json
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
   describe "GET #show" do
     it "assigns the requested group as @group" do
       group = create :group
-      get :show, format: :json, params: { id: group.to_param }
+      get :show, format: :json, params: { id: group.to_param, api_token: 'a-token' }
 
       expect(assigns(:group)).to eq(group)
     end
@@ -17,25 +35,25 @@ RSpec.describe GroupsController, type: :controller do
     context "with valid params" do
       it "creates a new Group" do
         expect {
-          post :create, format: :json, params: { group: valid_attributes }
+          post :create, format: :json, params: { group: valid_attributes, api_token: 'a-token' }
         }.to change(Group, :count).by(1)
       end
 
       it "assigns a newly created group as @group" do
-        post :create, format: :json, params: { group: valid_attributes }
+        post :create, format: :json, params: { group: valid_attributes, api_token: 'a-token' }
         expect(assigns(:group)).to be_a(Group)
         expect(assigns(:group)).to be_persisted
       end
 
-      it "assigns :created (201) status code" do
-        post :create, format: :json, params: { group: valid_attributes }
+      it "redirects to the created group" do
+        post :create, format: :json, params: { group: valid_attributes, api_token: 'a-token' }
         expect(response.status).to eq(201)
       end
     end
 
     context "with invalid params" do
       it "assigns a newly created but unsaved group as @group" do
-        post :create, format: :json, params: { group: invalid_attributes }
+        post :create, format: :json, params: { group: invalid_attributes, api_token: 'a-token' }
 
         expect(assigns(:group)).to be_a_new(Group)
         expect(assigns(:group).errors).to_not be_empty

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :group do
+    sequence(:slug) { |index| "slug-#{index}" }
+    sequence(:name) { |index| "name-#{index}" }
+    sequence(:group_type) { |index| "group-type-#{index}" }
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Group, type: :model do
+  it { should validate_uniqueness_of(:slug) }
+  it { should validate_presence_of(:slug) }
+  it { should validate_presence_of(:group_type) }
+  it { should validate_presence_of(:name) }
+
+  it { should have_many(:children).class_name('Group').with_foreign_key(:parent_group_id) }
+  it { should belong_to(:parent).class_name('Group') }
+end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -43,10 +43,22 @@ RSpec.describe "API::Groups", type: :request do
 
       context "when a list a content IDs is provided" do
         it "add the Content Items to the group" do
-          valid_params[:group].merge!(content_item_ids: ["content_id_1", "content_id_2"])
+          valid_params[:group][:content_item_ids] = %w(content_id_1 content_id_2)
 
           post groups_path params: valid_params, format: :json
-          expect(Group.first.content_item_ids).to eq(["content_id_1", "content_id_2"])
+          expect(Group.first.content_item_ids).to eq(%w(content_id_1 content_id_2))
+        end
+      end
+
+      context "when a parent_group is provided" do
+        it "creates an association with the parent" do
+          parent = create(:group, slug: "parent-slug")
+          valid_params[:group].merge!(parent_group_slug: "parent-slug", slug: "child-slug")
+
+          post groups_path params: valid_params, format: :json
+
+          child = Group.find_by(slug: "child-slug")
+          expect(child.parent).to eq(parent)
         end
       end
     end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe "API::Groups", type: :request do
           group_type: "the-group-type"
         )
       end
+
+      context "when a list a content IDs is provided" do
+        it "add the Content Items to the group" do
+          valid_params[:group].merge!(content_item_ids: ["content_id_1", "content_id_2"])
+
+          post groups_path params: valid_params, format: :json
+          expect(Group.first.content_item_ids).to eq(["content_id_1", "content_id_2"])
+        end
+      end
     end
 
     context "with invalid params" do

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -3,11 +3,18 @@ require 'rails_helper'
 RSpec.describe "API::Groups", type: :request do
   let(:headers) { { "ACCEPT" => "application/json" } }
 
+  before do
+    @old_content_performance_manager_token = ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN']
+    ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN'] = 'a-token'
+  end
+
+  after { ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN'] = @old_content_performance_manager_token }
+
   describe "GET /groups/{id}" do
     let!(:group) { create :group, name: "a-name", slug: "the-slug" }
 
     before do
-      get "/groups/#{group.id}", params: {}, headers: headers
+      get "/groups/#{group.id}", params: { api_token: "a-token" }, headers: headers
     end
 
     it "returns JSON with the group " do
@@ -19,7 +26,7 @@ RSpec.describe "API::Groups", type: :request do
 
   describe "POST /groups" do
     context "with valid params" do
-      let(:params) { { group: attributes_for(:group) } }
+      let(:params) { { group: attributes_for(:group), api_token: "a-token" } }
 
       it "creates the group" do
         expect {
@@ -69,7 +76,7 @@ RSpec.describe "API::Groups", type: :request do
     end
 
     context "with invalid params" do
-      let(:invalid_params) { { group: { name: "a-name" } } }
+      let(:invalid_params) { { group: { name: "a-name" }, api_token: "a-token" } }
 
       before do
         post "/groups", params: invalid_params, headers: headers

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "API::Groups", type: :request do
+  describe "GET /groups/{id}" do
+    it "returns JSON with the group " do
+      group = create :group, name: "a-name", slug: "the-slug"
+      get group_path(group), format: :json
+
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json).to include(
+        name: "a-name",
+        slug: "the-slug"
+      )
+    end
+  end
+end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -13,4 +13,50 @@ RSpec.describe "API::Groups", type: :request do
       )
     end
   end
+
+  describe "POST /groups" do
+    context "with valid params" do
+      let(:valid_params) { { group: { name: "a-name", slug: "the-slug", group_type: "the-group-type" } } }
+
+      it "creates the group" do
+        expect {
+          post groups_path params: valid_params, format: :json
+        }.to change(Group, :count).by(1)
+      end
+
+      it "returns status `:created` status code" do
+        post groups_path params: valid_params, format: :json
+
+        expect(response).to have_http_status(201)
+      end
+
+      it "returns a JSON with the group details" do
+        post groups_path params: valid_params, format: :json
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json).to include(
+          name: "a-name",
+          slug: "the-slug",
+          group_type: "the-group-type"
+        )
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) { { group: { name: "a-name" } } }
+
+      it "returns a `:unprocessable_entity` status code" do
+        post groups_path params: invalid_params, format: :json
+
+        expect(response).to have_http_status(422)
+      end
+
+      it "returns JSON including the errror details" do
+        post groups_path params: invalid_params, format: :json
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json).to include(group_type: ["can't be blank"])
+      end
+    end
+  end
 end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,61 +1,66 @@
 require 'rails_helper'
 
 RSpec.describe "API::Groups", type: :request do
-  describe "GET /groups/{id}" do
-    it "returns JSON with the group " do
-      group = create :group, name: "a-name", slug: "the-slug"
-      get group_path(group), format: :json
+  let(:headers) { { "ACCEPT" => "application/json" } }
 
+  describe "GET /groups/{id}" do
+    let!(:group) { create :group, name: "a-name", slug: "the-slug" }
+
+    before do
+      get "/groups/#{group.id}", params: {}, headers: headers
+    end
+
+    it "returns JSON with the group " do
       json = JSON.parse(response.body).deep_symbolize_keys
-      expect(json).to include(
-        name: "a-name",
-        slug: "the-slug"
-      )
+
+      expect(json).to include(name: "a-name", slug: "the-slug")
     end
   end
 
   describe "POST /groups" do
     context "with valid params" do
-      let(:valid_params) { { group: { name: "a-name", slug: "the-slug", group_type: "the-group-type" } } }
+      let(:params) { { group: attributes_for(:group) } }
 
       it "creates the group" do
         expect {
-          post groups_path params: valid_params, format: :json
+          post "/groups", params: params, headers: headers
         }.to change(Group, :count).by(1)
       end
 
-      it "returns status `:created` status code" do
-        post groups_path params: valid_params, format: :json
+      it "returns status code :created" do
+        post "/groups", params: params, headers: headers
 
         expect(response).to have_http_status(201)
       end
 
       it "returns a JSON with the group details" do
-        post groups_path params: valid_params, format: :json
+        params[:group][:name] = "a-name"
+        params[:group][:slug] = "the-slug"
+        post "/groups", params: params, headers: headers
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json).to include(
           name: "a-name",
-          slug: "the-slug",
-          group_type: "the-group-type"
+          slug: "the-slug"
         )
       end
 
-      context "when a list a content IDs is provided" do
-        it "add the Content Items to the group" do
-          valid_params[:group][:content_item_ids] = %w(content_id_1 content_id_2)
+      context "when a list of content IDs is provided" do
+        it "adds the Content IDs to the group" do
+          params[:group][:content_item_ids] = %w(content_id_1 content_id_2)
 
-          post groups_path params: valid_params, format: :json
+          post "/groups", params: params, headers: headers
           expect(Group.first.content_item_ids).to eq(%w(content_id_1 content_id_2))
         end
       end
 
       context "when a parent_group is provided" do
-        it "creates an association with the parent" do
-          parent = create(:group, slug: "parent-slug")
-          valid_params[:group].merge!(parent_group_slug: "parent-slug", slug: "child-slug")
+        let!(:parent) { create(:group, slug: "parent-slug") }
 
-          post groups_path params: valid_params, format: :json
+        it "creates an association with the parent" do
+          params[:group].merge!(parent_group_slug: "parent-slug", slug: "child-slug")
+
+          post "/groups", params: params, headers: headers
 
           child = Group.find_by(slug: "child-slug")
           expect(child.parent).to eq(parent)
@@ -66,15 +71,15 @@ RSpec.describe "API::Groups", type: :request do
     context "with invalid params" do
       let(:invalid_params) { { group: { name: "a-name" } } }
 
-      it "returns a `:unprocessable_entity` status code" do
-        post groups_path params: invalid_params, format: :json
+      before do
+        post "/groups", params: invalid_params, headers: headers
+      end
 
+      it "returns a `:unprocessable_entity` status code" do
         expect(response).to have_http_status(422)
       end
 
       it "returns JSON including the errror details" do
-        post groups_path params: invalid_params, format: :json
-
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json).to include(group_type: ["can't be blank"])
       end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe "API::Groups", type: :request do
 
   after { ENV['CONTENT-PERFORMANCE-MANAGER-TOKEN'] = @old_content_performance_manager_token }
 
-  describe "GET /groups/{id}" do
+  describe "GET /groups/{slug}" do
     let!(:group) { create :group, name: "a-name", slug: "the-slug" }
 
     before do
-      get "/groups/#{group.id}", params: { api_token: "a-token" }, headers: headers
+      get "/groups/the-slug", params: { api_token: "a-token" }, headers: headers
     end
 
     it "returns JSON with the group " do

--- a/spec/routes/groups_routing_spec.rb
+++ b/spec/routes/groups_routing_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe GroupsController, type: :routing do
+  describe "routing" do
+    it "routes to #show" do
+      expect(get: "/groups/1").to route_to("groups#show", id: "1")
+    end
+  end
+end

--- a/spec/routes/groups_routing_spec.rb
+++ b/spec/routes/groups_routing_spec.rb
@@ -5,5 +5,8 @@ RSpec.describe GroupsController, type: :routing do
     it "routes to #show" do
       expect(get: "/groups/1").to route_to("groups#show", id: "1")
     end
+    it "routes to #create" do
+      expect(post: "/groups").to route_to("groups#create")
+    end
   end
 end

--- a/spec/routes/groups_routing_spec.rb
+++ b/spec/routes/groups_routing_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe GroupsController, type: :routing do
   describe "routing" do
     it "routes to #show" do
-      expect(get: "/groups/1").to route_to("groups#show", id: "1")
+      expect(get: "/groups/the-slug").to route_to("groups#show", slug: "the-slug")
     end
     it "routes to #create" do
       expect(post: "/groups").to route_to("groups#create")

--- a/spec/views/groups/show.json.jbuilder_spec.rb
+++ b/spec/views/groups/show.json.jbuilder_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "groups/show.json.jbuilder", type: :view do
+  it "renders GROUP in JSON format" do
+    group = create :group, id: 18, slug: 'the-slug', name: 'a-name', group_type: 'type'
+    assign(:group, group)
+    render
+
+    response = JSON.parse(rendered)
+    expect(response).to include(
+      "id" => 18,
+      "slug" => "the-slug",
+      "name" => "a-name",
+      "group_type" => "type",
+      "url" => "http://test.host/groups/18.json"
+    )
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/OiKWmsiP/194-8-api-endpoint-to-create-a-group-of-content-items)

### Goal:

Add API endpoints to support basic operations on Groups.

### Groups

* A group **is a set of content IDs** with no predefined order with the following properties: `slug`, `name`, `group_type`, `parent_group_id`

* Groups have a **tree structure**, with no limit in the number of descendants.
* Groups **slugs are uniq**
* The set of content IDs is stored as an Array of the group. This approach could have drawbacks in the long run if we need to include complex logic, but the approach is so easy to change, that it seems a better approach to keep things simple, and not make modelling decisions yet. 
* I am not creating a many-to-many association with ContentItem as the ContentItem model is will no be persisted in the long run as we will rely on the [Publishing API](https://github.com/alphagov/publishing-api).
* Groups are hierarchical, so we can assign a parent to any group.
* Authentication is done via the environment variable ‘CONTENT-PERFORMNCE-MANAGER-TOKEN’  and the URL parameter `api-token`. In incoming sprints we will use the GOV.UK SignOn to generate and validate the requests.

### API Samples

* Create a group

```terminal
curl -X "POST" "http://content-performance-manager.dev.gov.uk/groups.json" \
     -H "Content-Type: application/json" \
     -d $'{
  "group": {
    "slug": "the-slug",
    "group_type": "the-group-type",
    "name": "the-name",
    "content_item_ids": [
      "content-id-1",
      "content-id-2"
    ],
    "parent_group_slug": "the-parent-slug"
  },
  "api_token": "1234567"
}'
```

* Show a group

```terminal
curl "http://content-performance-manager.dev.gov.uk/groups/3.json?api_token=1234567" \
     -H "Content-Type: application/json"
```
