### PR TITLE
Add Taxonomy Project

### DIFF
--- a/app/controllers/taxonomy_projects_controller.rb
+++ b/app/controllers/taxonomy_projects_controller.rb
@@ -1,0 +1,9 @@
+class TaxonomyProjectsController < ApplicationController
+  def index
+    @projects = TaxonomyProject.all
+  end
+
+  def show
+    @project = TaxonomyProject.find(params[:id])
+  end
+end

--- a/app/models/taxonomy_project.rb
+++ b/app/models/taxonomy_project.rb
@@ -1,0 +1,12 @@
+# A Taxonomy Project is part of the process to create a new branch of the
+# single-subject taxonomy.
+#
+# The goal of the process is to generate a set of terms that describe the
+# content. The terms will then be cleaned, merged and grouped. They'll form the
+# basis of the new taxonomy branch after user research. A project has many
+# "todos", which are pages content designers have to generate terms for. The
+# todos will be created by a import script.
+class TaxonomyProject < ApplicationRecord
+  has_many :taxonomy_todos
+  has_many :content_items, through: :taxonomy_todos
+end

--- a/app/models/taxonomy_todo.rb
+++ b/app/models/taxonomy_todo.rb
@@ -1,0 +1,4 @@
+class TaxonomyTodo < ApplicationRecord
+  belongs_to :content_item
+  belongs_to :taxonomy_project
+end

--- a/app/views/taxonomy_projects/index.html.erb
+++ b/app/views/taxonomy_projects/index.html.erb
@@ -1,0 +1,18 @@
+<h1>Taxonomy projects</h1>
+
+<table class="table table-bordered table-hover">
+  <thead>
+  <tr class="table-header">
+    <td>Title</td>
+    <td>Items</td>
+  </tr>
+  </thead>
+  <tbody>
+    <% @projects.each do |project| %>
+      <tr>
+        <td><%= link_to project.name, project %></td>
+        <td><%= project.content_items.count %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/taxonomy_projects/show.html.erb
+++ b/app/views/taxonomy_projects/show.html.erb
@@ -1,0 +1,16 @@
+<h1><%= @project.name %></h1>
+
+<table class="table table-bordered table-hover">
+  <thead>
+  <tr class="table-header">
+    <td>Title</td>
+  </tr>
+  </thead>
+  <tbody>
+    <% @project.content_items.each do |content_item| %>
+      <tr>
+        <td><%= link_to content_item.title, content_item %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
 
   resources :audits, only: %w(index)
+  resources :taxonomy_projects, path: '/taxonomy-projects', only: %w(index show)
 
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"

--- a/db/migrate/20170606163123_create_taxonomy_projects.rb
+++ b/db/migrate/20170606163123_create_taxonomy_projects.rb
@@ -1,0 +1,9 @@
+class CreateTaxonomyProjects < ActiveRecord::Migration[5.1]
+  def change
+    create_table :taxonomy_projects do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170606163951_create_taxonomy_todos.rb
+++ b/db/migrate/20170606163951_create_taxonomy_todos.rb
@@ -1,0 +1,12 @@
+class CreateTaxonomyTodos < ActiveRecord::Migration[5.1]
+  def change
+    create_table :taxonomy_todos do |t|
+      t.belongs_to :content_item, foreign_key: true
+      t.belongs_to :taxonomy_project, foreign_key: true
+      t.datetime :completed_at
+      t.string :completed_by
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170606110152) do
+ActiveRecord::Schema.define(version: 20170606163951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,23 @@ ActiveRecord::Schema.define(version: 20170606110152) do
     t.index ["question_id"], name: "index_responses_on_question_id"
   end
 
+  create_table "taxonomy_projects", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "taxonomy_todos", force: :cascade do |t|
+    t.bigint "content_item_id"
+    t.bigint "taxonomy_project_id"
+    t.datetime "completed_at"
+    t.string "completed_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_item_id"], name: "index_taxonomy_todos_on_content_item_id"
+    t.index ["taxonomy_project_id"], name: "index_taxonomy_todos_on_taxonomy_project_id"
+  end
+
   create_table "taxons", id: :serial, force: :cascade do |t|
     t.string "content_id"
     t.string "title"
@@ -127,4 +144,6 @@ ActiveRecord::Schema.define(version: 20170606110152) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "taxonomy_todos", "content_items"
+  add_foreign_key "taxonomy_todos", "taxonomy_projects"
 end

--- a/spec/factories/taxonomy_projects_factory.rb
+++ b/spec/factories/taxonomy_projects_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :taxonomy_project do
+    name "My taxonomy project"
+  end
+end

--- a/spec/factories/taxonomy_todos_factory.rb
+++ b/spec/factories/taxonomy_todos_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :taxonomy_todo do
+    content_item
+    taxonomy_project
+  end
+end

--- a/spec/features/taxonomy_generation/taxonomy_generation_spec.rb
+++ b/spec/features/taxonomy_generation/taxonomy_generation_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Taxonomy generation", type: :feature do
+  it "has an index page" do
+    taxonomy_project = create(:taxonomy_project, name: "Project Foo")
+    create(:taxonomy_todo, taxonomy_project: taxonomy_project, content_item: create(:content_item, title: "Title Foo"))
+    create(:taxonomy_todo, taxonomy_project: taxonomy_project, content_item: create(:content_item, title: "Title Bar"))
+
+    visit taxonomy_projects_path
+
+    click_on "Project Foo"
+
+    expect(page).to have_content "Project Foo"
+    expect(page).to have_content "Title Foo"
+    expect(page).to have_content "Title Bar"
+  end
+end

--- a/spec/models/taxonomy_project_spec.rb
+++ b/spec/models/taxonomy_project_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe TaxonomyProject, type: :model do
+end

--- a/spec/models/taxonomy_todo_spec.rb
+++ b/spec/models/taxonomy_todo_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe TaxonomyTodo, type: :model do
+end


### PR DESCRIPTION
We're currently working to create a new feature in this app that will allow content designers to generate terms for a set of pages. The terms will be used to create a new branch of the taxonomy (we're currently working on environment and transport related content).

This commit creates two new models, which we will use in subsequent pull requests (one to create an importer to create todos, the other one with the term generation interface).

## Screenies

![screen shot 2017-06-07 at 10 47 12](https://user-images.githubusercontent.com/233676/26872534-c47925e0-4b6e-11e7-9eb0-827ccedc9c02.png)

![screen shot 2017-06-07 at 10 47 16](https://user-images.githubusercontent.com/233676/26872535-c47c6232-4b6e-11e7-8054-b6c9ca87c73b.png)


https://trello.com/c/9qaQepxu