### PR TITLE
Standardise naming of databases across dev, test and prod

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,52 +1,6 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = 'content-performance-manager'
-
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-  try {
-    stage('Checkout') {
-      checkout scm
-    }
-
-    stage('Clean') {
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-    }
-
-    stage('Bundle') {
-      govuk.bundleApp()
-    }
-
-    stage('Linter') {
-      govuk.rubyLinter()
-    }
-
-    stage('Database') {
-      govuk.setEnvar('RAILS_ENV', 'test')
-      govuk.runRakeTask('db:environment:set db:drop db:create db:schema:load')
-    }
-
-    stage('Tests') {
-      govuk.runTests()
-    }
-
-    stage('Push release tag') {
-      govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
-    }
-
-    stage('Deploy to Integration') {
-      // Deploy on Integration (only master)
-      govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
-    }
-
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject()
 }

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,4 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task :lint do
-  sh "bundle exec govuk-lint-ruby"
-end
-
-task default: [:spec, :lint]
+task default: [:spec]

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,8 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task default: [:spec]
+task :lint do
+  sh "bundle exec govuk-lint-ruby app config lib spec"
+end
+
+task default: [:spec, :lint]

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,11 +5,11 @@ default: &default
 
 development:
   <<: *default
-  database: content-performance-manager_development
+  database: content_performance_manager_development
 
 test:
   <<: *default
-  database: content-performance-manager_test
+  database: content_performance_manager_test
 
 production:
   <<: *default


### PR DESCRIPTION
The data replication script was failing to update Rails for me. Because of a naming mismatch
between dev, test, and production, my locally checked out out application wasn't picking up on the replicated data.

<img width="1021" alt="screen shot 2017-06-02 at 11 20 59" src="https://cloud.githubusercontent.com/assets/608867/26721887/a371819a-4785-11e7-84be-449d810bd1c0.png">


This change will break your local dev and test environments.

Keep 'em ticking over by running the following SQL in a postgres console:
```
$ psql
ALTER DATABASE content-performance-manager_development RENAME TO content_performance_manager_development;
```

Your test database doesn't exist anymore either, so recreate it using
the Rails commands:
`$ RAILS_ENV=test bundle exec rake db:drop db:test:prepare`