### PR TITLE
Revert "Include subpaths when querying GA for Unique Visits"

### DIFF
--- a/app/jobs/import_pageviews_job.rb
+++ b/app/jobs/import_pageviews_job.rb
@@ -9,9 +9,8 @@ class ImportPageviewsJob < ApplicationJob
   def perform(*args)
     content_items = args[0]
     base_paths = content_items.pluck(:base_path)
-    base_paths_with_subpaths = base_paths.map { |path| path.concat("/*") }
 
-    results = google_analytics_service.page_views(base_paths_with_subpaths)
+    results = google_analytics_service.page_views(base_paths)
     results.each do |result|
       content_item = ContentItem.find_by(base_path: result[:base_path])
       content_item.update!(result.slice(:one_month_page_views, :six_months_page_views))

--- a/spec/jobs/import_pageviews_job_spec.rb
+++ b/spec/jobs/import_pageviews_job_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ImportPageviewsJob, type: :job do
   it "updates the content items with pageviews" do
     content_item = create(:content_item, base_path: '/the-base-path')
     service = double(:google_analytics_service)
-    allow(service).to receive(:page_views).with(['/the-base-path/*']).and_return(
+    allow(service).to receive(:page_views).with(['/the-base-path']).and_return(
       [
         {
           base_path: '/the-base-path',


### PR DESCRIPTION
Reverts alphagov/content-performance-manager#156

I am reverting this PR because we need to clarify how subpaths are being resolved
by Content Store, and how we count Unique Visits for Google Analytics.

The current version would work for a subset of the subpaths, but not for all of them.
It is preferable to stick to our previous way of counting unique visits and provide a 
robust solution to address subpaths for all Content Items.

We will be working on subpaths and Google Analytics from Monday.
This came out of a long discussion with @cbaines 



