### PR TITLE
Summary view number formatting

### DIFF
--- a/app/models/metrics/pages_with_pdfs.rb
+++ b/app/models/metrics/pages_with_pdfs.rb
@@ -7,8 +7,11 @@ module Metrics
     end
 
     def run
+      percentage = 0
       total = content_items.where("number_of_pdfs > ?", 0).count
-      percentage = (total.to_f / content_items.count.to_f) * 100
+
+      percentage = (total.to_f / content_items.count.to_f) * 100 if total > 0
+
       {
         pages_with_pdfs: {
           value: total,

--- a/app/views/content_items/_summary.html.erb
+++ b/app/views/content_items/_summary.html.erb
@@ -1,15 +1,15 @@
 <div class="summary">
   <div class="row">
     <div class="summary-item col-xs-4">
-      <span class="summary-item-value"><%= @metrics[:total_pages][:value] %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @metrics[:total_pages][:value] %></span> 
       <span class="summary-item-label">Live pages</span>
     </div>
     <div class="summary-item col-xs-4">
-      <span class="summary-item-value"><%= @metrics[:zero_page_views][:value] %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @metrics[:zero_page_views][:value] %></span> 
       <span class="summary-item-label">Pages with zero views per month</span>
     </div>
     <div class="summary-item col-xs-4">
-      <span class="summary-item-value"><%= @metrics[:pages_not_updated][:value] %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @metrics[:pages_not_updated][:value] %></span> 
       <span class="summary-item-label">Pages not updated in 6 months</span>
     </div>
   </div>

--- a/spec/models/metrics/pages_with_pdfs_spec.rb
+++ b/spec/models/metrics/pages_with_pdfs_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Metrics::PagesWithPdfs do
     expect(result[:pages_with_pdfs][:value]).to eq(1)
   end
 
+  it "returns zero percent if there are no content items with pdfs" do
+    result = subject.new(ContentItem.where("number_of_pdfs = ?", 0)).run
+
+    expect(result[:pages_with_pdfs][:percentage]).to eq(0)
+  end
+
   it "returns the number of items with pdfs as a percentage of the collection" do
     result = subject.new(ContentItem.all).run
 


### PR DESCRIPTION
# Motivation

Numbers in the `summary` area are currently unformatted, meaning large numbers can be quite visually hard to digest.

Trello - https://trello.com/c/HZTCyo1m/238-2-format-numbers-in-summary-area

# Description

This PR adds rails formatting helpers into the `summary` partial so large numbers are delimited with commas.

This work also includes a bug fix to `NaN` being returned by the `pages_with_pdfs` metric.

# Before

<img width="825" alt="before_formatting" src="https://cloud.githubusercontent.com/assets/6338228/26104132/4f237d9a-3a34-11e7-8851-40c7e4bcc7d4.png">

<img width="796" alt="before_nan" src="https://cloud.githubusercontent.com/assets/6338228/26104134/4f2a3a18-3a34-11e7-9131-062d536df9e4.png">

# After

<img width="816" alt="after_format" src="https://cloud.githubusercontent.com/assets/6338228/26104131/4f090726-3a34-11e7-87c3-b0d7241ac15a.png">

<img width="818" alt="after_nan" src="https://cloud.githubusercontent.com/assets/6338228/26104133/4f274e66-3a34-11e7-91ff-16003d85af20.png">

