### PR TITLE
Include subpaths when querying GA for Unique Visits

### DIFF
--- a/app/jobs/import_pageviews_job.rb
+++ b/app/jobs/import_pageviews_job.rb
@@ -9,8 +9,9 @@ class ImportPageviewsJob < ApplicationJob
   def perform(*args)
     content_items = args[0]
     base_paths = content_items.pluck(:base_path)
+    base_paths_with_subpaths = base_paths.map { |path| path.concat("/*") }
 
-    results = google_analytics_service.page_views(base_paths)
+    results = google_analytics_service.page_views(base_paths_with_subpaths)
     results.each do |result|
       content_item = ContentItem.find_by(base_path: result[:base_path])
       content_item.update!(result.slice(:one_month_page_views, :six_months_page_views))

--- a/spec/jobs/import_pageviews_job_spec.rb
+++ b/spec/jobs/import_pageviews_job_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ImportPageviewsJob, type: :job do
   it "updates the content items with pageviews" do
     content_item = create(:content_item, base_path: '/the-base-path')
     service = double(:google_analytics_service)
-    allow(service).to receive(:page_views).with(['/the-base-path']).and_return(
+    allow(service).to receive(:page_views).with(['/the-base-path/*']).and_return(
       [
         {
           base_path: '/the-base-path',


### PR DESCRIPTION
A Guidance has many sub-pages, but only the root one is represented in the
`publishing-api`. 

As a result, when querying for stats to Google Analytics, we are not getting aggregate values for the subpaths, just the number of unique visitors to the index page (which is not correct)

This PR addresses this issue by concatenating `/*` to the basepath. It still needs to be confirmed if this rule applies to every format.