### PR TITLE
Use "topics" to be consistent with Whitehall

### DIFF
--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -3,16 +3,16 @@
   <%= form_tag content_items_path, method: :get do %>
     <div class="form-group">
       <%= label_tag 'query', 'Search term:', class: '' %>
-      <%= text_field_tag 'query', params[:query], placeholder: 'Enter search term...', class: 'form-control' %>  
+      <%= text_field_tag 'query', params[:query], placeholder: 'Enter search term...', class: 'form-control' %>
     </div>
-    
+
     <div class="form-group">
       <%= label_tag 'Organisation:' %>
       <%= select_tag :organisation_content_id, options_from_collection_for_select(@organisations, :content_id, :title, params[:organisation_content_id]), include_blank: true, class: "form-control" %>
     </div>
-    
+
     <div class="form-group">
-      <%= label_tag 'Taxonomy:' %>
+      <%= label_tag 'Topics (new taxonomy):' %>
       <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies || [], :content_id, :title, params[:taxonomy_content_id]), include_blank: true, class: "form-control" %>  
     </div>
 

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -50,7 +50,7 @@
       <td>Number of pdfs</td>
       <td><%= @content_item.number_of_pdfs %></td>
     </tr>
-      <td>Taxonomies</td>
+      <td>Topics (new taxonomy)</td>
       <td><%= @content_item.taxons_as_string %></td>
     </tr>
   </tbody>


### PR DESCRIPTION
In the Whitehall user interface taxons are called "topics". To differentiate them from the other topics (https://www.gov.uk/topic) we've put in "new taxonomy" in parentheses in some places.

<img width="1213" alt="screen shot 2017-05-11 at 16 13 25" src="https://cloud.githubusercontent.com/assets/233676/25957077/590305f6-3665-11e7-98ae-9533471af1b6.png">
<img width="1216" alt="screen shot 2017-05-11 at 16 13 37" src="https://cloud.githubusercontent.com/assets/233676/25957078/5907ce9c-3665-11e7-8e44-d9d3d387a858.png">

Since the users of Whitehall & CPM will be the same, we should probably use the same terminology across applications.

