### PR TITLE
Fix label attributes

### DIFF
--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -7,12 +7,12 @@
     </div>
 
     <div class="form-group">
-      <%= label_tag 'Organisation:' %>
+      <%= label_tag :organisation_content_id, 'Organisation:' %>
       <%= select_tag :organisation_content_id, options_from_collection_for_select(@organisations, :content_id, :title, params[:organisation_content_id]), include_blank: true, class: "form-control" %>
     </div>
 
     <div class="form-group">
-      <%= label_tag 'Topics (new taxonomy):' %>
+      <%= label_tag :taxonomy_content_id, 'Topics (new taxonomy):' %>
       <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies || [], :content_id, :title, params[:taxonomy_content_id]), include_blank: true, class: "form-control" %>
     </div>
 


### PR DESCRIPTION
# Motivation
HTML form `labels` have an attribute `for`, this is meant to equal the `name` attribute of the form component they are labelling e.g.

```
<label for="my-form-input">My Input:</label>
<input type="text" name="my-form-input"/>
```

This is currently not the case for the `organisation` and `taxonomy` filters in the sidebar.

# Description
The `label_tag` was not being passed in the name of its corresponding input, this PR adds them in.
There is not resulting visual change.
