### PR TITLE
Check dependencies on startup

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-bundle install
+bundle check || bundle install
 
 bundle exec rails s -b 0.0.0.0 -p 3206


### PR DESCRIPTION
Checks if the dependencies listed in the Gemfile are satisfied by currently installed gems and only attempts to `bundle install` if they're not. This reduces startup time.