### PR TITLE
Define Capybara module so deployments do not break

### DIFF
--- a/config/initializers/silence_poltergeist.rb
+++ b/config/initializers/silence_poltergeist.rb
@@ -1,7 +1,9 @@
 # Silence the Poltergeist version warning.
-module Capybara::Poltergeist
-  class Client
-    def warn(*)
+module Capybara
+  module Poltergeist
+    class Client
+      def warn(*)
+      end
     end
   end
 end


### PR DESCRIPTION
When running deploy to staging via [command][1], we were getting a 
deployment error because Capybara module couldn’t be found.

It seems that Capybara has not been loaded yet, hence the module can’t
be found. We can fix this issue by defining the module explicitly.

This is the [build error](https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/3763/console) that triggered this PR

[1]: govuk_setenv content-performance-manager bundle exec rake RAILS_ENV=production RAILS_GROUPS=assets assets:precompile
