### PR TITLE
Remove temporary audit link

### DIFF
--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -49,7 +49,3 @@
     </tr>
   </tbody>
 </table>
-
-<div class="temporary-audit-link">
-  <%= link_to "Audit", content_item_audit_path(@content_item), class: "btn btn-primary" %>
-</div>


### PR DESCRIPTION
Now we have the audit index page, we no longer
need this.