### PR TITLE
Create a true many-to-many relationship for Groups and ContentItems

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,6 @@ class Group < ApplicationRecord
 
   belongs_to :parent, class_name: 'Group', foreign_key: :parent_group_id, optional: true
   has_many :children, class_name: 'Group', foreign_key: :parent_group_id
+
+  has_and_belongs_to_many :content_items
 end

--- a/db/migrate/20170606105748_create_join_table_group_content_item.rb
+++ b/db/migrate/20170606105748_create_join_table_group_content_item.rb
@@ -1,0 +1,9 @@
+class CreateJoinTableGroupContentItem < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :groups, :content_items do |t|
+      t.index [:content_item_id]
+      t.index [:group_id]
+      t.index [:group_id, :content_item_id], name: "index_group_content_items", unique: true
+    end
+  end
+end

--- a/db/migrate/20170606110152_remove_content_ids_list_from_groups.rb
+++ b/db/migrate/20170606110152_remove_content_ids_list_from_groups.rb
@@ -1,0 +1,5 @@
+class RemoveContentIdsListFromGroups < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :groups, :content_item_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170605161124) do
+ActiveRecord::Schema.define(version: 20170606110152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,14 @@ ActiveRecord::Schema.define(version: 20170605161124) do
     t.index ["title"], name: "index_content_items_on_title"
   end
 
+  create_table "content_items_groups", id: false, force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.bigint "content_item_id", null: false
+    t.index ["content_item_id"], name: "index_content_items_groups_on_content_item_id"
+    t.index ["group_id", "content_item_id"], name: "index_group_content_items", unique: true
+    t.index ["group_id"], name: "index_content_items_groups_on_group_id"
+  end
+
   create_table "content_items_organisations", id: false, force: :cascade do |t|
     t.integer "content_item_id", null: false
     t.integer "organisation_id", null: false
@@ -59,7 +67,6 @@ ActiveRecord::Schema.define(version: 20170605161124) do
     t.integer "parent_group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "content_item_ids", default: [], array: true
   end
 
   create_table "links", id: :serial, force: :cascade do |t|

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -3,5 +3,17 @@ FactoryGirl.define do
     sequence(:slug) { |index| "slug-#{index}" }
     sequence(:name) { |index| "name-#{index}" }
     sequence(:group_type) { |index| "group-type-#{index}" }
+
+    trait :with_two_content_items do
+      after(:create) do |group|
+        group.content_items = create_list(:content_item, 2)
+      end
+    end
+
+    trait :with_one_content_item do
+      after(:create) do |group|
+        group.content_items << create(:content_item)
+      end
+    end
   end
 end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "API::Groups", type: :request do
 
   describe "GET /groups" do
     it "returns JSON with all the Groups and number of Content IDs" do
-      create :group, slug: "slug-1", content_item_ids: %w(1 2)
+      create :group, :with_two_content_items, slug: "slug-1"
       get "/groups", params: { api_token: "a-token" }, headers: headers
 
       json = JSON.parse(response.body).deep_symbolize_keys
@@ -83,10 +83,11 @@ RSpec.describe "API::Groups", type: :request do
 
       context "when a list of content IDs is provided" do
         it "adds the Content IDs to the group" do
-          params[:group][:content_item_ids] = %w(content_id_1 content_id_2)
+          content_item = create(:content_item)
+          params[:group][:content_item_ids] = [content_item.id]
 
           post "/groups", params: params, headers: headers
-          expect(Group.first.content_item_ids).to eq(%w(content_id_1 content_id_2))
+          expect(Group.first.content_items.first).to eq(content_item)
         end
       end
 

--- a/spec/views/groups/index.json.jbuilder_spec.rb
+++ b/spec/views/groups/index.json.jbuilder_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "groups/index.json.jbuilder", type: :view do
   it "renders JSON with all the Groups and number of Content IDs" do
-    group1 = build :group, id: 1, slug: "slug-1", content_item_ids: %w(1 2)
-    group2 = build :group, id: 2, slug: "slug-2", content_item_ids: %w(1)
+    group1 = create :group, :with_two_content_items, id: 1, slug: "slug-1"
+    group2 = create :group, :with_one_content_item, id: 2, slug: "slug-2"
     assign :groups, [group1, group2]
     render
 


### PR DESCRIPTION
By creating a join table we make it faster to query larger groups. 

This migration assumes there are no Groups as there are none in my recently replicated data. 
*It will totally squash any data that's in the Groups->content_item_ids field*

