### PR TITLE
Update url parameter to use organisation

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -25,7 +25,7 @@ class ContentItemsController < ApplicationController
 private
 
   def set_organisation
-    @organisation = Organisation.find_by(slug: params[:organisation_slug]) if params[:organisation_slug]
+    @organisation = Organisation.find_by(content_id: params[:organisation_id]) if params[:organisation_id]
   end
 
   def set_taxonomy

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -15,7 +15,7 @@ class ContentItemDecorator < Draper::Decorator
 
   def organisation_links
     names = object.organisations.collect do |organisation|
-      helpers.link_to(organisation.title, helpers.content_items_path(organisation_slug: organisation.slug))
+      helpers.link_to(organisation.title, helpers.content_items_path(organisation_id: organisation.content_id))
     end
 
     names.join(', ').html_safe

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -24,7 +24,7 @@ module TableHelper
 
     def link(label, order)
       if view.instance_variable_get(:@organisation).present?
-        link_to content_items_path(organisation_slug: view.instance_variable_get(:@organisation).slug, sort: attribute_name, order: order, query: params[:query]) do
+        link_to content_items_path(organisation_id: view.instance_variable_get(:@organisation).content_id, sort: attribute_name, order: order, query: params[:query]) do
           "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
         end
       else

--- a/app/models/importers/all_organisations.rb
+++ b/app/models/importers/all_organisations.rb
@@ -9,8 +9,8 @@ module Importers
   private
 
     def create_or_update!(attributes)
-      organisation_slug = attributes.fetch(:slug)
-      organisation = Organisation.find_or_create_by(slug: organisation_slug)
+      organisation_id = attributes.fetch(:content_id)
+      organisation = Organisation.find_or_create_by(content_id: organisation_id)
       organisation.update!(attributes)
     end
   end

--- a/app/views/content_items/filter.html.erb
+++ b/app/views/content_items/filter.html.erb
@@ -1,9 +1,9 @@
 <%= form_tag content_items_path, method: :get, class: 'form-horizontal' do %>
   <div class="form-group">
-    <label for="organisation_slug" class="col-sm-2 control-label"></label>
+    <label for="organisation_id" class="col-sm-2 control-label"></label>
     <div class="col-sm-10">
       <%= label_tag 'Organisation' %>
-      <%= select_tag :organisation_slug, options_from_collection_for_select(@organisations, :slug, :title), include_blank: true, class: "form-control" %>
+      <%= select_tag :organisation_id, options_from_collection_for_select(@organisations, :content_id, :title), include_blank: true, class: "form-control" %>
       <%= label_tag 'Taxonomy' %>
       <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies, :content_id, :title), include_blank: true, class: "form-control" %>
     </div>

--- a/app/views/organisations/_organisation.html.erb
+++ b/app/views/organisations/_organisation.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <td><%= link_to organisation.title, content_items_path(organisation_slug: organisation.slug) %></td>
+  <td><%= link_to organisation.title, content_items_path(organisation_id: organisation.content_id) %></td>
   <td><%= organisation.content_items.count %></td>
 </tr>

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,11 +1,4 @@
 namespace :import do
-  desc 'Creates / Updates all the content items belonging to an organisation'
-  task :content_items_by_organisation, [:slug] => :environment do |_, args|
-    raise 'Missing slug parameter' unless args.slug
-
-    Importers::ContentItemsByOrganisation.new.run(args.slug)
-  end
-
   desc 'Import all organisations (without content items)'
   task all_organisations: :environment do
     Importers::AllOrganisations.new.run

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe ContentItemsController, type: :controller do
       get :index, params: expected_params
     end
 
-    it "assigns the organisation provided the slug" do
-      create(:organisation, slug: 'the-slug')
+    it "assigns the organisation provided the content_id" do
+      create(:organisation, content_id: 'the-organisation-id')
 
-      get :index, params: { organisation_slug: 'the-slug' }
-      expect(assigns(:organisation).slug).to eq('the-slug')
+      get :index, params: { organisation_id: 'the-organisation-id' }
+      expect(assigns(:organisation).content_id).to eq('the-organisation-id')
     end
 
     it "assigns the taxonomy provided by the taxonomy content id" do
@@ -48,7 +48,7 @@ RSpec.describe ContentItemsController, type: :controller do
       let(:organisation) { create(:organisation_with_content_items, content_items_count: 1) }
 
       before do
-        get :show, params: { organisation_slug: organisation.slug, id: organisation.content_items.first.id }
+        get :show, params: { id: organisation.content_items.first.id }
       end
 
       it "returns http success" do

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe ContentItemDecorator, type: :decorator do
   describe "#organisation_links" do
     let(:organisations) do
       [
-        build(:organisation, slug: "slug-1", title: "title-1"),
-        build(:organisation, slug: "slug-2", title: "title-2")
+        build(:organisation, content_id: "content-id-1", title: "title-1"),
+        build(:organisation, content_id: "content-id-2", title: "title-2")
       ]
     end
 
@@ -32,8 +32,8 @@ RSpec.describe ContentItemDecorator, type: :decorator do
     it "has a comma between names" do
       organisation_links = content_item.organisation_links
 
-      expect(organisation_links).to include(%{<a href=\"/content_items?organisation_slug=slug-1\">title-1</a>})
-      expect(organisation_links).to include(%{<a href=\"/content_items?organisation_slug=slug-2\">title-2</a>})
+      expect(organisation_links).to include(%{<a href=\"/content_items?organisation_id=content-id-1\">title-1</a>})
+      expect(organisation_links).to include(%{<a href=\"/content_items?organisation_id=content-id-2\">title-2</a>})
     end
   end
 

--- a/spec/factories/organisations_factory.rb
+++ b/spec/factories/organisations_factory.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:id) { |index| index }
     sequence(:slug) { |index| "slug-#{index}" }
     sequence(:title) { |index| "organisation-title-#{index}" }
+    sequence(:content_id) { |index| "organisation-content-id-#{index}" }
 
     factory :organisation_with_content_items do
       transient do

--- a/spec/features/content_items_spec.rb
+++ b/spec/features/content_items_spec.rb
@@ -21,14 +21,14 @@ RSpec.feature "Content Items List", type: :feature do
   describe "Filtering content items" do
     context "by organisation" do
       scenario "the user selects an organisation from the organisations select box, clicks the filter button and retrieves a filtered list of the organisation's content items" do
-        create :organisation, slug: "the-slug-1", title: "title 1"
-        create :organisation, slug: "the-slug-2", title: "title 2"
+        create :organisation, content_id: "the-content-id-1", title: "title 1"
+        create :organisation, content_id: "the-content-id-2", title: "title 2"
 
         visit "/content_items/filter"
-        select "title 2", from: "organisation_slug"
+        select "title 2", from: "organisation_id"
         click_on "Filter"
 
-        expected_path = URI.escape "/content_items?utf8=✓&organisation_slug=the-slug-2"
+        expected_path = URI.escape "/content_items?utf8=✓&organisation_id=the-content-id-2"
 
         expect(current_url).to include(expected_path)
       end
@@ -42,7 +42,7 @@ RSpec.feature "Content Items List", type: :feature do
         select "Taxon A", from: "taxonomy_content_id"
         click_on "Filter"
 
-        expected_path = URI.escape "/content_items?utf8=✓&organisation_slug=&taxonomy_content_id=123"
+        expected_path = URI.escape "/content_items?utf8=✓&organisation_id=&taxonomy_content_id=123"
 
         expect(current_url).to include(expected_path)
       end

--- a/spec/features/importers/all_organisations_spec.rb
+++ b/spec/features/importers/all_organisations_spec.rb
@@ -4,15 +4,15 @@ RSpec.feature 'rake import:all_organisations', type: :feature do
   let(:two_organisations) {
     {
       results: [
-        { base_path: 'slug-1', title: 'title-1' },
-        { base_path: 'slug-2', title: 'title-2' }
+        { base_path: 'slug-1', title: 'title-1', content_id: 'content-id-1' },
+        { base_path: 'slug-2', title: 'title-2', content_id: 'content-id-2' }
       ]
     }.to_json
   }
 
   before do
     Rake::Task['import:all_organisations'].reenable
-    stub_request(:get, %r{.*}).to_return(status: 200, body:  two_organisations)
+    stub_request(:get, %r{.*}).to_return(status: 200, body: two_organisations)
   end
 
   it 'creates all organisations' do
@@ -25,5 +25,6 @@ RSpec.feature 'rake import:all_organisations', type: :feature do
     organisation = Organisation.find_by(slug: 'slug-1')
     expect(organisation.title).to eq('title-1')
     expect(organisation.slug).to eq('slug-1')
+    expect(organisation.content_id).to eq('content-id-1')
   end
 end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -12,12 +12,12 @@ RSpec.feature "Organisations list", type: :feature do
   end
 
   scenario "The user can navigate to an organisation detail page" do
-    create :organisation, slug: "the-slug", title: "organisation title"
+    create :organisation, title: "organisation title", content_id: "the-content-id"
 
     visit organisations_path
     click_on "organisation title"
 
-    expected_path = "/content_items?organisation_slug=the-slug"
+    expected_path = "/content_items?organisation_id=the-content-id"
     expect(current_url).to include(expected_path)
   end
 

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe TableHelper, type: :helper do
     let(:organisation) { build(:organisation) }
     before { assign(:organisation, organisation) }
 
-    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_slug: organisation.slug } }
-    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_slug: organisation.slug } }
+    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_id: organisation.content_id } }
+    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_id: organisation.content_id } }
 
     let(:heading) { 'Last Updated' }
     let(:attribute_name) { 'public_updated_at' }

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe ContentItem, type: :model do
 
     it "updates a content item if it already exists" do
       create(:content_item, content_id: "the_id", title: "the title")
-
       content_item = { content_id: "the_id", title: "a new title", taxons: [], organisations: [] }
 
       expect { ContentItem.create_or_update!(content_item) }.to change { ContentItem.count }.by(0)

--- a/spec/models/importers/all_organisations_spec.rb
+++ b/spec/models/importers/all_organisations_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe Importers::AllOrganisations do
   describe '#run' do
     context 'when the organisation does not exist' do
       it 'creates an organisation per attribute group' do
-        attrs1 = { slug: 'a-slug-1', title: 'a-title-1' }
-        attrs2 = { slug: 'a-slug-2', title: 'a-title-2' }
+        attrs1 = { slug: 'a-slug-1', title: 'a-title-1', content_id: "content-item-1" }
+        attrs2 = { slug: 'a-slug-2', title: 'a-title-2', content_id: "content-item-2" }
         allow_any_instance_of(OrganisationsService).to receive(:find_each).and_yield(attrs1).and_yield(attrs2)
 
         expect { subject.run }.to change { Organisation.count }.by(2)
       end
 
       it 'updates the attributes' do
-        attrs1 = { slug: 'a-slug-1', title: 'a-title-1' }
+        attrs1 = { slug: 'a-slug-1', title: 'a-title-1', content_id: "content-item-1" }
         allow_any_instance_of(OrganisationsService).to receive(:find_each).and_yield(attrs1)
         subject.run
 
-        attributes = Organisation.find_by(slug: 'a-slug-1').attributes.symbolize_keys
+        attributes = Organisation.find_by(content_id: 'content-item-1').attributes.symbolize_keys
         expect(attributes).to include(slug: 'a-slug-1', title: 'a-title-1')
       end
     end
 
     context 'when the organisation already exists' do
-      let(:organisation) { create(:organisation, slug: 'the-slug') }
+      let!(:organisation) { create(:organisation, content_id: "content-item-1") }
 
       it 'does not create a new one' do
-        attributes = { slug: organisation.slug, title: 'some-title' }
+        attributes = { slug: 'a-slug', title: 'some-title', content_id: "content-item-1" }
         allow_any_instance_of(OrganisationsService).to receive(:find_each).and_yield(attributes)
 
         expect { subject.run }.to change { Organisation.count }.by(0)
@@ -33,7 +33,7 @@ RSpec.describe Importers::AllOrganisations do
 
       it 'updates the attributes' do
         organisation.update(title: 'a-title')
-        allow_any_instance_of(OrganisationsService).to receive(:find_each).and_yield(slug: organisation.slug, title: 'new-title')
+        allow_any_instance_of(OrganisationsService).to receive(:find_each).and_yield(slug: organisation.slug, title: 'new-title', content_id: "content-item-1")
         subject.run
 
         expect(Organisation.first.title).to eq('new-title')

--- a/spec/views/content_items/filter.html.erb_spec.rb
+++ b/spec/views/content_items/filter.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "content_items/filter.html.erb", type: :view do
         assign(:organisations, organisations)
         render
 
-        expect(rendered).to have_selector('form select#organisation_slug option', count: 3)
+        expect(rendered).to have_selector('form select#organisation_id option', count: 3)
       end
     end
 

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
 
       it 'contains a descending and ascending links in table heading' do
         render
-        href = content_items_path(organisation_slug: organisation.slug, order: :asc, sort: :public_updated_at)
+        href = content_items_path(organisation_id: organisation.content_id, order: :asc, sort: :public_updated_at)
 
         expect(rendered).to have_link('Last Updated', href: href)
       end

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -31,9 +31,11 @@ RSpec.describe 'organisations/index.html.erb', type: :view do
     end
 
     it "should render a link for each organisation" do
-      organisations.first.title = "Organisation 1"
-      organisations.first.slug = "the-slug"
-      organisation_link = content_items_path(organisation_slug: "the-slug")
+      organisation = organisations.first
+      organisation.title = "Organisation 1"
+      organisation.slug = "the-slug"
+      organisation.content_id = "the-content-id"
+      organisation_link = content_items_path(organisation_id: "the-content-id")
       render
 
       expect(rendered).to have_selector("a[href='#{organisation_link}']", text: "Organisation 1")


### PR DESCRIPTION
[Trello card](https://trello.com/c/kIgXEGsM)

### Goal

Change the Query parameter from `organisation_slug` to `organisation_id`

### Why

Content Performance Manager is moving towards searching Content 
Items using the Search API. As part of this process, it seems sensible 
to mimic the Search API query parameters so we can bypass them 
and get the most of the existing work.

This is a PR to prepare our codebase to the transition from using our
local database and migrate to Search API. We are first adding the 
`content_id` attribute to each organisation locally, as this is going to
be the attribute name that is going to be reused in the Search API.
