### PR TITLE
Don't explicitly require rspec in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,8 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
-require "rspec/core/rake_task"
 
 Rails.application.load_tasks
-RSpec::Core::RakeTask.new(:spec)
 
 task :lint do
   sh "bundle exec govuk-lint-ruby"


### PR DESCRIPTION
This is so that the production environment rake tasks
can run.