### PR TITLE
Update labels to “Last major update”

### DIFF
--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -63,7 +63,7 @@
     </div>
 
     <div id="last-updated">
-      <h4>Last updated</h4>
+      <h4>Last major update</h4>
       <p><%= @audit.content_item.last_updated %></p>
     </div>
 

--- a/app/views/content_items/index.html.erb
+++ b/app/views/content_items/index.html.erb
@@ -13,7 +13,7 @@
       <%= sort_table_header heading: "Doc type", attribute: "document_type", filter_options: @filter_options %>
       <%= sort_table_header heading: "Page views (1mth)", attribute: "one_month_page_views", filter_options: @filter_options %>
       <%= sort_table_header heading: "Page views (6mth)", attribute: "six_months_page_views", filter_options: @filter_options %>
-      <%= sort_table_header heading: "Last Updated", attribute: "public_updated_at", filter_options: @filter_options %>
+      <%= sort_table_header heading: "Last major update", attribute: "public_updated_at", filter_options: @filter_options %>
     </tr>
   </thead>
   <tbody>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -23,7 +23,7 @@
       <td><%= number_with_delimiter @content_item.six_months_page_views %></td>
     </tr>
     <tr>
-      <td>Last updated</td>
+      <td>Last major update</td>
       <td>
         <%= @content_item.last_updated %>
       </td>

--- a/spec/features/performance/content_item_list_spec.rb
+++ b/spec/features/performance/content_item_list_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Content Items List", type: :feature do
     expect(page).to have_selector('thead', text: 'Title')
     expect(page).to have_selector('thead tr:first-child th', text: 'Doc type')
     expect(page).to have_selector('thead tr:first-child th', text: 'Page views (1mth)')
-    expect(page).to have_selector('thead tr:first-child th', text: 'Last Updated')
+    expect(page).to have_selector('thead tr:first-child th', text: 'Last major update')
   end
 
   scenario "Renders content item details" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/qdC41p3x)

Instead of saying “Last updated” as it’s not clear which type of update occurred (minor, silent or major).

## Before
![image](https://user-images.githubusercontent.com/424772/27194385-50bf1bea-51fa-11e7-87cd-b812c1432a9a.png)

![image](https://user-images.githubusercontent.com/424772/27194429-6c6ecaf2-51fa-11e7-8e06-1d56f4de50a6.png)

![image](https://user-images.githubusercontent.com/424772/27194445-7d7bdfec-51fa-11e7-820c-9c32d44beab1.png)

## After
![image](https://user-images.githubusercontent.com/424772/27194412-5e3c2a4c-51fa-11e7-9d20-1c238cc06ca6.png)

![image](https://user-images.githubusercontent.com/424772/27194496-a768ab3c-51fa-11e7-8355-e6e052f1f5e1.png)

![image](https://user-images.githubusercontent.com/424772/27194464-864463ba-51fa-11e7-92ea-a104df2cc40e.png)


