### PR TITLE
Tune the `targets_of` query

### DIFF
--- a/spec/domain/search_spec.rb
+++ b/spec/domain/search_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Search do
 
   it "can filter by a single type and single target" do
     subject.filter_by(link_type: "organisations", target_ids: "org1")
-    expect(content_ids).to eq %w(id1 id3)
+    expect(content_ids).to match_array %w(id1 id3)
   end
 
   it "can filter by a single type and multiple targets" do


### PR DESCRIPTION
The previous query was slow because it needed to
sort the results before it could apply the group
by operation. This approach is about 4x faster.

The audit listing page now loads in ~5 seconds, which is still slow. Perhaps this can be improved further.