### PR TITLE
Add Endpoint list all Groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,6 +4,14 @@ class GroupsController < ApplicationController
   before_action :ensure_valid_token
   before_action :set_parent_group, only: :create
 
+  def index
+    @groups = if params[:group_type]
+                Group.where(group_type: params[:group_type])
+              else
+                Group.all
+              end
+  end
+
   def show
     @group = Group.find_by(slug: params[:slug])
   end

--- a/app/views/groups/index.json.jbuilder
+++ b/app/views/groups/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.groups @groups do |group|
+  json.slug group.slug
+  json.total group.content_item_ids.length
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'organisations#index'
 
-  resources :groups, only: %w(show create), param: "slug"
+  resources :groups, only: %w(show create index), param: "slug"
 
   resources :organisations, only: %w(index)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -42,3 +42,10 @@ curl -X "POST" "http://content-performance-manager.dev.gov.uk/groups.json" \
 curl "http://content-performance-manager.dev.gov.uk/groups/the-slug.json?api_token=1234567" \
      -H "Content-Type: application/json"
 ```
+
+* List all groups
+
+```terminal
+curl "http://content-performance-manager.dev.gov.uk/groups.json?api_token=1234567" \
+     -H "Content-Type: application/json"
+```

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe GroupsController, type: :controller do
     end
   end
 
+  describe "GET #index" do
+    it "assigns all groups as @groups" do
+      group = create(:group)
+      get :index, params: { api_token: 'a-token' }, format: :json
+
+      expect(assigns(:groups)).to eq([group])
+    end
+
+    it "filters by group type" do
+      create(:group)
+      group2 = create(:group, group_type: 'the-type')
+      get :index, params: { group_type: 'the-type', api_token: 'a-token' }, format: :json
+
+      expect(assigns(:groups)).to eq([group2])
+    end
+  end
+
   describe "GET #show" do
     it "assigns the requested group as @group" do
       group = create :group, slug: "the-slug"

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe "API::Groups", type: :request do
     end
   end
 
+  describe "GET /groups" do
+    it "returns JSON with all the Groups and number of Content IDs" do
+      create :group, slug: "slug-1", content_item_ids: %w( 1 2)
+      get "/groups", params: { api_token: "a-token" }, headers: headers
+
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json).to include(
+        groups: [
+          { slug: 'slug-1', total: 2 }
+        ]
+      )
+    end
+  end
+
   describe "POST /groups" do
     context "with valid params" do
       let(:params) { { group: attributes_for(:group), api_token: "a-token" } }

--- a/spec/routes/groups_routing_spec.rb
+++ b/spec/routes/groups_routing_spec.rb
@@ -8,5 +8,8 @@ RSpec.describe GroupsController, type: :routing do
     it "routes to #create" do
       expect(post: "/groups").to route_to("groups#create")
     end
+    it "routes to #index" do
+      expect(get: "/groups").to route_to("groups#index")
+    end
   end
 end

--- a/spec/views/groups/index.json.jbuilder_spec.rb
+++ b/spec/views/groups/index.json.jbuilder_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "groups/index.json.jbuilder", type: :view do
+  it "renders JSON with all the Groups and number of Content IDs" do
+    group1 = build :group, id: 1, slug: "slug-1", content_item_ids: %w( 1 2)
+    group2 = build :group, id: 2, slug: "slug-2", content_item_ids: %w( 1 )
+    assign :groups, [group1, group2]
+    render
+
+    json = JSON.parse(rendered).deep_symbolize_keys
+    expect(json).to match(
+      groups: [
+        { slug: 'slug-1', total: 2 },
+        { slug: 'slug-2', total: 1 }
+      ]
+    )
+  end
+end


### PR DESCRIPTION
## DO NOT MERGE BEFORE #96 
Only commit: 1ae92b3dffe1825d30d35753536e715523b5ecc8 applies

### Description

* Add endpoint to list all groups. 
* The list of groups can be filtered by `group_type`

### Samples

* List all groups

```terminal
curl "http://content-performance-manager.dev.gov.uk/groups.json?api_token=1234567" \
     -H "Content-Type: application/json"
```

* List all groups belonging to a type

```terminal
curl "http://content-performance-manager.dev.gov.uk/groups.json?api_token=1234567&group_type=inventory" \
     -H "Content-Type: application/json"
```

