### PR TITLE
Decrease batch size when querying PublishingAPI

### DIFF
--- a/app/services/content_items_service.rb
+++ b/app/services/content_items_service.rb
@@ -1,5 +1,5 @@
 class ContentItemsService
-  PER_PAGE = Integer(ENV.fetch("PUBLISHING_API_BATCH_SIZE", 1_000))
+  PER_PAGE = Integer(ENV.fetch("PUBLISHING_API_BATCH_SIZE", 500))
 
   def content_ids
     results = paginate do |p|

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe ContentItemsService do
   include GdsApi::TestHelpers::PublishingApiV2
 
   describe "#content_ids" do
-    let(:content_ids) { 1001.times.map { |i| "id-#{i}" } }
+    let(:page_size) { described_class::PER_PAGE }
+    let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 
     before do
       1.upto(2) do |page|
@@ -11,7 +12,7 @@ RSpec.describe ContentItemsService do
           fields: %w(content_id),
           states: %w(published),
           page: page,
-          per_page: 1_000,
+          per_page: page_size,
         )
       end
     end


### PR DESCRIPTION
We are getting 504 errors from PublishingAPI when we paginate through
all the content. Even with some performance improvements it is [not
working robustly enough for us to rely on it][1].

As a temporary solution, I am decreasing the batch size to 500 because
when I run it this way [the process seems more robust][2]


[1]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_all_inventory/
[2]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_all_inventory/12/console