### PR TITLE
Ensure ordering of questions

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,7 +1,7 @@
 class Template
   def questions
     fail "You need to run rake db:seed to create the questions" if Question.none?
-    Question.all.to_a
+    Question.all.order(:id).to_a
   end
 
   def mandatory?(question)

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe Response do
       a.save!
 
       expect(Response.all).to eq [a, b]
+
+      a.question.text = "New text"
+      a.save!
+
+      expect(Response.all).to eq [a, b]
     end
   end
 


### PR DESCRIPTION
Before this change, if we made a change to existing questions the order
of questions returned in an odd way. We are setting to ID for now so that
it is at least deterministic.