### PR TITLE
Increase page size when querying publishing-api

### DIFF
--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -2,7 +2,7 @@ require 'gds_api/publishing_api_v2'
 
 module Clients
   class PublishingAPI
-    PER_PAGE = 100
+    PER_PAGE = 700
 
     attr_accessor :deprecated_publishing_api, :per_page
 
@@ -12,7 +12,7 @@ module Clients
         disable_cache: true,
         bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
       )
-      @per_page = 100
+      @per_page = 700
     end
 
     def content_ids

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Clients::PublishingAPI do
   subject { Clients::PublishingAPI.new }
 
   describe "#content_ids" do
-    let(:page_size) { 100 }
+    let(:page_size) { 700 }
 
     let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/9r3iD9sW/298-quick-fix-to-overcome-issue-in-publishing-api)

Setting a page size to 100 has decreased the success ratio when 
querying publishing-API to retrieve Content Items.

The page size can't be very high, but at the same time, if we set 
a value that is too low we are also getting `504` errors. These
errors could be related to random failures in the endpoint. 

I am trying with a page size of `700` to see if we increase the success
ratio of our process.

I am not preparing a more robust solution as [there is work planned
to improve the endpoint in `publishing-api`](https://trello.com/c/iAdftXss/510-help-content-tools-get-content-out-of-publishing-api-faster-more-get-content-woes)
