### PR TITLE
Navigate through a list of Content Items

### DIFF
--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -1,3 +1,21 @@
+.prev-next-links {
+  margin: 5em 0 3em 0;
+
+  a {
+    font-size: 16px;
+    color: black;
+    text-decoration: underline;
+
+    &:visited {
+      color: black;
+    }
+  }
+
+  .next-item {
+    float: right;
+  }
+}
+
 .description {
   margin: 2em 0 4em 0;
 }

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,4 +1,6 @@
 class AuditsController < ApplicationController
+  helper_method :filter_params
+
   def index
     content_items
   end
@@ -10,14 +12,18 @@ class AuditsController < ApplicationController
 
   def save
     audit.user = current_user
+    updated = audit.update(audit_params)
 
-    if audit.update(audit_params)
+    if next_item && updated
+      flash.notice = "Saved successfully and continued to next item."
+      redirect_to content_item_audit_path(next_item, filter_params)
+    elsif updated
       flash.now.notice = "Saved successfully."
+      render :show
     else
       flash.now.alert = error_message
+      render :show
     end
-
-    render :show
   end
 
 private
@@ -52,6 +58,12 @@ private
     params
       .require(:audit)
       .permit(responses_attributes: [:id, :value, :question_id])
+  end
+
+  def filter_params
+    request
+      .query_parameters
+      .deep_symbolize_keys
   end
 
   def error_message

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,15 +1,11 @@
 class AuditsController < ApplicationController
   def index
-    search = Search.new
-    search.page = params[:page]
-    search.audit_status = params[:audit_status] if params[:audit_status]
-    search.execute
-
-    @content_items = search.content_items.decorate
+    content_items
   end
 
   def show
     audit.questions = audit.template.questions if audit.new_record?
+    next_item
   end
 
   def save
@@ -32,6 +28,24 @@ private
 
   def content_item
     @content_item ||= ContentItem.find(params.fetch(:content_item_id)).decorate
+  end
+
+  def content_items
+    @content_items ||= search.content_items.decorate
+  end
+
+  def next_item
+    @next_item ||= content_items.next_item(content_item)
+  end
+
+  def search
+    @search ||= (
+      search = Search.new
+      search.page = params[:page]
+      search.audit_status = params[:audit_status] if params[:audit_status]
+      search.execute
+      search
+    )
   end
 
   def audit_params

--- a/app/decorators/content_items_decorator.rb
+++ b/app/decorators/content_items_decorator.rb
@@ -1,5 +1,14 @@
 class ContentItemsDecorator < Draper::CollectionDecorator
-  delegate :current_page, :total_pages, :limit_value, :entry_name, :total_count, :offset_value, :last_page?
+  delegate(
+    :current_page,
+    :total_pages,
+    :limit_value,
+    :entry_name,
+    :total_count,
+    :offset_value,
+    :last_page?,
+    :next_item,
+  )
 
   def header(filters = {})
     organisation = filters[:organisation]

--- a/app/helpers/param_helper.rb
+++ b/app/helpers/param_helper.rb
@@ -1,0 +1,7 @@
+module ParamHelper
+  def filter_params
+    request
+      .query_parameters
+      .deep_symbolize_keys
+  end
+end

--- a/app/helpers/param_helper.rb
+++ b/app/helpers/param_helper.rb
@@ -1,7 +1,0 @@
-module ParamHelper
-  def filter_params
-    request
-      .query_parameters
-      .deep_symbolize_keys
-  end
-end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -4,6 +4,12 @@ class ContentItem < ApplicationRecord
   has_one :audit, primary_key: :content_id, foreign_key: :content_id
 
 
+  def self.next_item(current_item)
+    ids = pluck(:id)
+    index = ids.index(current_item.id)
+    all[index + 1] if index
+  end
+
   def topics
     linked_content("topics")
   end

--- a/app/views/audits/_content_item.html.erb
+++ b/app/views/audits/_content_item.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <td><%= link_to content_item.title, content_item_audit_path(content_item) %></td>
+  <td><%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %></td>
   <td><%= content_item.six_months_page_views %></td>
 </tr>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -28,7 +28,7 @@
     <%= @audit.content_item.description %>
   </p>
 
-  <%= form_for [@audit.content_item, @audit], url: content_item_audit_path do |form| %>
+  <%= form_for [@audit.content_item, @audit], url: content_item_audit_path(filter_params) do |form| %>
     <%= form.fields_for :responses do |builder| %>
       <% response = builder.object %>
       <% question = response.question %>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -18,7 +18,7 @@
   <h1>GOV.UK Content Audit</h1>
 
   <nav class="prev-next-links">
-    <%= link_to "< All items", audits_path(filter_params), class: "all-items" %>
+    <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
     <%= link_to "Next", content_item_audit_path(@next_item, filter_params), class: "next-item" if @next_item %>
   </nav>
 

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -17,6 +17,11 @@
 
   <h1>GOV.UK Content Audit</h1>
 
+  <nav class="prev-next-links">
+    <%= link_to "< All items", audits_path(filter_params), class: "all-items" %>
+    <%= link_to "Next", content_item_audit_path(@next_item, filter_params), class: "next-item" if @next_item %>
+  </nav>
+
   <h2><%= link_to @content_item.title, @content_item.url, target: :_blank %></h2>
 
   <p class="description">

--- a/spec/features/audit/list_content_items_to_audit_spec.rb
+++ b/spec/features/audit/list_content_items_to_audit_spec.rb
@@ -1,8 +1,6 @@
 require 'features/common/pagination_spec_helper'
 
 RSpec.feature "List Content Items to Audit", type: :feature do
-  let!(:user) { FactoryGirl.create(:user) }
-
   let!(:content_item_1) { FactoryGirl.create(:content_item, title: "All about flooding.") }
   let!(:content_item_2) { FactoryGirl.create(:content_item, title: "All about gardening.") }
 

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -27,4 +27,12 @@ RSpec.feature "Navigation" do
     expected = audits_path(some_filter: "value")
     expect(current_url).to end_with(expected)
   end
+
+  scenario "returning to the first page of the index" do
+    visit content_item_audit_path(first, some_filter: "value", page: "123")
+    click_link "< All items"
+
+    expected = audits_path(some_filter: "value")
+    expect(current_url).to end_with(expected)
+  end
 end

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -35,4 +35,38 @@ RSpec.feature "Navigation" do
     expected = audits_path(some_filter: "value")
     expect(current_url).to end_with(expected)
   end
+
+  scenario "continuing to next item on save" do
+    visit content_item_audit_path(first, some_filter: "value")
+
+    within("#question-1") { choose "Yes" }
+    within("#question-2") { choose "Yes" }
+    within("#question-3") { choose "Yes" }
+    within("#question-4") { choose "Yes" }
+    within("#question-5") { choose "Yes" }
+    within("#question-6") { choose "Yes" }
+
+    click_on "Save"
+
+    expected = content_item_audit_path(second, some_filter: "value")
+    expect(current_url).to end_with(expected)
+
+    expect(page).to have_content("Success: Saved successfully and continued to next item.")
+  end
+
+  scenario "not continuing to next item if fails to save" do
+    visit content_item_audit_path(first, some_filter: "value")
+
+    click_on "Save"
+
+    expected = content_item_audit_path(first, some_filter: "value")
+    expect(current_url).to end_with(expected)
+
+    expect(page).to have_content("Warning: Mandatory field missing")
+
+    click_on "Next"
+
+    expected = content_item_audit_path(second, some_filter: "value")
+    expect(current_url).to end_with(expected)
+  end
 end

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -1,0 +1,30 @@
+RSpec.feature "Navigation" do
+  let!(:first) { FactoryGirl.create(:content_item, title: "First") }
+  let!(:second) { FactoryGirl.create(:content_item, title: "Second") }
+  let!(:third) { FactoryGirl.create(:content_item, title: "Third") }
+
+  scenario "navigating between audits and the index page" do
+    visit audits_path(some_filter: "value")
+    click_link "First"
+
+    expected = content_item_audit_path(first, some_filter: "value")
+    expect(current_url).to end_with(expected)
+
+    click_link "Next"
+
+    expected = content_item_audit_path(second, some_filter: "value")
+    expect(current_url).to end_with(expected)
+
+    click_link "Next"
+
+    expected = content_item_audit_path(third, some_filter: "value")
+    expect(current_url).to end_with(expected)
+
+    expect(page).to have_no_link("Next")
+
+    click_link "< All items"
+
+    expected = audits_path(some_filter: "value")
+    expect(current_url).to end_with(expected)
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,4 +1,45 @@
 RSpec.describe ContentItem, type: :model do
+  describe ".next_item" do
+    let!(:content_items) { FactoryGirl.create_list(:content_item, 5) }
+
+    it "returns the next item given the current item" do
+      result = ContentItem.all.next_item(content_items[0])
+      expect(result).to eq(content_items[1])
+
+      result = ContentItem.all.next_item(content_items[1])
+      expect(result).to eq(content_items[2])
+
+      result = ContentItem.all.next_item(content_items[2])
+      expect(result).to eq(content_items[3])
+
+      result = ContentItem.all.next_item(content_items[3])
+      expect(result).to eq(content_items[4])
+    end
+
+    it "returns nil if there's no next item" do
+      result = ContentItem.all.next_item(content_items[4])
+      expect(result).to be_nil
+    end
+
+    it "returns nil if the current item isn't in the scope" do
+      result = ContentItem.offset(1).next_item(ContentItem.first)
+      expect(result).to be_nil
+    end
+
+    it "is based on the filtered, ordered scope" do
+      scope = ContentItem.limit(3).offset(1).order("id desc")
+
+      result = scope.next_item(content_items[3])
+      expect(result).to eq(content_items[2])
+
+      result = scope.next_item(content_items[2])
+      expect(result).to eq(content_items[1])
+
+      result = scope.next_item(content_items[1])
+      expect(result).to be_nil
+    end
+  end
+
   describe "#url" do
     it "returns a url to a content item on gov.uk" do
       content_item = build(:content_item, base_path: "/api/content/item/path/1")


### PR DESCRIPTION
[Trello](https://trello.com/c/Qc2N5ORf/268-(2)-navigate-through-a-list-of-content-items)

Adds '< All items' and 'Next' links to the top of the audit page and makes it so successful saves automatically continue to the next item.

![screen shot 2017-06-01 at 12 31 22](https://cloud.githubusercontent.com/assets/892251/26678001/49885fec-46c6-11e7-83a2-d0a8a330531f.png)

