### PR TITLE
Revert "Autocorrect lint errors when using Guard"

### DIFF
--- a/lib/guard/lint.rb
+++ b/lib/guard/lint.rb
@@ -2,7 +2,7 @@ require 'guard/compat/plugin'
 
 module Guard
   class Lint < Plugin
-    CMD = "bundle exec govuk-lint-ruby -a".freeze
+    CMD = "bundle exec govuk-lint-ruby".freeze
 
     def run_all
       system(CMD)


### PR DESCRIPTION
Reverts alphagov/content-performance-manager#124

This was not a very good idea because when lint autocorrect 
an offence usually the IDE reload the content and you loose 
data.