### PR TITLE
Fix PDFs counter for a Content Item

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -3,6 +3,8 @@ class ContentItem < ApplicationRecord
   has_and_belongs_to_many :taxons
   has_one :audit, primary_key: :content_id, foreign_key: :content_id
 
+  attr_accessor :details
+
   def self.targets_of(link_type:, scope_to_count: all)
     sql = scope_to_count.to_sql.presence
     sql ||= "select * from content_items where id = -1"

--- a/app/models/importers/single_content_item.rb
+++ b/app/models/importers/single_content_item.rb
@@ -44,7 +44,7 @@ module Importers
     end
 
     def set_metrics(content_item)
-      metrics = metric_builder.run_all(content_item.attributes)
+      metrics = metric_builder.run_all(content_item)
       metrics.each { |k, v| content_item.public_send(:"#{k}=", v) }
     end
 

--- a/app/models/metrics/number_of_pdfs.rb
+++ b/app/models/metrics/number_of_pdfs.rb
@@ -17,8 +17,8 @@ module Metrics
   private
 
     def extract_documents
-      if content_item[:details].is_a?(Hash)
-        details = content_item[:details].symbolize_keys
+      if content_item.details.is_a?(Hash)
+        details = content_item.details.symbolize_keys
         documents = document_keys.map do |k|
           details.fetch(k, nil)
         end

--- a/app/services/content_items_service.rb
+++ b/app/services/content_items_service.rb
@@ -10,7 +10,7 @@ class ContentItemsService
   end
 
   def fetch(content_id)
-    attribute_names = %i(public_updated_at base_path title document_type description content_id)
+    attribute_names = %i(public_updated_at base_path title document_type description content_id details)
     all_attributes = client.fetch(content_id)
 
     ContentItem.new(all_attributes.slice(*attribute_names))

--- a/spec/models/metric_builder_spec.rb
+++ b/spec/models/metric_builder_spec.rb
@@ -1,22 +1,26 @@
 RSpec.describe MetricBuilder do
   describe "#run_all" do
-    let(:metrics) { { m1: 1 } }
-
+    let(:content_item) { create :content_item, number_of_pdfs: 1 }
     it "calls each metric class once" do
-      expect_any_instance_of(Metrics::NumberOfPdfs).to receive(:run).exactly(1).times
-
-      subject.run_all({})
+      result = subject.run_all(content_item)
+      expect(result).to eq(number_of_pdfs: 0)
     end
   end
 
   describe "#run_collection" do
-    it "calls each collection metric class once" do
-      expect_any_instance_of(Metrics::TotalPages).to receive(:run).exactly(1).times.and_return({})
-      expect_any_instance_of(Metrics::ZeroPageViews).to receive(:run).exactly(1).times.and_return({})
-      expect_any_instance_of(Metrics::PagesNotUpdated).to receive(:run).exactly(1).times.and_return({})
-      expect_any_instance_of(Metrics::PagesWithPdfs).to receive(:run).exactly(1).times.and_return({})
+    it "return collection metrics" do
+      create :content_item, number_of_pdfs: 1
+      create :content_item, one_month_page_views: 2
 
-      subject.run_collection([])
+      result = subject.run_collection(ContentItem.all)
+      expected_result = {
+        total_pages: { value: 2 },
+        zero_page_views: { value: 1 },
+        pages_not_updated: { value: 0 },
+        pages_with_pdfs: { value: 1, percentage: 50.0 }
+      }
+
+      expect(result).to eq(expected_result)
     end
   end
 end

--- a/spec/models/metrics/number_of_pdfs_spec.rb
+++ b/spec/models/metrics/number_of_pdfs_spec.rb
@@ -2,27 +2,27 @@ RSpec.describe Metrics::NumberOfPdfs do
   subject { Metrics::NumberOfPdfs }
 
   let(:content_with_pdfs) {
-    {
-      details: {
-        documents: [
-          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
-          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>'
-        ],
-        final_outcome_documents: [
-          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>'
-        ]
-      }
-    }
+    build(:content_item, details: {
+      documents: [
+        '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
+        '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
+      ],
+      final_outcome_documents: [
+        '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
+      ]
+    })
   }
   let(:content_without_pdfs) {
-    {
+    build(:content_item, details: {
       details: {
-        "documents" => ['<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>']
+        "documents" => [
+          '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>',
+        ]
       }
-    }
+    })
   }
-  let(:content_without_document_keys) { { details: {} } }
-  let(:content_without_details_key) { {} }
+  let(:content_without_document_keys) { build(:content_item, details: {}) }
+  let(:content_without_details_key) { build(:content_item) }
 
   it "returns the number of pdfs present" do
     expect(subject.new(content_with_pdfs).run).to eq(number_of_pdfs: 3)

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ContentItemsService do
         title: "title",
         description: "description",
         content_store: "live",
+        details: { the: :details },
       )
 
       content_item = subject.fetch("id-123")
@@ -27,6 +28,7 @@ RSpec.describe ContentItemsService do
       expect(content_item.content_id).to eq("id-123")
       expect(content_item.title).to eq("title")
       expect(content_item.description).to eq("description")
+      expect(content_item.details).to eq(the: :details)
     end
   end
 


### PR DESCRIPTION
We are not storing properly the number of Pdfs for Content Items. After
a few refactors we removed the `details` attribute from the API so
we were not counting PDF.

We are storing the content of a Content Item in the attribute `details`.
I am not storing it in the database because I can’t see now a real need
to do it, and I prefer to postpone this decision for a later moment.

Metrics are calculated based on the `ContentItem` class and no on a `Hash`
of attributes, which is in itself another improvement.