### PR TITLE
Add alpha banner

### DIFF
--- a/app/assets/stylesheets/_phase_banner.scss
+++ b/app/assets/stylesheets/_phase_banner.scss
@@ -1,0 +1,20 @@
+.phase-banner {
+  border-bottom: 1px solid $dev-color;
+  margin-bottom: 40px;  // Add header margin height*2  
+  margin-top: -20px;  // Offset the header margin.  
+  padding: 8px 0;
+  
+  .label {
+    font-size: 100%;
+    margin-right: 10px;
+  }
+
+  p {
+    display: table;
+    margin: 0;
+  }
+
+  span {
+    display: table-cell;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,4 @@
 @import 'govuk_admin_template';
 @import 'tables';
 @import 'pagination';
+@import 'phase_banner';

--- a/app/views/application/_phase_banner.html.erb
+++ b/app/views/application/_phase_banner.html.erb
@@ -1,0 +1,6 @@
+<div class="phase-banner">
+  <p>
+    <strong class="label label-primary">ALPHA</strong>
+    <span>This is a new service, all content is subject to change.</span>
+  </p>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 <% end %>
 
 <% content_for :content do %>
+  <%= render 'application/phase_banner' %>
   <%= content_for?(:main) ? yield(:main) : yield %>
 <% end %>
 

--- a/spec/features/phase_banner_spec.rb
+++ b/spec/features/phase_banner_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.feature "Phase banner", type: :feature do
+  scenario "The user can see a phase banner" do
+    visit "/"
+
+    expect(page).to have_selector(".phase-banner", count: 1)
+  end
+end


### PR DESCRIPTION
### Motivation
Users should know that the application is in a state of flux to manage their expectations.
https://trello.com/c/PGhcXKcu/147-2-add-the-alpha-banner-to-the-content-performance-manager

### Description
Adds a very lightweight alpha banner to the application using the built in bootstrap classes.

### Before
<img width="1120" alt="ban_before" src="https://cloud.githubusercontent.com/assets/6338228/24095533/8ad7bd8a-0d55-11e7-99c0-f6852e635400.png">

### After
<img width="1193" alt="ban_after" src="https://cloud.githubusercontent.com/assets/6338228/24095536/92479612-0d55-11e7-9d68-a89d0bc40222.png">

