### PR TITLE
Add link to feedex for content item details page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Plek for determining basepaths for appropriate environment
+gem 'plek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ DEPENDENCIES
   kaminari (~> 0.17.0)
   listen (~> 3.0.5)
   pg (~> 0.18)
+  plek
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing (~> 1.0.1)

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -9,6 +9,10 @@ class ContentItemDecorator < Draper::Decorator
     end
   end
 
+  def feedex_link
+    helpers.link_to "View feedback on FeedEx", "https://support.publishing.service.gov.uk/anonymous_feedback?path=#{object.base_path}"
+  end
+
   def organisation_links
     names = object.organisations.collect do |organisation|
       helpers.link_to(organisation.title, helpers.content_items_path(organisation_slug: organisation.slug))

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -10,7 +10,7 @@ class ContentItemDecorator < Draper::Decorator
   end
 
   def feedex_link
-    helpers.link_to "View feedback on FeedEx", "https://support.publishing.service.gov.uk/anonymous_feedback?path=#{object.base_path}"
+    helpers.link_to "View feedback on FeedEx", "#{Plek.find('support')}/anonymous_feedback?path=#{object.base_path}"
   end
 
   def organisation_links

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -31,8 +31,9 @@
       </td>
     </tr>
     <tr>
+      <td>Support contacts</td>
       <td>
-        <%= link_to "Support contacts", "https://support.publishing.service.gov.uk/anonymous_feedback?path=#{@content_item.base_path}" %>
+        <%= @content_item.feedex_link %>
       </td>
     </tr>
     <tr>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -31,6 +31,11 @@
       </td>
     </tr>
     <tr>
+      <td>
+        <%= link_to "Support contacts", "https://support.publishing.service.gov.uk/anonymous_feedback?path=#{@content_item.base_path}" %>
+      </td>
+    </tr>
+    <tr>
       <td>Organisation</td>
       <td>
         <%= @content_item.organisation_links %>

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -1,11 +1,21 @@
 require "rails_helper"
 
 RSpec.describe ContentItemDecorator, type: :decorator do
+  include Capybara::RSpecMatchers
+
   describe "#last_updated" do
     let(:content_item) { build(:content_item, public_updated_at: nil).decorate }
 
-    it 'displays Never when content item has not been updated' do
+    it "displays Never when content item has not been updated" do
       expect(content_item.last_updated).to eq('Never')
+    end
+  end
+
+  describe "#feedex_link" do
+    let(:content_item) { build(:content_item, base_path: "/the-base-path").decorate }
+
+    it "has a link to FeedEx" do
+      expect(content_item.feedex_link).to have_link("View feedback on FeedEx", href: "https://support.publishing.service.gov.uk/anonymous_feedback?path=/the-base-path")
     end
   end
 

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ContentItemDecorator, type: :decorator do
     let(:content_item) { build(:content_item, base_path: "/the-base-path").decorate }
 
     it "has a link to FeedEx" do
-      expect(content_item.feedex_link).to have_link("View feedback on FeedEx", href: "https://support.publishing.service.gov.uk/anonymous_feedback?path=/the-base-path")
+      expect(content_item.feedex_link).to have_link("View feedback on FeedEx", href: "#{Plek.find('support')}/anonymous_feedback?path=/the-base-path")
     end
   end
 

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ContentItemDecorator, type: :decorator do
-  describe '#last_updated' do
+  describe "#last_updated" do
     let(:content_item) { build(:content_item, public_updated_at: nil).decorate }
 
     it 'displays Never when content item has not been updated' do
@@ -9,17 +9,17 @@ RSpec.describe ContentItemDecorator, type: :decorator do
     end
   end
 
-  describe '#organisation_links' do
+  describe "#organisation_links" do
     let(:organisations) do
       [
-        build(:organisation, slug: 'slug-1', title: 'title-1'),
-        build(:organisation, slug: 'slug-2', title: 'title-2')
+        build(:organisation, slug: "slug-1", title: "title-1"),
+        build(:organisation, slug: "slug-2", title: "title-2")
       ]
     end
 
     let(:content_item) { build(:content_item, organisations: organisations).decorate }
 
-    it 'has a comma between names' do
+    it "has a comma between names" do
       organisation_links = content_item.organisation_links
 
       expect(organisation_links).to include(%{<a href=\"/content_items?organisation_slug=slug-1\">title-1</a>})
@@ -28,7 +28,7 @@ RSpec.describe ContentItemDecorator, type: :decorator do
   end
 
   describe "#list_taxons" do
-    let(:taxonomies) { [build(:taxonomy, title: 'taxon 1'), build(:taxonomy, title: 'taxon 2')] }
+    let(:taxonomies) { [build(:taxonomy, title: "taxon 1"), build(:taxonomy, title: "taxon 2")] }
     let(:content_item) { build(:content_item, taxonomies: taxonomies).decorate }
 
     it "returns a string of taxons separated by a comma" do

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
 
   it 'renders a link to FeedEx' do
     content_item.base_path = '/the-base-path'
-    feedex_link = "https://support.publishing.service.gov.uk/anonymous_feedback?path=/the-base-path"
+    feedex_link = "#{Plek.find('support')}/anonymous_feedback?path=/the-base-path"
     render
 
     expect(rendered).to have_link('View feedback on FeedEx', href: feedex_link)

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     expect(rendered).to have_selector('td + td', text: '2 months ago')
   end
 
+  it 'renders a link to FeedEx' do
+    content_item.base_path = '/the-base-path'
+    feedex_link = "https://support.publishing.service.gov.uk/anonymous_feedback?path=/the-base-path"
+    render
+
+    expect(rendered).to have_link('Support contacts', href: feedex_link)
+  end
+
   it 'renders the description of the content item' do
     content_item.description = 'The description of a content item'
     render

--- a/spec/views/content_items/show.html.erb_spec.rb
+++ b/spec/views/content_items/show.html.erb_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'content_items/show.html.erb', type: :view do
     feedex_link = "https://support.publishing.service.gov.uk/anonymous_feedback?path=/the-base-path"
     render
 
-    expect(rendered).to have_link('Support contacts', href: feedex_link)
+    expect(rendered).to have_link('View feedback on FeedEx', href: feedex_link)
   end
 
   it 'renders the description of the content item' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/kUebR1t4)

## Background

> As a Content Designer, I want the number of ‘support contacts’ shown on the content items details page to link through to the respective content item page in FeedEx, so that I can begin to explore and understand the issues that have been raised in more detail.

This is the super-simple MVP to link straight to the relevant page in FeedEx for a given page.

## Before
![image](https://cloud.githubusercontent.com/assets/424772/24301148/a69d69f8-10a6-11e7-8c69-2e96a848664b.png)

## After
![image](https://cloud.githubusercontent.com/assets/424772/24301160/af608192-10a6-11e7-8c97-3466803cc782.png)
![image](https://cloud.githubusercontent.com/assets/424772/24301177/c217ac02-10a6-11e7-9e10-2e94c2a45ebe.png)
