### PR TITLE
Don’t show survey link in audit tool

### DIFF
--- a/app/views/application/_phase_banner.html.erb
+++ b/app/views/application/_phase_banner.html.erb
@@ -1,6 +1,11 @@
 <div class="phase-banner">
   <p>
     <strong class="label label-primary">ALPHA</strong>
-    <span>This is a new service. Please answer <a href="https://www.surveymonkey.co.uk/r/YFZ69HL">these quick questions</a> to help us make it better.</span>
+    <span>
+      This is a new service.
+      <% if controller_name == "content_items" %>
+          Please answer <a href="https://www.surveymonkey.co.uk/r/YFZ69HL">these quick questions</a> to help us make it better.
+      <% end %>
+    </span>
   </p>
 </div>

--- a/spec/features/audit/list_content_items_to_audit_spec.rb
+++ b/spec/features/audit/list_content_items_to_audit_spec.rb
@@ -4,6 +4,12 @@ RSpec.feature "List Content Items to Audit", type: :feature do
   let!(:content_item_1) { FactoryGirl.create(:content_item, title: "All about flooding.") }
   let!(:content_item_2) { FactoryGirl.create(:content_item, title: "All about gardening.") }
 
+  scenario "User does not see CPM feedback survey link in banner" do
+    visit audits_path
+
+    expect(page).to have_no_link("these quick questions")
+  end
+
   scenario "List Content Items to Audit" do
     content_item_1.update!(six_months_page_views: 1234)
 

--- a/spec/features/performance/content_item_list_spec.rb
+++ b/spec/features/performance/content_item_list_spec.rb
@@ -11,6 +11,12 @@ RSpec.feature "Content Items List", type: :feature do
     it_behaves_like 'a paginated list', 'content_items'
   end
 
+  scenario "User does can see CPM feedback survey link in banner" do
+    visit "/content_items"
+
+    expect(page).to have_link("these quick questions")
+  end
+
   scenario "Renders the page title" do
     visit "/content_items"
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/fLiKQ4kx)

It should only appear for the Content Performance Manager parts of the
CPM app.