### PR TITLE
Remove Guard from autoload if not defined

### DIFF
--- a/lib/guard/lint.rb
+++ b/lib/guard/lint.rb
@@ -1,15 +1,17 @@
-require 'guard/compat/plugin'
+if defined?(Guard)
+  require 'guard/compat/plugin'
 
-module Guard
-  class Lint < Plugin
-    CMD = "bundle exec govuk-lint-ruby".freeze
+  module Guard
+    class Lint < Plugin
+      CMD = "bundle exec govuk-lint-ruby".freeze
 
-    def run_all
-      system(CMD)
-    end
+      def run_all
+        system(CMD)
+      end
 
-    def run_on_modifications(files)
-      system("#{CMD} #{files.join(' ')}")
+      def run_on_modifications(files)
+        system("#{CMD} #{files.join(' ')}")
+      end
     end
   end
 end


### PR DESCRIPTION
Guard was being required in production because of the autoload 
configuration. 

This commit prevent the application from not starting
when Guard is not defined (which basically happens in production)