### PR TITLE
Show/Hide filters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,14 @@ group :development, :test do
   gem 'listen', '~> 3.0.5'
   gem 'guard-rspec', require: false
   gem 'pry-rails'
+  gem 'poltergeist'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'spring-commands-rspec'
   gem 'capybara'
   gem 'webmock'
   gem 'rails-controller-testing', '~>1.0.1'
+  gem 'database_cleaner'
 end
+
+gem 'web-console', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -83,6 +84,7 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     domain_name (0.5.20170223)
@@ -241,6 +243,10 @@ GEM
       ast (~> 2.2)
     pg (0.19.0)
     plek (2.0.0)
+    poltergeist (1.13.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -417,6 +423,7 @@ DEPENDENCIES
   airbrake!
   capybara
   coffee-rails (~> 4.2)
+  database_cleaner
   draper (= 3.0.0.pre1)
   factory_girl_rails
   gds-api-adapters (~> 41.0.0)
@@ -433,6 +440,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   pg (~> 0.18)
   plek
+  poltergeist
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
@@ -452,4 +460,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,23 @@
 @import 'pagination';
 @import 'phase_banner';
 @import 'summary';
+
+// TODO: move any styles below to modules once more established
+
+[data-toggle] {
+
+  &[aria-expanded="true"] {
+
+    [data-close-label] {
+      display: inline;
+    }
+
+    [data-open-label] {
+      display: none;
+    }
+  }
+
+  [data-close-label] {
+    display: none;
+  }
+}

--- a/app/helpers/content_items_helper.rb
+++ b/app/helpers/content_items_helper.rb
@@ -1,0 +1,5 @@
+module ContentItemsHelper
+  def advanced_filter_enabled?
+    params[:taxonomy_content_id].present?
+  end
+end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -11,12 +11,22 @@
       <%= select_tag :organisation_content_id, options_from_collection_for_select(@organisations, :content_id, :title, params[:organisation_content_id]), include_blank: true, class: "form-control" %>
     </div>
 
+    <div id="additionalFilters" class="collapse">
+      <div class="form-group">
+        <%= label_tag 'Topics (new taxonomy):' %>
+        <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies || [], :content_id, :title, params[:taxonomy_content_id]), include_blank: true, class: "form-control" %>  
+      </div>  
+    </div>
     <div class="form-group">
-      <%= label_tag :taxonomy_content_id, 'Topics (new taxonomy):' %>
-      <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies || [], :content_id, :title, params[:taxonomy_content_id]), include_blank: true, class: "form-control" %>
+      <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
     </div>
 
-    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
+    <div class="form-group">
+      <a class="" role="button" data-toggle="collapse" href="#additionalFilters" aria-expanded="false" aria-controls="additionalFilters">
+        <span data-open-label>More filter options</span>
+        <span data-close-label>Less filter options</span>
+      </a>
+    </div>
 
     <%= hidden_field_tag :sort, params[:sort] %>
     <%= hidden_field_tag :order, params[:order] %>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -11,7 +11,7 @@
       <%= select_tag :organisation_content_id, options_from_collection_for_select(@organisations, :content_id, :title, params[:organisation_content_id]), include_blank: true, class: "form-control" %>
     </div>
 
-    <div id="additionalFilters" class="collapse">
+    <div id="additionalFilters" class="collapse<% if advanced_filter_enabled? %> in<% end %>">
       <div class="form-group">
         <%= label_tag 'Topics (new taxonomy):' %>
         <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies || [], :content_id, :title, params[:taxonomy_content_id]), include_blank: true, class: "form-control" %>  
@@ -22,7 +22,7 @@
     </div>
 
     <div class="form-group">
-      <a class="" role="button" data-toggle="collapse" href="#additionalFilters" aria-expanded="false" aria-controls="additionalFilters">
+      <a class="" role="button" data-toggle="collapse" href="#additionalFilters" aria-expanded="<%=advanced_filter_enabled? %>" aria-controls="additionalFilters">
         <span data-open-label>More filter options</span>
         <span data-close-label>Less filter options</span>
       </a>

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -95,4 +95,20 @@ RSpec.feature "Filter in content items", type: :feature do
       expect(page).to have_select(:taxonomy_content_id, selected: "taxon 1")
     end
   end
+
+  context "additional filters" do
+    scenario "the user cannot see the additional filters by default", js: true do
+      visit "/content_items"
+
+      expect(page).to have_selector('#additionalFilters', visible: false)
+    end
+
+    scenario "the user can toggle the visibility of the additional filters", js: true do
+      visit "/content_items"
+
+      click_on "More filter options"
+
+      expect(page).to have_selector('#additionalFilters', visible: true)
+    end
+  end
 end

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -110,5 +110,13 @@ RSpec.feature "Filter in content items", type: :feature do
 
       expect(page).to have_selector('#additionalFilters', visible: true)
     end
+
+    scenario "the user can see the additional filters if they are currently filtering by one of them", js: true do
+      create :taxonomy, title: "taxon 1", content_id: "123"
+
+      visit "/content_items?taxonomy_content_id=123"
+
+      expect(page).to have_selector('#additionalFilters', visible: true)
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,8 +7,10 @@ require "rspec/rails"
 require "support/authentication"
 require "support/factory_girl"
 require "webmock/rspec"
+require "capybara/poltergeist"
 require "gds_api/test_helpers/publishing_api_v2"
 require "pry"
+require "database_cleaner"
 
 ActiveRecord::Migration.maintain_test_schema!
 
@@ -28,7 +30,52 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+  WebMock.disable_net_connect! allow_localhost: true
+
+  Capybara.javascript_driver = :poltergeist
+
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    if config.use_transactional_fixtures?
+      raise(<<-MSG)
+        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
+        (or set it to false) to prevent uncommitted transactions being used in
+        JavaScript-dependent specs.
+
+        During testing, the app-under-test that the browser driver connects to
+        uses a different database connection to the database connection used by
+        the spec. The app's database connection would not be able to access
+        uncommitted transaction data setup over the spec's database connection.
+      MSG
+    end
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    if !driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
 end


### PR DESCRIPTION
# Motivation

Currently the "useful" filters are `search term` and `organisation` as the `taxonomy` filter currently only applies to education content. To deal with showing additional filters while not overwhelming the user it would be useful to be able to by default hide filters perceived as "less useful".

Trello: https://trello.com/c/5rIJ0cg3/241-5-collapse-taxonomy-filter

# Description

This PR wraps the `taxonomy` filter in a collapsible `div` which can be toggled by clicking a link in the sidebar.

It also adds logic to the `ContentItemsController` to render the additional filters in an open state if the user is currently filtering by one of them.

New `gems` added to allow feature testing with `javascript`, namely `selenium` and `poltergeist` for headless browser support.

# Before
<img width="287" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/26098834/e828dbd4-3a20-11e7-800d-ed98b8b6e2a0.png">

# After
<img width="309" alt="after_1" src="https://cloud.githubusercontent.com/assets/6338228/26098955/39d58612-3a21-11e7-9c6d-42a8a2f68289.png">
<img width="289" alt="after_2" src="https://cloud.githubusercontent.com/assets/6338228/26098954/39ac78b2-3a21-11e7-938a-7ade15cd9488.png">


