### PR TITLE
Add progress stats to project page

### DIFF
--- a/app/models/taxonomy/project_stats.rb
+++ b/app/models/taxonomy/project_stats.rb
@@ -1,0 +1,25 @@
+module Taxonomy
+  class ProjectStats
+    attr_reader :scope
+
+    def initialize(scope)
+      @scope = scope
+    end
+
+    def todo_count
+      @todo_count ||= scope.taxonomy_todos.count
+    end
+
+    def done_count
+      @done_count ||= scope.taxonomy_todos.done.count
+    end
+
+    def still_todo_count
+      @still_todo_count ||= scope.taxonomy_todos.still_todo.count
+    end
+
+    def progress_percentage
+      (done_count / todo_count.to_f) * 100
+    end
+  end
+end

--- a/app/models/taxonomy_project.rb
+++ b/app/models/taxonomy_project.rb
@@ -13,4 +13,8 @@ class TaxonomyProject < ApplicationRecord
   def next_todo
     taxonomy_todos.still_todo.first
   end
+
+  def stats
+    Taxonomy::ProjectStats.new(self)
+  end
 end

--- a/app/models/taxonomy_todo.rb
+++ b/app/models/taxonomy_todo.rb
@@ -5,6 +5,7 @@ class TaxonomyTodo < ApplicationRecord
   belongs_to :user, primary_key: :uid, foreign_key: :completed_by, optional: true
 
   scope :still_todo, -> { where(completed_at: nil) }
+  scope :done, -> { where('completed_at IS NOT NULL') }
 
   def completed?
     completed_at && completed_by

--- a/app/views/taxonomy_projects/show.html.erb
+++ b/app/views/taxonomy_projects/show.html.erb
@@ -1,5 +1,26 @@
 <h1><%= @project.name %></h1>
 
+<div class="summary">
+  <div class="row">
+    <div class="summary-item col-xs-3">
+      <span class="summary-item-value"><%= number_with_delimiter @project.stats.todo_count %></span>
+      <span class="summary-item-label">Pages in project</span>
+    </div>
+    <div class="summary-item col-xs-3">
+      <span class="summary-item-value"><%= number_with_delimiter @project.stats.done_count %></span>
+      <span class="summary-item-label">Done</span>
+    </div>
+    <div class="summary-item col-xs-3">
+      <span class="summary-item-value"><%= number_with_delimiter @project.stats.still_todo_count %></span>
+      <span class="summary-item-label">Still to do</span>
+    </div>
+    <div class="summary-item col-xs-3">
+      <span class="summary-item-value"><%= number_with_precision @project.stats.progress_percentage, precision: 1 %>%</span>
+      <span class="summary-item-label">Complete</span>
+    </div>
+  </div>
+</div>
+
 <h2>Terms</h2>
 
 <table class="table table-bordered table-hover">

--- a/spec/models/taxonomy/project_stats_spec.rb
+++ b/spec/models/taxonomy/project_stats_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Taxonomy::ProjectStats do
+  let(:project) { create(:taxonomy_project, name: 'A Fancy Group') }
+
+  describe '#todo_count' do
+    it 'returns the total number of todos' do
+      create(:taxonomy_todo, taxonomy_project: project)
+      create(:taxonomy_todo, taxonomy_project: project)
+
+      stats = Taxonomy::ProjectStats.new(project)
+
+      expect(stats.todo_count).to eql(2)
+    end
+  end
+
+  describe '#done_count' do
+    it 'returns the number of done todos' do
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project)
+
+      stats = Taxonomy::ProjectStats.new(project)
+
+      expect(stats.done_count).to eql(2)
+    end
+  end
+
+  describe '#still_todo_count' do
+    it 'returns the number of todos still to do' do
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project)
+
+      stats = Taxonomy::ProjectStats.new(project)
+
+      expect(stats.still_todo_count).to eql(1)
+    end
+  end
+
+  describe '#progress_percentage' do
+    it 'returns percentage of todos done' do
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project)
+
+      stats = Taxonomy::ProjectStats.new(project)
+
+      expect(stats.progress_percentage).to eql(75.0)
+    end
+  end
+end


### PR DESCRIPTION
This adds progress stats to the taxonomy project page. Users can use
this to see how much work they still have to do.

## Screenshot

<img width="1197" alt="screen shot 2017-06-28 at 11 28 28" src="https://user-images.githubusercontent.com/233676/27632879-fc10e79a-5bf4-11e7-99fe-d3243161cc28.png">

https://trello.com/c/FfihRuUx