### PR TITLE
Enable RSpec feature to run only failing tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.example_status_persistence_file_path = "#{Rails.root}/tmp/examples.txt"
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.use_transactional_fixtures = false


### PR DESCRIPTION
I find useful being able to run only failing tests:

```bash
  rspec --only-failures
```

see: https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures#running-`rspec---only-failures`-loads-only-spec-files-with-failures-and-runs-only-the-failures