### PR TITLE
Filter by organisations (and other things)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ group :development, :test do
   gem 'govuk-lint'
   gem 'guard-rspec', require: false
   gem 'listen'
+  gem 'pry-rails'
+  gem 'byebug'
   gem 'poltergeist'
   gem 'pry-rails'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     builder (3.2.3)
+    byebug (9.0.6)
     capybara (2.14.0)
       addressable
       mime-types (>= 1.16)
@@ -434,6 +435,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake!
+  byebug
   capybara
   database_cleaner
   draper

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -47,8 +47,9 @@ private
   def search
     @search ||= (
       search = Search.new
+      filter_by_audit_status!(search)
+      filter_by_link_types!(search)
       search.page = params[:page]
-      search.audit_status = params[:audit_status] if params[:audit_status]
       search.execute
       search
     )
@@ -68,5 +69,16 @@ private
 
   def error_message
     audit.errors.messages.values.join(', ').capitalize
+  end
+
+  def filter_by_audit_status!(search)
+    search.audit_status = params[:audit_status] if params[:audit_status]
+  end
+
+  def filter_by_link_types!(search)
+    params.slice(*Search::LINK_TYPE_FILTERS).each do |link_type, content_id|
+      next if content_id.blank?
+      search.filter_by(link_type: link_type, target_ids: content_id)
+    end
   end
 end

--- a/app/domain/search.rb
+++ b/app/domain/search.rb
@@ -1,4 +1,12 @@
 class Search
+  LINK_TYPE_FILTERS = [
+    Link::PRIMARY_ORG,
+    Link::ALL_ORGS,
+    Link::POLICY_AREAS,
+    Link::TOPICS,
+    Link::TAXONS,
+  ].freeze
+
   def initialize
     self.query = Query.new
   end
@@ -42,6 +50,12 @@ class Search
 
   def sort
     query.sort
+  end
+
+  def link_type_filters
+    LINK_TYPE_FILTERS.map do |link_type|
+      [link_type, result.options_for(link_type)]
+    end
   end
 
   def self.all_audit_status

--- a/app/domain/search/executor.rb
+++ b/app/domain/search/executor.rb
@@ -4,19 +4,57 @@ class Search
       new(query).execute
     end
 
-    attr_accessor :query, :scope
+    attr_accessor :query, :scope, :filter_options
 
     def initialize(query)
       self.query = query
       self.scope = ContentItem.all
+      self.filter_options = {}
     end
 
     def execute
-      query.filters.each { |f| self.scope = f.apply(scope) }
-      self.scope = query.sort.apply(scope)
-      self.scope = scope.page(query.page).per(query.per_page)
+      build_filter_options
 
-      Result.new(scope)
+      apply_filters
+      apply_sort
+      paginate
+
+      Result.new(scope, filter_options)
+    end
+
+  private
+
+    def build_filter_options
+      Search::LINK_TYPE_FILTERS.each do |link_type|
+        filter_options.merge!(
+          link_type => ContentItem.targets_of(
+            link_type: link_type,
+            scope_to_count: apply_filters_except_for(link_type),
+          )
+        )
+      end
+    end
+
+    def apply_filters_except_for(link_type)
+      query.filters.inject(self.scope) do |scope, filter|
+        if filter.respond_to?(:link_type) && filter.link_type == link_type
+          scope
+        else
+          filter.apply(scope)
+        end
+      end
+    end
+
+    def apply_filters
+      query.filters.each { |f| self.scope = f.apply(scope) }
+    end
+
+    def apply_sort
+      self.scope = query.sort.apply(scope)
+    end
+
+    def paginate
+      self.scope = scope.page(query.page).per(query.per_page)
     end
   end
 end

--- a/app/domain/search/query.rb
+++ b/app/domain/search/query.rb
@@ -48,15 +48,19 @@ class Search
   private
 
     def raise_if_already_filtered_by_link_type(filter)
-      if filters.any? { |f| f.link_type == filter.link_type }
+      if link_filters.any? { |f| f.link_type == filter.link_type }
         raise FilterError, "duplicate filter for #{filter.link_type}"
       end
     end
 
     def raise_if_mixing_source_and_target(filter)
-      if filters.any? { |f| f.by_source? != filter.by_source? }
+      if link_filters.any? { |f| f.by_source? != filter.by_source? }
         raise FilterError, "attempting to filter by source and target"
       end
+    end
+
+    def link_filters
+      filters.select { |f| f.is_a?(LinkFilter) }
     end
 
     class ::FilterError < StandardError; end

--- a/app/domain/search/result.rb
+++ b/app/domain/search/result.rb
@@ -1,13 +1,18 @@
 class Search
   class Result
-    attr_accessor :scope
+    attr_accessor :scope, :filter_options
 
-    def initialize(scope)
+    def initialize(scope, filter_options)
       self.scope = scope
+      self.filter_options = filter_options
     end
 
     def content_items
       scope
+    end
+
+    def options_for(link_type)
+      filter_options.fetch(link_type)
     end
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -30,15 +30,15 @@ class ContentItem < ApplicationRecord
   end
 
   def topics
-    linked_content("topics")
+    linked_content(Link::TOPICS)
   end
 
   def organisations_tmp
-    linked_content("organisations")
+    linked_content(Link::ALL_ORGS)
   end
 
   def policy_areas
-    linked_content("policy-areas")
+    linked_content(Link::POLICY_AREAS)
   end
 
   def guidance?

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -3,6 +3,25 @@ class ContentItem < ApplicationRecord
   has_and_belongs_to_many :taxons
   has_one :audit, primary_key: :content_id, foreign_key: :content_id
 
+  has_many :links,
+    primary_key: :content_id,
+    foreign_key: :source_content_id
+
+  has_many :reverse_links,
+    class_name: :Link,
+    primary_key: :content_id,
+    foreign_key: :target_content_id
+
+  def self.targets_of(link_type:, scope_to_count: all)
+    x = scope_to_count
+
+    joins(:reverse_links)
+      .where(links: { link_type: link_type })
+      .group(:id)
+      .select("content_items.*")
+      .joins("LEFT JOIN (#{x.to_sql}) x ON x.content_id = links.source_content_id")
+      .select("count(x.id) as incoming_links_count")
+  end
 
   def self.next_item(current_item)
     ids = pluck(:id)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -29,6 +29,14 @@ class ContentItem < ApplicationRecord
     all[index + 1] if index
   end
 
+  def title_with_count
+    if respond_to?(:incoming_links_count)
+      "#{title} (#{incoming_links_count})"
+    else
+      title
+    end
+  end
+
   def topics
     linked_content(Link::TOPICS)
   end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,2 +1,13 @@
 class Link < ApplicationRecord
+  belongs_to :source,
+    class_name: :ContentItem,
+    foreign_key: :source_content_id,
+    primary_key: :content_id,
+    optional: true
+
+  belongs_to :target,
+    class_name: :ContentItem,
+    foreign_key: :target_content_id,
+    primary_key: :content_id,
+    optional: true
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,4 +1,10 @@
 class Link < ApplicationRecord
+  PRIMARY_ORG = "primary_publishing_organisation".freeze
+  ALL_ORGS = "organisations".freeze
+  POLICY_AREAS = "policy_areas".freeze
+  TOPICS = "topics".freeze
+  TAXONS = "taxons".freeze
+
   belongs_to :source,
     class_name: :ContentItem,
     foreign_key: :source_content_id,

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -6,9 +6,28 @@
       <%= label_tag :audit_status, 'Status:' %>
       <%= select_tag :audit_status,
           options_from_collection_for_select(Search.all_audit_status, :identifier, :name, params[:audit_status]),
-          include_blank: true,
+          include_blank: "All",
           class: "form-control" %>
     </div>
+
+    <% @search.link_type_filters.each do |link_type, options| %>
+      <% disabled_options = options.select { |o| o.incoming_links_count.zero? } %>
+
+      <div class="form-group">
+        <%= label_tag link_type, "#{link_type.titleize}:" %>
+        <%= select_tag(
+              link_type,
+              options_from_collection_for_select(
+                options.order(:title),
+                :content_id,
+                :title_with_count,
+                selected: params[link_type],
+                disabled: disabled_options.map(&:content_id),
+              ),
+              include_blank: "All",
+              class: "form-control") %>
+      </div>
+    <% end %>
 
     <div class="form-group">
       <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>

--- a/spec/domain/search/query_spec.rb
+++ b/spec/domain/search/query_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe Search::Query do
         .to raise_error(FilterError, /source and target/)
     end
 
+    it "raises errors correctly when other types of filters are set" do
+      subject.audit_status = :audited
+      subject.filter_by("organisations", nil, "org1")
+
+      expect { subject.filter_by("policies", "id2", nil) }
+        .to raise_error(FilterError, /source and target/)
+    end
+
     it "stores the list of filters" do
       subject.filter_by("organisations", nil, "org1")
       subject.filter_by("policies", nil, "org2")

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -1,7 +1,15 @@
 RSpec.feature "Filter Content Items to Audit", type: :feature do
   before do
-    create(:audit, content_item: create(:content_item, title: "Audited content item"))
-    create(:content_item, title: "Non-audited content item")
+    audited = FactoryGirl.create(:content_item, title: "Audited content item")
+    FactoryGirl.create(:audit, content_item: audited)
+
+    non_audited = FactoryGirl.create(:content_item, title: "Non-audited content item")
+
+    hmrc = FactoryGirl.create(:content_item, title: "HMRC")
+    FactoryGirl.create(:link, source: audited, target: hmrc, link_type: "organisations")
+
+    dfe = FactoryGirl.create(:content_item, title: "DFE")
+    FactoryGirl.create(:link, source: non_audited, target: dfe, link_type: "organisations")
   end
 
   scenario "List all content items (audited and not audited)" do
@@ -18,7 +26,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     click_on "Filter"
 
     expect(page).to have_content("Audited content item")
-    expect(page).to_not have_content("Non-audited content item")
+    expect(page).to have_no_content("Non-audited content item")
     expect(page).to have_select("audit_status", selected: "Audited")
   end
 
@@ -28,9 +36,28 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
     click_on "Filter"
 
-    expect(page).to_not have_content("Audited content item")
+    expect(page).to have_no_content("Audited content item")
     expect(page).to have_content("Non-audited content item")
     expect(page).to have_select("audit_status", selected: "Non Audited")
+  end
+
+  scenario "filtering by organisation" do
+    visit audits_path
+    select "HMRC", from: "organisations"
+
+    click_on "Filter"
+
+    expect(page).to have_content("Audited content item")
+    expect(page).to have_no_content("Non-audited content item")
+
+    expect(page).to have_content("HMRC (1)")
+    expect(page).to have_content("DFE (1)")
+
+    select "Audited", from: "audit_status"
+
+    click_on "Filter"
+    expect(page).to have_content("HMRC (1)")
+    expect(page).to have_content("DFE (0)")
   end
 
   scenario "Reseting page to 1 after filtering" do

--- a/spec/features/audit/metadata_spec.rb
+++ b/spec/features/audit/metadata_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Audit metadata", type: :feature do
     create_linked_content("organisations", "Home office")
     create_linked_content("topics", "Immigration")
     create_linked_content("topics", "Borders")
-    create_linked_content("policy-areas", "Borders and Immigration")
+    create_linked_content("policy_areas", "Borders and Immigration")
 
     visit content_item_audit_path(content_item)
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -40,6 +40,49 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
+  describe ".targets_of" do
+    let!(:a) { FactoryGirl.create(:content_item) }
+    let!(:b) { FactoryGirl.create(:content_item) }
+    let!(:c) { FactoryGirl.create(:content_item) }
+
+    before do
+      FactoryGirl.create(:link, source: a, target: b, link_type: "type1")
+      FactoryGirl.create(:link, source: b, target: a, link_type: "type1")
+
+      FactoryGirl.create(:link, source: a, target: c, link_type: "type2")
+      FactoryGirl.create(:link, source: b, target: c, link_type: "type2")
+    end
+
+    it "returns a scope of items that have links to them with the given type" do
+      results = described_class.targets_of(link_type: "type1")
+      expect(results).to match_array [a, b]
+
+      results = described_class.targets_of(link_type: "type2")
+      expect(results).to eq [c]
+
+      results = described_class.targets_of(link_type: "type3")
+      expect(results).to eq []
+    end
+
+    it "selects a count of the number of incoming links" do
+      results = described_class.targets_of(link_type: "type1")
+      expect(results.map(&:incoming_links_count)).to eq [1, 1]
+
+      results = described_class.targets_of(link_type: "type2")
+      expect(results.map(&:incoming_links_count)).to eq [2]
+    end
+
+    it "can count incoming links for a subset of content items" do
+      subset = described_class.where(id: [a])
+
+      results = described_class.targets_of(link_type: "type1", scope_to_count: subset)
+      expect(results.map(&:incoming_links_count)).to match_array [0, 1]
+
+      results = described_class.targets_of(link_type: "type2", scope_to_count: subset)
+      expect(results.map(&:incoming_links_count)).to eq [1]
+    end
+  end
+
   describe "#url" do
     it "returns a url to a content item on gov.uk" do
       content_item = build(:content_item, base_path: "/api/content/item/path/1")

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -83,6 +83,23 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
+  describe "#title_with_count" do
+    before do
+      item = FactoryGirl.create(:content_item, title: "Title")
+      FactoryGirl.create(:link, source: item, target: item, link_type: "type")
+    end
+
+    it "returns the title with the count of incoming links" do
+      item = described_class.targets_of(link_type: "type").first
+      expect(item.title_with_count).to eq("Title (1)")
+    end
+
+    it "returns the title if incoming_links_count isn't set" do
+      item = described_class.first
+      expect(item.title_with_count).to eq("Title")
+    end
+  end
+
   describe "#url" do
     it "returns a url to a content item on gov.uk" do
       content_item = build(:content_item, base_path: "/api/content/item/path/1")

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe ContentItem, type: :model do
     describe "#policy_areas" do
       it "returns the topics linked to the Content Item" do
         policy_area = create(:content_item, content_id: "policy_area_1")
-        Link.create(link_type: "policy-areas", source_content_id: "cid1", target_content_id: "policy_area_1")
+        Link.create(link_type: "policy_areas", source_content_id: "cid1", target_content_id: "policy_area_1")
 
         expect(content_item.policy_areas).to match_array([policy_area])
       end


### PR DESCRIPTION
I've added the capability to filter by link_types in a general way, so it's trivial to add new filters if needed. For now, I've added in a few others that might be useful to show what sort of data is available.
![screen shot 2017-06-06 at 16 44 44](https://user-images.githubusercontent.com/892251/26838241-7bbd8cde-4ad7-11e7-8814-7feb6a81f831.png)
