### PR TITLE
Pages not updated metric

### DIFF
--- a/app/misc/metric_builder.rb
+++ b/app/misc/metric_builder.rb
@@ -25,7 +25,8 @@ private
   def collection_metrics
     [
       Metrics::TotalPages,
-      Metrics::ZeroPageViews
+      Metrics::ZeroPageViews,
+      Metrics::PagesNotUpdated
     ]
   end
 end

--- a/app/misc/metrics/pages_not_updated.rb
+++ b/app/misc/metrics/pages_not_updated.rb
@@ -1,0 +1,13 @@
+module Metrics
+  class PagesNotUpdated
+    attr_accessor :content_items
+
+    def initialize(content_items)
+      @content_items = content_items
+    end
+
+    def run
+      { pages_not_updated: { value: content_items.where("public_updated_at < ?", 6.months.ago).count } }
+    end
+  end
+end

--- a/app/views/content_items/_summary.html.erb
+++ b/app/views/content_items/_summary.html.erb
@@ -7,4 +7,8 @@
     <span class="summary-item-value"><%= @metrics[:zero_page_views][:value] %></span> 
     <span class="summary-item-label">Pages with zero views</span>
   </div>
+  <div class="summary-item col-xs-4">
+    <span class="summary-item-value"><%= @metrics[:pages_not_updated][:value] %></span> 
+    <span class="summary-item-label">Pages not updated in 6 months</span>
+  </div>
 </div>  

--- a/spec/features/summary_spec.rb
+++ b/spec/features/summary_spec.rb
@@ -17,4 +17,13 @@ RSpec.feature "Summary area", type: :feature do
 
     expect(page).to have_selector('.summary-item-value', text: 1)
   end
+
+  scenario "user can see the total number of pages not updated in the last 6 months" do
+    create :content_item, public_updated_at: 7.months.ago
+    create :content_item, public_updated_at: Date.today
+
+    visit 'content_items'
+
+    expect(page).to have_selector('.summary-item-value', text: 1)
+  end
 end

--- a/spec/misc/metric_builder_spec.rb
+++ b/spec/misc/metric_builder_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe MetricBuilder do
     it "calls each collection metric class once" do
       expect_any_instance_of(Metrics::TotalPages).to receive(:run).exactly(1).times.and_return({})
       expect_any_instance_of(Metrics::ZeroPageViews).to receive(:run).exactly(1).times.and_return({})
+      expect_any_instance_of(Metrics::PagesNotUpdated).to receive(:run).exactly(1).times.and_return({})
 
       subject.run_collection([])
     end

--- a/spec/misc/metrics/pages_not_updated_spec.rb
+++ b/spec/misc/metrics/pages_not_updated_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::PagesNotUpdated do
+  subject { Metrics::PagesNotUpdated }
+
+  let!(:content_items) {
+    [
+      create(:content_item, public_updated_at: 7.months.ago),
+      create(:content_item, public_updated_at: Date.today)
+    ]
+  }
+
+  it "returns the number of items with zero page views in the collection" do
+    expect(subject.new(ContentItem.all).run).to eq(pages_not_updated: { value: 1 })
+  end
+end

--- a/spec/views/content_items/_summary.html.erb_spec.rb
+++ b/spec/views/content_items/_summary.html.erb_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe 'content_items/_summary.html.erb', type: :view do
   let(:metrics) {
     {
       total_pages: { value: 0 },
-      zero_page_views: { value: 0 }
+      zero_page_views: { value: 0 },
+      pages_not_updated: { value: 0 }
     }
   }
 
@@ -25,6 +26,16 @@ RSpec.describe 'content_items/_summary.html.erb', type: :view do
     render
 
     expect(rendered).to have_selector(".summary-item-label", text: "Pages with zero views")
+    expect(rendered).to have_selector(".summary-item-value", text: "123")
+  end
+
+  it "renders the pages not updated metric" do
+    metrics[:pages_not_updated][:value] = 123
+    assign(:metrics, metrics)
+
+    render
+
+    expect(rendered).to have_selector(".summary-item-label", text: "Pages not updated in 6 months")
     expect(rendered).to have_selector(".summary-item-value", text: "123")
   end
 end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   before do
     assign(:organisations, [])
     assign(:taxonomies, [])
-    assign(:metrics, total_pages: {}, zero_page_views: {})
+    assign(:metrics, total_pages: {}, zero_page_views: {}, pages_not_updated: {})
     assign(:content_items, ContentItemsDecorator.new(build_list(:content_item, 1)))
     allow(view).to receive(:paginate)
   end


### PR DESCRIPTION
### Motivation
As part of ongoing design iteration we are adding aggregate metrics to the summary area for `/content_items`. This PR adds a new metric "pages not updated" which is rendered in the summary area.

### Description
Adds a new metric type `PagesNotUpdated`, renders it in the summary partial. Currently the metric uses 6 months as the timeframe to judge whether something has been updated or not.

### Before
<img width="1200" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/24547936/51d96246-160a-11e7-9e16-1e40c7472636.png">

### After
<img width="1208" alt="after" src="https://cloud.githubusercontent.com/assets/6338228/24547938/550b523a-160a-11e7-8ee9-5ca555dca942.png">


