### PR TITLE
Filter by document types from the filter menu

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -50,6 +50,7 @@ private
       filter_by_audit_status!(search)
       filter_by_link_types!(search)
       filter_by_theme!(search)
+      filter_by_document_type!(search)
       search.page = params[:page]
       search.execute
       search
@@ -85,5 +86,9 @@ private
 
   def filter_by_theme!(search)
     search.theme = params[:theme] if params[:theme]
+  end
+
+  def filter_by_document_type!(search)
+    search.document_type = params[:document_type] if params[:document_type]
   end
 end

--- a/app/controllers/inventory_controller.rb
+++ b/app/controllers/inventory_controller.rb
@@ -44,8 +44,10 @@ private
   def assign_content_items
     search = Search.new
     search.execute
-    options = search.options_for(@link_types)
-    @content_items = options.fetch(@link_type).order(:title)
+
+    @content_items = search
+      .options_for(@link_type)
+      .order(:title)
   end
 
   def lookup_link_type

--- a/app/domain/search.rb
+++ b/app/domain/search.rb
@@ -66,8 +66,8 @@ class Search
     query.sort
   end
 
-  def options_for(link_types)
-    link_types.map { |t| [t, result.options_for(t)] }.to_h
+  def options_for(identifier)
+    result.options_for(identifier)
   end
 
   def self.all_link_types

--- a/app/domain/search.rb
+++ b/app/domain/search.rb
@@ -25,6 +25,10 @@ class Search
     query.theme = identifier
   end
 
+  def document_type=(document_type)
+    query.document_type = document_type
+  end
+
   def filter_by(link_type:, source_ids: nil, target_ids: nil)
     query.filter_by(link_type, source_ids, target_ids)
   end

--- a/app/domain/search/document_type_filter.rb
+++ b/app/domain/search/document_type_filter.rb
@@ -1,0 +1,13 @@
+class Search
+  class DocumentTypeFilter
+    attr_accessor :document_type
+
+    def initialize(document_type)
+      self.document_type = document_type
+    end
+
+    def apply(scope)
+      scope.where(document_type: document_type)
+    end
+  end
+end

--- a/app/domain/search/executor.rb
+++ b/app/domain/search/executor.rb
@@ -13,47 +13,55 @@ class Search
     end
 
     def execute
-      build_filter_options
+      build_link_type_options!
+      build_document_type_options!
 
-      apply_filters
-      apply_sort
-      paginate
+      apply_filters!
+      apply_sort!
+      paginate!
 
       Result.new(scope, filter_options)
     end
 
   private
 
-    def build_filter_options
+    def build_link_type_options!
       Search.all_link_types.each do |link_type|
-        filter_options.merge!(
-          link_type => ContentItem.targets_of(
-            link_type: link_type,
-            scope_to_count: apply_filters_except_for(link_type),
-          )
+        other_filters = query.filters.reject { |f| matches?(f, LinkFilter, link_type) }
+        scope_to_count = apply_filters(other_filters, self.scope)
+
+        filter_options[link_type] = ContentItem.targets_of(
+          link_type: link_type,
+          scope_to_count: scope_to_count,
         )
       end
     end
 
-    def apply_filters_except_for(link_type)
-      query.filters.inject(self.scope) do |scope, filter|
-        if filter.respond_to?(:link_type) && filter.link_type == link_type
-          scope
-        else
-          filter.apply(scope)
-        end
-      end
+    def build_document_type_options!
+      other_filters = query.filters.reject { |f| matches?(f, DocumentTypeFilter) }
+      scope_to_count = apply_filters(other_filters, self.scope)
+
+      filter_options[:document_type] = scope_to_count.document_type_counts
     end
 
-    def apply_filters
-      query.filters.each { |f| self.scope = f.apply(scope) }
+    def matches?(filter, type, link_type = nil)
+      filter.is_a?(type) && (link_type.nil? || filter.link_type == link_type)
     end
 
-    def apply_sort
+    def apply_filters!
+      self.scope = apply_filters(query.filters, self.scope)
+    end
+
+    def apply_filters(filters, scope)
+      filters.each { |f| scope = f.apply(scope) }
+      scope
+    end
+
+    def apply_sort!
       self.scope = query.sort.apply(scope)
     end
 
-    def paginate
+    def paginate!
       self.scope = scope.page(query.page).per(query.per_page)
     end
   end

--- a/app/domain/search/query.rb
+++ b/app/domain/search/query.rb
@@ -25,6 +25,11 @@ class Search
       set_filter_of_type(filter, type: RulesFilter)
     end
 
+    def document_type=(document_type)
+      filter = DocumentTypeFilter.new(document_type) if document_type.present?
+      set_filter_of_type(filter, type: DocumentTypeFilter)
+    end
+
     def filter_by(link_type, source_ids, target_ids)
       filter = LinkFilter.new(
         link_type: link_type,

--- a/app/domain/search/result.rb
+++ b/app/domain/search/result.rb
@@ -11,8 +11,8 @@ class Search
       scope
     end
 
-    def options_for(link_type)
-      filter_options.fetch(link_type)
+    def options_for(identifier)
+      filter_options.fetch(identifier)
     end
   end
 end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -1,12 +1,48 @@
 module DropdownHelper
-  def grouped_themes_and_subthemes
-    Theme.all.map do |theme|
+  def theme_and_subtheme_options
+    groups = Theme.all.map do |theme|
       theme = ThemeOption.new(theme)
       subthemes = theme.subthemes.map { |s| SubthemeOption.new(s) }
       options = [theme, *subthemes].map { |o| [o.name, o.value] }
 
       [theme.name, options]
     end
+
+    grouped_options_for_select(groups, params[:theme])
+  end
+
+  def audit_status_options
+    options_from_collection_for_select(
+      Search.all_audit_status,
+      :identifier,
+      :name,
+      params[:audit_status],
+    )
+  end
+
+  def link_type_options(link_type)
+    options = @search.options_for(link_type)
+    disabled_options = options.select { |o| o.incoming_links_count.zero? }
+
+    options_from_collection_for_select(
+      options,
+      :content_id,
+      :title_with_count,
+      selected: params[link_type],
+      disabled: disabled_options.map(&:content_id),
+    )
+  end
+
+  def document_type_options
+    options = @search.options_for(:document_type)
+    options = options.map { |o| DocumentTypeOption.new(o) }
+
+    options_from_collection_for_select(
+      options,
+      :value,
+      :name,
+      params[:document_type],
+    )
   end
 
   class ThemeOption < SimpleDelegator
@@ -22,6 +58,16 @@ module DropdownHelper
   class SubthemeOption < SimpleDelegator
     def value
       "Subtheme_#{id}"
+    end
+  end
+
+  class DocumentTypeOption < SimpleDelegator
+    def name
+      "#{first.titleize} (#{second})"
+    end
+
+    def value
+      first
     end
   end
 end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -22,14 +22,12 @@ module DropdownHelper
 
   def link_type_options(link_type)
     options = @search.options_for(link_type)
-    disabled_options = options.select { |o| o.incoming_links_count.zero? }
 
     options_from_collection_for_select(
       options,
       :content_id,
       :title_with_count,
       selected: params[link_type],
-      disabled: disabled_options.map(&:content_id),
     )
   end
 

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -29,6 +29,7 @@ class ContentItem < ApplicationRecord
       .select(:document_type, "count(1) as count")
       .group(:document_type)
       .map { |r| [r.document_type, r.count] }
+      .sort_by(&:first)
       .to_h
   end
 

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -24,6 +24,14 @@ class ContentItem < ApplicationRecord
     all[index + 1] if index
   end
 
+  def self.document_type_counts
+    all
+      .select(:document_type, "count(1) as count")
+      .group(:document_type)
+      .map { |r| [r.document_type, r.count] }
+      .to_h
+  end
+
   def title_with_count
     if respond_to?(:incoming_links_count)
       "#{title} (#{incoming_links_count})"

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -9,7 +9,7 @@ class ContentItem < ApplicationRecord
 
     nested = Link
       .select(:target_content_id, "count(x.id) as c")
-      .joins("left join (#{sql}) x on content_id = source_content_id")
+      .joins("join (#{sql}) x on content_id = source_content_id")
       .where(link_type: link_type)
       .group(:target_content_id)
 

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -5,7 +5,7 @@
     <div class="form-group">
       <%= label_tag :audit_status, 'Audit status' %>
       <%= select_tag :audit_status,
-          options_from_collection_for_select(Search.all_audit_status, :identifier, :name, params[:audit_status]),
+          audit_status_options,
           include_blank: "All",
           class: "form-control" %>
     </div>
@@ -13,36 +13,27 @@
     <div class="form-group">
       <%= label_tag :theme, 'Theme' %>
       <%= select_tag :theme,
-          grouped_options_for_select(grouped_themes_and_subthemes, params[:theme]),
+          theme_and_subtheme_options,
           include_blank: "All",
           class: "form-control" %>
     </div>
 
-    <% @search.options_for(Search::FILTERABLE_LINK_TYPES).each do |link_type, options| %>
-      <% disabled_options = options.select { |o| o.incoming_links_count.zero? } %>
-
+    <% Search::FILTERABLE_LINK_TYPES.each do |link_type| %>
       <div class="form-group">
         <%= label_tag link_type, link_type.titleize.singularize %>
-        <%= select_tag(
-              link_type,
-              options_from_collection_for_select(
-                options.order(:title),
-                :content_id,
-                :title_with_count,
-                selected: params[link_type],
-                disabled: disabled_options.map(&:content_id),
-              ),
-              include_blank: "All",
-              class: "form-control") %>
+        <%= select_tag link_type,
+            link_type_options(link_type),
+            include_blank: "All",
+            class: "form-control" %>
       </div>
     <% end %>
 
     <div class="form-group">
-      <%= label_tag :content_type, 'Content type' %>
-      <%= select_tag :content_type,
-          options_from_collection_for_select([], :TODO, :TODO, params[:TODO]),
-          include_blank: "This filter is not implemented yet",
-          class: "form-control", disabled: true %>
+      <%= label_tag :document_type, 'Content type' %>
+      <%= select_tag :document_type,
+          document_type_options,
+          include_blank: "All",
+          class: "form-control" %>
     </div>
 
     <div class="form-group">

--- a/spec/domain/search/query_spec.rb
+++ b/spec/domain/search/query_spec.rb
@@ -127,6 +127,29 @@ RSpec.describe Search::Query do
     end
   end
 
+  describe "document_type" do
+    it "defaults to not filter by document type" do
+      expect(subject.filters).to be_empty
+    end
+
+    it "adds a filter when setting the document type" do
+      subject.document_type = "organisation"
+      expect(subject.filters).to be_present
+    end
+
+    it "does not add a filter if blank" do
+      subject.document_type = nil
+      expect(subject.filters).to be_empty
+    end
+
+    it "removes the existing audit filter when blank" do
+      subject.document_type = "organisation"
+      subject.document_type = nil
+
+      expect(subject.filters).to be_empty
+    end
+  end
+
   describe "#filter_by" do
     it "raises an error if a filter already exists for a type" do
       subject.filter_by("organisations", nil, "org1")

--- a/spec/domain/search_spec.rb
+++ b/spec/domain/search_spec.rb
@@ -100,4 +100,12 @@ RSpec.describe Search do
     subject.audit_status = "audited"
     expect(content_ids).to eq %w(id2)
   end
+
+  it "can filter by document type" do
+    content_item = ContentItem.find_by!(content_id: "id2")
+    content_item.update!(document_type: "travel_advice")
+
+    subject.document_type = "travel_advice"
+    expect(content_ids).to eq %w(id2)
+  end
 end

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     select "Audited", from: "audit_status"
 
     click_on "Filter"
-    expect(page).to have_content("HMRC (0)")
+    expect(page).to have_no_content("HMRC (0)")
     expect(page).to have_content("DFE (1)")
   end
 

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -127,6 +127,20 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     end
   end
 
+  scenario "filtering by document type" do
+    hmrc.update!(document_type: "organisation")
+
+    visit audits_path
+    select "Organisation", from: "document_type"
+
+    click_on "Filter"
+
+    within("table") do
+      expect(page).to have_content("HMRC")
+      expect(page).to have_no_content("Flying to countries abroad")
+    end
+  end
+
   scenario "Reseting page to 1 after filtering" do
     FactoryGirl.create_list(:content_item, 25)
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ContentItem, type: :model do
       subset = described_class.where(id: [a])
 
       results = described_class.targets_of(link_type: "type1", scope_to_count: subset)
-      expect(results.map(&:incoming_links_count)).to match_array [0, 1]
+      expect(results.map(&:incoming_links_count)).to eq [1]
 
       results = described_class.targets_of(link_type: "type2", scope_to_count: subset)
       expect(results.map(&:incoming_links_count)).to eq [1]

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe ContentItem, type: :model do
       result = scope.document_type_counts
       expect(result).to eq("organisation" => 2)
     end
+
+    it "orders alphabetically" do
+      FactoryGirl.create_list(:content_item, 4, document_type: "guide")
+
+      result = described_class.document_type_counts
+      expect(result.to_a).to eq [
+        ["guide", 4],
+        ["organisation", 2],
+        ["policy", 3],
+      ]
+    end
   end
 
   describe "#title_with_count" do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -90,6 +90,25 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
+  describe ".document_type_counts" do
+    before do
+      FactoryGirl.create_list(:content_item, 2, document_type: "organisation")
+      FactoryGirl.create_list(:content_item, 3, document_type: "policy")
+    end
+
+    it "returns a hash of document_types to the count of items" do
+      result = described_class.document_type_counts
+      expect(result).to eq("organisation" => 2, "policy" => 3)
+    end
+
+    it "can be chained on scopes" do
+      scope = described_class.where(document_type: "organisation")
+
+      result = scope.document_type_counts
+      expect(result).to eq("organisation" => 2)
+    end
+  end
+
   describe "#title_with_count" do
     before do
       item = FactoryGirl.create(:content_item, title: "Title")


### PR DESCRIPTION
As part of this work, I tried to simplify the `_sidebar` partial by extracting some view-logic into a helper. I also removed `(0)` options from the other filters as the team agrees these aren't helpful.

![screen shot 2017-06-20 at 12 12 06](https://user-images.githubusercontent.com/892251/27330529-b5ece8a2-55b1-11e7-8e88-dc27b5ab5537.png)