### PR TITLE
Rename "Taxonomy" to "Taxon"

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,10 +1,10 @@
 class ContentItemsController < ApplicationController
   before_action :set_organisation, only: :index
-  before_action :set_taxonomy, only: :index
+  before_action :set_taxon, only: :index
   before_action :set_filter_options, only: :index
   before_action :set_query_options, only: :index
   before_action :set_all_organisations, only: :index
-  before_action :set_all_taxonomies, only: :index
+  before_action :set_all_taxons, only: :index
 
   def index
     query = Queries::ContentItemsQuery.new(@query_options)
@@ -24,7 +24,7 @@ private
       order: params[:order],
       query: params[:query],
       page: params[:page],
-      taxonomy: @taxonomy,
+      taxon: @taxon,
       organisation: @organisation
     }
   end
@@ -33,22 +33,22 @@ private
     @organisations = Organisation.order(:title)
   end
 
-  def set_all_taxonomies
-    @taxonomies = Taxonomy.order(:title)
+  def set_all_taxons
+    @taxons = Taxon.order(:title)
   end
 
   def set_organisation
     @organisation = Organisation.find_by(content_id: params[:organisation_content_id]) if params[:organisation_content_id]
   end
 
-  def set_taxonomy
-    @taxonomy = Taxonomy.find_by(content_id: params[:taxonomy_content_id]) if params[:taxonomy_content_id]
+  def set_taxon
+    @taxon = Taxon.find_by(content_id: params[:taxon_content_id]) if params[:taxon_content_id]
   end
 
   def set_filter_options
     @filter_options = {}
     @filter_options[:organisation_content_id] = params[:organisation_content_id]
-    @filter_options[:taxonomy_content_id] = params[:taxonomy_content_id]
+    @filter_options[:taxon_content_id] = params[:taxon_content_id]
     @filter_options[:query] = params[:query]
   end
 end

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -18,7 +18,7 @@ class ContentItemDecorator < Draper::Decorator
   end
 
   def taxons_as_string
-    object.taxonomies.map(&:title).join(', ')
+    object.taxons.map(&:title).join(', ')
   end
 
   def topics

--- a/app/decorators/content_items_decorator.rb
+++ b/app/decorators/content_items_decorator.rb
@@ -3,14 +3,14 @@ class ContentItemsDecorator < Draper::CollectionDecorator
 
   def header(filters = {})
     organisation = filters[:organisation]
-    taxonomy = filters[:taxonomy]
+    taxon = filters[:taxon]
 
-    if organisation.present? && taxonomy.present?
-      "#{organisation.title} + #{taxonomy.title}"
+    if organisation.present? && taxon.present?
+      "#{organisation.title} + #{taxon.title}"
     elsif organisation.present?
       organisation.title
-    elsif taxonomy.present?
-      taxonomy.title
+    elsif taxon.present?
+      taxon.title
     else
       "GOV.UK"
     end

--- a/app/helpers/content_items_helper.rb
+++ b/app/helpers/content_items_helper.rb
@@ -1,5 +1,5 @@
 module ContentItemsHelper
   def advanced_filter_enabled?
-    params[:taxonomy_content_id].present?
+    params[:taxon_content_id].present?
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,6 @@
 class ContentItem < ApplicationRecord
   has_and_belongs_to_many :organisations
-  has_and_belongs_to_many :taxonomies
+  has_and_belongs_to_many :taxons
   has_one :audit, primary_key: :content_id, foreign_key: :content_id
 
 
@@ -35,10 +35,10 @@ class ContentItem < ApplicationRecord
     end
   end
 
-  def add_taxonomies_by_id(taxons)
-    taxons.each do |t|
-      taxon = Taxonomy.find_by(content_id: t)
-      taxonomies << taxon unless taxon.nil? || taxonomies.include?(taxon)
+  def add_taxons_by_id(taxon_ids)
+    taxon_ids.each do |taxon_id|
+      taxon = Taxon.find_by(content_id: taxon_id)
+      taxons << taxon unless taxon.nil? || taxons.include?(taxon)
     end
   end
 

--- a/app/models/importers/all_taxons.rb
+++ b/app/models/importers/all_taxons.rb
@@ -1,16 +1,16 @@
 module Importers
   class AllTaxons
-    attr_accessor :taxonomies_service
+    attr_accessor :taxons
 
     def initialize
-      @taxonomies_service = TaxonomiesService.new
+      @taxons = TaxonomyService.new
     end
 
     def run
-      taxonomies_service.find_each do |attributes|
+      taxons.find_each do |attributes|
         content_id = attributes.fetch(:content_id)
-        taxonomy = Taxonomy.find_or_create_by(content_id: content_id)
-        taxonomy.update!(attributes.slice(:title, :content_id))
+        taxon = Taxon.find_or_create_by(content_id: content_id)
+        taxon.update!(attributes.slice(:title, :content_id))
       end
     end
   end

--- a/app/models/importers/single_content_item.rb
+++ b/app/models/importers/single_content_item.rb
@@ -16,7 +16,7 @@ module Importers
       links = content_items_service.links(content_id)
 
       set_organisations(content_item, links)
-      set_taxonomies(content_item, links)
+      set_taxons(content_item, links)
       set_metrics(content_item)
 
       ActiveRecord::Base.transaction do
@@ -35,12 +35,12 @@ module Importers
       content_item.add_organisations_by_id(org_ids)
     end
 
-    def set_taxonomies(content_item, links)
+    def set_taxons(content_item, links)
       taxon_ids = links
         .select { |l| l.link_type == "taxons" }
         .map(&:target_content_id)
 
-      content_item.add_taxonomies_by_id(taxon_ids)
+      content_item.add_taxons_by_id(taxon_ids)
     end
 
     def set_metrics(content_item)
@@ -59,7 +59,7 @@ module Importers
 
         existing.attributes = attributes
         existing.organisations = content_item.organisations
-        existing.taxonomies = content_item.taxonomies
+        existing.taxons = content_item.taxons
 
         existing.save!
       else

--- a/app/models/queries/content_items_query.rb
+++ b/app/models/queries/content_items_query.rb
@@ -19,15 +19,15 @@ module Queries
 
     def build_query(options = {})
       relation = ContentItem.all
-      relation = filter_by_taxonomy(relation, options[:taxonomy])
+      relation = filter_by_taxon(relation, options[:taxon])
       relation = filter_by_organisations(relation, options[:organisation])
       relation = filter_by_title(relation, options[:query])
       relation.order("#{options[:sort]} #{options[:order]}")
     end
 
-    def filter_by_taxonomy(relation, taxonomy)
-      return relation unless taxonomy
-      relation.joins(:taxonomies).where('taxonomies.id = ?', taxonomy.id)
+    def filter_by_taxon(relation, taxon)
+      return relation unless taxon
+      relation.joins(:taxons).where('taxons.id = ?', taxon.id)
     end
 
     def filter_by_organisations(relation, organisation)

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,3 +1,3 @@
-class Taxonomy < ApplicationRecord
+class Taxon < ApplicationRecord
   has_and_belongs_to_many :content_items
 end

--- a/app/services/taxonomy_service.rb
+++ b/app/services/taxonomy_service.rb
@@ -1,4 +1,4 @@
-class TaxonomiesService
+class TaxonomyService
   attr_accessor :publishing_api
 
   def initialize
@@ -6,8 +6,8 @@ class TaxonomiesService
   end
 
   def find_each
-    publishing_api.find_each(query_fields, query_options) do |taxonomy|
-      yield taxonomy
+    publishing_api.find_each(query_fields, query_options) do |taxon|
+      yield taxon
     end
   end
 

--- a/app/views/content_items/_sidebar.html.erb
+++ b/app/views/content_items/_sidebar.html.erb
@@ -14,8 +14,8 @@
     <div id="additionalFilters" class="collapse<% if advanced_filter_enabled? %> in<% end %>">
       <div class="form-group">
         <%= label_tag 'Topics (new taxonomy):' %>
-        <%= select_tag :taxonomy_content_id, options_from_collection_for_select(@taxonomies || [], :content_id, :title, params[:taxonomy_content_id]), include_blank: true, class: "form-control" %>  
-      </div>  
+        <%= select_tag :taxon_content_id, options_from_collection_for_select(@taxons || [], :content_id, :title, params[:taxon_content_id]), include_blank: true, class: "form-control" %>  
+      </div>
     </div>
     <div class="form-group">
       <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -2,7 +2,7 @@
   <%= render 'sidebar' %>
 <% end %>
 
-<h1><%= @content_items.header organisation: @organisation, taxonomy: @taxonomy %></h1>
+<h1><%= @content_items.header organisation: @organisation, taxon: @taxon %></h1>
 
 <%= render 'summary' %>
 

--- a/db/migrate/20170605161124_rename_taxonomies_to_taxons.rb
+++ b/db/migrate/20170605161124_rename_taxonomies_to_taxons.rb
@@ -1,0 +1,7 @@
+class RenameTaxonomiesToTaxons < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :taxonomies, :taxons
+    rename_table :content_items_taxonomies, :content_items_taxons
+    rename_column :content_items_taxons, :taxonomy_id, :taxon_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,34 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170526095145) do
+ActiveRecord::Schema.define(version: 20170605161124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "audits", force: :cascade do |t|
-    t.string   "content_id", null: false
-    t.string   "uid",        null: false
+  create_table "audits", id: :serial, force: :cascade do |t|
+    t.string "content_id", null: false
+    t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["content_id"], name: "index_audits_on_content_id", unique: true, using: :btree
-    t.index ["uid"], name: "index_audits_on_uid", using: :btree
+    t.index ["content_id"], name: "index_audits_on_content_id", unique: true
+    t.index ["uid"], name: "index_audits_on_uid"
   end
 
-  create_table "content_items", force: :cascade do |t|
-    t.string   "content_id"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+  create_table "content_items", id: :serial, force: :cascade do |t|
+    t.string "content_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "public_updated_at"
-    t.string   "base_path"
-    t.string   "title"
-    t.string   "document_type"
-    t.string   "description"
-    t.integer  "one_month_page_views",  default: 0
-    t.integer  "number_of_pdfs",        default: 0
-    t.integer  "six_months_page_views", default: 0
-    t.index ["content_id"], name: "index_content_items_on_content_id", unique: true, using: :btree
-    t.index ["title"], name: "index_content_items_on_title", using: :btree
+    t.string "base_path"
+    t.string "title"
+    t.string "document_type"
+    t.string "description"
+    t.integer "one_month_page_views", default: 0
+    t.integer "number_of_pdfs", default: 0
+    t.integer "six_months_page_views", default: 0
+    t.index ["content_id"], name: "index_content_items_on_content_id", unique: true
+    t.index ["title"], name: "index_content_items_on_title"
   end
 
   create_table "content_items_organisations", id: false, force: :cascade do |t|
@@ -45,79 +45,79 @@ ActiveRecord::Schema.define(version: 20170526095145) do
     t.integer "organisation_id", null: false
   end
 
-  create_table "content_items_taxonomies", id: false, force: :cascade do |t|
+  create_table "content_items_taxons", id: false, force: :cascade do |t|
     t.integer "content_item_id", null: false
-    t.integer "taxonomy_id",     null: false
-    t.index ["content_item_id"], name: "index_content_items_taxonomies_on_content_item_id", using: :btree
-    t.index ["taxonomy_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true, using: :btree
+    t.integer "taxon_id", null: false
+    t.index ["content_item_id"], name: "index_content_items_taxons_on_content_item_id"
+    t.index ["taxon_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true
   end
 
-  create_table "groups", force: :cascade do |t|
-    t.string   "slug"
-    t.string   "name"
-    t.string   "group_type"
-    t.integer  "parent_group_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.text     "content_item_ids", default: [],              array: true
-  end
-
-  create_table "links", force: :cascade do |t|
-    t.string   "source_content_id"
-    t.string   "link_type"
-    t.string   "target_content_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.index ["link_type"], name: "index_links_on_link_type", using: :btree
-    t.index ["source_content_id"], name: "index_links_on_source_content_id", using: :btree
-    t.index ["target_content_id"], name: "index_links_on_target_content_id", using: :btree
-  end
-
-  create_table "organisations", force: :cascade do |t|
-    t.string   "slug"
+  create_table "groups", id: :serial, force: :cascade do |t|
+    t.string "slug"
+    t.string "name"
+    t.string "group_type"
+    t.integer "parent_group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "title"
-    t.string   "content_id"
-    t.index ["slug"], name: "index_organisations_on_slug", unique: true, using: :btree
+    t.text "content_item_ids", default: [], array: true
   end
 
-  create_table "questions", force: :cascade do |t|
-    t.string   "type",       null: false
-    t.text     "text",       null: false
+  create_table "links", id: :serial, force: :cascade do |t|
+    t.string "source_content_id"
+    t.string "link_type"
+    t.string "target_content_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["type"], name: "index_questions_on_type", using: :btree
+    t.index ["link_type"], name: "index_links_on_link_type"
+    t.index ["source_content_id"], name: "index_links_on_source_content_id"
+    t.index ["target_content_id"], name: "index_links_on_target_content_id"
   end
 
-  create_table "responses", force: :cascade do |t|
-    t.integer  "audit_id"
-    t.integer  "question_id"
-    t.text     "value"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["audit_id"], name: "index_responses_on_audit_id", using: :btree
-    t.index ["question_id"], name: "index_responses_on_question_id", using: :btree
+  create_table "organisations", id: :serial, force: :cascade do |t|
+    t.string "slug"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "content_id"
+    t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "taxonomies", force: :cascade do |t|
-    t.string   "content_id"
-    t.string   "title"
+  create_table "questions", id: :serial, force: :cascade do |t|
+    t.string "type", null: false
+    t.text "text", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["type"], name: "index_questions_on_type"
+  end
+
+  create_table "responses", id: :serial, force: :cascade do |t|
+    t.integer "audit_id"
+    t.integer "question_id"
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["audit_id"], name: "index_responses_on_audit_id"
+    t.index ["question_id"], name: "index_responses_on_question_id"
+  end
+
+  create_table "taxons", id: :serial, force: :cascade do |t|
+    t.string "content_id"
+    t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "uid"
-    t.string   "organisation_slug"
-    t.string   "organisation_content_id"
-    t.text     "permissions"
-    t.boolean  "remotely_signed_out",     default: false
-    t.boolean  "disabled",                default: false
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "uid"
+    t.string "organisation_slug"
+    t.string "organisation_content_id"
+    t.text "permissions"
+    t.boolean "remotely_signed_out", default: false
+    t.boolean "disabled", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/doc/importing_data.md
+++ b/doc/importing_data.md
@@ -4,7 +4,7 @@
 
 The application contains a number of `rake` tasks used to populate the database, these are listed below.
 
-The imports for `organisations`, `taxonomies` and `content_items` use the `publishing-api` therefore you will need to run the `publishing-api` via the [VM](https://github.com/alphagov/govuk-puppet/tree/master/development-vm) to import locally else you will receive timeout errors.
+The imports for `organisations`, `taxons` and `content_items` use the `publishing-api` therefore you will need to run the `publishing-api` via the [VM](https://github.com/alphagov/govuk-puppet/tree/master/development-vm) to import locally else you will receive timeout errors.
 
 **All organisations:**
 
@@ -12,7 +12,7 @@ The imports for `organisations`, `taxonomies` and `content_items` use the `publi
 $ rake import:all_organisations
 ```
 
-**All taxonomies:**
+**All taxons:**
 
 ```bash
 $ rake import:all_taxons

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ContentItemsController, type: :controller do
     end
 
     it "build the paged query with the expected params" do
-      expected_params = { sort: 'title', order: 'asc', page: '1', taxonomy: nil, organisation: nil, query: 'a title' }
+      expected_params = { sort: 'title', order: 'asc', page: '1', taxon: nil, organisation: nil, query: 'a title' }
       result = double('collection', paginated_results: double(decorate: :the_results), results: [])
 
       expect(Queries::ContentItemsQuery).to receive(:new).with(expected_params).and_return(result)
@@ -37,7 +37,7 @@ RSpec.describe ContentItemsController, type: :controller do
     end
 
     it "build the unpaged query with the expected params" do
-      expected_params = { sort: 'title', order: 'asc', page: '1', taxonomy: nil, organisation: nil, query: 'a title' }
+      expected_params = { sort: 'title', order: 'asc', page: '1', taxon: nil, organisation: nil, query: 'a title' }
       expect_any_instance_of(Queries::ContentItemsQuery).to receive(:results).and_return([])
 
       get :index, params: expected_params
@@ -50,11 +50,11 @@ RSpec.describe ContentItemsController, type: :controller do
       expect(assigns(:organisation).content_id).to eq('the-organisation-id')
     end
 
-    it "assigns the taxonomy provided by the taxonomy content id" do
-      create(:taxonomy, content_id: "123")
+    it "assigns the taxon provided by the taxon content id" do
+      create(:taxon, content_id: "123")
 
-      get :index, params: { taxonomy_content_id: "123" }
-      expect(assigns(:taxonomy).content_id).to eq("123")
+      get :index, params: { taxon_content_id: "123" }
+      expect(assigns(:taxon).content_id).to eq("123")
     end
 
     it "renders the :index template" do
@@ -63,18 +63,18 @@ RSpec.describe ContentItemsController, type: :controller do
       expect(subject).to render_template(:index)
     end
 
-    it "assigns the lists of taxonomies and organisations ordered ASC by title" do
+    it "assigns the lists of taxons and organisations ordered ASC by title" do
       create(:organisation, title: "Z")
       create(:organisation, title: "A")
-      create(:taxonomy, title: "Z")
-      create(:taxonomy, title: "A")
+      create(:taxon, title: "Z")
+      create(:taxon, title: "A")
 
       get :index
 
       expect(assigns(:organisations).count).to eq(2)
       expect(assigns(:organisations).first.title).to eq("A")
-      expect(assigns(:taxonomies).count).to eq(2)
-      expect(assigns(:taxonomies).first.title).to eq("A")
+      expect(assigns(:taxons).count).to eq(2)
+      expect(assigns(:taxons).first.title).to eq("A")
     end
   end
 

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe ContentItemDecorator, type: :decorator do
   end
 
   describe "#list_taxons" do
-    let(:taxonomies) { [build(:taxonomy, title: "taxon 1"), build(:taxonomy, title: "taxon 2")] }
-    let(:content_item) { build(:content_item, taxonomies: taxonomies).decorate }
+    let(:taxons) { [build(:taxon, title: "taxon 1"), build(:taxon, title: "taxon 2")] }
+    let(:content_item) { build(:content_item, taxons: taxons).decorate }
 
     it "returns a string of taxons separated by a comma" do
       taxons = content_item.taxons_as_string

--- a/spec/decorators/content_items_decorator_spec.rb
+++ b/spec/decorators/content_items_decorator_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ContentItemsDecorator, type: :decorator do
   let(:organisation) { build(:organisation, title: "Organisation title") }
-  let(:taxonomy) { build(:taxonomy, title: "taxonomy a") }
+  let(:taxon) { build(:taxon, title: "taxon a") }
 
   context "without filter params" do
     it "renders the default page title" do
@@ -19,21 +19,21 @@ RSpec.describe ContentItemsDecorator, type: :decorator do
     end
   end
 
-  context "with taxonomy filter" do
-    it "renders the taxonomy title as page title" do
-      content_items = [build(:content_item, taxonomies: [taxonomy])]
+  context "with taxon filter" do
+    it "renders the taxon title as page title" do
+      content_items = [build(:content_item, taxons: [taxon])]
       subject = ContentItemsDecorator.new(content_items)
 
-      expect(subject.header(taxonomy: taxonomy)).to eq("taxonomy a")
+      expect(subject.header(taxon: taxon)).to eq("taxon a")
     end
   end
 
-  context "with both organisation and taxonomy filters" do
-    it "renders the organisation and taxonomy titles seperated by a '+'" do
-      content_items = [build(:content_item, organisations: [organisation], taxonomies: [taxonomy])]
+  context "with both organisation and taxon filters" do
+    it "renders the organisation and taxon titles seperated by a '+'" do
+      content_items = [build(:content_item, organisations: [organisation], taxons: [taxon])]
       subject = ContentItemsDecorator.new(content_items)
 
-      expect(subject.header(organisation: organisation, taxonomy: taxonomy)).to eq("Organisation title + taxonomy a")
+      expect(subject.header(organisation: organisation, taxon: taxon)).to eq("Organisation title + taxon a")
     end
   end
 end

--- a/spec/factories/taxons_factory.rb
+++ b/spec/factories/taxons_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :taxonomy do
+  factory :taxon do
     sequence(:content_id) { |index| "content-id-#{index}" }
     sequence(:title) { |index| "title-#{index}" }
   end

--- a/spec/features/performance/content_item_spec.rb
+++ b/spec/features/performance/content_item_spec.rb
@@ -39,14 +39,14 @@ RSpec.feature "Content Item Details", type: :feature do
     expect(page).to have_text("99")
   end
 
-  scenario "Renders the taxonomies" do
+  scenario "Renders the taxons" do
     content_item = create(:content_item)
-    content_item.taxonomies << create(:taxonomy, title: 'A Taxonomy')
-    content_item.taxonomies << create(:taxonomy, title: 'Another Taxonomy')
+    content_item.taxons << create(:taxon, title: 'A Taxon')
+    content_item.taxons << create(:taxon, title: 'Another Taxon')
 
     visit "/content_items/#{content_item.id}"
 
-    expect(page).to have_text('A Taxonomy, Another Taxonomy')
+    expect(page).to have_text('A Taxon, Another Taxon')
   end
 
   scenario "Renders stats for Google Analytics" do

--- a/spec/features/performance/filter_spec.rb
+++ b/spec/features/performance/filter_spec.rb
@@ -63,36 +63,36 @@ RSpec.feature "Filter in content items", type: :feature do
 
   context "filtering by taxon" do
     scenario "the user selects a taxon from the taxons box, clicks the filter button and retrieves the filtered list of taxon's content items" do
-      create :taxonomy, title: "taxon 1", content_id: "123"
+      create :taxon, title: "taxon 1", content_id: "123"
 
       visit "/content_items"
-      select "taxon 1", from: "taxonomy_content_id"
+      select "taxon 1", from: "taxon_content_id"
       click_on "Filter"
 
-      expected_path = "taxonomy_content_id=123"
+      expected_path = "taxon_content_id=123"
 
       expect(current_url).to include(expected_path)
     end
 
-    scenario "the users previously filtered taxonomy is selected after filtering" do
-      create :taxonomy, title: "taxon 1"
+    scenario "the users previously filtered taxon is selected after filtering" do
+      create :taxon, title: "taxon 1"
 
       visit "/content_items"
-      select "taxon 1", from: "taxonomy_content_id"
+      select "taxon 1", from: "taxon_content_id"
       click_on "Filter"
 
-      expect(page).to have_select(:taxonomy_content_id, selected: 'taxon 1')
+      expect(page).to have_select(:taxon_content_id, selected: 'taxon 1')
     end
 
-    scenario "the user's previously filtered taxonomy is selected after sorting" do
-      create :taxonomy, title: "taxon 1", content_id: "123"
+    scenario "the user's previously filtered taxon is selected after sorting" do
+      create :taxon, title: "taxon 1", content_id: "123"
 
       visit "content_items"
-      page.select "taxon 1", from: "taxonomy_content_id"
+      page.select "taxon 1", from: "taxon_content_id"
       click_on "Filter"
 
       click_on "Title"
-      expect(page).to have_select(:taxonomy_content_id, selected: "taxon 1")
+      expect(page).to have_select(:taxon_content_id, selected: "taxon 1")
     end
   end
 
@@ -112,9 +112,9 @@ RSpec.feature "Filter in content items", type: :feature do
     end
 
     scenario "the user can see the additional filters if they are currently filtering by one of them", js: true do
-      create :taxonomy, title: "taxon 1", content_id: "123"
+      create :taxon, title: "taxon 1", content_id: "123"
 
-      visit "/content_items?taxonomy_content_id=123"
+      visit "/content_items?taxon_content_id=123"
 
       expect(page).to have_selector('#additionalFilters', visible: true)
     end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -29,26 +29,26 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
-  describe "#add_taxonomies_by_id" do
-    it "adds taxonomies to the content item by taxon content_id" do
+  describe "#add_taxons_by_id" do
+    it "adds taxons to the content item by taxon content_id" do
       content_item = create(:content_item)
       taxons = %w(taxon_1 taxon_2)
-      create(:taxonomy, content_id: "taxon_1")
-      create(:taxonomy, content_id: "taxon_2")
+      create(:taxon, content_id: "taxon_1")
+      create(:taxon, content_id: "taxon_2")
 
-      content_item.add_taxonomies_by_id(taxons)
+      content_item.add_taxons_by_id(taxons)
 
-      expect(content_item.taxonomies.count).to eq(2)
+      expect(content_item.taxons.count).to eq(2)
     end
 
-    it "does not add taxonomies already associated with the content item" do
+    it "does not add taxons already associated with the content item" do
       content_item = create(:content_item)
-      taxon = create(:taxonomy, content_id: "taxon_1")
-      content_item.taxonomies << taxon
+      taxon = create(:taxon, content_id: "taxon_1")
+      content_item.taxons << taxon
 
-      content_item.add_taxonomies_by_id(%w(taxon_1))
+      content_item.add_taxons_by_id(%w(taxon_1))
 
-      expect(content_item.taxonomies.count).to eq(1)
+      expect(content_item.taxons.count).to eq(1)
     end
   end
 

--- a/spec/models/importers/all_taxons_spec.rb
+++ b/spec/models/importers/all_taxons_spec.rb
@@ -1,27 +1,27 @@
 RSpec.describe Importers::AllTaxons do
   describe '#run' do
-    it 'creates a new Taxonomy if not present' do
+    it 'creates a new Taxon if not present' do
       attrs1 = { content_id: 'a-content-item_-1', title: 'a-title-1' }
       attrs2 = { content_id: 'a-content-item_-2', title: 'a-title-2' }
-      subject.taxonomies_service = double
+      subject.taxons = double
 
-      allow(subject.taxonomies_service).to receive(:find_each).and_yield(attrs1).and_yield(attrs2)
+      allow(subject.taxons).to receive(:find_each).and_yield(attrs1).and_yield(attrs2)
 
-      expect { subject.run }.to change { Taxonomy.count }.by(2)
+      expect { subject.run }.to change { Taxon.count }.by(2)
     end
 
-    context 'when the taxonomy exists' do
-      before { create :taxonomy, title: 'old-title' }
+    context 'when the taxon exists' do
+      before { create :taxon, title: 'old-title' }
 
       it 'updates the attributes' do
         attrs1 = { content_id: 'a-content-id-1', title: 'a-title-1' }
-        subject.taxonomies_service = double
+        subject.taxons = double
 
-        allow(subject.taxonomies_service).to receive(:find_each).and_yield(attrs1)
+        allow(subject.taxons).to receive(:find_each).and_yield(attrs1)
 
         subject.run
 
-        taxon = Taxonomy.find_by(content_id: 'a-content-id-1')
+        taxon = Taxon.find_by(content_id: 'a-content-id-1')
         expect(taxon.title).to eq('a-title-1')
       end
     end

--- a/spec/models/importers/single_content_item_spec.rb
+++ b/spec/models/importers/single_content_item_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Importers::SingleContentItem do
   let!(:org1) { FactoryGirl.create(:organisation, content_id: "org-1") }
   let!(:org2) { FactoryGirl.create(:organisation, content_id: "org-2") }
 
-  let!(:taxon1) { FactoryGirl.create(:taxonomy, content_id: "taxon-1") }
-  let!(:taxon2) { FactoryGirl.create(:taxonomy, content_id: "taxon-2") }
+  let!(:taxon1) { FactoryGirl.create(:taxon, content_id: "taxon-1") }
+  let!(:taxon2) { FactoryGirl.create(:taxon, content_id: "taxon-2") }
 
   let(:content_item) { FactoryGirl.build(:content_item, content_id: content_id, title: "title") }
 
@@ -41,7 +41,7 @@ RSpec.describe Importers::SingleContentItem do
 
     expect(content_item.title).to eq("title")
     expect(content_item.organisations).to eq [org1, org2]
-    expect(content_item.taxonomies).to eq [taxon1, taxon2]
+    expect(content_item.taxons).to eq [taxon1, taxon2]
     expect(content_item.number_of_pdfs).to eq(10)
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Importers::SingleContentItem do
         content_id: content_id,
         title: "old title",
         organisations: [org1],
-        taxonomies: [taxon2],
+        taxons: [taxon2],
         number_of_pdfs: 5,
       )
     end
@@ -81,7 +81,7 @@ RSpec.describe Importers::SingleContentItem do
       expect { subject.run(content_id) }
         .to  change { ContentItem.last.title }.from("old title").to("title")
         .and change { ContentItem.last.organisations.to_a }.from([org1]).to([org1, org2])
-        .and change { ContentItem.last.taxonomies.to_a }.from([taxon2]).to([taxon1, taxon2])
+        .and change { ContentItem.last.taxons.to_a }.from([taxon2]).to([taxon1, taxon2])
         .and change { ContentItem.last.number_of_pdfs }.from(5).to(10)
     end
   end

--- a/spec/models/queries/content_items_query_spec.rb
+++ b/spec/models/queries/content_items_query_spec.rb
@@ -52,33 +52,33 @@ RSpec.describe Queries::ContentItemsQuery, type: :query do
       expect(results).to match_array(content_items)
     end
 
-    it "returns the content items belonging to the taxonomy" do
+    it "returns the content items belonging to the taxon" do
       create(:content_item)
       content_items = [create(:content_item)]
-      taxonomy = create(:taxonomy, content_items: content_items)
+      taxon = create(:taxon, content_items: content_items)
 
-      results = subject.new(taxonomy: taxonomy).results
+      results = subject.new(taxon: taxon).results
 
       expect(results).to match_array(content_items)
     end
 
-    it "returns the content items belonging to the organisation and taxonomy" do
+    it "returns the content items belonging to the organisation and taxon" do
       create(:content_item)
       content_items = [create(:content_item)]
-      taxonomy = create(:taxonomy, content_items: content_items)
+      taxon = create(:taxon, content_items: content_items)
       organisation = create(:organisation, content_items: content_items)
 
-      results = subject.new(organisation: organisation, taxonomy: taxonomy).results
+      results = subject.new(organisation: organisation, taxon: taxon).results
 
       expect(results).to match_array(content_items)
     end
 
-    it "returns the content items belonging to the organisation and taxonomy where the title is like the query" do
+    it "returns the content items belonging to the organisation and taxon where the title is like the query" do
       content_items = [create(:content_item, title: "title 1")]
-      taxonomy = create(:taxonomy, content_items: content_items)
+      taxon = create(:taxon, content_items: content_items)
       organisation = create(:organisation, content_items: content_items)
 
-      results = subject.new(organisation: organisation, taxonomy: taxonomy, query: "title 1").results
+      results = subject.new(organisation: organisation, taxon: taxon, query: "title 1").results
 
       expect(results).to match_array(content_items)
     end

--- a/spec/services/taxonomy_service_spec.rb
+++ b/spec/services/taxonomy_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TaxonomiesService do
+RSpec.describe TaxonomyService do
   describe '#find_each' do
     it 'queries the publishing API for the given fields of taxons' do
       subject.publishing_api = double


### PR DESCRIPTION
The word "taxonomy" describes the structure (as in "we're working towards a single-subject taxonomy"). We do have multiple taxonomies on GOV.UK at the moment, like the "specialist sector" taxonomy (https://www.gov.uk/topic), the browse page taxonomy (https://www.gov.uk/browse).

The items in the taxonomy we call "taxons" in code and content tagger, and "topics" in some publisher applications. This commit renames "Taxonomy" so that it's clear we're talking about the same thing.

