### PR TITLE
Update audit criteria and add links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'gds-sso'
 gem 'govuk_admin_template'
 gem 'govuk_sidekiq'
 gem 'plek'
+gem "govspeak", "~> 5.0.3"
 
 # third party gems
 gem 'draper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       xpath (~> 2.0)
     cliver (0.3.2)
     coderay (1.1.1)
+    commander (4.4.3)
+      highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     crack (0.4.3)
@@ -136,6 +138,16 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    govspeak (5.0.3)
+      actionview (>= 4.1, < 6)
+      addressable (>= 2.3.8, < 3)
+      commander (~> 4.4)
+      htmlentities (~> 4)
+      i18n (~> 0.7)
+      kramdown (~> 1.12.0)
+      money (~> 6.7)
+      nokogiri (~> 1.5)
+      sanitize (~> 2.1.0)
     govuk-lint (2.1.0)
       rubocop (~> 0.43.0)
       scss_lint
@@ -166,6 +178,8 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.4)
     hashie (3.5.5)
+    highline (1.7.8)
+    htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.15.5)
@@ -193,6 +207,7 @@ GEM
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
     kgio (2.11.0)
+    kramdown (1.12.0)
     link_header (0.0.8)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -222,6 +237,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.2)
+    money (6.9.0)
+      i18n (>= 0.6.4, < 0.9)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -351,6 +368,8 @@ GEM
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
+    sanitize (2.1.0)
+      nokogiri (>= 1.4.4)
     sass (3.4.24)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -446,6 +465,7 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   google-api-client (~> 0.9)
+  govspeak (~> 5.0.3)
   govuk-lint
   govuk_admin_template
   govuk_sidekiq

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -20,11 +20,22 @@
   margin: 2em 0 4em 0;
 }
 
+.question {
+  &.is-there-content-out-of-date {
+    margin-top: 4em;
+  }
+}
+
 .free-text-question {
   &.redirect-or-combine-with-url {
     textarea {
       height: 2em;
     }
+  }
+
+  &.ur-ls-of-similar-pages {
+    border-left: solid;
+    padding-left: 2em;
   }
 }
 

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -34,6 +34,10 @@ class AuditsController < ApplicationController
     send_data(csv, filename: "Transformation_audit_report_CSV_download.csv")
   end
 
+  def guidance
+    @body = Govspeak::Document.new(File.read("doc/guidance.md")).to_html.html_safe
+  end
+
 private
 
   def audit

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -12,7 +12,7 @@ class Question < ApplicationRecord
 end
 
 class BooleanQuestion < Question
-  PASS = "yes".freeze
+  PASS = "no".freeze
 end
 
 class FreeTextQuestion < Question

--- a/app/views/audits/guidance.html.erb
+++ b/app/views/audits/guidance.html.erb
@@ -1,0 +1,3 @@
+<div class="col-sm-7">
+  <%= @body %>
+</div>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -28,6 +28,14 @@
     <%= @audit.content_item.description %>
   </p>
 
+  <%if @audit.content_item.whitehall_url %>
+    <p>
+      <%= link_to "Open in Whitehall Publisher", @audit.content_item.whitehall_url %>
+    </p>
+  <% end %>
+
+  <hr/>
+
   <%= form_for [@audit.content_item, @audit], url: content_item_audit_path(filter_params) do |form| %>
     <%= form.fields_for :responses do |builder| %>
       <% response = builder.object %>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -36,6 +36,8 @@
 
   <hr/>
 
+  <h4>Do these things need to change?</h4>
+
   <%= form_for [@audit.content_item, @audit], url: content_item_audit_path(filter_params) do |form| %>
     <%= form.fields_for :responses do |builder| %>
       <% response = builder.object %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,12 +9,15 @@ Rails.application.routes.draw do
     patch :audit, to: "audits#save"
   end
 
-  resources :audits, only: %w(index)
+  resources :audits, only: %w(index guidance)
 
   namespace :audits do
     get :report
     get :export
+    get :guidance
   end
+
+  get "audit-guidance", to: "audits#guidance"
 
   namespace :inventory do
     root action: "show"

--- a/db/migrate/20170626153519_re_seed_questions.rb
+++ b/db/migrate/20170626153519_re_seed_questions.rb
@@ -1,0 +1,20 @@
+class ReSeedQuestions < ActiveRecord::Migration[5.1]
+  class Audit < ActiveRecord::Base
+  end
+
+  class Question < ActiveRecord::Base
+  end
+
+  class Response < ActiveRecord::Base
+  end
+
+  def up
+    #   Drop audits, questions and responses then run seed
+
+    Response.delete_all
+    Question.delete_all
+    Audit.delete_all
+
+    Seeder.questions!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626133926) do
+ActiveRecord::Schema.define(version: 20170706143916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/doc/guidance.md
+++ b/doc/guidance.md
@@ -1,0 +1,383 @@
+# Audit GOV.UK content
+We've created this document to help you understand the questions on the audit spreadsheet before your team starts auditing content. We've also provided guidance about things to consider, and examples of good and bad content.
+
+---
+
+## Before you start
+You can group similar content together by sorting the spreadsheet by `Title` and then `Organisation` or `Content type > Sub type`.
+ 
+Keep in mind any:
+* upcoming content that could affect older pieces - for example a policy update
+* recently renamed policies or groups - for example Transport Focus (formerly Passenger Focus)
+
+---
+
+## Does the title need to change?
+
+Titles should:
+
+* be 65 characters or less (see 'Title length' column)
+be unique, clear and descriptive
+* be front-loaded and optimised for search
+* use a colon to break up longer titles
+* not contain dashes or slashes
+* not have a full stop at the end
+* not use acronyms unless they are well-known, like EU
+* not include the format type, for example 'form' or 'consultation'
+
+References: [Style guide (Titles)](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#titles) and [Writing for GOV.UK (Titles)](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#titles)
+
+### Consider
+
+Check whether the title would make sense:
+ 
+* as the link text in the new navigation (where all titles from the topic area are listed together)
+* in search results
+* in collections
+ 
+Are there acronyms that are widely known that don’t need spelling out? For example, RAIB, DVLA, DVSA.
+
+#### Good example
+
+> Hand luggage restrictions at UK airports
+
+#### Bad example
+> Addendum to the 2002 Guidance to the Civil Aviation Authority (CAA) on environmental objectives relating to the exercise of its air aviation functions"
+
+Reason: Too long and repeats what’s in the summary.
+ 
+#### Alternative 
+
+> Updates to Civil Aviation Authority environmental guidance since 2002
+ 
+---
+
+## Does the summary need to change?
+
+Summaries should:
+ 
+* be 140 characters (see 'Desc. length' column)
+* not repeat the title
+Use terms that you know users are searching for, as you would when you write the content. Summaries are a good place to include alternative search terms that aren’t in the content. 
+
+References: [Writing for GOV.UK: titles and summaries](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#titles-and-summaries) and [How to optimise your content for search](https://www.gov.uk/guidance/content-design/data-and-analytics#how-to-optimise-your-content-for-search)
+
+### Consider
+
+What terms can be drawn from the content, and do they feature in the summary?
+
+#### Good example
+
+> Handbook and software to help assess the risks of contaminated land exposure for human health.
+
+#### Bad example
+
+> Complete if you are applying for a new permit, applying to change or transfer an existing permit.
+ 
+Reason: It’s not clear what or who the permit is for.
+ 
+#### Alternative
+
+> Complete the application to apply for a new environmental permit, or apply to change or transfer a standard facilities permit you already have.
+
+--- 
+
+## Does the page detail need to change?
+
+Page detail (body text) should:
+
+* begin with what’s most important to users (not to government)
+* be concise and easy to scan (with subheads every 3-5 paragraphs)
+* be written in plain English (no jargon) and be easy to understand
+* use short sentences - ideally no more than 25 words
+* define acronyms and abbreviations the first time they’re used (with Markdown)
+* explain any technical terms
+* be shorter than 500 words if possible
+
+Reference: Structuring your content
+
+### Consider
+
+Is content in the correct tense? For example, 
+
+> applications will close on 2 February 2015’ should be changed to say ‘applications closed…
+ 
+Replace a minister's name with their role. For example, change 
+
+> Claire Perry opened… 
+
+to 
+
+> the Rail Minister opened…
+ 
+Is there content that's no longer relevant? Or is there content that can be removed or repositioned so that the most important content is at the top?
+ 
+Look at related links. Do you want to keep links to withdrawn content? (Probably yes, if it’s important for users to be able to find it.)
+ 
+Has $CTA (call to action markdown) been used to 'highlight' content?
+
+#### Good example
+
+> List of post holders who can receive driving tests and instructors statistics up to 24 hours before release to the general public.
+ 
+Reason: It gives detail on who this is for, what it’s used for and when the statistics will be available.
+
+#### Bad example
+
+> Index table of vehicle
+ 
+Reason: Doesn’t give any detail on what a user would need this for or what the table represents.
+ 
+#### Alternative
+
+> "A list of vehicle licensing statistics that shows how many vehicles were registered and licensed in 2013. This includes cars, motorcycles, light vans, HGVs, buses and coaches."
+ 
+---
+
+## Do the attachments need work?
+
+This isn’t a priority for the content transformation audit. But while you’re reviewing a page, take note of potential content improvement work, such as attachments that:
+
+* should have organisation branding - there should at least be a logo; exceptions include reports produced by consultants, but they'll generally include the consultant’s logo
+
+* are no longer current - the attachment needs to have a 'withdrawn' message added, such as in this [old webTAG unit](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/603749/webtag-tag-unit-a1-3-user-and-provider-impacts-november-2014.pdf)
+
+* should be direct links to the document on an agency website
+
+References: [Viewing government documents](https://www.gov.uk/government/publications/open-standards-for-government/viewing-government-documents) and [Open formats](https://www.gov.uk/guidance/content-design/planning-content#open-formats)
+
+### Consider
+
+There should only be multiple attachments on a publication page when the attachments are:
+
+* a form and its guidance
+
+* 'chapters' of one document
+
+* 'versions' of the same document, for example an interim report and a final report
+
+* multiple language versions of the same document
+
+It’s fine to have multiple attachments on a consultation page.
+
+With a PDF, can you:
+
+* tag it for accessibility?
+
+* convert it to PDF/A-2a?
+
+* add an HTML or ODT version?
+
+* longer term, consider removing it entirely if there's an HTML version?
+
+With a form, can you replace it with an editable PDF, ODT, ODS or an online form?
+
+With a spreadsheet, can you:
+
+* replace an Excel sheet with a CSV or ODS - or HTML tables?
+
+* replace a spreadsheet ‘calculator’ with an online form?
+
+#### Good example
+
+> [Infant immunisation poster](https://www.gov.uk/government/publications/infant-immunisation-poster)
+
+#### Bad example
+
+> [Format 2 - PDF - Times and heights of high and low waters, split into morning and afternoon, one month per page, with a table drawn around the date (A4 portrait)](https://www.gov.uk/government/publications/ukho-tidal-prediction-service-sample-pdf-format-two)
+
+Reason: Attachment name is too long and repeats what’s in the page title and summary. The PDF doesn’t have the organisation branding, and should be in HTML table format for better accessibility. 
+
+* * *
+
+
+## Do we need to change the format?
+
+For the content transformation audit it’s particularly important that guidance content is published in one of the guidance formats.
+
+User guidance takes a user through completing a task, for example [Become a driving examiner](https://www.gov.uk/guidance/become-a-driving-examiner).
+
+Non-guidance content types will start appearing in the new navigation at the end of 2017, so it’s important to check that content in a guidance format really is guidance.
+
+The main Whitehall guidance formats are:
+
+* [Detailed guide](https://www.gov.uk/guidance/content-design/content-types#detailed-guide) - answers a specific, task-oriented user need
+
+* [Publication: guidance](https://www.gov.uk/guidance/content-design/content-types#guidance) - non-statutory documents that offer advice
+
+* [Publication: statutory guidance](https://www.gov.uk/guidance/content-design/content-types#statutory-guidance) - guidance that users are legally obliged to follow
+
+* [Publication: form](https://www.gov.uk/guidance/content-design/content-types#form) - forms, and instructions on how to fill them in
+
+* [Publication: regulations](https://www.gov.uk/guidance/content-design/content-types#regulations) - regulations imposed by an independent regulatory authority
+
+* [Manuals](https://www.gov.uk/guidance/content-design/content-types#manual) - long, complex, chaptered documents, usually for specialists
+
+Reference: [List and explanation of all GOV.UK content types](https://www.gov.uk/guidance/content-design/content-types)
+
+### Consider
+
+Add guidance about completing a form to the form page. Use the 'Form' format for the page.
+
+Check that content published as ‘Correspondence’ isn't actually guidance, policy, a 'Decision' or a 'Notice'.
+
+Make sure that 'Promotional material’ content isn't actually 'Correspondence' or guidance.
+
+Withdraw interim reports rather than merging them with final reports.
+
+If the attachment is an electronic version of a printed leaflet and addresses user needs that are already met elsewhere ([INS57P: information on driving licences](https://www.gov.uk/government/publications/ins57p-information-on-driving-licences), for example) use the format 'Promotional material' and add it to a leaflet collection.
+
+#### Good example
+
+> [Car and small van driving syllabus](http://alphagov.github.io/govuk-content-best-practices/snapshots/car-and-small-van-driving-syllabus) (demo content)
+
+#### Bad example
+
+> [Discussion paper in ‘Guidance’ format - should be ‘Policy’](https://www.gov.uk/government/collections/airports-commission-discussion-papers--2)
+
+Reason: It’s informing users of a policy discussion, not taking them through completing a task.
+
+* * *
+
+
+## Do we need to check if the content is current?
+
+Content that is no longer current should be:
+
+* withdrawn - if a record of it still needs to be available, for example previous instructions on how to assess an ongoing project
+
+* merged or consolidated into another page, and unpublished - if there is duplicate content, or using the old content will cause legal problems; for example, superseded instructions
+
+If you're unsure, select 'Yes' to flag the page for checking with content owners.
+
+Reference: [Withdrawing and unpublishing content](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy)
+
+### Consider
+
+Does the content refer to a date that's already passed? For example, "[Central to the strategy is the ring-fencing of £35 million funding per year, until 2015](https://www.gov.uk/government/publications/access-for-all-stations)".
+
+Does it help users complete a task that’s still relevant?
+
+#### Good example
+
+> [Disabled parking badges](https://www.gov.uk/government/collections/disabled-parking-badges-statistics)
+
+#### Bad example
+
+> [Rail passenger franchises from 2005](https://www.gov.uk/government/publications/rail-passenger-franchises)
+
+Reason: It's an old invitation to tender. It needs to be reviewed to check it's still being used, and if there are any other pages it could be merged with. If not, it can be withdrawn.* * *
+
+
+## What kind of work is required?
+
+The options are:
+
+* none (keep as is) - the content is OK and doesn’t need work
+
+* involved update - we need to consult content owners about the changes, or consider this content together with related content
+
+* simple update - the content contains typos, unknown acronyms, a title or summary that needs work, or something else that the digital team can do without consulting content owners
+
+* withdraw - the content has been superseded, but a record needs to be kept - so please check if the title, summary and details need improving, as the content will still appear on GOV.UK
+
+* outside audit required - this content isn't owned by your organisation, or needs to be reviewed by another department
+
+* out of scope - the content doesn’t fit into this audit's theme
+
+### Consider
+
+Will you be comfortable making updates or do you need content owners to fact check?
+
+* * *
+
+
+## Do we need to remove this as a duplicate or unnecessary page?
+
+The options are:
+
+* no - page is unique, up-to-date, and doesn't need to be merged or unpublished
+
+* merge - you can consolidate the content into a new or existing similar page
+
+* unpublish - this content was published in error, or can be merged into another page that we'll redirect to
+
+If you select 'merge' or 'unpublish', add the destination url in the 'Redirect or combine with URL' column. 
+
+References: [Withdrawing and unpublishing content](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy) and [Unpublishing content](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy#unpublishing-content)
+
+### Consider
+
+Check if there are similar pages by searching GOV.UK with the title of the content. Have different agencies duplicated the same kind of content?
+
+Does the page contain information that's easily available elsewhere?
+
+#### Example
+
+> [Driving tests and instructors statistics notes and definitions](https://www.gov.uk/government/statistics/driver-and-rider-tests-and-instructor-statistics-2012-13) should be merged with [Driver and rider tests and instructor statistics: 2012-13](https://www.gov.uk/government/statistics/driver-and-rider-tests-and-instructor-statistics-2012-13), so the guidance notes are in the same place as the statistics.
+
+* * *
+
+
+## Notes
+
+Add notes or reminders that will help later in the audit or improvement stage.
+
+* * *
+
+
+## Is work needed?
+
+This column will automatically populate with ‘Yes’ or ‘No’ based on your answers to the other questions. It's used to populate the ‘need work’ and ‘no work needed’ totals on the 'Summary' tab of the spreadsheet.
+
+* * *
+
+
+## Improvement subject
+
+Use this dropdown to identify groups of similar content. 
+
+You can then sort the spreadsheet by this column to more easily:
+
+* audit groups of similar content
+
+* assign content for improvement work
+
+If you have a new subject for the dropdown, add it to the list on the ‘improvement-subjects’ tab of the spreadsheet.
+
+### Consider
+
+Think about how you might assign improvement work, and add subjects accordingly.
+
+These subjects are only to help coordinate the audit and improvement work - they won't be used for the new taxonomy or navigation.
+
+You can create more granular subjects by adding commas, for example:
+
+* driving instructors
+
+* driving instructors, cars
+
+* driving instructors, motorcycles
+
+* driving instructors, HGV
+
+* driving instructors, PSV
+
+* * *
+
+
+## After the audit: content improvement
+
+When you've completed the audit, we'll make a copy of the spreadsheet so you can keep track of content updates and consultations with content owners.
+
+We can discuss additional columns that might help you, such as:
+
+* name of the person making the updates
+
+* name of the content owner or team
+
+* progress - with content owner, 2i check, published...
+
+* automatic 'last time status was updated' column
+
+We can also set up a Trello board to help everyone keep track of progress.

--- a/lib/seeder.rb
+++ b/lib/seeder.rb
@@ -7,14 +7,16 @@ module Seeder
   def self.questions!
     return if Question.any?
 
-    BooleanQuestion.create!(text: "Is the title clear in isolation?")
-    BooleanQuestion.create!(text: "Is the description optimised?")
-    BooleanQuestion.create!(text: "Is there a clear user need?")
-    BooleanQuestion.create!(text: "Is the page out of date?")
-    BooleanQuestion.create!(text: "Is the page the right format?")
-    BooleanQuestion.create!(text: "Are there similar pages? (Merge pages)")
+    BooleanQuestion.create!(text: "Title")
+    BooleanQuestion.create!(text: "Summary")
+    BooleanQuestion.create!(text: "Page detail")
+    BooleanQuestion.create!(text: "Attachments")
+    BooleanQuestion.create!(text: "Document type")
+    BooleanQuestion.create!(text: "Is there content out of date?")
+    BooleanQuestion.create!(text: "Should the content be removed?")
+    BooleanQuestion.create!(text: "Is this content very similar to other pages?")
 
-    FreeTextQuestion.create!(text: "Redirect or combine with URL")
+    FreeTextQuestion.create!(text: "URLs of similar pages")
     FreeTextQuestion.create!(text: "Notes")
   end
 

--- a/spec/domain/search_spec.rb
+++ b/spec/domain/search_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Search do
       :response,
       question: FactoryGirl.create(:boolean_question),
       audit: audit,
-      value: "yes"
+      value: "no"
     )
 
     subject.passing = true
@@ -122,7 +122,7 @@ RSpec.describe Search do
       :response,
       question: FactoryGirl.create(:boolean_question),
       audit: audit,
-      value: "no"
+      value: "yes"
     )
 
     subject.passing = false

--- a/spec/features/audit/audit_spec.rb
+++ b/spec/features/audit/audit_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Auditing a content item", type: :feature do
       title: "Flooding",
       description: "All about flooding.",
       base_path: "/flooding",
+      publishing_app: "whitehall",
     )
   end
 
@@ -18,6 +19,8 @@ RSpec.feature "Auditing a content item", type: :feature do
     visit content_item_audit_path(content_item)
     expect(page).to have_link("Flooding", href: "https://gov.uk/flooding")
     expect(page).to have_content("All about flooding.")
+
+    expect(page).to have_link("Open in Whitehall Publisher")
 
     within("#question-1") { choose "Yes" }
     within("#question-2") { choose "No" }

--- a/spec/features/audit/audit_spec.rb
+++ b/spec/features/audit/audit_spec.rb
@@ -22,28 +22,33 @@ RSpec.feature "Auditing a content item", type: :feature do
 
     expect(page).to have_link("Open in Whitehall Publisher")
 
-    within("#question-1") { choose "Yes" }
-    within("#question-2") { choose "No" }
-    within("#question-3") { choose "Yes" }
-    within("#question-8") { fill_in "Notes", with: "something" }
+    expect(page).to have_content("Do these things need to change?")
+
+    within("#question-1") { choose "No" }
+    within("#question-2") { choose "Yes" }
+    within("#question-3") { choose "No" }
+    within("#question-10") { fill_in "Notes", with: "something" }
 
     click_on "Save"
     expect(page).to have_content("Warning: Mandatory field missing")
 
-    within("#question-4") { choose "No" }
-    within("#question-5") { choose "Yes" }
-    within("#question-6") { choose "No" }
+    within("#question-4") { choose "Yes" }
+    within("#question-5") { choose "No" }
+    within("#question-6") { choose "Yes" }
+    within("#question-7") { choose "Yes" }
+    within("#question-8") { choose "Yes" }
+    within("#question-9") { fill_in "URLs of similar pages", with: "something" }
 
     click_on "Save"
     expect(page).to have_content("Success: Saved successfully.")
 
-    within("#question-1") { expect(chosen_radio_button.value).to eq("yes") }
-    within("#question-2") { expect(chosen_radio_button.value).to eq("no") }
-    within("#question-3") { expect(chosen_radio_button.value).to eq("yes") }
-    within("#question-4") { expect(chosen_radio_button.value).to eq("no") }
-    within("#question-5") { expect(chosen_radio_button.value).to eq("yes") }
-    within("#question-6") { expect(chosen_radio_button.value).to eq("no") }
-    within("#question-8") { expect(find_field("Notes").value).to eq("something") }
+    within("#question-1") { expect(chosen_radio_button.value).to eq("no") }
+    within("#question-2") { expect(chosen_radio_button.value).to eq("yes") }
+    within("#question-3") { expect(chosen_radio_button.value).to eq("no") }
+    within("#question-4") { expect(chosen_radio_button.value).to eq("yes") }
+    within("#question-5") { expect(chosen_radio_button.value).to eq("no") }
+    within("#question-6") { expect(chosen_radio_button.value).to eq("yes") }
+    within("#question-10") { expect(find_field("Notes").value).to eq("something") }
 
     within("#question-4") { choose "Yes" }
     within("#question-5") { choose "No" }
@@ -52,9 +57,9 @@ RSpec.feature "Auditing a content item", type: :feature do
     click_on "Save"
     expect(page).to have_content("Success: Saved successfully.")
 
-    within("#question-1") { expect(chosen_radio_button.value).to eq("yes") }
-    within("#question-2") { expect(chosen_radio_button.value).to eq("no") }
-    within("#question-3") { expect(chosen_radio_button.value).to eq("yes") }
+    within("#question-1") { expect(chosen_radio_button.value).to eq("no") }
+    within("#question-2") { expect(chosen_radio_button.value).to eq("yes") }
+    within("#question-3") { expect(chosen_radio_button.value).to eq("no") }
     within("#question-4") { expect(chosen_radio_button.value).to eq("yes") }
     within("#question-5") { expect(chosen_radio_button.value).to eq("no") }
     within("#question-6") { expect(chosen_radio_button.value).to eq("yes") }

--- a/spec/features/audit/guidance_spec.rb
+++ b/spec/features/audit/guidance_spec.rb
@@ -1,0 +1,8 @@
+RSpec.feature "Auditing a content item", type: :feature do
+  scenario "visiting the guidance page" do
+    visit "/audit-guidance"
+
+    expect(page).to have_css("h1")
+    expect(page).to have_content("Audit GOV.UK content")
+  end
+end

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -39,12 +39,14 @@ RSpec.feature "Navigation" do
   scenario "continuing to next item on save" do
     visit content_item_audit_path(first, some_filter: "value")
 
-    within("#question-1") { choose "Yes" }
-    within("#question-2") { choose "Yes" }
-    within("#question-3") { choose "Yes" }
-    within("#question-4") { choose "Yes" }
-    within("#question-5") { choose "Yes" }
-    within("#question-6") { choose "Yes" }
+    within("#question-1") { choose "No" }
+    within("#question-2") { choose "No" }
+    within("#question-3") { choose "No" }
+    within("#question-4") { choose "No" }
+    within("#question-5") { choose "No" }
+    within("#question-6") { choose "No" }
+    within("#question-7") { choose "No" }
+    within("#question-8") { choose "No" }
 
     click_on "Save"
 

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Navigation" do
-  let!(:first) { FactoryGirl.create(:content_item, title: "First") }
-  let!(:second) { FactoryGirl.create(:content_item, title: "Second") }
-  let!(:third) { FactoryGirl.create(:content_item, title: "Third") }
+  let!(:first) { FactoryGirl.create(:content_item, title: "First", six_months_page_views: 3) }
+  let!(:second) { FactoryGirl.create(:content_item, title: "Second", six_months_page_views: 2) }
+  let!(:third) { FactoryGirl.create(:content_item, title: "Third", six_months_page_views: 1) }
 
   scenario "navigating between audits and the index page" do
     visit audits_path(some_filter: "value")
@@ -74,10 +74,10 @@ RSpec.feature "Navigation" do
 
   context "when on the second page of content items" do
     before do
-      FactoryGirl.create_list(:content_item, 25)
+      FactoryGirl.create_list(:content_item, 25, six_months_page_views: 2)
 
-      FactoryGirl.create(:content_item, title: "Penultimate item")
-      FactoryGirl.create(:content_item, title: "Last item")
+      FactoryGirl.create(:content_item, title: "Penultimate item", six_months_page_views: 1)
+      FactoryGirl.create(:content_item, title: "Last item", six_months_page_views: 0)
 
       visit audits_path(page: 2)
     end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe Audit do
       bool = FactoryGirl.create(:boolean_question)
       free = FactoryGirl.create(:free_text_question)
 
-      FactoryGirl.create(:response, audit: passing_audit, question: bool, value: "yes")
-      FactoryGirl.create(:response, audit: passing_audit, question: bool, value: "yes")
+      FactoryGirl.create(:response, audit: passing_audit, question: bool, value: "no")
+      FactoryGirl.create(:response, audit: passing_audit, question: bool, value: "no")
       FactoryGirl.create(:response, audit: passing_audit, question: free, value: "Hello")
 
-      FactoryGirl.create(:response, audit: failing_audit, question: bool, value: "yes")
       FactoryGirl.create(:response, audit: failing_audit, question: bool, value: "no")
+      FactoryGirl.create(:response, audit: failing_audit, question: bool, value: "yes")
       FactoryGirl.create(:response, audit: failing_audit, question: free, value: "Hello")
     end
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Audit do
     let(:bool) { FactoryGirl.create(:boolean_question) }
 
     it "is passing if all responses are passing" do
-      response = FactoryGirl.create(:response, question: bool, value: "yes")
+      response = FactoryGirl.create(:response, question: bool, value: "no")
       audit = FactoryGirl.create(:audit, responses: [response])
 
       expect(audit).to be_passing
@@ -91,7 +91,7 @@ RSpec.describe Audit do
     end
 
     it "is failing if any response is failing" do
-      response = FactoryGirl.create(:response, question: bool, value: "no")
+      response = FactoryGirl.create(:response, question: bool, value: "yes")
       audit = FactoryGirl.create(:audit, responses: [response])
 
       expect(audit).not_to be_passing

--- a/spec/models/report_row_spec.rb
+++ b/spec/models/report_row_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe ReportRow do
 
   specify { expect(subject.title).to eq                   "Title" }
   specify { expect(subject.url).to eq                     "https://gov.uk/example/path" }
-  specify { expect(subject.is_work_needed).to eq          "No" }
+  specify { expect(subject.is_work_needed).to eq          "Yes" }
   specify { expect(subject.page_views).to eq              "1,234" }
-  specify { expect(subject.response_values).to start_with %w(Yes Yes Yes) }
+  specify { expect(subject.response_values).to start_with %w(No No No) }
   specify { expect(subject.primary_organisation).to eq    "HMRC" }
   specify { expect(subject.other_organisations).to eq     "" }
   specify { expect(subject.content_type).to eq            "Travel Advice" }
@@ -50,7 +50,7 @@ RSpec.describe ReportRow do
     before { audit.destroy }
 
     specify { expect(subject.is_work_needed).to be_nil }
-    specify { expect(subject.response_values).to eq [nil] * 8 }
+    specify { expect(subject.response_values).to eq [nil] * 10 }
   end
 
   context "when the content item has many organisations" do

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -103,13 +103,13 @@ RSpec.describe Response do
     end
 
     it "is passing for responses to boolean questions with a 'yes' value" do
-      response = FactoryGirl.create(:response, question: bool, value: "yes")
+      response = FactoryGirl.create(:response, question: bool, value: "no")
       expect(response).to be_passing
       expect(response).not_to be_failing
     end
 
     it "is failing for responses to boolean questions with a 'no' value" do
-      response = FactoryGirl.create(:response, question: bool, value: "no")
+      response = FactoryGirl.create(:response, question: bool, value: "yes")
       expect(response).not_to be_passing
       expect(response).to be_failing
     end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Response do
     let!(:bool) { FactoryGirl.create(:boolean_question) }
     let!(:free) { FactoryGirl.create(:free_text_question) }
 
-    let!(:passing_response) { FactoryGirl.create(:response, question: bool, value: "yes") }
-    let!(:failing_response) { FactoryGirl.create(:response, question: bool, value: "no") }
+    let!(:passing_response) { FactoryGirl.create(:response, question: bool, value: "no") }
+    let!(:failing_response) { FactoryGirl.create(:response, question: bool, value: "yes") }
     let!(:text_response) { FactoryGirl.create(:response, question: free, value: "Hello") }
 
     describe ".boolean" do

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Template do
     it "returns an ordered list of questions" do
       q = subject.questions
 
-      expect(q.first.text).to eq("Is the title clear in isolation?")
+      expect(q.first.text).to eq("Title")
       expect(q.last.text).to eq("Notes")
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/fwzqa4Fj)

Re-works the criteria questions: passing an audit is inverted from all being “Yes” answers to all being “No” answers - as in from being “Does the content have these valid attributes” to “Does the content have to change for each of these criterion”.

For content items that are editable by Whitehall publisher, include a link to edit that item. Ideally we would do this for all content items, whatever their publishing application. This is just a first iteration for a short deadline.

Add hardcoded auditing guidance content.