### PR TITLE
Add 6 months pageviews and fetch all GA stats in sidekiq jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'draper', '3.0.0.pre1'
 gem 'unicorn', '~> 5.1.0'
 
 gem 'gds-api-adapters', '~> 41.0.0'
+gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
+gem 'govuk_sidekiq', '~>1.0.3'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/alphagov/airbrake.git
+  revision: fe881d667ac55b592588e474c4ba3a44ced50a01
+  branch: silence-dep-warnings-for-rails-5
+  specs:
+    airbrake (4.3.8)
+      builder
+      multi_json
+      rails (>= 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -71,6 +81,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
+    connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
@@ -127,6 +138,13 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.1.1)
       rails (>= 3.2.0)
+    govuk_sidekiq (1.0.3)
+      airbrake (>= 3.1.0)
+      gds-api-adapters (>= 19.1.0)
+      redis-namespace (~> 1.5.2)
+      sidekiq (~> 4.2.8)
+      sidekiq-logging-json (~> 0.0)
+      sidekiq-statsd (~> 0.1)
     guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -210,6 +228,8 @@ GEM
     rack (2.0.1)
     rack-cache (1.7.0)
       rack (>= 0.4)
+    rack-protection (2.0.0)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.1)
@@ -245,6 +265,9 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.3.3)
+    redis-namespace (1.5.3)
+      redis (~> 3.0, >= 3.0.4)
     representable (2.3.0)
       uber (~> 0.0.7)
     request_store (1.3.2)
@@ -295,6 +318,17 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    sidekiq (4.2.10)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
+    sidekiq-logging-json (0.0.16)
+      sidekiq (>= 3, < 5)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -315,6 +349,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.4.0)
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -353,6 +388,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake!
   byebug
   capybara
   coffee-rails (~> 4.2)
@@ -362,6 +398,7 @@ DEPENDENCIES
   google-api-client (~> 0.9)
   govuk-lint
   govuk_admin_template (~> 5.0)
+  govuk_sidekiq (~> 1.0.3)
   guard-rspec
   httparty
   jbuilder (~> 2.5)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/app/jobs/import_pageviews_job.rb
+++ b/app/jobs/import_pageviews_job.rb
@@ -1,0 +1,19 @@
+class ImportPageviewsJob < ApplicationJob
+  attr_accessor :google_analytics_service
+
+  def initialize(*)
+    super
+    self.google_analytics_service = GoogleAnalyticsService.new
+  end
+
+  def perform(*args)
+    content_items = args[0]
+    base_paths = content_items.pluck(:base_path)
+
+    results = google_analytics_service.page_views(base_paths)
+    results.each do |result|
+      content_item = ContentItem.find_by(base_path: result[:base_path])
+      content_item.update!(result.slice(:one_month_page_views, :six_months_page_views))
+    end
+  end
+end

--- a/app/misc/metrics/zero_page_views.rb
+++ b/app/misc/metrics/zero_page_views.rb
@@ -7,7 +7,7 @@ module Metrics
     end
 
     def run
-      { zero_page_views: { value: content_items.where("unique_page_views = 0").count } }
+      { zero_page_views: { value: content_items.where("one_month_page_views = 0").count } }
     end
   end
 end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -1,19 +1,16 @@
 module Importers
   class NumberOfViewsByOrganisation
-    BATCH_SIZE = 3000
+    attr_accessor :batch_size
+
+    def initialize
+      self.batch_size = 500
+    end
 
     def run(slug)
       organisation = Organisation.find_by(slug: slug)
-      google_analytics_service = GoogleAnalyticsService.new
 
-      organisation.content_items.find_in_batches(batch_size: BATCH_SIZE) do |content_items|
-        base_paths = content_items.pluck(:base_path)
-
-        results = google_analytics_service.page_views(base_paths)
-        results.each do |result|
-          content_item = ContentItem.find_by(base_path: result[:base_path])
-          content_item.update!(one_month_page_views: result[:page_views][:one_month])
-        end
+      organisation.content_items.find_in_batches(batch_size: batch_size) do |content_items|
+        ImportPageviewsJob.perform_later(content_items)
       end
     end
   end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -12,7 +12,7 @@ module Importers
         results = google_analytics_service.page_views(base_paths)
         results.each do |result|
           content_item = ContentItem.find_by(base_path: result[:base_path])
-          content_item.update!(unique_page_views: result[:page_views])
+          content_item.update!(unique_page_views: result[:page_views][:one_month])
         end
       end
     end

--- a/app/models/importers/number_of_views_by_organisation.rb
+++ b/app/models/importers/number_of_views_by_organisation.rb
@@ -12,7 +12,7 @@ module Importers
         results = google_analytics_service.page_views(base_paths)
         results.each do |result|
           content_item = ContentItem.find_by(base_path: result[:base_path])
-          content_item.update!(unique_page_views: result[:page_views][:one_month])
+          content_item.update!(one_month_page_views: result[:page_views][:one_month])
         end
       end
     end

--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -6,15 +6,16 @@ module GoogleAnalytics
     class PageViewsRequest
       include Google::Apis::AnalyticsreportingV4
 
-      def build(base_paths, start_dates: ["7daysAgo"], end_date: "today")
+      def build(args = {})
+        end_date = args[:end_date] || "today"
         GetReportsRequest.new.tap do |reports|
           reports.report_requests = Array.new.push(
             ReportRequest.new.tap do |request|
               request.metrics = metrics(unique_page_views)
               request.view_id = view_id
-              request.dimension_filter_clauses = filters(base_paths, page_path)
+              request.dimension_filter_clauses = filters(args[:base_paths], page_path)
               request.dimensions = dimensions(page_path)
-              request.date_ranges = date_ranges(start_dates, end_date)
+              request.date_ranges = date_ranges(args[:start_dates], end_date)
             end
           )
         end

--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -6,7 +6,7 @@ module GoogleAnalytics
     class PageViewsRequest
       include Google::Apis::AnalyticsreportingV4
 
-      def build(base_paths, start_date: "7daysAgo", end_date: "today")
+      def build(base_paths, start_dates: ["7daysAgo"], end_date: "today")
         GetReportsRequest.new.tap do |reports|
           reports.report_requests = Array.new.push(
             ReportRequest.new.tap do |request|
@@ -14,7 +14,7 @@ module GoogleAnalytics
               request.view_id = view_id
               request.dimension_filter_clauses = filters(base_paths, page_path)
               request.dimensions = dimensions(page_path)
-              request.date_ranges = date_ranges(start_date, end_date)
+              request.date_ranges = date_ranges(start_dates, end_date)
             end
           )
         end
@@ -22,11 +22,14 @@ module GoogleAnalytics
 
     private
 
-      def date_ranges(start_date, end_date)
-        date_range = DateRange.new
-        date_range.start_date = start_date
-        date_range.end_date = end_date
-        [date_range]
+      def date_ranges(start_dates, end_date)
+        date_ranges = start_dates.map do |start_date|
+          date_range = DateRange.new
+          date_range.start_date = start_date
+          date_range.end_date = end_date
+          date_range
+        end
+        date_ranges
       end
 
       def dimensions(name)

--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -12,7 +12,8 @@ module GoogleAnalytics
           {
             base_path: row.dimensions.first,
             page_views: {
-              one_month: row.metrics.first.values.first.to_i
+              one_month: row.metrics.first.values.first.to_i,
+              six_months: row.metrics.second.values.first.to_i
             },
           }
         end

--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -11,10 +11,8 @@ module GoogleAnalytics
         report.data.rows.map do |row|
           {
             base_path: row.dimensions.first,
-            page_views: {
-              one_month: row.metrics.first.values.first.to_i,
-              six_months: row.metrics.second.values.first.to_i
-            },
+            one_month_page_views: row.metrics.first.values.first.to_i,
+            six_months_page_views: row.metrics.second.values.first.to_i
           }
         end
       end

--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -11,7 +11,9 @@ module GoogleAnalytics
         report.data.rows.map do |row|
           {
             base_path: row.dimensions.first,
-            page_views: row.metrics.first.values.first.to_i
+            page_views: {
+              one_month: row.metrics.first.values.first.to_i
+            },
           }
         end
       end

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -8,7 +8,7 @@ class GoogleAnalyticsService
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
       base_paths,
-      start_dates: [1.month.ago.strftime("%Y-%m-%d")]
+      start_dates: [1.month.ago.strftime("%Y-%m-%d"), 6.months.ago.strftime("%Y-%m-%d")]
     )
     response = client.batch_get_reports(request)
     GoogleAnalytics::Responses::PageViewsResponse.new.parse(response)

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -8,7 +8,7 @@ class GoogleAnalyticsService
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
       base_paths,
-      start_date: 1.month.ago.strftime("%Y-%m-%d")
+      start_dates: [1.month.ago.strftime("%Y-%m-%d")]
     )
     response = client.batch_get_reports(request)
     GoogleAnalytics::Responses::PageViewsResponse.new.parse(response)

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -7,7 +7,7 @@ class GoogleAnalyticsService
     raise "base_paths isn't an array" unless base_paths.is_a?(Array)
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
-      base_paths,
+      base_paths: base_paths,
       start_dates: [1.month.ago.strftime("%Y-%m-%d"), 6.months.ago.strftime("%Y-%m-%d")]
     )
     response = client.batch_get_reports(request)

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -2,6 +2,7 @@
   <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
   <td><%= content_item.document_type %></td>
   <td><%= content_item.one_month_page_views %></td>
+  <td><%= content_item.six_months_page_views %></td>
   <td>
     <% if content_item.public_updated_at %>
       <%= time_ago_in_words(content_item.public_updated_at) %> ago

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
   <td><%= content_item.document_type %></td>
-  <td><%= content_item.unique_page_views %></td>
+  <td><%= content_item.one_month_page_views %></td>
   <td>
     <% if content_item.public_updated_at %>
       <%= time_ago_in_words(content_item.public_updated_at) %> ago

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -12,6 +12,7 @@
       <%= sort_table_header heading: "Title", attribute: "title", filter_options: @filter_options %>
       <%= sort_table_header heading: "Doc type", attribute: "document_type", filter_options: @filter_options %>
       <%= sort_table_header heading: "Page views (1mth)", attribute: "one_month_page_views", filter_options: @filter_options %>
+      <%= sort_table_header heading: "Page views (6mth)", attribute: "six_months_page_views", filter_options: @filter_options %>
       <%= sort_table_header heading: "Last Updated", attribute: "public_updated_at", filter_options: @filter_options %>
     </tr>
   </thead>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar do %>
-  <%= render 'application/sidebar' %>  
+  <%= render 'application/sidebar' %>
 <% end %>
 
 <h1><%= @content_items.header organisation: @organisation, taxonomy: @taxonomy %></h1>
@@ -11,7 +11,7 @@
     <tr class="table-header">
       <%= sort_table_header heading: "Title", attribute: "title", filter_options: @filter_options %>
       <%= sort_table_header heading: "Doc type", attribute: "document_type", filter_options: @filter_options %>
-      <%= sort_table_header heading: "Page views (1mth)", attribute: "unique_page_views", filter_options: @filter_options %>
+      <%= sort_table_header heading: "Page views (1mth)", attribute: "one_month_page_views", filter_options: @filter_options %>
       <%= sort_table_header heading: "Last Updated", attribute: "public_updated_at", filter_options: @filter_options %>
     </tr>
   </thead>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -22,7 +22,7 @@
     </tr>
     <tr>
       <td>Page views (1 month)</td>
-      <td><%= @content_item.unique_page_views %></td>
+      <td><%= @content_item.one_month_page_views %></td>
     </tr>
     <tr>
       <td>Last updated</td>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -25,6 +25,10 @@
       <td><%= @content_item.one_month_page_views %></td>
     </tr>
     <tr>
+      <td>Page views (6 months)</td>
+      <td><%= @content_item.six_months_page_views %></td>
+    </tr>
+    <tr>
       <td>Last updated</td>
       <td>
         <%= @content_item.last_updated %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,6 @@ module ContentPerformanceManager
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.document_types = config_for(:document_types)["types"]
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+# config/sidekiq.yml
+---
+:concurrency:  3

--- a/db/migrate/20170301154536_rename_page_views_to_one_month_page_views.rb
+++ b/db/migrate/20170301154536_rename_page_views_to_one_month_page_views.rb
@@ -1,0 +1,5 @@
+class RenamePageViewsToOneMonthPageViews < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :content_items, :unique_page_views, :one_month_page_views
+  end
+end

--- a/db/migrate/20170301165728_add_six_months_column.rb
+++ b/db/migrate/20170301165728_add_six_months_column.rb
@@ -1,0 +1,5 @@
+class AddSixMonthsColumn < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :six_months_page_views, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,16 +17,16 @@ ActiveRecord::Schema.define(version: 20170327105838) do
 
   create_table "content_items", force: :cascade do |t|
     t.string   "content_id"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.datetime "public_updated_at"
     t.string   "base_path"
     t.string   "title"
     t.string   "document_type"
     t.string   "description"
     t.integer  "one_month_page_views",  default: 0
-    t.integer  "number_of_pdfs",        default: 0
     t.integer  "six_months_page_views", default: 0
+    t.integer  "number_of_pdfs",    default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["title"], name: "index_content_items_on_title", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,15 +17,16 @@ ActiveRecord::Schema.define(version: 20170327105838) do
 
   create_table "content_items", force: :cascade do |t|
     t.string   "content_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.datetime "public_updated_at"
     t.string   "base_path"
     t.string   "title"
     t.string   "document_type"
     t.string   "description"
-    t.integer  "unique_page_views", default: 0
-    t.integer  "number_of_pdfs",    default: 0
+    t.integer  "one_month_page_views",  default: 0
+    t.integer  "number_of_pdfs",        default: 0
+    t.integer  "six_months_page_views", default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
     t.index ["title"], name: "index_content_items_on_title", using: :btree
   end

--- a/spec/factories/google_analytics/page_views_response_factory.rb
+++ b/spec/factories/google_analytics/page_views_response_factory.rb
@@ -14,7 +14,7 @@ module GoogleAnalytics
                     metrics: [
                       Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
                         values: [
-                          response.fetch(:page_views)
+                          response.fetch(:page_views, {}).fetch(:one_month, nil)
                         ]
                       )
                     ]

--- a/spec/factories/google_analytics/page_views_response_factory.rb
+++ b/spec/factories/google_analytics/page_views_response_factory.rb
@@ -16,6 +16,11 @@ module GoogleAnalytics
                         values: [
                           response.fetch(:page_views, {}).fetch(:one_month, nil)
                         ]
+                      ),
+                      Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
+                        values: [
+                          response.fetch(:page_views, {}).fetch(:six_months, nil)
+                        ]
                       )
                     ]
                   )

--- a/spec/factories/google_analytics/page_views_response_factory.rb
+++ b/spec/factories/google_analytics/page_views_response_factory.rb
@@ -14,12 +14,12 @@ module GoogleAnalytics
                     metrics: [
                       Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
                         values: [
-                          response.fetch(:page_views, {}).fetch(:one_month, nil)
+                          response.fetch(:one_month_page_views)
                         ]
                       ),
                       Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
                         values: [
-                          response.fetch(:page_views, {}).fetch(:six_months, nil)
+                          response.fetch(:six_months_page_views)
                         ]
                       )
                     ]

--- a/spec/features/content_item_spec.rb
+++ b/spec/features/content_item_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Content Item Details", type: :feature do
   end
 
   scenario "Renders stats for Google Analytics" do
-    content_item = create :content_item, unique_page_views: 77
+    content_item = create :content_item, one_month_page_views: 77
 
     visit "/content_items/#{content_item.id}"
 

--- a/spec/features/content_items_spec.rb
+++ b/spec/features/content_items_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Content Items List", type: :feature do
     create(:content_item,
       title: "a-title",
       document_type: "guide",
-      unique_page_views: "99",
+      one_month_page_views: "99",
       public_updated_at: 2.months.ago
     )
 

--- a/spec/features/summary_spec.rb
+++ b/spec/features/summary_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature "Summary area", type: :feature do
   end
 
   scenario "user can see the total number of pages with zero views" do
-    create :content_item, unique_page_views: 1
-    create :content_item, unique_page_views: 0
+    create :content_item, one_month_page_views: 1
+    create :content_item, one_month_page_views: 0
 
     visit 'content_items'
 

--- a/spec/jobs/import_pageviews_job_spec.rb
+++ b/spec/jobs/import_pageviews_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ImportPageviewsJob, type: :job do
+  it "updates the content items with pageviews" do
+    content_item = create(:content_item, base_path: '/the-base-path')
+    service = double(:google_analytics_service)
+    allow(service).to receive(:page_views).with(['/the-base-path']).and_return(
+      [
+        {
+          base_path: '/the-base-path',
+          one_month_page_views: 88,
+          six_months_page_views: 888
+        }
+      ]
+    )
+    subject.google_analytics_service = service
+
+    subject.perform([content_item])
+
+    content_item.reload
+    expect(content_item.one_month_page_views).to eq(88)
+    expect(content_item.six_months_page_views).to eq(888)
+  end
+end

--- a/spec/misc/metrics/zero_page_views_spec.rb
+++ b/spec/misc/metrics/zero_page_views_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Metrics::ZeroPageViews do
 
   let!(:content_items) {
     [
-      create(:content_item, unique_page_views: 1),
-      create(:content_item, unique_page_views: 0),
-      create(:content_item, unique_page_views: 0)
+      create(:content_item, one_month_page_views: 1),
+      create(:content_item, one_month_page_views: 0),
+      create(:content_item, one_month_page_views: 0)
     ]
   }
 

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -11,11 +11,15 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
         [
           {
             base_path: 'the-link/first',
-            page_views: 3,
+            page_views: {
+              one_month: 3,
+            },
           },
           {
             base_path: 'the-link/second',
-            page_views: 2,
+            page_views: {
+              one_month: 2,
+            },
           },
         ]
       )

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -1,56 +1,25 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Importers::NumberOfViewsByOrganisation do
-  describe '#run' do
-    let!(:organisation) { create(:organisation, slug: 'the-slug') }
-    let!(:content_item_first) { create(:content_item, base_path: 'the-link/first', organisations: [organisation]) }
-    let!(:content_item_second) { create(:content_item, base_path: 'the-link/second', organisations: [organisation]) }
+  describe "#run" do
+    let(:organisation) { create(:organisation, slug: "the-slug") }
 
-    it "updates the number of views for all content items" do
-      allow_any_instance_of(GoogleAnalyticsService).to receive(:page_views).and_return(
-        [
-          {
-            base_path: 'the-link/first',
-            page_views: {
-              one_month: 3,
-            },
-          },
-          {
-            base_path: 'the-link/second',
-            page_views: {
-              one_month: 2,
-            },
-          },
-        ]
-      )
+    it "creates a job to import pageviews for content items" do
+      content_items = [create(:content_item)]
+      organisation.content_items << content_items
 
-      stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 1)
+      expect(ImportPageviewsJob).to receive(:perform_later).with(content_items)
 
-      subject.run('the-slug')
-
-      content_item_one = ContentItem.find_by(base_path: 'the-link/first')
-      content_item_two = ContentItem.find_by(base_path: 'the-link/second')
-
-      expect(content_item_one.one_month_page_views).to eq(3)
-      expect(content_item_two.one_month_page_views).to eq(2)
+      subject.run("the-slug")
     end
 
-    context "performs the request to google api in batches" do
-      it "makes two requests when the batch size is one" do
-        expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).twice.and_return([])
+    it "creates a job per batch of content items" do
+      organisation.content_items << create_list(:content_item, 2)
+      subject.batch_size = 1
 
-        stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 1)
+      expect(ImportPageviewsJob).to receive(:perform_later).twice
 
-        subject.run('the-slug')
-      end
-
-      it "makes one request when the batch size is two" do
-        expect_any_instance_of(GoogleAnalyticsService).to receive(:page_views).once.and_return([])
-
-        stub_const("Importers::NumberOfViewsByOrganisation::BATCH_SIZE", 2)
-
-        subject.run('the-slug')
-      end
+      subject.run("the-slug")
     end
   end
 end

--- a/spec/models/importers/number_of_views_by_organisation_spec.rb
+++ b/spec/models/importers/number_of_views_by_organisation_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Importers::NumberOfViewsByOrganisation do
       content_item_one = ContentItem.find_by(base_path: 'the-link/first')
       content_item_two = ContentItem.find_by(base_path: 'the-link/second')
 
-      expect(content_item_one.unique_page_views).to eq(3)
-      expect(content_item_two.unique_page_views).to eq(2)
+      expect(content_item_one.one_month_page_views).to eq(3)
+      expect(content_item_two.one_month_page_views).to eq(2)
     end
 
     context "performs the request to google api in batches" do

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -63,7 +63,7 @@ module GoogleAnalytics
 
           request = PageViewsRequest.new.build(
             ["/check-uk-visa"],
-            start_date: "2016/11/22",
+            start_dates: ["2016/11/22"],
             end_date: "2016/12/22")
 
           expect(request.as_json).to include(page_views_request)

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -50,21 +50,16 @@ module GoogleAnalytics
           }.deep_stringify_keys!
         end
 
-        it "builds the requests body with default arguments" do
-          request = PageViewsRequest.new.build(["/check-uk-visa"])
-
-          expect(request.as_json).to include(page_views_request)
-        end
-
         it "builds the requests body with supplied arguments" do
           date_range = page_views_request["report_requests"][0]["date_ranges"][0]
           date_range["start_date"] = "2016/11/22"
           date_range["end_date"] = "2016/12/22"
 
           request = PageViewsRequest.new.build(
-            ["/check-uk-visa"],
+            base_paths: ["/check-uk-visa"],
             start_dates: ["2016/11/22"],
-            end_date: "2016/12/22")
+            end_date: "2016/12/22"
+            )
 
           expect(request.as_json).to include(page_views_request)
         end

--- a/spec/services/google_analytics/responses/page_views_response_spec.rb
+++ b/spec/services/google_analytics/responses/page_views_response_spec.rb
@@ -9,12 +9,14 @@ module GoogleAnalytics
             base_path: "/check-uk-visa",
             page_views: {
               one_month: 400,
+              six_months: 4800,
             },
           },
           {
             base_path: "/marriage-abroad",
             page_views: {
               one_month: 500,
+              six_months: 6000,
             },
           }
         ])
@@ -27,12 +29,14 @@ module GoogleAnalytics
             base_path: "/check-uk-visa",
             page_views: {
               one_month: 400,
+              six_months: 4800,
             },
           },
           {
             base_path: "/marriage-abroad",
             page_views: {
               one_month: 500,
+              six_months: 6000,
             },
           }
         ]

--- a/spec/services/google_analytics/responses/page_views_response_spec.rb
+++ b/spec/services/google_analytics/responses/page_views_response_spec.rb
@@ -7,17 +7,13 @@ module GoogleAnalytics
         GoogleAnalytics::PageViewsResponseFactory.build([
           {
             base_path: "/check-uk-visa",
-            page_views: {
-              one_month: 400,
-              six_months: 4800,
-            },
+            one_month_page_views: 400,
+            six_months_page_views: 4800,
           },
           {
             base_path: "/marriage-abroad",
-            page_views: {
-              one_month: 500,
-              six_months: 6000,
-            },
+            one_month_page_views: 500,
+            six_months_page_views: 6000,
           }
         ])
       end
@@ -27,17 +23,13 @@ module GoogleAnalytics
         expected_response = [
           {
             base_path: "/check-uk-visa",
-            page_views: {
-              one_month: 400,
-              six_months: 4800,
-            },
+            one_month_page_views: 400,
+            six_months_page_views: 4800,
           },
           {
             base_path: "/marriage-abroad",
-            page_views: {
-              one_month: 500,
-              six_months: 6000,
-            },
+            one_month_page_views: 500,
+            six_months_page_views: 6000,
           }
         ]
 

--- a/spec/services/google_analytics/responses/page_views_response_spec.rb
+++ b/spec/services/google_analytics/responses/page_views_response_spec.rb
@@ -7,11 +7,15 @@ module GoogleAnalytics
         GoogleAnalytics::PageViewsResponseFactory.build([
           {
             base_path: "/check-uk-visa",
-            page_views: 400
+            page_views: {
+              one_month: 400,
+            },
           },
           {
             base_path: "/marriage-abroad",
-            page_views: 500
+            page_views: {
+              one_month: 500,
+            },
           }
         ])
       end
@@ -21,11 +25,15 @@ module GoogleAnalytics
         expected_response = [
           {
             base_path: "/check-uk-visa",
-            page_views: 400
+            page_views: {
+              one_month: 400,
+            },
           },
           {
             base_path: "/marriage-abroad",
-            page_views: 500
+            page_views: {
+              one_month: 500,
+            },
           }
         ]
 

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe GoogleAnalyticsService do
         [
           {
             base_path: '/path-1',
-            page_views: {
-              one_month: 5,
-              six_months: 60,
-            },
+            one_month_page_views: 5,
+            six_months_page_views: 60,
           }
         ]
       )
@@ -31,10 +29,8 @@ RSpec.describe GoogleAnalyticsService do
       expect(response).to eq([
         {
           base_path: '/path-1',
-          page_views: {
-            one_month: 5,
-            six_months: 60,
-          },
+          one_month_page_views: 5,
+          six_months_page_views: 60,
         }
       ])
     end

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -14,14 +14,25 @@ RSpec.describe GoogleAnalyticsService do
     end
 
     it 'returns a hash containing the page views' do
-      google_response = GoogleAnalytics::PageViewsResponseFactory.build([{ base_path: '/path-1', page_views: 5 }])
+      google_response = GoogleAnalytics::PageViewsResponseFactory.build(
+        [
+          {
+            base_path: '/path-1',
+            page_views: {
+              one_month: 5,
+            },
+          }
+        ]
+      )
       allow(google_client).to receive(:batch_get_reports).and_return(google_response)
 
       response = subject.page_views(%w(/path-1))
       expect(response).to eq([
         {
           base_path: '/path-1',
-          page_views: 5
+          page_views: {
+            one_month: 5,
+          },
         }
       ])
     end

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe GoogleAnalyticsService do
             base_path: '/path-1',
             page_views: {
               one_month: 5,
+              six_months: 60,
             },
           }
         ]
@@ -32,6 +33,7 @@ RSpec.describe GoogleAnalyticsService do
           base_path: '/path-1',
           page_views: {
             one_month: 5,
+            six_months: 60,
           },
         }
       ])


### PR DESCRIPTION
[Trello card](https://trello.com/c/jwrJjjhs/142-3-get-one-month-and-twelve-months-of-unique-page-view-data)

## Background

This PR does 2 main things:

* adds 6 months of pageviews stats
* makes the rake task fire off an ActiveJob to handle the large number of requests to Google Analytics API in batches

As part of the 2nd change above, in this PR we:
* adds `govuk_sidekiq` gem
* adds the alphagov fork of airbrake gem

Related PRs:

* https://github.com/alphagov/govuk-app-deployment/pull/111
* https://github.gds/gds/development/pull/384 (note the project merged into govuk_puppet)
* https://github.gds/gds/development/pull/385
* https://github.com/alphagov/sidekiq-monitoring/pull/27
* https://github.com/alphagov/govuk-puppet/pull/5685

# Expected outcomes

The outcome of this is that when you run the `import:number_of_views_by_organisation` task, it will delegate the work to the job queue. This helps with timeout errors and update failures from the GA API, as sidekiq will retry (up to 3 times which is the default).

Once the stats are updated you should also see a new column for 6 months of pageviews:

## Before
![image](https://cloud.githubusercontent.com/assets/424772/25895167/b24d3fc2-3576-11e7-994d-98d5581bbf75.png)

## After
![image](https://cloud.githubusercontent.com/assets/424772/25895151/a07165d0-3576-11e7-95e5-b9c48aa1af9f.png)
