### PR TITLE
Reduces pagination size to query publishing-API

### DIFF
--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -2,7 +2,7 @@ require 'gds_api/publishing_api_v2'
 
 module Clients
   class PublishingAPI
-    PER_PAGE = 1_000
+    PER_PAGE = 100
 
     attr_accessor :deprecated_publishing_api, :per_page
 

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Clients::PublishingAPI do
   subject { Clients::PublishingAPI.new }
 
   describe "#content_ids" do
-    let(:content_ids) { 1001.times.map { |i| "id-#{i}" } }
+    let(:page_size) { 100 }
+
+    let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 
     before do
       1.upto(2) do |page|
@@ -13,7 +15,7 @@ RSpec.describe Clients::PublishingAPI do
           fields: %w(content_id),
           states: %w(published),
           page: page,
-          per_page: 1_000,
+          per_page: page_size,
         )
       end
     end


### PR DESCRIPTION
This is a temporary step to prevent the daily import from [failing on
a daily basis][1]. We are in conversations with PublishingAPI to prevent
this process from failing when increasing the page size.


[1]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_all_inventory/23/console