### PR TITLE
Import organisations using the publishing api

### DIFF
--- a/app/services/organisations_service.rb
+++ b/app/services/organisations_service.rb
@@ -1,12 +1,36 @@
 class OrganisationsService
+  attr_accessor :publishing_api
+
+  def initialize
+    @publishing_api = Clients::PublishingAPI.new
+  end
+
   def find_each
     raise 'missing block!' unless block_given?
 
-    query = { filter_format: 'organisation' }
-    fields = %w(slug title)
-
-    Clients::SearchAPI.find_each(query: query, fields: fields) do |attributes|
-      yield attributes
+    publishing_api.find_each(query_fields, query_options) do |organisation|
+      yield build_slug(organisation)
     end
+  end
+
+private
+
+  def query_options
+    @options ||= { document_type: 'organisation' }
+  end
+
+  def query_fields
+    @fields ||= %i(base_path title)
+  end
+
+  def build_slug(organisation)
+    organisation.tap do |org|
+      org[:slug] = org[:base_path].tap { |b| b.slice!(path_prefix) }
+      org.except!(:base_path)
+    end
+  end
+
+  def path_prefix
+    "/government/organisations/"
   end
 end

--- a/app/services/taxonomies_service.rb
+++ b/app/services/taxonomies_service.rb
@@ -6,14 +6,18 @@ class TaxonomiesService
   end
 
   def find_each
-    publishing_api.find_each(attribute_names) do |taxonomy|
+    publishing_api.find_each(query_fields, query_options) do |taxonomy|
       yield taxonomy
     end
   end
 
 private
 
-  def attribute_names
-    @names ||= %i(content_id title)
+  def query_options
+    @options ||= { document_type: "taxon" }
+  end
+
+  def query_fields
+    @fields ||= %i(content_id title)
   end
 end

--- a/doc/importing_data.md
+++ b/doc/importing_data.md
@@ -3,9 +3,9 @@
 ## Local environment
 
 The application contains a number of `rake` tasks used to populate the database, these are listed below.
-Currently when importing `organisations` and `content_items` the live `search-api` and `content-store` are used respectively.
+Currently when importing `content_items` the live `content-store` is used.
 
-The importing of taxonomies however uses the `publishing-api` therefore an additional step is required to run a local import (noted below).
+The importing of `organisations` and `taxonomies` uses the `publishing-api` therefore you will need to run the `publishing-api` via the [VM](https://github.com/alphagov/govuk-puppet/tree/master/development-vm) to import locally else you will receive timeout errors.
 
 **All organisations:**
 
@@ -14,9 +14,6 @@ $ rake import:all_organisations
 ```
 
 **All taxonomies:**
-
-**Note:** You will need to run the `publishing-api` via the [VM](https://github.com/alphagov/govuk-puppet/tree/master/development-vm) to import taxons locally else you will receive timeout errors.
-
 
 ```bash
 $ rake import:all_taxons

--- a/spec/features/importers/all_organisations_spec.rb
+++ b/spec/features/importers/all_organisations_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature 'rake import:all_organisations', type: :feature do
   let(:two_organisations) {
     {
       results: [
-        { slug: 'slug-1', title: 'title-1' },
-        { slug: 'slug-2', title: 'title-2' }
+        { base_path: 'slug-1', title: 'title-1' },
+        { base_path: 'slug-2', title: 'title-2' }
       ]
     }.to_json
   }

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -5,22 +5,37 @@ RSpec.describe Clients::PublishingAPI do
 
   it "loops through paged results from the gds publishing api" do
     subject.publishing_api = double
-    page_1 = { "results" => [], "pages" => 2, "current_page" => 1 }
-    page_2 = { "results" => [], "pages" => 2, "current_page" => 2 }
+    page_1 = { "results" => [{}], "pages" => 2, "current_page" => 1 }
+    page_2 = { "results" => [{}], "pages" => 2, "current_page" => 2 }
 
     expect(subject.publishing_api).to receive(:get_content_items).exactly(2).times.and_return(page_1, page_2)
 
     subject.find_each([]) {}
   end
 
-  it "yields the taxon fields that were requested" do
+  it "yields the results" do
     yielded = []
     subject.publishing_api = double
-    results = { "results" => ["content_id" => "an_id", "another" => "field"], "pages" => 1, "current_page" => 1 }
+    results = { "results" => [{ some: "thing" }], "pages" => 1, "current_page" => 1 }
     allow(subject.publishing_api).to receive(:get_content_items).and_return(results)
 
-    subject.find_each(%i(content_id)) { |x| yielded << x }
+    subject.find_each([]) { |x| yielded << x }
 
-    expect(yielded).to eq([{ content_id: "an_id" }])
+    expect(yielded).to eq([{ some: "thing" }])
+  end
+
+  it "queries with the passed in options" do
+    subject.publishing_api = double
+    expected_query = {
+      document_type: 'a_document_type',
+      order: 'a_order',
+      q: 'a_search_term',
+      fields: [:field_1, :field_2]
+    }
+    result = { "results" => [{}], "pages" => 1, "current_page" => 1 }
+
+    expect(subject.publishing_api).to receive(:get_content_items).with(hash_including(expected_query)).and_return(result)
+
+    subject.find_each([:field_1, :field_2], document_type: 'a_document_type', order: 'a_order', q: 'a_search_term') {}
   end
 end

--- a/spec/services/organisations_service_spec.rb
+++ b/spec/services/organisations_service_spec.rb
@@ -2,22 +2,24 @@ require 'rails_helper'
 
 RSpec.describe OrganisationsService do
   describe '#find_each' do
-    it 'queries the search API for all organisations' do
-      expected_params = {
-        query: { filter_format: 'organisation' },
-        fields: %w(slug title)
-      }
-      expect(Clients::SearchAPI).to receive(:find_each).with(expected_params)
+    it 'queries the publishing API for all organisations' do
+      expected_field_params = %i(base_path title)
+      expected_query_params = { document_type: 'organisation' }
+
+      subject.publishing_api = double
+      expect(subject.publishing_api).to receive(:find_each).with(expected_field_params, expected_query_params)
 
       subject.find_each {}
     end
 
-    it 'yields the response' do
+    it 'yields the response with the base_path mapped to slug' do
       result = []
-      allow(Clients::SearchAPI).to receive(:find_each).and_yield(:a).and_yield(:b)
+      subject.publishing_api = double
+      allow(subject.publishing_api).to receive(:find_each).and_yield(base_path: "/government/organisations/slug-1").and_yield(base_path: "/government/organisations/slug-2")
+
       subject.find_each { |value| result << value }
 
-      expect(result).to match_array([:a, :b])
+      expect(result).to match_array([{ slug: "slug-1" }, { slug: "slug-2" }])
     end
 
     it 'raises an exception if no block passed' do

--- a/spec/services/taxonomies_service_spec.rb
+++ b/spec/services/taxonomies_service_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe TaxonomiesService do
   describe '#find_each' do
-    it 'queries the publishing API for the given fields' do
+    it 'queries the publishing API for the given fields of taxons' do
       subject.publishing_api = double
-      expected_params = %i(content_id title)
+      field_params = %i(content_id title)
+      query_params = { document_type: "taxon" }
 
-      expect(subject.publishing_api).to receive(:find_each).with(expected_params)
+      expect(subject.publishing_api).to receive(:find_each).with(field_params, query_params)
 
       subject.find_each {}
     end


### PR DESCRIPTION
### Motivation
We already import taxonomies using the publishing api, this is another step toward unifying the services we use when importing data. 
https://trello.com/c/Ds2NC2Yb/187-use-publishing-api-to-retrieve-organisations

### Description
Previously `organisations` were imported using the `search-api`, this has now been switched to use the `publishing-api`.

As part of this work the publishing api client in the app was expanded to be more flexible with the queries it can make.
