### PR TITLE
Table number formatting

### DIFF
--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
   <td><%= content_item.document_type %></td>
-  <td><%= content_item.one_month_page_views %></td>
-  <td><%= content_item.six_months_page_views %></td>
+  <td><%= number_with_delimiter content_item.one_month_page_views %></td>
+  <td><%= number_with_delimiter content_item.six_months_page_views %></td>
   <td>
     <% if content_item.public_updated_at %>
       <%= time_ago_in_words(content_item.public_updated_at) %> ago


### PR DESCRIPTION
# Motivation
Large numbers in the `content-items` table can be hard to read. We need to improve this.

Trello - https://trello.com/c/4ResF2FY/239-2-format-numbers-in-table-with-content-items

# Description
This PR comma separate large numbers in the view using Rails built in number formatting.

# Before
<img width="863" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/26107089/0429a8c6-3a40-11e7-995d-39438224a53d.png">

# After
<img width="862" alt="after" src="https://cloud.githubusercontent.com/assets/6338228/26107096/0732e96a-3a40-11e7-80b7-8dacae8836ca.png">
