### PR TITLE
Report page

### DIFF
--- a/app/assets/stylesheets/_report.scss
+++ b/app/assets/stylesheets/_report.scss
@@ -1,0 +1,4 @@
+.report-export, .report-export:visited {
+  color: black;
+  text-decoration: underline;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import 'phase_banner';
 @import 'summary';
 @import 'audit';
+@import 'report';
 @import 'inventory';
 
 // TODO: move any styles below to modules once more established

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -86,7 +86,7 @@ private
   end
 
   def filter_by_audit_status!(search)
-    search.audit_status = params[:audit_status] if params[:audit_status]
+    search.audit_status = params[:audit_status].to_sym if params[:audit_status].present?
   end
 
   def filter_by_link_types!(search)
@@ -97,10 +97,10 @@ private
   end
 
   def filter_by_theme!(search)
-    search.theme = params[:theme] if params[:theme]
+    search.theme = params[:theme] if params[:theme].present?
   end
 
   def filter_by_document_type!(search)
-    search.document_type = params[:document_type] if params[:document_type]
+    search.document_type = params[:document_type] if params[:document_type].present?
   end
 end

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,8 +1,8 @@
 class AuditsController < ApplicationController
   helper_method :filter_params
+  before_action :content_items, only: %i(index report export)
 
   def index
-    content_items
   end
 
   def show
@@ -26,10 +26,22 @@ class AuditsController < ApplicationController
     end
   end
 
+  def report
+  end
+
+  def export
+    csv = Report.generate(audits)
+    send_data(csv, filename: "report.csv")
+  end
+
 private
 
   def audit
     @audit ||= Audit.find_or_initialize_by(content_item: content_item).decorate
+  end
+
+  def audits
+    @audits ||= Audit.where(content_item: content_items.object)
   end
 
   def content_item

--- a/app/domain/report.rb
+++ b/app/domain/report.rb
@@ -1,0 +1,33 @@
+class Report
+  def self.generate(*args)
+    new(*args).generate
+  end
+
+  attr_accessor :audits
+
+  def initialize(audits)
+    self.audits = audits.includes(:content_item, :user)
+  end
+
+  def generate
+    CSV.generate do |csv|
+      csv << headers
+
+      each do |_audit, item, user|
+        csv << [item.title, user.name]
+      end
+    end
+  end
+
+private
+
+  def headers
+    ["Title", "Audited by"]
+  end
+
+  def each
+    audits.find_each do |audit|
+      yield [audit, audit.content_item, audit.user]
+    end
+  end
+end

--- a/app/domain/search.rb
+++ b/app/domain/search.rb
@@ -16,6 +16,8 @@ class Search
   DIMENSIONS = {
     audited: -> (s) { s.audit_status = :audited },
     not_audited: -> (s) { s.audit_status = :non_audited },
+    passing: -> (s) { s.passing = true },
+    not_passing: -> (s) { s.passing = false },
   }.freeze
 
   def initialize
@@ -24,6 +26,10 @@ class Search
 
   def audit_status=(identifier)
     query.audit_status = identifier
+  end
+
+  def passing=(bool)
+    query.passing = bool
   end
 
   def theme=(identifier)

--- a/app/domain/search/audit_filter.rb
+++ b/app/domain/search/audit_filter.rb
@@ -20,7 +20,7 @@ class Search
       if self.identifier == :audited
         scope.joins(:audit)
       elsif self.identifier == :non_audited
-        scope.left_outer_joins(:audit).where("content_items.content_id not IN( select content_id from audits)")
+        scope.where.not(content_id: Audit.all.select(:content_id))
       else
         scope
       end

--- a/app/domain/search/passing_filter.rb
+++ b/app/domain/search/passing_filter.rb
@@ -1,0 +1,19 @@
+class Search
+  class PassingFilter
+    attr_reader :identifier, :name
+
+    def initialize(passing)
+      @passing = passing
+    end
+
+    def apply(scope)
+      things = Response.joins(:question).where(
+        "responses.audit_id = audits.id AND questions.type = 'BooleanQuestion' AND responses.value = 'no'"
+      )
+
+      scope.joins(:audit).where(
+        @passing ? things.exists.not : things.exists
+      )
+    end
+  end
+end

--- a/app/domain/search/passing_filter.rb
+++ b/app/domain/search/passing_filter.rb
@@ -1,19 +1,14 @@
 class Search
   class PassingFilter
-    attr_reader :identifier, :name
+    attr_accessor :passing
 
     def initialize(passing)
-      @passing = passing
+      self.passing = passing
     end
 
     def apply(scope)
-      things = Response.joins(:question).where(
-        "responses.audit_id = audits.id AND questions.type = 'BooleanQuestion' AND responses.value = 'no'"
-      )
-
-      scope.joins(:audit).where(
-        @passing ? things.exists.not : things.exists
-      )
+      nested = passing ? Audit.passing : Audit.failing
+      scope.where(content_id: nested.select(:content_id))
     end
   end
 end

--- a/app/domain/search/query.rb
+++ b/app/domain/search/query.rb
@@ -10,35 +10,23 @@ class Search
     end
 
     def audit_status=(identifier)
-      set_filter_of_type(
-        identifier.blank? ? nil : AuditFilter.find(identifier.to_sym),
-        type: AuditFilter
-      )
+      filters.push(AuditFilter.find(identifier))
     end
 
     def passing=(bool)
-      set_filter_of_type(
-        bool.nil? ? nil : PassingFilter.new(bool),
-        type: PassingFilter
-      )
+      filters.push(PassingFilter.new(bool))
     end
 
     def theme=(identifier)
       type, id = identifier.to_s.split("_")
+      return unless %(Theme Subtheme).include?(type)
 
-      if id.present? && %(Theme Subtheme).include?(type)
-        model = type.constantize.find(id)
-        filter = RulesFilter.new(rules: model.inventory_rules)
-      end
-
-      set_filter_of_type(filter, type: RulesFilter)
+      model = type.constantize.find(id)
+      filters.push(RulesFilter.new(rules: model.inventory_rules))
     end
 
     def document_type=(document_type)
-      set_filter_of_type(
-        document_type.blank? ? nil : DocumentTypeFilter.new(document_type),
-        type: DocumentTypeFilter
-      )
+      filters.push(DocumentTypeFilter.new(document_type))
     end
 
     def filter_by(link_type, source_ids, target_ids)
@@ -69,11 +57,6 @@ class Search
     end
 
   private
-
-    def set_filter_of_type(filter, type:)
-      filters.delete_if { |f| f.is_a?(type) }
-      filters.push(filter) if filter
-    end
 
     def raise_if_already_filtered_by_link_type(filter)
       if link_filters.any? { |f| f.link_type == filter.link_type }

--- a/app/domain/search/query.rb
+++ b/app/domain/search/query.rb
@@ -14,6 +14,13 @@ class Search
       set_filter_of_type(filter, type: AuditFilter)
     end
 
+    def passing=(bool)
+      set_filter_of_type(
+        bool.nil? ? nil : PassingFilter.new(bool),
+        type: PassingFilter
+      )
+    end
+
     def theme=(identifier)
       type, id = identifier.to_s.split("_")
 

--- a/app/domain/search/query.rb
+++ b/app/domain/search/query.rb
@@ -60,11 +60,8 @@ class Search
   private
 
     def set_filter_of_type(filter, type:)
-      if filter
-        filters.push(filter)
-      else
-        filters.delete_if { |f| f.is_a?(type) }
-      end
+      filters.delete_if { |f| f.is_a?(type) }
+      filters.push(filter) if filter
     end
 
     def raise_if_already_filtered_by_link_type(filter)

--- a/app/domain/search/query.rb
+++ b/app/domain/search/query.rb
@@ -10,8 +10,10 @@ class Search
     end
 
     def audit_status=(identifier)
-      filter = AuditFilter.find(identifier.to_sym) if identifier.present?
-      set_filter_of_type(filter, type: AuditFilter)
+      set_filter_of_type(
+        identifier.blank? ? nil : AuditFilter.find(identifier.to_sym),
+        type: AuditFilter
+      )
     end
 
     def passing=(bool)
@@ -33,8 +35,10 @@ class Search
     end
 
     def document_type=(document_type)
-      filter = DocumentTypeFilter.new(document_type) if document_type.present?
-      set_filter_of_type(filter, type: DocumentTypeFilter)
+      set_filter_of_type(
+        document_type.blank? ? nil : DocumentTypeFilter.new(document_type),
+        type: DocumentTypeFilter
+      )
     end
 
     def filter_by(link_type, source_ids, target_ids)

--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -3,6 +3,14 @@ module FormatHelper
     number_with_delimiter(n, delimiter: ",")
   end
 
+  def format_percentage(p, precision: 0)
+    number_with_precision(
+      p,
+      precision: precision,
+      strip_insignificant_zeros: true,
+    ) + "%"
+  end
+
   def format_datetime(d)
     return "Never" unless d
 

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,0 +1,24 @@
+module ReportHelper
+  def audited_count
+    @search.dimension(:audited).content_items.total_count
+  end
+
+  def not_audited_count
+    @search.dimension(:not_audited).content_items.total_count
+  end
+
+  def audited_percentage
+    percentage(audited_count, out_of: @content_items.total_count)
+  end
+
+  def not_audited_percentage
+    percentage(not_audited_count, out_of: @content_items.total_count)
+  end
+
+private
+
+  def percentage(number, out_of:)
+    return 0 if out_of.zero?
+    number.to_f / out_of * 100
+  end
+end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -15,6 +15,22 @@ module ReportHelper
     percentage(not_audited_count, out_of: @content_items.total_count)
   end
 
+  def passing_count
+    @search.dimension(:passing).content_items.total_count
+  end
+
+  def not_passing_count
+    @search.dimension(:not_passing).content_items.total_count
+  end
+
+  def passing_percentage
+    percentage(passing_count, out_of: audited_count)
+  end
+
+  def not_passing_percentage
+    percentage(not_passing_count, out_of: audited_count)
+  end
+
 private
 
   def percentage(number, out_of:)

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -8,6 +8,9 @@ class Audit < ApplicationRecord
   validates :content_item, presence: true
   validates :user, presence: true
 
+  scope :passing, -> { where.not(id: failing) }
+  scope :failing, -> { where(id: Response.failing.select(:audit_id)) }
+
   accepts_nested_attributes_for :responses
 
   def template

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -12,6 +12,7 @@ class Question < ApplicationRecord
 end
 
 class BooleanQuestion < Question
+  PASS = "yes".freeze
 end
 
 class FreeTextQuestion < Question

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -7,6 +7,10 @@ class Response < ApplicationRecord
   validates :audit, presence: true
   validates :question, presence: true
 
+  scope :boolean, -> { joins(:question).where(questions: { type: "BooleanQuestion" }) }
+  scope :passing, -> { boolean.where(value: BooleanQuestion::PASS) }
+  scope :failing, -> { boolean.where.not(id: passing) }
+
   validates :value, presence: { message: "mandatory field missing" },
     if: -> { audit && audit.template.mandatory?(question) }
 end

--- a/app/views/audits/_progress_bar.html.erb
+++ b/app/views/audits/_progress_bar.html.erb
@@ -1,0 +1,14 @@
+<% formatted = format_percentage(percentage, precision: 5) %>
+
+<div class="progress">
+  <div class="progress-bar"
+        role="progressbar"
+        aria-valuenow="<%= percentage %>"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        style="width: <%= formatted %>;">
+    <span class="sr-only">
+      <%= formatted %> Complete
+    </span>
+  </div>
+</div>

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div class="col-sm-3 sidebar">
   <h1>Filter</h1>
-  <%= form_tag audits_path, method: :get do %>
+  <%= form_tag submit_path, method: :get do %>
 
     <div class="form-group">
       <%= label_tag :audit_status, 'Audit status' %>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,9 +1,14 @@
 
 <% content_for :sidebar do %>
-    <%= render 'sidebar' %>
+  <%= render 'sidebar', submit_path: audits_path %>
 <% end %>
 
 <h1>GOV.UK Content Audit</h1>
+
+<ul class="tabs">
+  <li class="active">Content</li>
+  <li><%= link_to "Report", audits_report_path(filter_params) %></li>
+</ul>
 
 <table class="table table-bordered table-hover">
   <thead>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -5,10 +5,16 @@
 
 <h1>GOV.UK Content Audit</h1>
 
-<ul class="tabs">
-  <li class="active">Content</li>
-  <li><%= link_to "Report", audits_report_path(filter_params) %></li>
+<ul class="nav nav-tabs">
+  <li role="presentation" class="active">
+    <%= link_to "Content", "#", aria_controls: "home", role: "tab" %>
+  </li>
+  <li role="presentation">
+    <%= link_to "Report", audits_report_path(filter_params), aria_controls: "home", role: "tab" %>
+  </li>
 </ul>
+
+<div class="tab-content">
 
 <table class="table table-bordered table-hover">
   <thead>
@@ -23,3 +29,5 @@
 </table>
 
 <%= paginate @content_items, :window => 2 %>
+
+</div>

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -26,18 +26,7 @@
 <div id="progress">
   <h3>Audit progress</h3>
 
-  <div class="progress">
-    <div class="progress-bar"
-         role="progressbar"
-         aria-valuenow="<%= audited_percentage %>"
-         aria-valuemin="0"
-         aria-valuemax="100"
-         style="width: <%= format_percentage(audited_percentage, precision: 5) %>;">
-      <span class="sr-only">
-        <%= format_percentage(audited_percentage, precision: 5) %> Complete
-      </span>
-    </div>
-  </div>
+  <%= render "progress_bar", percentage: audited_percentage %>
 
   <table class="table">
     <tr>
@@ -56,18 +45,7 @@
 <div id="items-needing-improvement">
   <h3>Items needing improvement</h3>
 
-  <div class="progress">
-    <div class="progress-bar"
-         role="progressbar"
-         aria-valuenow="<%= passing_percentage %>"
-         aria-valuemin="0"
-         aria-valuemax="100"
-         style="width: <%= format_percentage(passing_percentage, precision: 5) %>;">
-      <span class="sr-only">
-        <%= format_percentage(passing_percentage, precision: 5) %> Complete
-      </span>
-    </div>
-  </div>
+  <%= render "progress_bar", percentage: passing_percentage %>
 
   <table class="table">
     <tr>

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -4,11 +4,18 @@
 
 <h1>GOV.UK Content Audit</h1>
 
-<ul class="tabs">
-  <li><%= link_to "Content", audits_path(filter_params) %></li>
-  <li class="active">Report</li>
+<ul class="nav nav-tabs">
+  <li role="presentation">
+    <%= link_to "Content", audits_path(filter_params), aria_controls: "home", role: "tab" %>
+  </li>
+  <li role="presentation" class="active">
+    <%= link_to "Report", "#", aria_controls: "home", role: "tab" %>
+  </li>
 </ul>
 
+<div class="tab-content">
+
+<br>
 <%= link_to "Export filtered audit to CSV", audits_export_path(filter_params), class: "report-export" %>
 
 <div class="report-section">

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -9,4 +9,8 @@
   <li class="active">Report</li>
 </ul>
 
-<%= link_to "Export", audits_export_path(filter_params) %>
+<%= link_to "Export filtered audit to CSV", audits_export_path(filter_params), class: "report-export" %>
+
+<h3><%= format_number(@content_items.total_count) %></h3>
+<p>Content items</p>
+

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -1,0 +1,12 @@
+<% content_for :sidebar do %>
+  <%= render 'sidebar', submit_path: audits_report_path %>
+<% end %>
+
+<h1>GOV.UK Content Audit</h1>
+
+<ul class="tabs">
+  <li><%= link_to "Content", audits_path(filter_params) %></li>
+  <li class="active">Report</li>
+</ul>
+
+<%= link_to "Export", audits_export_path(filter_params) %>

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -46,9 +46,34 @@
   </table>
 </div>
 
-  <div class="statistic">
-    <span class="name">Items still to audit</span>
-    <span><%= format_number(not_audited_count) %></span>
-    <span><%= format_percentage(not_audited_percentage) %></span>
+<div id="items-needing-improvement">
+  <h3>Items needing improvement</h3>
+
+  <div class="progress">
+    <div class="progress-bar"
+         role="progressbar"
+         aria-valuenow="<%= passing_percentage %>"
+         aria-valuemin="0"
+         aria-valuemax="100"
+         style="width: <%= format_percentage(passing_percentage, precision: 5) %>;">
+      <span class="sr-only">
+        <%= format_percentage(passing_percentage, precision: 5) %> Complete
+      </span>
+    </div>
   </div>
+
+  <table class="table">
+    <tr>
+      <td class="col-md-6">Items that need improvement</td>
+      <td class="col-md-3"><%= format_number(passing_count) %></td>
+      <td class="col-md-3"><%= format_percentage(passing_percentage) %></td>
+    </tr>
+    <tr>
+      <td class="col-md-6">Items that don't need improvement</td>
+      <td class="col-md-3"><%= format_number(not_passing_count) %></td>
+      <td class="col-md-3"><%= format_percentage(not_passing_percentage) %></td>
+    </tr>
+  </table>
+</div>
+
 </div>

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -11,6 +11,27 @@
 
 <%= link_to "Export filtered audit to CSV", audits_export_path(filter_params), class: "report-export" %>
 
-<h3><%= format_number(@content_items.total_count) %></h3>
-<p>Content items</p>
+<div class="report-section">
+  <h3><%= format_number(@content_items.total_count) %></h3>
+  <p>Content items</p>
+<div>
 
+<div class="report-section" id="progress">
+  <h3>Audit progress</h3>
+
+  <div class="bar">
+    <div class="inner" style="width: <%= format_percentage(audited_percentage, precision: 5) %>"></div>
+  </div>
+
+  <div class="statistic">
+    <span class="name">Items audited</span>
+    <span><%= format_number(audited_count) %></span>
+    <span><%= format_percentage(audited_percentage) %></span>
+  </div>
+
+  <div class="statistic">
+    <span class="name">Items still to audit</span>
+    <span><%= format_number(not_audited_count) %></span>
+    <span><%= format_percentage(not_audited_percentage) %></span>
+  </div>
+</div>

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -16,18 +16,35 @@
   <p>Content items</p>
 <div>
 
-<div class="report-section" id="progress">
+<div id="progress">
   <h3>Audit progress</h3>
 
-  <div class="bar">
-    <div class="inner" style="width: <%= format_percentage(audited_percentage, precision: 5) %>"></div>
+  <div class="progress">
+    <div class="progress-bar"
+         role="progressbar"
+         aria-valuenow="<%= audited_percentage %>"
+         aria-valuemin="0"
+         aria-valuemax="100"
+         style="width: <%= format_percentage(audited_percentage, precision: 5) %>;">
+      <span class="sr-only">
+        <%= format_percentage(audited_percentage, precision: 5) %> Complete
+      </span>
+    </div>
   </div>
 
-  <div class="statistic">
-    <span class="name">Items audited</span>
-    <span><%= format_number(audited_count) %></span>
-    <span><%= format_percentage(audited_percentage) %></span>
-  </div>
+  <table class="table">
+    <tr>
+      <td class="col-md-6">Items audited</td>
+      <td class="col-md-3"><%= format_number(audited_count) %></td>
+      <td class="col-md-3"><%= format_percentage(audited_percentage) %></td>
+    </tr>
+    <tr>
+      <td class="col-md-6">Items still to audit</td>
+      <td class="col-md-3"><%= format_number(not_audited_count) %></td>
+      <td class="col-md-3"><%= format_percentage(not_audited_percentage) %></td>
+    </tr>
+  </table>
+</div>
 
   <div class="statistic">
     <span class="name">Items still to audit</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
 
   resources :audits, only: %w(index)
 
+  namespace :audits do
+    get :report
+    get :export
+  end
+
   namespace :inventory do
     root action: "show"
     get :toggle, action: "toggle"

--- a/spec/domain/report_spec.rb
+++ b/spec/domain/report_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe Report do
+  it "outputs a header row" do
+    csv = described_class.generate(Audit.none)
+    expect(csv).to eq("Title,Audited by\n")
+  end
+end

--- a/spec/domain/search/query_spec.rb
+++ b/spec/domain/search/query_spec.rb
@@ -40,39 +40,18 @@ RSpec.describe Search::Query do
     end
   end
 
-  describe "audit_status" do
-    it "defaults to not filter by audit status" do
-      expect(subject.filters).to be_empty
-    end
+  it "does not apply any filters by default" do
+    expect(subject.filters).to be_empty
+  end
 
-    it "adds a filter when setting the audit status" do
+  describe "audit_status" do
+    it "adds a filter" do
       subject.audit_status = :audited
       expect(subject.filters).to be_present
-    end
-
-    it "does not add a filter if blank" do
-      subject.audit_status = nil
-      expect(subject.filters).to be_empty
-    end
-
-    it "removes the existing audit filter when blank" do
-      subject.audit_status = :audited
-      subject.audit_status = nil
-
-      expect(subject.filters).to be_empty
     end
   end
 
   describe "theme" do
-    it "defaults to not filter by theme" do
-      expect(subject.filters).to be_empty
-    end
-
-    it "does not add a filter if blank" do
-      subject.theme = nil
-      expect(subject.filters).to be_empty
-    end
-
     it "does not add a filter if an unrecognised type" do
       subject.theme = "Unknown_123"
       expect(subject.filters).to be_empty
@@ -87,13 +66,6 @@ RSpec.describe Search::Query do
 
         expect(subject.filters).to be_present
         expect(subject.filters.first).to be_a(Search::RulesFilter)
-      end
-
-      it "removes the existing rules filter when blank" do
-        subject.theme = identifier
-        subject.theme = nil
-
-        expect(subject.filters).to be_empty
       end
 
       it "raises an error if theme doesn't exist" do
@@ -113,13 +85,6 @@ RSpec.describe Search::Query do
         expect(subject.filters.first).to be_a(Search::RulesFilter)
       end
 
-      it "removes the existing rules filter when blank" do
-        subject.theme = identifier
-        subject.theme = nil
-
-        expect(subject.filters).to be_empty
-      end
-
       it "raises an error if subtheme doesn't exist" do
         expect { subject.theme = "Subtheme_999" }
           .to raise_error(ActiveRecord::RecordNotFound)
@@ -128,25 +93,9 @@ RSpec.describe Search::Query do
   end
 
   describe "document_type" do
-    it "defaults to not filter by document type" do
-      expect(subject.filters).to be_empty
-    end
-
-    it "adds a filter when setting the document type" do
+    it "adds a filter" do
       subject.document_type = "organisation"
       expect(subject.filters).to be_present
-    end
-
-    it "does not add a filter if blank" do
-      subject.document_type = nil
-      expect(subject.filters).to be_empty
-    end
-
-    it "removes the existing audit filter when blank" do
-      subject.document_type = "organisation"
-      subject.document_type = nil
-
-      expect(subject.filters).to be_empty
     end
   end
 

--- a/spec/domain/search_spec.rb
+++ b/spec/domain/search_spec.rb
@@ -101,6 +101,34 @@ RSpec.describe Search do
     expect(content_ids).to eq %w(id2)
   end
 
+  it "can filter by passing status" do
+    content_item = ContentItem.find_by!(content_id: "id2")
+    audit = FactoryGirl.create(:audit, content_item: content_item)
+    FactoryGirl.create(
+      :response,
+      question: FactoryGirl.create(:boolean_question),
+      audit: audit,
+      value: "yes"
+    )
+
+    subject.passing = true
+    expect(content_ids).to eq %w(id2)
+  end
+
+  it "can filter by not passing status" do
+    content_item = ContentItem.find_by!(content_id: "id2")
+    audit = FactoryGirl.create(:audit, content_item: content_item)
+    FactoryGirl.create(
+      :response,
+      question: FactoryGirl.create(:boolean_question),
+      audit: audit,
+      value: "no"
+    )
+
+    subject.passing = false
+    expect(content_ids).to eq %w{id2}
+  end
+
   it "can filter by document type" do
     content_item = ContentItem.find_by!(content_id: "id2")
     content_item.update!(document_type: "travel_advice")

--- a/spec/domain/search_spec.rb
+++ b/spec/domain/search_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Search do
     content_item = ContentItem.find_by!(content_id: "id2")
     FactoryGirl.create(:audit, content_item: content_item)
 
-    subject.audit_status = "audited"
+    subject.audit_status = :audited
     expect(content_ids).to eq %w(id2)
   end
 
@@ -156,12 +156,14 @@ RSpec.describe Search do
       expect(audited.page).to eq(2)
     end
 
-    it "applies the block after query parameters have been set" do
-      subject.audit_status = :non_audited
+    it "returns no results if contradictory dimensions are set" do
+      search = subject
+        .dimension(:audited)
+        .dimension(:not_audited)
 
-      audited = subject.dimension(:audited)
-      content_ids = audited.content_items.map(&:content_id)
-      expect(content_ids).to eq %w(id2)
+
+      content_ids = search.content_items.map(&:content_id)
+      expect(content_ids).to be_empty
     end
 
     it "does not mutate the existing Search" do

--- a/spec/features/report/csv_export_spec.rb
+++ b/spec/features/report/csv_export_spec.rb
@@ -1,0 +1,36 @@
+RSpec.feature "Exporting a CSV from the report page" do
+  def content_type
+    page.response_headers.fetch("Content-Type")
+  end
+
+  def content_disposition
+    page.response_headers.fetch("Content-Disposition")
+  end
+
+  before do
+    example = FactoryGirl.create(:content_item, title: "Example")
+    FactoryGirl.create(:audit, content_item: example)
+  end
+
+  scenario "Exporting a csv file as an attachment" do
+    visit audits_report_path
+    click_link "Export"
+
+    expect(content_type).to eq("text/csv")
+    expect(content_disposition).to start_with("attachment")
+    expect(content_disposition).to include('filename="report.csv"')
+
+    expect(page).to have_content("Title,Audited by")
+    expect(page).to have_content("Example,Test User")
+  end
+
+  scenario "Applying the filters to the export" do
+    visit audits_report_path
+
+    select "Non Audited", from: "audit_status"
+    click_on "Filter"
+
+    click_link "Export"
+    expect(page).to have_no_content("Example,Test User")
+  end
+end

--- a/spec/features/report/csv_export_spec.rb
+++ b/spec/features/report/csv_export_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Exporting a CSV from the report page" do
 
   scenario "Exporting a csv file as an attachment" do
     visit audits_report_path
-    click_link "Export"
+    click_link "Export filtered audit to CSV"
 
     expect(content_type).to eq("text/csv")
     expect(content_disposition).to start_with("attachment")
@@ -30,7 +30,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     select "Non Audited", from: "audit_status"
     click_on "Filter"
 
-    click_link "Export"
+    click_link "Export filtered audit to CSV"
     expect(page).to have_no_content("Example,Test User")
   end
 end

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -6,6 +6,10 @@ RSpec.feature "Reporting on audit progress" do
   let!(:flying) { FactoryGirl.create(:content_item, title: "Flying abroad", document_type: "policy") }
   let!(:insurance) { FactoryGirl.create(:content_item, title: "Travel insurance", document_type: "policy") }
 
+  before do
+    FactoryGirl.create(:audit, content_item: flying)
+  end
+
   scenario "Displaying the number of items included in the audit" do
     visit audits_report_path
     expect(page).to have_content("3 Content items")
@@ -17,5 +21,15 @@ RSpec.feature "Reporting on audit progress" do
     select "Policy", from: "document_type"
     click_on "Filter"
     expect(page).to have_content("2 Content items")
+  end
+
+  scenario "Displaying the number of items audited/not audited" do
+    visit audits_report_path
+
+    expect(page).to have_content("Items audited 1 33%")
+    expect(page).to have_content("Items still to audit 2 67%")
+
+    bar = page.find("#progress .bar .inner")
+    expect(bar[:style]).to eq("width: 33.33333%")
   end
 end

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -1,0 +1,21 @@
+RSpec.feature "Reporting on audit progress" do
+  # Organisations:
+  let!(:hmrc) { FactoryGirl.create(:content_item, title: "HMRC", document_type: "organisation") }
+
+  # Policies:
+  let!(:flying) { FactoryGirl.create(:content_item, title: "Flying abroad", document_type: "policy") }
+  let!(:insurance) { FactoryGirl.create(:content_item, title: "Travel insurance", document_type: "policy") }
+
+  scenario "Displaying the number of items included in the audit" do
+    visit audits_report_path
+    expect(page).to have_content("3 Content items")
+
+    select "Organisation", from: "document_type"
+    click_on "Filter"
+    expect(page).to have_content("1 Content items")
+
+    select "Policy", from: "document_type"
+    click_on "Filter"
+    expect(page).to have_content("2 Content items")
+  end
+end

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -24,6 +24,10 @@ RSpec.feature "Reporting on audit progress" do
     )
   end
 
+  def width(id)
+    page.find("#{id} .progress .progress-bar")[:style]
+  end
+
   scenario "Displaying the number of items included in the audit" do
     visit audits_report_path
     expect(page).to have_content("3 Content items")
@@ -42,9 +46,7 @@ RSpec.feature "Reporting on audit progress" do
 
     expect(page).to have_content("Items audited 2 67%")
     expect(page).to have_content("Items still to audit 1 33%")
-
-    bar = page.find("#progress .progress .progress-bar")
-    expect(bar[:style]).to eq("width: 66.66667%;")
+    expect(width("#progress")).to eq("width: 66.66667%;")
   end
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
@@ -52,8 +54,30 @@ RSpec.feature "Reporting on audit progress" do
 
     expect(page).to have_content("Items that need improvement 1 50%")
     expect(page).to have_content("Items that don't need improvement 1 50%")
+    expect(width("#items-needing-improvement")).to eq("width: 50%;")
+  end
 
-    bar = page.find("#items-needing-improvement .progress .progress-bar")
-    expect(bar[:style]).to eq("width: 50%;")
+  scenario "Displaying sensible output when 'audit_status' is selected" do
+    visit audits_report_path
+
+    select "Audited", from: "audit_status"
+    click_on "Filter"
+
+    expect(page).to have_content("2 Content items")
+    expect(page).to have_content("Items audited 2 100%")
+    expect(page).to have_content("Items still to audit 0 0%")
+    expect(page).to have_content("Items that need improvement 1 50%")
+    expect(page).to have_content("Items that don't need improvement 1 50%")
+    expect(width("#progress")).to eq("width: 100%;")
+
+    select "Non Audited", from: "audit_status"
+    click_on "Filter"
+
+    expect(page).to have_content("1 Content items")
+    expect(page).to have_content("Items audited 0 0%")
+    expect(page).to have_content("Items still to audit 1 100%")
+    expect(page).to have_content("Items that need improvement 0 0%")
+    expect(page).to have_content("Items that don't need improvement 0 0%")
+    expect(width("#items-needing-improvement")).to eq("width: 0%;")
   end
 end

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -7,7 +7,21 @@ RSpec.feature "Reporting on audit progress" do
   let!(:insurance) { FactoryGirl.create(:content_item, title: "Travel insurance", document_type: "policy") }
 
   before do
-    FactoryGirl.create(:audit, content_item: flying)
+    flying_audit = FactoryGirl.create(:audit, content_item: flying)
+    FactoryGirl.create(
+      :response,
+      question: FactoryGirl.create(:boolean_question),
+      audit: flying_audit,
+      value: "no"
+    )
+
+    insurance_audit = FactoryGirl.create(:audit, content_item: insurance)
+    FactoryGirl.create(
+      :response,
+      question: FactoryGirl.create(:boolean_question),
+      audit: insurance_audit,
+      value: "yes"
+    )
   end
 
   scenario "Displaying the number of items included in the audit" do
@@ -26,10 +40,20 @@ RSpec.feature "Reporting on audit progress" do
   scenario "Displaying the number of items audited/not audited" do
     visit audits_report_path
 
-    expect(page).to have_content("Items audited 1 33%")
-    expect(page).to have_content("Items still to audit 2 67%")
+    expect(page).to have_content("Items audited 2 67%")
+    expect(page).to have_content("Items still to audit 1 33%")
 
-    bar = page.find("#progress .bar .inner")
-    expect(bar[:style]).to eq("width: 33.33333%")
+    bar = page.find("#progress .progress .progress-bar")
+    expect(bar[:style]).to eq("width: 66.66667%;")
+  end
+
+  scenario "Displaying the number of items needing improvement/not needing improvement" do
+    visit audits_report_path
+
+    expect(page).to have_content("Items that need improvement 1 50%")
+    expect(page).to have_content("Items that don't need improvement 1 50%")
+
+    bar = page.find("#items-needing-improvement .progress .progress-bar")
+    expect(bar[:style]).to eq("width: 50%;")
   end
 end

--- a/spec/features/report/tabs_spec.rb
+++ b/spec/features/report/tabs_spec.rb
@@ -1,0 +1,15 @@
+RSpec.feature "Tabs" do
+  scenario "preserving filters across tabs" do
+    visit audits_path
+    select "Audited", from: "audit_status"
+
+    click_on "Filter"
+    expect(page).to have_select("audit_status", selected: "Audited")
+
+    click_link "Report"
+    expect(page).to have_select("audit_status", selected: "Audited")
+
+    click_link "Content"
+    expect(page).to have_select("audit_status", selected: "Audited")
+  end
+end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -31,4 +31,44 @@ RSpec.describe Audit do
       expect(subject).to be_invalid
     end
   end
+
+  describe "scopes" do
+    let!(:passing_audit) { FactoryGirl.create(:audit) }
+    let!(:failing_audit) { FactoryGirl.create(:audit) }
+
+    before do
+      bool = FactoryGirl.create(:boolean_question)
+      free = FactoryGirl.create(:free_text_question)
+
+      FactoryGirl.create(:response, audit: passing_audit, question: bool, value: "yes")
+      FactoryGirl.create(:response, audit: passing_audit, question: bool, value: "yes")
+      FactoryGirl.create(:response, audit: passing_audit, question: free, value: "Hello")
+
+      FactoryGirl.create(:response, audit: failing_audit, question: bool, value: "yes")
+      FactoryGirl.create(:response, audit: failing_audit, question: bool, value: "no")
+      FactoryGirl.create(:response, audit: failing_audit, question: free, value: "Hello")
+    end
+
+    describe ".passing" do
+      it "returns audits where all boolean responses are 'yes'" do
+        expect(Audit.passing).to eq [passing_audit]
+      end
+
+      it "can be chained" do
+        scope = Audit.where(id: failing_audit)
+        expect(scope.passing).to be_empty
+      end
+    end
+
+    describe ".failing" do
+      it "returns audits where any one boolean response is 'no'" do
+        expect(Audit.failing).to eq [failing_audit]
+      end
+
+      it "can be chained" do
+        scope = Audit.where(id: passing_audit)
+        expect(scope.failing).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -49,4 +49,46 @@ RSpec.describe Response do
       expect(Response.all).to eq [a, b]
     end
   end
+
+  describe "scopes" do
+    let!(:bool) { FactoryGirl.create(:boolean_question) }
+    let!(:free) { FactoryGirl.create(:free_text_question) }
+
+    let!(:passing_response) { FactoryGirl.create(:response, question: bool, value: "yes") }
+    let!(:failing_response) { FactoryGirl.create(:response, question: bool, value: "no") }
+    let!(:text_response) { FactoryGirl.create(:response, question: free, value: "Hello") }
+
+    describe ".boolean" do
+      it "returns responses for boolean questions" do
+        expect(Response.boolean).to match_array [passing_response, failing_response]
+      end
+
+      it "can be chained" do
+        scope = Response.where(id: passing_response)
+        expect(scope.boolean).to eq [passing_response]
+      end
+    end
+
+    describe ".passing" do
+      it "returns responses for boolean questions with a value of 'yes'" do
+        expect(Response.passing).to eq [passing_response]
+      end
+
+      it "can be chained" do
+        scope = Response.where(id: failing_response)
+        expect(scope.passing).to be_empty
+      end
+    end
+
+    describe ".failing" do
+      it "returns responses for boolean questions with a value of 'no'" do
+        expect(Response.failing).to eq [failing_response]
+      end
+
+      it "can be chained" do
+        scope = Response.where(id: passing_response)
+        expect(scope.failing).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
- https://trello.com/c/KP0BnFzF/303-2-report-page-page-3-display-the-number-of-content-items-on-the-reports-page
- https://trello.com/c/c93bmgUk/304-3-report-page-page-3-display-the-audit-progress-on-the-reports-page
- https://trello.com/c/ZsET1yUA/305-report-page-page-3-display-the-number-of-items-passing-and-failing-on-the-reports-page

The 'export' link works but only exports a minimal number of fields. We'll address this in:
https://trello.com/c/SOUSMhFj/290-3-ability-to-export-csv-file-from-the-report-page

We also need to decide what to do with the the 'Audit status' filter, which doesn't make sense for this page. We'll address this separately, too.

![screen shot 2017-06-21 at 14 53 28](https://user-images.githubusercontent.com/892251/27387716-699bc47e-5691-11e7-9007-a55481326355.png)
