### PR TITLE
Fix broken heading for filtering by taxonomy

### DIFF
--- a/app/decorators/content_items_decorator.rb
+++ b/app/decorators/content_items_decorator.rb
@@ -2,12 +2,12 @@ class ContentItemsDecorator < Draper::CollectionDecorator
   delegate :current_page, :total_pages, :limit_value, :entry_name, :total_count, :offset_value, :last_page?
 
   def header
-    if organisation_slug.present? && taxonomy.present?
-      "#{Organisation.find_by(slug: organisation_slug).title} + #{taxonomy}"
+    if organisation_slug.present? && taxonomy_content_id.present?
+      "#{Organisation.find_by(slug: organisation_slug).title} + #{Taxonomy.find_by(content_id: taxonomy_content_id).title}"
     elsif organisation_slug.present?
       Organisation.find_by(slug: organisation_slug).title
-    elsif taxonomy.present?
-      taxonomy
+    elsif taxonomy_content_id.present?
+      Taxonomy.find_by(content_id: taxonomy_content_id).title
     else
       "GOV.UK"
     end
@@ -19,7 +19,7 @@ private
     helpers.params[:organisation_slug]
   end
 
-  def taxonomy
-    helpers.params[:taxonomy]
+  def taxonomy_content_id
+    helpers.params[:taxonomy_content_id]
   end
 end

--- a/spec/decorators/content_items_decorator_spec.rb
+++ b/spec/decorators/content_items_decorator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ContentItemsDecorator, type: :decorator do
   include Draper::ViewHelpers
 
   let(:organisation) { create(:organisation, title: "Organisation title", slug: "the-slug") }
-  let(:taxonomy) { create(:taxonomy, title: "taxonomy a") }
+  let(:taxonomy) { create(:taxonomy, title: "taxonomy a", content_id: "content-id-for-taxon123") }
 
   context "without filter params" do
     it "renders the default page title" do
@@ -28,7 +28,7 @@ RSpec.describe ContentItemsDecorator, type: :decorator do
 
   context "with taxonomy filter" do
     it "renders the taxonomy title as page title" do
-      allow(helpers).to receive(:params).and_return(taxonomy: "taxonomy a")
+      allow(helpers).to receive(:params).and_return(taxonomy_content_id: "content-id-for-taxon123")
       content_items = [build(:content_item, taxonomies: [taxonomy])]
       subject = ContentItemsDecorator.new(content_items)
 
@@ -38,7 +38,7 @@ RSpec.describe ContentItemsDecorator, type: :decorator do
 
   context "with both organisation and taxonomy filters" do
     it "renders the organisation and taxonomy titles seperated by a '+'" do
-      allow(helpers).to receive(:params).and_return(organisation_slug: "the-slug", taxonomy: "taxonomy a")
+      allow(helpers).to receive(:params).and_return(organisation_slug: "the-slug", taxonomy_content_id: "content-id-for-taxon123")
       content_items = [build(:content_item, organisations: [organisation], taxonomies: [taxonomy])]
       subject = ContentItemsDecorator.new(content_items)
 


### PR DESCRIPTION
A recent switch to using content ids for taxonomies affected the
decorator that determined which taxonomy was being used to filter by.

This commit fixes that bug.