### PR TITLE
Allow users to mark pages as not relevant or "don't know"

### DIFF
--- a/app/assets/stylesheets/_term_generation.scss
+++ b/app/assets/stylesheets/_term_generation.scss
@@ -1,0 +1,3 @@
+.state-changers .button_to {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import 'report';
 @import 'inventory';
 @import 'bootstrap-tagsinput';
+@import 'term_generation';
 
 // TODO: move any styles below to modules once more established
 

--- a/app/controllers/taxonomy_todos_controller.rb
+++ b/app/controllers/taxonomy_todos_controller.rb
@@ -12,6 +12,26 @@ class TaxonomyTodosController < ApplicationController
     redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
   end
 
+  def dont_know
+    taxonomy_todo.update!(
+      status: TaxonomyTodo::STATE_DONT_KNOW,
+      completed_at: Time.zone.now,
+      completed_by: current_user.uid
+    )
+
+    redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
+  end
+
+  def not_relevant
+    taxonomy_todo.update!(
+      status: TaxonomyTodo::STATE_NOT_RELEVANT,
+      completed_at: Time.zone.now,
+      completed_by: current_user.uid
+    )
+
+    redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
+  end
+
 private
 
   def taxonomy_todo

--- a/app/controllers/taxonomy_todos_controller.rb
+++ b/app/controllers/taxonomy_todos_controller.rb
@@ -13,21 +13,13 @@ class TaxonomyTodosController < ApplicationController
   end
 
   def dont_know
-    taxonomy_todo.update!(
-      status: TaxonomyTodo::STATE_DONT_KNOW,
-      completed_at: Time.zone.now,
-      completed_by: current_user.uid
-    )
+    taxonomy_todo.change_state!(TaxonomyTodo::STATE_DONT_KNOW, current_user)
 
     redirect_to_next_item
   end
 
   def not_relevant
-    taxonomy_todo.update!(
-      status: TaxonomyTodo::STATE_NOT_RELEVANT,
-      completed_at: Time.zone.now,
-      completed_by: current_user.uid
-    )
+    taxonomy_todo.change_state!(TaxonomyTodo::STATE_NOT_RELEVANT, current_user)
 
     redirect_to_next_item
   end

--- a/app/controllers/taxonomy_todos_controller.rb
+++ b/app/controllers/taxonomy_todos_controller.rb
@@ -9,7 +9,7 @@ class TaxonomyTodosController < ApplicationController
     todo_form.user = current_user
     todo_form.save
 
-    redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
+    redirect_to_next_item
   end
 
   def dont_know
@@ -19,7 +19,7 @@ class TaxonomyTodosController < ApplicationController
       completed_by: current_user.uid
     )
 
-    redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
+    redirect_to_next_item
   end
 
   def not_relevant
@@ -29,10 +29,14 @@ class TaxonomyTodosController < ApplicationController
       completed_by: current_user.uid
     )
 
-    redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
+    redirect_to_next_item
   end
 
 private
+
+  def redirect_to_next_item
+    redirect_to next_taxonomy_project_path(taxonomy_todo.taxonomy_project)
+  end
 
   def taxonomy_todo
     @taxonomy_todo ||= TaxonomyTodo.find(params[:id])

--- a/app/forms/taxonomy_todo_form.rb
+++ b/app/forms/taxonomy_todo_form.rb
@@ -18,11 +18,7 @@ class TaxonomyTodoForm
 private
 
   def update_todo
-    taxonomy_todo.update!(
-      status: TaxonomyTodo::STATE_TAGGED,
-      completed_at: Time.zone.now,
-      completed_by: user.uid
-    )
+    taxonomy_todo.change_state!(TaxonomyTodo::STATE_TAGGED, user)
   end
 
   def save_terms

--- a/app/forms/taxonomy_todo_form.rb
+++ b/app/forms/taxonomy_todo_form.rb
@@ -19,6 +19,7 @@ private
 
   def update_todo
     taxonomy_todo.update!(
+      status: TaxonomyTodo::STATE_TAGGED,
       completed_at: Time.zone.now,
       completed_by: user.uid
     )

--- a/app/models/taxonomy_todo.rb
+++ b/app/models/taxonomy_todo.rb
@@ -1,9 +1,9 @@
 class TaxonomyTodo < ApplicationRecord
-  STATE_TODO = 'todo'
-  STATE_TAGGED = 'tagged'
-  STATE_NOT_RELEVANT = 'not-relevant'
-  STATE_DONT_KNOW = 'dont-know'
-  DONE_STATES = [STATE_TAGGED, STATE_NOT_RELEVANT, STATE_DONT_KNOW]
+  STATE_TODO = 'todo'.freeze
+  STATE_TAGGED = 'tagged'.freeze
+  STATE_NOT_RELEVANT = 'not-relevant'.freeze
+  STATE_DONT_KNOW = 'dont-know'.freeze
+  DONE_STATES = [STATE_TAGGED, STATE_NOT_RELEVANT, STATE_DONT_KNOW].freeze
 
   belongs_to :content_item
   belongs_to :taxonomy_project

--- a/app/models/taxonomy_todo.rb
+++ b/app/models/taxonomy_todo.rb
@@ -1,13 +1,19 @@
 class TaxonomyTodo < ApplicationRecord
+  STATE_TODO = 'todo'
+  STATE_TAGGED = 'tagged'
+  STATE_NOT_RELEVANT = 'not-relevant'
+  STATE_DONT_KNOW = 'dont-know'
+  DONE_STATES = [STATE_TAGGED, STATE_NOT_RELEVANT, STATE_DONT_KNOW]
+
   belongs_to :content_item
   belongs_to :taxonomy_project
   has_and_belongs_to_many :terms
   belongs_to :user, primary_key: :uid, foreign_key: :completed_by, optional: true
 
-  scope :still_todo, -> { where(completed_at: nil) }
-  scope :done, -> { where('completed_at IS NOT NULL') }
+  scope :still_todo, -> { where(status: STATE_TODO) }
+  scope :done, -> { where(status: DONE_STATES) }
 
   def completed?
-    completed_at && completed_by
+    status.in?(DONE_STATES)
   end
 end

--- a/app/models/taxonomy_todo.rb
+++ b/app/models/taxonomy_todo.rb
@@ -17,6 +17,10 @@ class TaxonomyTodo < ApplicationRecord
     status.in?(DONE_STATES)
   end
 
+  def tagged?
+    status == STATE_TAGGED
+  end
+
   def change_state!(state, user)
     update!(
       status: state,

--- a/app/models/taxonomy_todo.rb
+++ b/app/models/taxonomy_todo.rb
@@ -16,4 +16,12 @@ class TaxonomyTodo < ApplicationRecord
   def completed?
     status.in?(DONE_STATES)
   end
+
+  def change_state!(state, user)
+    update!(
+      status: state,
+      completed_at: Time.zone.now,
+      completed_by: user.uid
+    )
+  end
 end

--- a/app/views/taxonomy_projects/show.html.erb
+++ b/app/views/taxonomy_projects/show.html.erb
@@ -59,7 +59,7 @@
         <td>
           <% if taxonomy_todo.completed? %>
             <%= taxonomy_todo.completed_at.to_s(:govuk_date) %> by <%= taxonomy_todo.user.name %>
-            <% if taxonomy_todo.status != "tagged" %>
+            <% unless taxonomy_todo.tagged? %>
               (<%= t("term_generation_states.#{taxonomy_todo.status}") %>)
             <% end %>
           <% end %>

--- a/app/views/taxonomy_projects/show.html.erb
+++ b/app/views/taxonomy_projects/show.html.erb
@@ -59,6 +59,9 @@
         <td>
           <% if taxonomy_todo.completed? %>
             <%= taxonomy_todo.completed_at.to_s(:govuk_date) %> by <%= taxonomy_todo.user.name %>
+            <% if taxonomy_todo.status != "tagged" %>
+              (<%= t("term_generation_states.#{taxonomy_todo.status}") %>)
+            <% end %>
           <% end %>
           </td>
       </tr>

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -39,6 +39,9 @@
     <%= @todo_form.description %>
   </p>
 
+  <%= button_to "I don't know", dont_know_taxonomy_todo_path(@todo_form.taxonomy_todo) %>
+  <%= button_to "This page is not relevant / relevant to different theme", not_relevant_taxonomy_todo_path(@todo_form.taxonomy_todo) %>
+
   <%= form_for @todo_form, url: taxonomy_todo_path(@todo_form.taxonomy_todo), method: 'put' do |f| %>
     <div class='form-group'>
       <%= f.label :new_terms, "New terms:", class: 'control-label' %>

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -39,9 +39,6 @@
     <%= @todo_form.description %>
   </p>
 
-  <%= button_to "I don't know", dont_know_taxonomy_todo_path(@todo_form.taxonomy_todo) %>
-  <%= button_to "This page is not relevant / relevant to different theme", not_relevant_taxonomy_todo_path(@todo_form.taxonomy_todo) %>
-
   <%= form_for @todo_form, url: taxonomy_todo_path(@todo_form.taxonomy_todo), method: 'put' do |f| %>
     <div class='form-group'>
       <%= f.label :new_terms, "New terms:", class: 'control-label' %>
@@ -52,11 +49,16 @@
 
     <%= f.submit "Save", class: "btn btn-success" %>
   <% end %>
+  or
+
+  <div class='state-changers'>
+    <%= button_to "I don't know", dont_know_taxonomy_todo_path(@todo_form.taxonomy_todo), class: 'btn btn-md btn-default' %>
+    <%= button_to "This page is not relevant / relevant to different theme", not_relevant_taxonomy_todo_path(@todo_form.taxonomy_todo), class: 'btn btn-md btn-default' %>
+  </div>
 
   <div class="add-top-padding">
     <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="800" scrolling="yes"></iframe>
   </div>
-
 </div>
 
 <div class="col-sm-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,7 @@
 
 en:
   hello: "Hello world"
+
+  term_generation_states:
+    dont-know: "Don't know"
+    not-relevant: "Not relevant to theme"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,10 @@ Rails.application.routes.draw do
     get 'next', on: :member
   end
 
-  resources :taxonomy_todos, only: %w(show update)
+  resources :taxonomy_todos, only: %w(show update) do
+    post 'dont_know', on: :member
+    post 'not_relevant', on: :member
+  end
 
   namespace :audits do
     get :report

--- a/db/migrate/20170706143917_add_status_to_taxonomy_todos.rb
+++ b/db/migrate/20170706143917_add_status_to_taxonomy_todos.rb
@@ -1,0 +1,5 @@
+class AddStatusToTaxonomyTodos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :taxonomy_todos, :status, :string, default: 'todo'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706143916) do
+ActiveRecord::Schema.define(version: 20170706143917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 20170706143916) do
     t.string "completed_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "todo"
     t.index ["content_item_id"], name: "index_taxonomy_todos_on_content_item_id"
     t.index ["taxonomy_project_id"], name: "index_taxonomy_todos_on_taxonomy_project_id"
   end

--- a/spec/features/taxonomy_generation/generate_terms_spec.rb
+++ b/spec/features/taxonomy_generation/generate_terms_spec.rb
@@ -15,6 +15,30 @@ RSpec.feature "Generating terms", type: :feature do
     then_i_see_the_generated_terms
   end
 
+  it "allows users to say that they don't know" do
+    given_theres_a_project_with_todos
+
+    when_i_visit_the_taxonomy_project_page
+    and_i_click_to_start_with_a_project
+    then_i_should_see_a_page
+
+    when_i_click_i_dont_know
+    then_the_todo_is_marked_as_dont_know
+    and_i_see_the_next_page
+  end
+
+  it "allows users to say that the page isn't relevant" do
+    given_theres_a_project_with_todos
+
+    when_i_visit_the_taxonomy_project_page
+    and_i_click_to_start_with_a_project
+    then_i_should_see_a_page
+
+    when_i_click_this_is_not_relevant
+    then_the_todo_is_marked_as_irrelevant
+    and_i_see_the_next_page
+  end
+
   def given_theres_a_project_with_todos
     @project = create(:taxonomy_project, name: 'A Fancy Group')
 
@@ -42,6 +66,21 @@ RSpec.feature "Generating terms", type: :feature do
     @todo.reload
   end
 
+  def when_i_click_i_dont_know
+    click_button "I don't know"
+    @todo.reload
+  end
+
+  def when_i_click_this_is_not_relevant
+    click_button "This page is not relevant / relevant to different theme"
+    @todo.reload
+  end
+
+  def then_the_todo_is_marked_as_dont_know
+    expect(@todo).to be_completed
+    expect(@todo.status).to eql(TaxonomyTodo::STATE_DONT_KNOW)
+  end
+
   def then_the_term_is_saved
     expect(@todo).to be_completed
     expect(@todo.terms.count).to eql(3)
@@ -49,6 +88,11 @@ RSpec.feature "Generating terms", type: :feature do
 
   def and_i_see_the_next_page
     expect(page.body).not_to match "A Fancy Content Item"
+  end
+
+  def then_the_todo_is_marked_as_irrelevant
+    expect(@todo).to be_completed
+    expect(@todo.status).to eql(TaxonomyTodo::STATE_NOT_RELEVANT)
   end
 
   def when_i_go_to_the_project_page

--- a/spec/models/taxonomy/project_stats_spec.rb
+++ b/spec/models/taxonomy/project_stats_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Taxonomy::ProjectStats do
 
   describe '#done_count' do
     it 'returns the number of done todos' do
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_TAGGED)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_DONT_KNOW)
       create(:taxonomy_todo, taxonomy_project: project)
 
       stats = Taxonomy::ProjectStats.new(project)
@@ -26,8 +26,8 @@ RSpec.describe Taxonomy::ProjectStats do
 
   describe '#still_todo_count' do
     it 'returns the number of todos still to do' do
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_TAGGED)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_DONT_KNOW)
       create(:taxonomy_todo, taxonomy_project: project)
 
       stats = Taxonomy::ProjectStats.new(project)
@@ -38,9 +38,9 @@ RSpec.describe Taxonomy::ProjectStats do
 
   describe '#progress_percentage' do
     it 'returns percentage of todos done' do
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
-      create(:taxonomy_todo, taxonomy_project: project, completed_at: Time.now)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_TAGGED)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_TAGGED)
+      create(:taxonomy_todo, taxonomy_project: project, status: TaxonomyTodo::STATE_TAGGED)
       create(:taxonomy_todo, taxonomy_project: project)
 
       stats = Taxonomy::ProjectStats.new(project)


### PR DESCRIPTION
These buttons will make it easier for content designers to skip a page that is irrelevant (perhaps because it was mistakenly included in a theme) or so difficult to read that it's not clear what the terms would be.

## Screenshots

![screen shot 2017-06-28 at 12 42 57](https://user-images.githubusercontent.com/233676/27635544-5be43546-5bff-11e7-939e-b17859558286.png)

![screen shot 2017-06-28 at 12 43 07](https://user-images.githubusercontent.com/233676/27635550-5ebf7564-5bff-11e7-9c6a-accb0339e659.png)

Trello: https://trello.com/c/RQxMmDdK