### PR TITLE
Add test for summary data

### DIFF
--- a/spec/features/summary_spec.rb
+++ b/spec/features/summary_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.feature "Summary area", type: :feature do
+  background do
+    @content_items = create_list :content_item, 3
+  end
+
+  scenario "user can see the total number of pages" do
+    visit 'content_items'
+
+    expect(page).to have_selector('.summary-item-value', text: 3)
+  end
+end


### PR DESCRIPTION
### Description
This adds a missing test for the  "total lives pages" value in the summary area for content items index.