### PR TITLE
Fix taxonomy filter is blanked out when applying sorting

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -37,7 +37,7 @@ private
   end
 
   def set_organisation
-    @organisation = Organisation.find_by(content_id: params[:organisation_id]) if params[:organisation_id]
+    @organisation = Organisation.find_by(content_id: params[:organisation_content_id]) if params[:organisation_content_id]
   end
 
   def set_taxonomy

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,6 +1,7 @@
 class ContentItemsController < ApplicationController
   before_action :set_organisation, only: :index
   before_action :set_taxonomy, only: :index
+  before_action :set_filter_options, only: :index
   before_action :set_query_options, only: :index
   before_action :set_all_organisations, only: :index
   before_action :set_all_taxonomies, only: :index
@@ -42,5 +43,12 @@ private
 
   def set_taxonomy
     @taxonomy = Taxonomy.find_by(content_id: params[:taxonomy_content_id]) if params[:taxonomy_content_id]
+  end
+
+  def set_filter_options
+    @filter_options = {}
+    @filter_options[:organisation_content_id] = params[:organisation_content_id]
+    @filter_options[:taxonomy_content_id] = params[:taxonomy_content_id]
+    @filter_options[:query] = params[:query]
   end
 end

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -1,17 +1,17 @@
 module TableHelper
-  def sort_table_header(heading, attribute_name)
-    SortTable.new(self, heading, attribute_name).render
+  def sort_table_header(heading, attribute)
+    SortTable.new(self, heading, attribute).render
   end
 
   class SortTable
-    attr_accessor :view, :heading, :attribute_name
+    attr_accessor :view, :heading, :attribute
 
     delegate :content_tag, :params, :link_to, :content_items_path, to: :view
 
-    def initialize(view, heading, attribute_name)
+    def initialize(view, heading, attribute)
       @view = view
       @heading = heading
-      @attribute_name = attribute_name
+      @attribute = attribute
     end
 
     def render
@@ -24,7 +24,7 @@ module TableHelper
 
     def link(label, order)
       link_options = {
-          sort: attribute_name,
+          sort: attribute,
           order: order,
           query: params[:query]
       }
@@ -38,7 +38,7 @@ module TableHelper
     end
 
     def currently_sorted_by?
-      params[:order].present? && params[:sort] == attribute_name
+      params[:order].present? && params[:sort] == attribute
     end
 
     def text_label

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -23,25 +23,17 @@ module TableHelper
   private
 
     def link(label, order)
-      org_id = view.instance_variable_get(:@organisation).content_id if view.instance_variable_get(:@organisation).present?
-      taxon_id = view.instance_variable_get(:@taxonomy).content_id if view.instance_variable_get(:@taxonomy).present?
+      link_options = {
+          sort: attribute_name,
+          order: order,
+          query: params[:query]
+      }
 
-      if org_id && !taxon_id
-        link_to content_items_path(organisation_id: org_id, sort: attribute_name, order: order, query: params[:query]) do
-          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
-        end
-      elsif taxon_id && !org_id
-        link_to content_items_path(taxonomy_content_id: taxon_id, sort: attribute_name, order: order, query: params[:query]) do
-          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
-        end
-      elsif org_id && taxon_id
-        link_to content_items_path(organisation_id: org_id, taxonomy_content_id: taxon_id, sort: attribute_name, order: order, query: params[:query]) do
-          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
-        end
-      else
-        link_to content_items_path(sort: attribute_name, order: order, query: params[:query]) do
-          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
-        end
+      link_options[:organisation_id] = view.instance_variable_get(:@organisation).content_id if view.instance_variable_get(:@organisation).present?
+      link_options[:taxonomy_content_id] = view.instance_variable_get(:@taxonomy).content_id if view.instance_variable_get(:@taxonomy).present?
+
+      link_to content_items_path(link_options) do
+        "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
       end
     end
 

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -1,5 +1,5 @@
 module TableHelper
-  def sort_table_header(heading, attribute)
+  def sort_table_header(heading:, attribute:)
     SortTable.new(self, heading, attribute).render
   end
 

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -1,36 +1,34 @@
 module TableHelper
-  def sort_table_header(heading:, attribute:)
-    SortTable.new(self, heading, attribute).render
+  def sort_table_header(heading:, attribute:, filter_options:)
+    SortTable.new(self, heading, attribute, filter_options).render
   end
 
   class SortTable
-    attr_accessor :view, :heading, :attribute
+    attr_accessor :view, :heading, :attribute, :filter_options
 
     delegate :content_tag, :params, :link_to, :content_items_path, to: :view
 
-    def initialize(view, heading, attribute)
+    def initialize(view, heading, attribute, filter_options)
       @view = view
       @heading = heading
       @attribute = attribute
+      @filter_options = filter_options
     end
 
     def render
       content_tag :th, "aria-sort" => aria_label do
-        link text_label, order_param
+        link text_label, order_param, filter_options
       end
     end
 
   private
 
-    def link(label, order)
+    def link(label, order, filter_options)
       link_options = {
           sort: attribute,
-          order: order,
-          query: params[:query]
+          order: order
       }
-
-      link_options[:organisation_content_id] = view.instance_variable_get(:@organisation).content_id if view.instance_variable_get(:@organisation).present?
-      link_options[:taxonomy_content_id] = view.instance_variable_get(:@taxonomy).content_id if view.instance_variable_get(:@taxonomy).present?
+      link_options.merge!(filter_options)
 
       link_to content_items_path(link_options) do
         "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -29,7 +29,7 @@ module TableHelper
           query: params[:query]
       }
 
-      link_options[:organisation_id] = view.instance_variable_get(:@organisation).content_id if view.instance_variable_get(:@organisation).present?
+      link_options[:organisation_content_id] = view.instance_variable_get(:@organisation).content_id if view.instance_variable_get(:@organisation).present?
       link_options[:taxonomy_content_id] = view.instance_variable_get(:@taxonomy).content_id if view.instance_variable_get(:@taxonomy).present?
 
       link_to content_items_path(link_options) do

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -23,8 +23,19 @@ module TableHelper
   private
 
     def link(label, order)
-      if view.instance_variable_get(:@organisation).present?
-        link_to content_items_path(organisation_id: view.instance_variable_get(:@organisation).content_id, sort: attribute_name, order: order, query: params[:query]) do
+      org_id = view.instance_variable_get(:@organisation).content_id if view.instance_variable_get(:@organisation).present?
+      taxon_id = view.instance_variable_get(:@taxonomy).content_id if view.instance_variable_get(:@taxonomy).present?
+
+      if org_id && !taxon_id
+        link_to content_items_path(organisation_id: org_id, sort: attribute_name, order: order, query: params[:query]) do
+          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
+        end
+      elsif taxon_id && !org_id
+        link_to content_items_path(taxonomy_content_id: taxon_id, sort: attribute_name, order: order, query: params[:query]) do
+          "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
+        end
+      elsif org_id && taxon_id
+        link_to content_items_path(organisation_id: org_id, taxonomy_content_id: taxon_id, sort: attribute_name, order: order, query: params[:query]) do
           "#{heading}#{content_tag :span, label, class: 'rm'}".html_safe
         end
       else

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -8,7 +8,7 @@
     
     <div class="form-group">
       <%= label_tag 'Organisation:' %>
-      <%= select_tag :organisation_id, options_from_collection_for_select(@organisations, :content_id, :title, params[:organisation_id]), include_blank: true, class: "form-control" %>  
+      <%= select_tag :organisation_content_id, options_from_collection_for_select(@organisations, :content_id, :title, params[:organisation_content_id]), include_blank: true, class: "form-control" %>
     </div>
     
     <div class="form-group">

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -9,10 +9,10 @@
 <table class="table table-bordered table-hover">
   <thead>
     <tr class="table-header">
-      <%= sort_table_header "Title", "title" %>
-      <%= sort_table_header "Doc type", "document_type" %>
-      <%= sort_table_header "Page views (1mth)", "unique_page_views" %>
-      <%= sort_table_header "Last Updated", "public_updated_at" %>
+      <%= sort_table_header heading: "Title", attribute: "title" %>
+      <%= sort_table_header heading: "Doc type", attribute: "document_type" %>
+      <%= sort_table_header heading: "Page views (1mth)", attribute: "unique_page_views" %>
+      <%= sort_table_header heading: "Last Updated", attribute: "public_updated_at" %>
     </tr>
   </thead>
   <tbody>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -9,10 +9,10 @@
 <table class="table table-bordered table-hover">
   <thead>
     <tr class="table-header">
-      <%= sort_table_header heading: "Title", attribute: "title" %>
-      <%= sort_table_header heading: "Doc type", attribute: "document_type" %>
-      <%= sort_table_header heading: "Page views (1mth)", attribute: "unique_page_views" %>
-      <%= sort_table_header heading: "Last Updated", attribute: "public_updated_at" %>
+      <%= sort_table_header heading: "Title", attribute: "title", filter_options: @filter_options %>
+      <%= sort_table_header heading: "Doc type", attribute: "document_type", filter_options: @filter_options %>
+      <%= sort_table_header heading: "Page views (1mth)", attribute: "unique_page_views", filter_options: @filter_options %>
+      <%= sort_table_header heading: "Last Updated", attribute: "public_updated_at", filter_options: @filter_options %>
     </tr>
   </thead>
   <tbody>

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ContentItemsController, type: :controller do
     it "assigns the organisation provided the content_id" do
       create(:organisation, content_id: 'the-organisation-id')
 
-      get :index, params: { organisation_id: 'the-organisation-id' }
+      get :index, params: { organisation_content_id: 'the-organisation-id' }
       expect(assigns(:organisation).content_id).to eq('the-organisation-id')
     end
 

--- a/spec/features/content_items_spec.rb
+++ b/spec/features/content_items_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require 'features/pagination_spec_helper'
+require "rails_helper"
+require "features/pagination_spec_helper"
 
 RSpec.feature "Content Items List", type: :feature do
   describe "User can navigate paged lists of content items" do

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -80,5 +80,16 @@ RSpec.feature "Filter in content items", type: :feature do
 
       expect(page).to have_select(:taxonomy_content_id, selected: 'taxon 1')
     end
+
+    scenario "the user's previously filtered taxonomy is selected after sorting" do
+      create :taxonomy, title: "taxon 1", content_id: "123"
+
+      visit "content_items"
+      page.select "taxon 1", from: "taxonomy_content_id"
+      click_on "Filter"
+
+      click_on "Title"
+      expect(page).to have_select(:taxonomy_content_id, selected: "taxon 1")
+    end
   end
 end

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -39,10 +39,10 @@ RSpec.feature "Filter in content items", type: :feature do
       create :organisation, content_id: "the-content-id-1", title: "org 1"
 
       visit "/content_items"
-      select "org 1", from: "organisation_id"
+      select "org 1", from: "organisation_content_id"
       click_on "Filter"
 
-      expected_path = "organisation_id=the-content-id-1"
+      expected_path = "organisation_content_id=the-content-id-1"
 
       expect(current_url).to include(expected_path)
     end
@@ -51,10 +51,10 @@ RSpec.feature "Filter in content items", type: :feature do
       create :organisation, title: "org 1"
 
       visit "/content_items"
-      select "org 1", from: "organisation_id"
+      select "org 1", from: "organisation_content_id"
       click_on "Filter"
 
-      expect(page).to have_select(:organisation_id, selected: 'org 1')
+      expect(page).to have_select(:organisation_content_id, selected: 'org 1')
     end
   end
 

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TableHelper, type: :helper do
     let(:heading) { 'Last Updated' }
     let(:attribute) { 'public_updated_at' }
 
-    subject { helper.sort_table_header(heading: heading, attribute: attribute) }
+    subject { helper.sort_table_header(heading: heading, attribute: attribute, filter_options: {}) }
 
     describe 'Accessibility' do
       context 'When the column is unsorted' do
@@ -50,6 +50,7 @@ RSpec.describe TableHelper, type: :helper do
     end
 
     describe 'Sorting' do
+      subject { helper.sort_table_header(heading: heading, attribute: attribute, filter_options: params_asc) }
       context 'When the column is unsorted' do
         it 'has a link to sort asc' do
           link_href = content_items_path(params_asc)
@@ -59,6 +60,7 @@ RSpec.describe TableHelper, type: :helper do
       end
 
       context 'When the column is sorted asc' do
+        subject { helper.sort_table_header(heading: heading, attribute: attribute, filter_options: params_desc) }
         before { controller.params = params_asc }
 
         it 'has a link to sort desc' do

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe TableHelper, type: :helper do
     let(:organisation) { build(:organisation) }
     before { assign(:organisation, organisation) }
 
-    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_content_id: organisation.content_id } }
-    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_content_id: organisation.content_id } }
+    let(:params_asc) { {order: 'asc', sort: attribute, organisation_content_id: organisation.content_id } }
+    let(:params_desc) { {order: 'desc', sort: attribute, organisation_content_id: organisation.content_id } }
 
     let(:heading) { 'Last Updated' }
-    let(:attribute_name) { 'public_updated_at' }
+    let(:attribute) { 'public_updated_at' }
 
-    subject { helper.sort_table_header(heading, attribute_name) }
+    subject { helper.sort_table_header(heading: heading, attribute: attribute) }
 
     describe 'Accessibility' do
       context 'When the column is unsorted' do

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe TableHelper, type: :helper do
     let(:organisation) { build(:organisation) }
     before { assign(:organisation, organisation) }
 
-    let(:params_asc) { {order: 'asc', sort: attribute, organisation_content_id: organisation.content_id } }
-    let(:params_desc) { {order: 'desc', sort: attribute, organisation_content_id: organisation.content_id } }
+    let(:params_asc) { { order: 'asc', sort: attribute, organisation_content_id: organisation.content_id } }
+    let(:params_desc) { { order: 'desc', sort: attribute, organisation_content_id: organisation.content_id } }
 
     let(:heading) { 'Last Updated' }
     let(:attribute) { 'public_updated_at' }

--- a/spec/helpers/table_helper_spec.rb
+++ b/spec/helpers/table_helper_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe TableHelper, type: :helper do
     let(:organisation) { build(:organisation) }
     before { assign(:organisation, organisation) }
 
-    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_id: organisation.content_id } }
-    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_id: organisation.content_id } }
+    let(:params_asc) { { order: 'asc', sort: attribute_name, organisation_content_id: organisation.content_id } }
+    let(:params_desc) { { order: 'desc', sort: attribute_name, organisation_content_id: organisation.content_id } }
 
     let(:heading) { 'Last Updated' }
     let(:attribute_name) { 'public_updated_at' }


### PR DESCRIPTION
[Trello](https://trello.com/c/W8yLmHzh)

## Description

The URL was constructed incorrectly in the header links for the table sorter. It was not passing the value of the currently applied taxonomy filter, so it defaulted back to no taxonomy filtering.

This bugfix also refactors the handling or query parameters in the table sorter, so that it  no longer knows what all of the query parameters are. The only ones left in the table sorter to parse relate to the sorting. The ones for filtering are passed in, but pre-determined by the controller. The table sorter is oblivious what these other query params are but appends it to url when constructing the links.

## Before 
![image](https://cloud.githubusercontent.com/assets/424772/25784843/dc7ce854-336b-11e7-8d4f-7c80f84f0369.png)

 ## After
![image](https://cloud.githubusercontent.com/assets/424772/25784854/f80b9868-336b-11e7-9b28-0bcaa9cba01e.png)

