### PR TITLE
Make themes.rake work in integration/production

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -1,17 +1,20 @@
 namespace :themes do
   desc "Backup themes, subthemes and inventory rules to a file"
   task backup: :environment do
-    db = Rails.configuration.database_configuration.dig(Rails.env, "database")
-    cmd = "pg_dump --data-only -t themes -t subthemes -t inventory_rules #{db} > themes.sql"
-    puts cmd
-    system(cmd)
+    run("pg_dump --data-only -t themes -t subthemes -t inventory_rules #{db} > themes.sql")
   end
 
   desc "Restore themes, subthemes and inventory rules from a file"
   task restore: :environment do
-    db = Rails.configuration.database_configuration.dig(Rails.env, "database")
-    cmd = "psql #{db} < themes.sql"
-    puts cmd
-    system(cmd)
+    run("psql #{db} < themes.sql")
   end
+end
+
+def db
+  ENV["DATABASE_URL"] || Rails.configuration.database_configuration.dig(Rails.env, "database")
+end
+
+def run(cmd)
+  puts cmd
+  system(cmd)
 end


### PR DESCRIPTION
It was failing before because the database isn't local to the machine. We need to run against `DATABASE_URL` if it is set.

Successful output on integration: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/2196/console