### PR TITLE
Content preview modal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 group :development, :test do
   gem 'capybara'
   gem 'database_cleaner'
+  gem 'phantomjs'
   gem 'factory_girl_rails'
   gem 'govuk-lint'
   gem 'guard-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
+    phantomjs (2.1.1.0)
     plek (2.0.0)
     poltergeist (1.15.0)
       capybara (~> 2.1)
@@ -454,6 +455,7 @@ DEPENDENCIES
   listen
   logstasher
   pg
+  phantomjs
   plek
   poltergeist
   pry-rails
@@ -476,4 +478,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -1,4 +1,22 @@
-<div class="col-sm-7">
+<!-- Modal -->
+<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+  <div class="modal-dialog modal-lg" role="document" >
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel"><%=@todo_form.title%></h4>
+      </div>
+      <div class="modal-body">
+        <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="600" scrolling="yes"></iframe>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="col-sm-9">
   <% if flash.notice %>
     <div class="alert alert-success" role="alert">
       <p>
@@ -32,28 +50,13 @@
     <%= f.submit "Save", class: "btn btn-success" %>
   <% end %>
 
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog modal-lg" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title" id="myModalLabel"><%=@todo_form.title%></h4>
-        </div>
-        <div class="modal-body">
-          <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="600" scrolling="yes"></iframe>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        </div>
-      </div>
-    </div>
+  <div class="add-top-padding">
+    <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="800" scrolling="yes"></iframe>
   </div>
-
 
 </div>
 
-<div class="col-sm-4">
+<div class="col-sm-3">
   <div id="metadata" class="term_review-metadata">
     <div id="organisations">
       <h4>Organisations</h4>

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -15,7 +15,7 @@
     </div>
   <% end %>
 
-  <h2><%= link_to @todo_form.title, @todo_form.url, target: :_blank %></h2>
+  <h2><%= link_to @todo_form.title, @todo_form.url, data: {toggle: "modal", target: "#myModal"} %></h2>
 
   <p class="description">
     <%= @todo_form.description %>
@@ -31,6 +31,26 @@
 
     <%= f.submit "Save", class: "btn btn-success" %>
   <% end %>
+
+  <!-- Modal -->
+  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="myModalLabel"><%=@todo_form.title%></h4>
+        </div>
+        <div class="modal-body">
+          <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="600" scrolling="yes"></iframe>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
 </div>
 
 <div class="col-sm-4">

--- a/spec/features/taxonomy_generation/content_preview_modal_spec.rb
+++ b/spec/features/taxonomy_generation/content_preview_modal_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Content Preview Modal", type: :feature, js: true do
+  it "pops up a modal when previewing content" do
+    given_theres_a_project_with_a_todo
+    when_i_visit_the_taxonomy_project_page
+    and_i_click_to_start_with_a_project
+    and_i_click_on_the_content_link
+    then_a_modal_with_the_content_pops_up
+  end
+
+  def given_theres_a_project_with_a_todo
+    @project = create(:taxonomy_project, name: 'A Fancy Group')
+    @content_item = create(:content_item, title: 'A Fancy Content Item', base_path: "/path/to/a/page.html")
+    @todo = create(:taxonomy_todo, content_item: @content_item, taxonomy_project: @project)
+  end
+
+  def when_i_visit_the_taxonomy_project_page
+    visit taxonomy_projects_path
+  end
+
+  def and_i_click_to_start_with_a_project
+    click_on 'Start tagging'
+  end
+
+  def and_i_click_on_the_content_link
+    click_on 'A Fancy Content Item'
+  end
+
+  def then_a_modal_with_the_content_pops_up
+    within('.modal-content') do
+      expect(page).to have_css('iframe[src="https://gov.uk/path/to/a/page.html"]')
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/4IT79oPH/157-concept-generator-being-able-to-see-side-by-side

When tagging content, users have reported it takes time to switch between the content tagger and the actual content. Users open the content in a new tab and switch between tabs to read content and do the tagging.

This pull request changes the link into a modal popup window so that reviewing content can be done on the same page. It is still possible to open up a window in a new tab by right clicking the link.

There is also a static Iframe at the bottom of the page. We need more user research to determine if the modal or the iframe at the bottom of the page is preferred

![screen shot 2017-06-28 at 11 15 57](https://user-images.githubusercontent.com/6050162/27633558-a0d0c10e-5bf7-11e7-8e8d-0214674a6d0e.png)
![screen shot 2017-06-27 at 15 34 29](https://user-images.githubusercontent.com/6050162/27593258-9bbeff18-5b4e-11e7-95c6-bbefc31c871b.png)

