### PR TITLE
Allow users to create taxonomy projects

### DIFF
--- a/app/controllers/taxonomy_projects_controller.rb
+++ b/app/controllers/taxonomy_projects_controller.rb
@@ -7,6 +7,16 @@ class TaxonomyProjectsController < ApplicationController
     @project = TaxonomyProject.find(params[:id])
   end
 
+  def new
+    @form = NewTaxonomyProject.new
+  end
+
+  def create
+    form = NewTaxonomyProject.new(taxonomy_project_params)
+    form.save
+    redirect_to taxonomy_project_path(form.project_id)
+  end
+
   def next
     project = TaxonomyProject.find(params[:id])
 
@@ -17,5 +27,11 @@ class TaxonomyProjectsController < ApplicationController
     else
       redirect_to project, notice: "All done!"
     end
+  end
+
+private
+
+  def taxonomy_project_params
+    params.require(:new_taxonomy_project).permit(:name, :csv_url)
   end
 end

--- a/app/forms/new_taxonomy_project.rb
+++ b/app/forms/new_taxonomy_project.rb
@@ -1,0 +1,25 @@
+class NewTaxonomyProject
+  include ActiveModel::Model
+  attr_accessor :name, :csv_url
+
+  def save
+    project = create_project
+    create_todos(project)
+  end
+
+  def project_id
+    create_project.id
+  end
+
+private
+
+  def create_project
+    @project ||= TaxonomyProject.create!(name: name)
+  end
+
+  def create_todos(project)
+    csv = RemoteCsv.new(csv_url)
+    importer = Importers::TodosForTaxonomyProject.new(project, csv)
+    importer.run
+  end
+end

--- a/app/models/importers/todos_for_taxonomy_project.rb
+++ b/app/models/importers/todos_for_taxonomy_project.rb
@@ -1,9 +1,9 @@
 module Importers
   class TodosForTaxonomyProject
-    attr_reader :errors, :completed
+    attr_reader :errors, :completed, :project
 
-    def initialize(group_name, csv_parser)
-      @name = group_name
+    def initialize(project, csv_parser)
+      @project = project
       @csv_parser = csv_parser
       @completed = []
       @errors = []
@@ -14,7 +14,7 @@ module Importers
         @csv_parser.each_row do |row|
           content_item = ContentItem.find_by(content_id: row['content_id'])
           if content_item
-            TaxonomyTodo.create(
+            TaxonomyTodo.create!(
               taxonomy_project: project,
               content_item: content_item
             )
@@ -34,10 +34,6 @@ module Importers
 
     def track_success(id)
       @completed << id
-    end
-
-    def project
-      @_project ||= TaxonomyProject.create(name: @name)
     end
   end
 end

--- a/app/views/taxonomy_projects/index.html.erb
+++ b/app/views/taxonomy_projects/index.html.erb
@@ -1,5 +1,9 @@
 <h1>Taxonomy projects</h1>
 
+<p>
+  <%= link_to "New project", new_taxonomy_project_path, class: 'btn btn-md btn-default' %>
+</p>
+
 <table class="table table-bordered table-hover">
   <thead>
   <tr class="table-header">

--- a/app/views/taxonomy_projects/new.html.erb
+++ b/app/views/taxonomy_projects/new.html.erb
@@ -1,0 +1,53 @@
+<h1>Create new project</h1>
+
+<div class='row'>
+  <div class='col-md-8'>
+    <%= form_for @form, url: taxonomy_projects_path do |f| %>
+      <div class="form-group">
+        <%= f.label :name, "Name", class: "control-label" %>
+
+        <div class="form-wrapper">
+          <%= f.text_field :name, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :csv_url, "Google Spreadsheet URL", class: "control-label" %>
+
+        <div class="form-wrapper">
+          <%= f.text_field :csv_url, class: "form-control" %>
+        </div>
+
+        <p>The spreadsheet should have a <code>content_id</code> column with the
+          content IDs of the pages. </p>
+      </div>
+
+      <%= f.submit "Save", class: "btn btn-success" %>
+    <% end %>
+  </div>
+
+  <div class='col-md-4'>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="panel-title">
+          <i class="glyphicon glyphicon-info-sign"></i>
+          How to generate a Google Spreadsheet URL
+        </div>
+      </div>
+      <div class="panel-body">
+        <p>In order to create a publicly available Google Spreadsheet URL, follow these instructions:</p>
+        <ul>
+          <li>Click <strong>File > Publish to the web</strong></li>
+          <li>In the <strong>Link</strong> tab, select the sheet you want to make public in the first dropdown and <strong>Tab-separated values (.tsv)</strong> in the second dropdown</li>
+          <li>Finalise by clicking <strong>Publish</strong> and copying the link</li>
+        </ul>
+
+        <p class='explain'>
+          See the <%= link_to "example spreadsheet",
+            "https://docs.google.com/spreadsheets/d/1tR07OxVJoak04KuHj-clH2fHDuHiy3JOMNOMJB7cnzA/pub?gid=2031568164&single=true&output=tsv" %>
+            for the correct format.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   resources :audits, only: %w(index)
 
-  resources :taxonomy_projects, path: '/taxonomy-projects', only: %w(index show) do
+  resources :taxonomy_projects, path: '/taxonomy-projects', only: %w(index show new create) do
     get 'next', on: :member
   end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -34,7 +34,8 @@ namespace :import do
   desc 'Import todos for taxonomy project'
   task :todos_for_taxonomy_project, [:name, :csv_url] => :environment do |_, args|
     csv = RemoteCsv.new(args.csv_url)
-    importer = Importers::TodosForTaxonomyProject.new(args.name, csv)
+    project = TaxonomyProject.create(args.name)
+    importer = Importers::TodosForTaxonomyProject.new(project, csv)
     importer.run
     puts "Imported #{importer.completed.size} with #{importer.errors.size} errors"
   end

--- a/spec/features/taxonomy_generation/taxonomy_generation_spec.rb
+++ b/spec/features/taxonomy_generation/taxonomy_generation_spec.rb
@@ -1,17 +1,42 @@
 require "rails_helper"
 
 RSpec.feature "Taxonomy generation", type: :feature do
-  it "has an index page" do
-    taxonomy_project = create(:taxonomy_project, name: "Project Foo")
-    create(:taxonomy_todo, taxonomy_project: taxonomy_project, content_item: create(:content_item, title: "Title Foo"))
-    create(:taxonomy_todo, taxonomy_project: taxonomy_project, content_item: create(:content_item, title: "Title Bar"))
+  scenario "User creates a project" do
+    when_i_visit_the_projects_page
+    and_i_click_on_the_new_project_button
+    and_i_submit_a_new_project
+    then_i_should_see_the_project
+  end
 
+  def when_i_visit_the_projects_page
     visit taxonomy_projects_path
+  end
 
-    click_on "Project Foo"
+  def and_i_click_on_the_new_project_button
+    click_link "New project"
+  end
 
+  def and_i_submit_a_new_project
+    create(:content_item, title: "Page Foo", content_id: "5d18871a-6d63-49aa-9c60-3bf7856aab84")
+    create(:content_item, title: "Page Bar", content_id: "5b4b844c-cf63-4a27-814c-a03b2c4b16ae")
+
+    csv = <<-doc
+content_id
+5d18871a-6d63-49aa-9c60-3bf7856aab84
+5b4b844c-cf63-4a27-814c-a03b2c4b16ae
+    doc
+
+    stub_request(:get, "https://example.org/spreadsheet.csv").
+      to_return(status: 200, body: csv)
+
+    fill_in :new_taxonomy_project_name, with: "Project Foo"
+    fill_in :new_taxonomy_project_csv_url, with: "https://example.org/spreadsheet.csv"
+    click_button "Save"
+  end
+
+  def then_i_should_see_the_project
     expect(page).to have_content "Project Foo"
-    expect(page).to have_content "Title Foo"
-    expect(page).to have_content "Title Bar"
+    expect(page).to have_content "Page Foo"
+    expect(page).to have_content "Page Bar"
   end
 end

--- a/spec/models/importers/todos_for_taxonomy_project_spec.rb
+++ b/spec/models/importers/todos_for_taxonomy_project_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Importers::TodosForTaxonomyProject do
-  subject { described_class.new("foo bar", csv_parser) }
+  subject { described_class.new(create(:taxonomy_project), csv_parser) }
   let(:csv_parser) { double(:remote_csv_parser_service) }
   let(:content_item) { create(:content_item) }
 
@@ -12,11 +12,6 @@ RSpec.describe Importers::TodosForTaxonomyProject do
   end
 
   describe "#run" do
-    it "creates a taxonomy project" do
-      expect { subject.run }.to change(TaxonomyProject, :count).from(0).to(1)
-      expect(TaxonomyProject.first.name).to eql "foo bar"
-    end
-
     it "creates the taxonomy todos" do
       expect { subject.run }.to change(TaxonomyTodo, :count).from(0).to(1)
     end


### PR DESCRIPTION
This adds interface for users to create new projects. This should make it easier to test by content designers, because there's no developer involvement.

Because the todos are created in the request, this might not work for large spreadsheets (the page might time out). In that case we can still use the rake task.

https://trello.com/c/Ng5Ggpsw