### PR TITLE
Pdf vs html metric

### DIFF
--- a/app/assets/stylesheets/_summary.scss
+++ b/app/assets/stylesheets/_summary.scss
@@ -2,6 +2,10 @@
   margin: 20px 0;
 }
 
+.summary-item {
+  margin-bottom: 20px;
+}
+
 .summary-item-value,
 .summary-item-label {
   display: block;

--- a/app/misc/metric_builder.rb
+++ b/app/misc/metric_builder.rb
@@ -26,7 +26,8 @@ private
     [
       Metrics::TotalPages,
       Metrics::ZeroPageViews,
-      Metrics::PagesNotUpdated
+      Metrics::PagesNotUpdated,
+      Metrics::PagesWithPdfs
     ]
   end
 end

--- a/app/misc/metrics/pages_with_pdfs.rb
+++ b/app/misc/metrics/pages_with_pdfs.rb
@@ -1,0 +1,20 @@
+module Metrics
+  class PagesWithPdfs
+    attr_accessor :content_items
+
+    def initialize(content_items)
+      @content_items = content_items
+    end
+
+    def run
+      total = content_items.where("number_of_pdfs > ?", 0).count
+      percentage = (total.to_f / content_items.count.to_f) * 100
+      {
+        pages_with_pdfs: {
+          value: total,
+          percentage: percentage
+        }
+      }
+    end
+  end
+end

--- a/app/views/content_items/_summary.html.erb
+++ b/app/views/content_items/_summary.html.erb
@@ -1,14 +1,22 @@
-<div class="summary row">
-  <div class="summary-item col-xs-4">
-    <span class="summary-item-value"><%= @metrics[:total_pages][:value] %></span> 
-    <span class="summary-item-label">Live pages</span>
+<div class="summary">
+  <div class="row">
+    <div class="summary-item col-xs-4">
+      <span class="summary-item-value"><%= @metrics[:total_pages][:value] %></span> 
+      <span class="summary-item-label">Live pages</span>
+    </div>
+    <div class="summary-item col-xs-4">
+      <span class="summary-item-value"><%= @metrics[:zero_page_views][:value] %></span> 
+      <span class="summary-item-label">Pages with zero views</span>
+    </div>
+    <div class="summary-item col-xs-4">
+      <span class="summary-item-value"><%= @metrics[:pages_not_updated][:value] %></span> 
+      <span class="summary-item-label">Pages not updated in 6 months</span>
+    </div>
   </div>
-  <div class="summary-item col-xs-4">
-    <span class="summary-item-value"><%= @metrics[:zero_page_views][:value] %></span> 
-    <span class="summary-item-label">Pages with zero views</span>
-  </div>
-  <div class="summary-item col-xs-4">
-    <span class="summary-item-value"><%= @metrics[:pages_not_updated][:value] %></span> 
-    <span class="summary-item-label">Pages not updated in 6 months</span>
+  <div class="row">
+    <div class="summary-item col-xs-4">
+      <span class="summary-item-value"><%= number_with_precision @metrics[:pages_with_pdfs][:percentage], precision: 1 %>%</span> 
+      <span class="summary-item-label">Pages that contain PDF content</span>
+    </div>
   </div>
 </div>  

--- a/spec/features/summary_spec.rb
+++ b/spec/features/summary_spec.rb
@@ -26,4 +26,13 @@ RSpec.feature "Summary area", type: :feature do
 
     expect(page).to have_selector('.summary-item-value', text: 1)
   end
+
+  scenario "user can see the total number of pages not updated in the last 6 months" do
+    create :content_item, number_of_pdfs: 1
+    create :content_item, number_of_pdfs: 0
+
+    visit 'content_items'
+
+    expect(page).to have_selector('.summary-item-value', text: "50.0%")
+  end
 end

--- a/spec/misc/metric_builder_spec.rb
+++ b/spec/misc/metric_builder_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe MetricBuilder do
       expect_any_instance_of(Metrics::TotalPages).to receive(:run).exactly(1).times.and_return({})
       expect_any_instance_of(Metrics::ZeroPageViews).to receive(:run).exactly(1).times.and_return({})
       expect_any_instance_of(Metrics::PagesNotUpdated).to receive(:run).exactly(1).times.and_return({})
+      expect_any_instance_of(Metrics::PagesWithPdfs).to receive(:run).exactly(1).times.and_return({})
 
       subject.run_collection([])
     end

--- a/spec/misc/metrics/pages_with_pdfs_spec.rb
+++ b/spec/misc/metrics/pages_with_pdfs_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::PagesWithPdfs do
+  subject { Metrics::PagesWithPdfs }
+
+  let!(:content_items) {
+    [
+      create(:content_item, number_of_pdfs: 1),
+      create(:content_item, number_of_pdfs: 0)
+    ]
+  }
+
+  it "returns the number of items with pdfs in the collection" do
+    result = subject.new(ContentItem.all).run
+
+    expect(result[:pages_with_pdfs][:value]).to eq(1)
+  end
+
+  it "returns the number of items with pdfs as a percentage of the collection" do
+    result = subject.new(ContentItem.all).run
+
+    expect(result[:pages_with_pdfs][:percentage]).to eq(50)
+  end
+end

--- a/spec/views/content_items/_summary.html.erb_spec.rb
+++ b/spec/views/content_items/_summary.html.erb_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'content_items/_summary.html.erb', type: :view do
     {
       total_pages: { value: 0 },
       zero_page_views: { value: 0 },
-      pages_not_updated: { value: 0 }
+      pages_not_updated: { value: 0 },
+      pages_with_pdfs: { value: 0, percentage: 0 }
     }
   }
 
@@ -37,5 +38,15 @@ RSpec.describe 'content_items/_summary.html.erb', type: :view do
 
     expect(rendered).to have_selector(".summary-item-label", text: "Pages not updated in 6 months")
     expect(rendered).to have_selector(".summary-item-value", text: "123")
+  end
+
+  it "renders the pages with pdfs metric" do
+    metrics[:pages_with_pdfs][:percentage] = 50
+    assign(:metrics, metrics)
+
+    render
+
+    expect(rendered).to have_selector(".summary-item-label", text: "Pages that contain PDF content")
+    expect(rendered).to have_selector(".summary-item-value", text: "50.0%")
   end
 end

--- a/spec/views/content_items/index.html.erb_spec.rb
+++ b/spec/views/content_items/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'content_items/index.html.erb', type: :view do
   before do
     assign(:organisations, [])
     assign(:taxonomies, [])
-    assign(:metrics, total_pages: {}, zero_page_views: {}, pages_not_updated: {})
+    assign(:metrics, total_pages: {}, zero_page_views: {}, pages_not_updated: {}, pages_with_pdfs: {})
     assign(:content_items, ContentItemsDecorator.new(build_list(:content_item, 1)))
     allow(view).to receive(:paginate)
   end


### PR DESCRIPTION
### Motivation
As part of ongoing design iteration we are adding aggregate metrics to the summary area for `/content_items`. This PR adds a new metric "pages with pdfs" which is rendered in the summary area.

### Description
Adds a new metric type `PagesWithPdfs`, renders it in the summary.

**Note: this PR does not implement the graph for this, just the text value**

### Before
<img width="1171" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/24554397/48cc563e-1625-11e7-9da2-5bd5a7d4f994.png">

### After
<img width="1175" alt="after" src="https://cloud.githubusercontent.com/assets/6338228/24554398/4a27d242-1625-11e7-8f5a-1607688cd153.png">
