### PR TITLE
Provide a checkbox to toggle primary/all orgs. filter

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -19,14 +19,14 @@ module DropdownHelper
     )
   end
 
-  def link_type_options(link_type)
-    options = @search.options_for(link_type).order(:title)
+  def organisation_options
+    options = @search.options_for(org_link_type).order(:title)
 
     options_from_collection_for_select(
       options,
       :content_id,
       :title_with_count,
-      selected: params[link_type],
+      selected: params[:organisations],
     )
   end
 

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -27,7 +27,7 @@
     </div>
 
     <div class="form-group">
-      <%= hidden_field_tag :primary, false %>
+      <%= hidden_field_tag :primary, false, id: nil %>
       <%= check_box_tag :primary, true, primary_org_only? %>
       <%= label_tag :primary, "Primary organisation only" %>
     </div>

--- a/app/views/audits/_sidebar.html.erb
+++ b/app/views/audits/_sidebar.html.erb
@@ -18,15 +18,19 @@
           class: "form-control" %>
     </div>
 
-    <% Search::FILTERABLE_LINK_TYPES.each do |link_type| %>
-      <div class="form-group">
-        <%= label_tag link_type, link_type.titleize.singularize %>
-        <%= select_tag link_type,
-            link_type_options(link_type),
-            include_blank: "All",
-            class: "form-control" %>
-      </div>
-    <% end %>
+    <div class="form-group">
+      <%= label_tag :organisations, "Organisation" %>
+      <%= select_tag :organisations,
+          organisation_options,
+          include_blank: "All",
+          class: "form-control" %>
+    </div>
+
+    <div class="form-group">
+      <%= hidden_field_tag :primary, false %>
+      <%= check_box_tag :primary, true, primary_org_only? %>
+      <%= label_tag :primary, "Primary organisation only" %>
+    </div>
 
     <div class="form-group">
       <%= label_tag :document_type, 'Content type' %>

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -104,6 +104,16 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     expect(page).to have_no_content("DFE")
   end
 
+  scenario "toggling the primary org checkbox by clicking its label" do
+    visit audits_path
+
+    page.find("label[for='primary']").click
+    expect(page.find("#primary")).not_to be_checked
+
+    page.find("label[for='primary']").click
+    expect(page.find("#primary")).to be_checked
+  end
+
   scenario "organisations are in alphabetical order" do
     visit audits_path
 

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -26,8 +26,10 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
   before do
     # Links:
+    FactoryGirl.create(:link, source: vat, target: hmrc, link_type: "primary_publishing_organisation")
+    FactoryGirl.create(:link, source: felling, target: dfe, link_type: "primary_publishing_organisation")
     FactoryGirl.create(:link, source: vat, target: hmrc, link_type: "organisations")
-    FactoryGirl.create(:link, source: felling, target: dfe, link_type: "organisations")
+    FactoryGirl.create(:link, source: insurance, target: hmrc, link_type: "organisations")
     FactoryGirl.create(:link, source: insurance, target: flying, link_type: "policies")
     FactoryGirl.create(:link, source: felling, target: management, link_type: "policies")
 
@@ -65,8 +67,10 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     expect(page).to have_select("audit_status", selected: "Non Audited")
   end
 
-  scenario "filtering by organisation" do
+  scenario "filtering by primary organisation" do
     visit audits_path
+    expect(page.find("#primary")).to be_checked
+
     select "HMRC", from: "organisations"
 
     click_on "Filter"
@@ -82,6 +86,22 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     click_on "Filter"
     expect(page).to have_no_content("HMRC (0)")
     expect(page).to have_content("DFE (1)")
+  end
+
+  scenario "filtering by organisation" do
+    visit audits_path
+    uncheck "primary"
+
+    select "HMRC", from: "organisations"
+
+    click_on "Filter"
+
+    expect(page).to have_content("VAT")
+    expect(page).to have_content("Travel insurance")
+    expect(page).to have_no_content("Tree felling")
+
+    expect(page).to have_content("HMRC (2)")
+    expect(page).to have_no_content("DFE")
   end
 
   scenario "organisations are in alphabetical order" do


### PR DESCRIPTION
https://trello.com/c/MzAVD2dG/320-2-update-org-filter-to-toggle-primary-filter-on-off

The hidden field means the URL param is set to
false when not explicitly overriden by the
checkbox. We need to do this because we want to
checkbox to default to checked.

The count of content for each organisation will
depend on whether the checkbox is selected during
page load. If the user changes the checkbox, those
numbers won’t be updated immediately.

We’d need to progressively enhance the form with
JS to solve this problem.