### PR TITLE
Zero page views summary

### DIFF
--- a/app/misc/metric_builder.rb
+++ b/app/misc/metric_builder.rb
@@ -24,7 +24,8 @@ private
 
   def collection_metrics
     [
-      Metrics::TotalPages
+      Metrics::TotalPages,
+      Metrics::ZeroPageViews
     ]
   end
 end

--- a/app/misc/metrics/zero_page_views.rb
+++ b/app/misc/metrics/zero_page_views.rb
@@ -1,0 +1,13 @@
+module Metrics
+  class ZeroPageViews
+    attr_accessor :content_items
+
+    def initialize(content_items)
+      @content_items = content_items
+    end
+
+    def run
+      { zero_page_views: { value: content_items.where("unique_page_views = 0").count } }
+    end
+  end
+end

--- a/app/views/content_items/_summary.html.erb
+++ b/app/views/content_items/_summary.html.erb
@@ -1,6 +1,10 @@
-<div class="summary">
-  <div class="summary-item">
+<div class="summary row">
+  <div class="summary-item col-xs-4">
     <span class="summary-item-value"><%= @metrics[:total_pages][:value] %></span> 
     <span class="summary-item-label">Live pages</span>
+  </div>
+  <div class="summary-item col-xs-4">
+    <span class="summary-item-value"><%= @metrics[:zero_page_views][:value] %></span> 
+    <span class="summary-item-label">Pages with zero views</span>
   </div>
 </div>  

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ContentItemsController, type: :controller do
+  before do
+    allow_any_instance_of(MetricBuilder).to receive(:run_collection).and_return(a: :b)
+  end
+
   describe "GET #index" do
     it "returns http success" do
       get :index

--- a/spec/features/summary_spec.rb
+++ b/spec/features/summary_spec.rb
@@ -1,13 +1,20 @@
 require 'rails_helper'
 
 RSpec.feature "Summary area", type: :feature do
-  background do
-    @content_items = create_list :content_item, 3
-  end
-
   scenario "user can see the total number of pages" do
+    create_list :content_item, 3
+
     visit 'content_items'
 
     expect(page).to have_selector('.summary-item-value', text: 3)
+  end
+
+  scenario "user can see the total number of pages with zero views" do
+    create :content_item, unique_page_views: 1
+    create :content_item, unique_page_views: 0
+
+    visit 'content_items'
+
+    expect(page).to have_selector('.summary-item-value', text: 1)
   end
 end

--- a/spec/misc/metric_builder_spec.rb
+++ b/spec/misc/metric_builder_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe MetricBuilder do
 
   describe "#run_collection" do
     it "calls each collection metric class once" do
-      expect_any_instance_of(Metrics::TotalPages).to receive(:run).exactly(1).times
+      expect_any_instance_of(Metrics::TotalPages).to receive(:run).exactly(1).times.and_return({})
+      expect_any_instance_of(Metrics::ZeroPageViews).to receive(:run).exactly(1).times.and_return({})
 
       subject.run_collection([])
     end

--- a/spec/misc/metrics/zero_page_views_spec.rb
+++ b/spec/misc/metrics/zero_page_views_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::ZeroPageViews do
+  subject { Metrics::ZeroPageViews }
+
+  let!(:content_items) {
+    [
+      create(:content_item, unique_page_views: 1),
+      create(:content_item, unique_page_views: 0),
+      create(:content_item, unique_page_views: 0)
+    ]
+  }
+
+  it "returns the number of items with zero page views in the collection" do
+    expect(subject.new(ContentItem.all).run).to eq(zero_page_views: { value: 2 })
+  end
+end

--- a/spec/views/content_items/_summary.html.erb_spec.rb
+++ b/spec/views/content_items/_summary.html.erb_spec.rb
@@ -1,13 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe 'content_items/_summary.html.erb', type: :view do
+  let(:metrics) {
+    {
+      total_pages: { value: 0 },
+      zero_page_views: { value: 0 }
+    }
+  }
+
   it "renders the total pages metric" do
-    metrics = { total_pages: { value: 123 } }
+    metrics[:total_pages][:value] = 123
     assign(:metrics, metrics)
 
     render
 
     expect(rendered).to have_selector(".summary-item-label", text: "Live pages")
+    expect(rendered).to have_selector(".summary-item-value", text: "123")
+  end
+
+  it "renders the zero page views metric" do
+    metrics[:zero_page_views][:value] = 123
+    assign(:metrics, metrics)
+
+    render
+
+    expect(rendered).to have_selector(".summary-item-label", text: "Pages with zero views")
     expect(rendered).to have_selector(".summary-item-value", text: "123")
   end
 end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   before do
     assign(:organisations, [])
     assign(:taxonomies, [])
-    assign(:metrics, total_pages: {})
+    assign(:metrics, total_pages: {}, zero_page_views: {})
     assign(:content_items, ContentItemsDecorator.new(build_list(:content_item, 1)))
     allow(view).to receive(:paginate)
   end


### PR DESCRIPTION
### Motivation

As part of ongoing design iteration we are adding aggregate metrics to the summary area for `/content_items`. This PR adds a new metric "zero page views" which is rendered in the summary area.

### Description
Adds a new metric type `ZeroPageViews`, renders it in the `summary` partial.

### Before
<img width="1191" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/24545443/10d7e32c-15ff-11e7-96ed-9980d07c944c.png">

### After
<img width="1188" alt="after" src="https://cloud.githubusercontent.com/assets/6338228/24545453/172c422c-15ff-11e7-8122-cd3bb02a3863.png">
