### PR TITLE
Add style guide route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,8 @@ Rails.application.routes.draw do
   resources :groups, only: %w(show create index destroy), param: "slug"
 
   resources :content_items, only: %w(index show)
+
+  if Rails.env.development?
+    mount GovukAdminTemplate::Engine, at: "/style-guide"
+  end
 end


### PR DESCRIPTION
# Motivation
Going forward it will be useful to know the existing patterns and styles available from `govuk_admin_template` to speed up development and stop the team from reinventing the wheel. 

# Description
The `govuk_admin_template` comes with a mountable `styleguide` see https://github.com/alphagov/govuk_admin_template#usage (search for "style-guide").

This PR mounts the styleguide when in a `development` environment so that it can be navigated to at `/style-guide`.

# After
<img width="515" alt="after" src="https://cloud.githubusercontent.com/assets/6338228/26108585/dec036f4-3a44-11e7-89c2-9ff4ea7aa6e6.png">
