### PR TITLE
Detail view number formatting

### DIFF
--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -22,11 +22,11 @@
     </tr>
     <tr>
       <td>Page views (1 month)</td>
-      <td><%= @content_item.one_month_page_views %></td>
+      <td><%= number_with_delimiter @content_item.one_month_page_views %></td>
     </tr>
     <tr>
       <td>Page views (6 months)</td>
-      <td><%= @content_item.six_months_page_views %></td>
+      <td><%= number_with_delimiter @content_item.six_months_page_views %></td>
     </tr>
     <tr>
       <td>Last updated</td>
@@ -48,7 +48,7 @@
     </tr>
     <tr>
       <td>Number of pdfs</td>
-      <td><%= @content_item.number_of_pdfs %></td>
+      <td><%= number_with_delimiter @content_item.number_of_pdfs %></td>
     </tr>
       <td>Topics (new taxonomy)</td>
       <td><%= @content_item.taxons_as_string %></td>


### PR DESCRIPTION
# Motivation
Large numbers in the `content-items` detail view can be hard to read. We need to improve this.

Trello - https://trello.com/c/bCawP6vX/240-2-format-numbers-in-details-page

# Description
This PR comma separates large numbers in the detail view using Rails built in number formatting.

# Before
<img width="426" alt="before" src="https://cloud.githubusercontent.com/assets/6338228/26107608/cd314926-3a41-11e7-8286-d8d8aaa48e33.png">

# After
<img width="477" alt="after" src="https://cloud.githubusercontent.com/assets/6338228/26107610/ce52ef30-3a41-11e7-829b-58524699b1ed.png">
