### PR TITLE
Make the filter menu more closely match the design

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -77,7 +77,7 @@ private
   end
 
   def filter_by_link_types!(search)
-    params.slice(*Search::LINK_TYPE_FILTERS).each do |link_type, content_id|
+    params.slice(*Search::FILTERABLE_LINK_TYPES).each do |link_type, content_id|
       next if content_id.blank?
       search.filter_by(link_type: link_type, target_ids: content_id)
     end

--- a/app/controllers/inventory_controller.rb
+++ b/app/controllers/inventory_controller.rb
@@ -33,14 +33,14 @@ class InventoryController < ApplicationController
 private
 
   def assign_link_types
-    @link_types = Search::LINK_TYPE_FILTERS
+    @link_types = Search::GROUPABLE_LINK_TYPES
   end
 
   def assign_content_items
     search = Search.new
     search.execute
-    filters = search.link_type_filters
-    @content_items = filters.to_h.fetch(@link_type).order(:title)
+    options = search.options_for(@link_types)
+    @content_items = options.fetch(@link_type).order(:title)
   end
 
   def lookup_link_type

--- a/app/domain/search.rb
+++ b/app/domain/search.rb
@@ -1,5 +1,10 @@
 class Search
-  LINK_TYPE_FILTERS = [
+  FILTERABLE_LINK_TYPES = [
+    Link::PRIMARY_ORG,
+    Link::ALL_ORGS,
+  ].freeze
+
+  GROUPABLE_LINK_TYPES = [
     Link::POLICY_AREAS,
     Link::POLICIES,
     Link::PRIMARY_ORG,
@@ -57,10 +62,12 @@ class Search
     query.sort
   end
 
-  def link_type_filters
-    LINK_TYPE_FILTERS.map do |link_type|
-      [link_type, result.options_for(link_type)]
-    end
+  def options_for(link_types)
+    link_types.map { |t| [t, result.options_for(t)] }.to_h
+  end
+
+  def self.all_link_types
+    (FILTERABLE_LINK_TYPES + GROUPABLE_LINK_TYPES).uniq
   end
 
   def self.all_audit_status

--- a/app/domain/search/executor.rb
+++ b/app/domain/search/executor.rb
@@ -25,7 +25,7 @@ class Search
   private
 
     def build_filter_options
-      Search::LINK_TYPE_FILTERS.each do |link_type|
+      Search.all_link_types.each do |link_type|
         filter_options.merge!(
           link_type => ContentItem.targets_of(
             link_type: link_type,

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -38,6 +38,14 @@
     <% end %>
 
     <div class="form-group">
+      <%= label_tag :content_type, 'Content type' %>
+      <%= select_tag :content_type,
+          options_from_collection_for_select([], :TODO, :TODO, params[:TODO]),
+          include_blank: "This filter is not implemented yet",
+          class: "form-control", disabled: true %>
+    </div>
+
+    <div class="form-group">
       <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
     </div>
   <% end %>

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -18,7 +18,7 @@
           class: "form-control" %>
     </div>
 
-    <% @search.link_type_filters.each do |link_type, options| %>
+    <% @search.options_for(Search::FILTERABLE_LINK_TYPES).each do |link_type, options| %>
       <% disabled_options = options.select { |o| o.incoming_links_count.zero? } %>
 
       <div class="form-group">

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -3,17 +3,17 @@
   <%= form_tag audits_path, method: :get do %>
 
     <div class="form-group">
-      <%= label_tag :subtheme, 'Subthemes' %>
-      <%= select_tag :subtheme,
-          options_from_collection_for_select(Search.all_subthemes, :id, :name, params[:subtheme]),
+      <%= label_tag :audit_status, 'Audit status' %>
+      <%= select_tag :audit_status,
+          options_from_collection_for_select(Search.all_audit_status, :identifier, :name, params[:audit_status]),
           include_blank: "All",
           class: "form-control" %>
     </div>
 
     <div class="form-group">
-      <%= label_tag :audit_status, 'Status:' %>
-      <%= select_tag :audit_status,
-          options_from_collection_for_select(Search.all_audit_status, :identifier, :name, params[:audit_status]),
+      <%= label_tag :subtheme, 'Theme' %>
+      <%= select_tag :subtheme,
+          options_from_collection_for_select(Search.all_subthemes, :id, :name, params[:subtheme]),
           include_blank: "All",
           class: "form-control" %>
     </div>
@@ -22,7 +22,7 @@
       <% disabled_options = options.select { |o| o.incoming_links_count.zero? } %>
 
       <div class="form-group">
-        <%= label_tag link_type, "#{link_type.titleize}:" %>
+        <%= label_tag link_type, link_type.titleize.singularize %>
         <%= select_tag(
               link_type,
               options_from_collection_for_select(


### PR DESCRIPTION
I spoke to Joe about the filters. This PR makes them match the design more closely.

We don't yet have a filter for `Content type` so I've added a placeholder in the filter menu and created a story here: https://trello.com/c/5QMjGUFM/169-filter-by-content-type-in-the-audit-tool

Depends on #178 and #181.