### PR TITLE
Hide the audit status filter on the report page

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,5 +1,6 @@
 class AuditsController < ApplicationController
-  helper_method :filter_params, :primary_org_only?, :org_link_type
+  helper_method :filter_params, :primary_org_only?, :org_link_type,
+                :audit_status_filter_enabled?
 
   layout "audit"
 
@@ -66,7 +67,7 @@ private
   def search
     @search ||= (
       search = Search.new
-      filter_by_audit_status!(search)
+      filter_by_audit_status!(search) if audit_status_filter_enabled?
       filter_by_organisation!(search)
       filter_by_theme!(search)
       filter_by_document_type!(search)
@@ -80,6 +81,10 @@ private
     params
       .require(:audit)
       .permit(responses_attributes: [:id, :value, :question_id])
+  end
+
+  def audit_status_filter_enabled?
+    action_name != "report"
   end
 
   def filter_params

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -2,13 +2,15 @@
   <h1>Filter</h1>
   <%= form_tag submit_path, method: :get do %>
 
-    <div class="form-group">
-      <%= label_tag :audit_status, 'Audit status' %>
-      <%= select_tag :audit_status,
-          audit_status_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
+    <% if audit_status_filter_enabled? %>
+      <div class="form-group">
+        <%= label_tag :audit_status, 'Audit status' %>
+        <%= select_tag :audit_status,
+        audit_status_options,
+        include_blank: "All",
+        class: "form-control" %>
+      </div>
+    <% end %>
 
     <div class="form-group">
       <%= label_tag :theme, 'Theme' %>

--- a/spec/features/report/csv_export_spec.rb
+++ b/spec/features/report/csv_export_spec.rb
@@ -7,14 +7,33 @@ RSpec.feature "Exporting a CSV from the report page" do
     page.response_headers.fetch("Content-Disposition")
   end
 
-  before do
-    example = FactoryGirl.create(
+  let!(:hmrc) {
+    FactoryGirl.create(
       :content_item,
-      title: "Example",
-      base_path: "/example",
+      title: "HMRC",
+      document_type: "organisation"
+    )
+  }
+
+  before do
+    example1 = FactoryGirl.create(
+      :content_item,
+      title: "Example 1",
+      base_path: "/example1",
     )
 
-    FactoryGirl.create(:audit, content_item: example)
+    FactoryGirl.create(
+      :link,
+      source_content_id: example1.content_id,
+      target_content_id: hmrc.content_id,
+      link_type: "primary_publishing_organisation",
+    )
+
+    FactoryGirl.create(
+      :content_item,
+      title: "Example 2",
+      base_path: "/example2",
+    )
   end
 
   scenario "Exporting a csv file as an attachment" do
@@ -28,13 +47,13 @@ RSpec.feature "Exporting a CSV from the report page" do
     )
 
     expect(page).to have_content("Title,URL")
-    expect(page).to have_content("Example,https://gov.uk/example")
+    expect(page).to have_content("Example 1,https://gov.uk/example1")
   end
 
   scenario "Applying the filters to the export" do
     visit audits_report_path
 
-    select "Non Audited", from: "audit_status"
+    select "HMRC (1)", from: "organisations"
     click_on "Filter"
 
     click_link "Export filtered audit to CSV"

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -57,27 +57,9 @@ RSpec.feature "Reporting on audit progress" do
     expect(width("#items-needing-improvement")).to eq("width: 50%;")
   end
 
-  scenario "Displaying sensible output when 'audit_status' is selected" do
+  scenario "Audit status filter is not present" do
     visit audits_report_path
 
-    select "Audited", from: "audit_status"
-    click_on "Filter"
-
-    expect(page).to have_content("2 Content items")
-    expect(page).to have_content("Items audited 2 100%")
-    expect(page).to have_content("Items still to audit 0 0%")
-    expect(page).to have_content("Items that need improvement 1 50%")
-    expect(page).to have_content("Items that don't need improvement 1 50%")
-    expect(width("#progress")).to eq("width: 100%;")
-
-    select "Non Audited", from: "audit_status"
-    click_on "Filter"
-
-    expect(page).to have_content("1 Content items")
-    expect(page).to have_content("Items audited 0 0%")
-    expect(page).to have_content("Items still to audit 1 100%")
-    expect(page).to have_content("Items that need improvement 0 0%")
-    expect(page).to have_content("Items that don't need improvement 0 0%")
-    expect(width("#items-needing-improvement")).to eq("width: 0%;")
+    expect(page).to have_no_content("Audit status")
   end
 end

--- a/spec/features/report/tabs_spec.rb
+++ b/spec/features/report/tabs_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature "Tabs" do
     expect(page).to have_select("audit_status", selected: "Audited")
 
     click_link "Report"
-    expect(page).to have_select("audit_status", selected: "Audited")
 
     click_link "Content"
     expect(page).to have_select("audit_status", selected: "Audited")


### PR DESCRIPTION
Also, don't filter by audit status at all on the report page.