### PR TITLE
Autocorrect lint errors when using Guard

### DIFF
--- a/lib/guard/lint.rb
+++ b/lib/guard/lint.rb
@@ -2,7 +2,7 @@ require 'guard/compat/plugin'
 
 module Guard
   class Lint < Plugin
-    CMD = "bundle exec govuk-lint-ruby".freeze
+    CMD = "bundle exec govuk-lint-ruby -a".freeze
 
     def run_all
       system(CMD)


### PR DESCRIPTION
When Lint detects an offence, if he knows how to fix it, then he applies
the patch without the user intervention. This covers most of the Lint 
errors and prevents the user from applying obvious changes.

For example, if an indentation offence is found in: `app/models/importers/all_content_items.rb` 
Lint will apply the fix automatically

```bash
inspecting 1 file

Offenses:

app/models/importers/all_content_items.rb:4:3: C: [Corrected] Style/IndentationConsistency: Inconsistent indentation detected.
  attr_writer :document_types
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, **1 offense corrected**
```