### PR TITLE
Change audit tool page layout

### DIFF
--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -1,6 +1,4 @@
 .prev-next-links {
-  margin: 5em 0 3em 0;
-
   a {
     font-size: 16px;
     color: black;
@@ -18,6 +16,10 @@
 
 .description {
   margin: 2em 0 4em 0;
+}
+
+.header-row {
+  margin-bottom: 1.5em;
 }
 
 .question {

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -46,8 +46,6 @@
 }
 
 .audit-metadata {
-  margin-left: 2em;
-
   h4 {
     margin-top: 2em;
   }

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,5 +1,8 @@
 class AuditsController < ApplicationController
   helper_method :filter_params, :primary_org_only?, :org_link_type
+
+  layout "audit"
+
   before_action :content_items, only: %i(index report export)
 
   def index

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -3,8 +3,7 @@
   <%= render 'sidebar', submit_path: audits_path %>
 <% end %>
 
-<h1>GOV.UK Content Audit</h1>
-
+<% content_for :header do %>
 <ul class="nav nav-tabs">
   <li role="presentation" class="active">
     <%= link_to "Content", "#", aria_controls: "home", role: "tab" %>
@@ -13,8 +12,7 @@
     <%= link_to "Report", audits_report_path(filter_params), aria_controls: "home", role: "tab" %>
   </li>
 </ul>
-
-<div class="tab-content">
+<% end %>
 
 <table class="table table-bordered table-hover">
   <thead>
@@ -29,5 +27,3 @@
 </table>
 
 <%= paginate @content_items, :window => 2 %>
-
-</div>

--- a/app/views/audits/report.html.erb
+++ b/app/views/audits/report.html.erb
@@ -2,8 +2,7 @@
   <%= render 'sidebar', submit_path: audits_report_path %>
 <% end %>
 
-<h1>GOV.UK Content Audit</h1>
-
+<% content_for :header do %>
 <ul class="nav nav-tabs">
   <li role="presentation">
     <%= link_to "Content", audits_path(filter_params), aria_controls: "home", role: "tab" %>
@@ -12,10 +11,8 @@
     <%= link_to "Report", "#", aria_controls: "home", role: "tab" %>
   </li>
 </ul>
+<% end %>
 
-<div class="tab-content">
-
-<br>
 <%= link_to "Export filtered audit to CSV", audits_export_path(filter_params), class: "report-export" %>
 
 <div class="report-section">
@@ -59,6 +56,4 @@
       <td class="col-md-3"><%= format_percentage(not_passing_percentage) %></td>
     </tr>
   </table>
-</div>
-
 </div>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -53,6 +53,8 @@
   <% end %>
 </div>
 
+<div class="col-sm-1"></div>
+
 <div class="col-sm-4">
   <div id="metadata" class="audit-metadata">
     <div id="audited">

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -15,8 +15,6 @@
     </div>
   <% end %>
 
-  <h1>GOV.UK Content Audit</h1>
-
   <nav class="prev-next-links">
     <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
     <%= link_to "Next", content_item_audit_path(@next_item, filter_params), class: "next-item" if @next_item %>

--- a/app/views/layouts/audit.html.erb
+++ b/app/views/layouts/audit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title do %>
+  Content Audit Tool
+<% end %>
+
+<% content_for :app_title do %>
+  Content Audit Tool
+<% end %>
+
+<% content_for :head do %>
+  <%= csrf_meta_tags %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+<% end %>
+
+<% content_for :content do %>
+  <%= render 'application/phase_banner' %>
+  <div class="row header-row">
+    <div class="col-md-12">
+      <%= yield :header %>
+    </div>
+  </div>
+  <div class="row">
+    <%= yield :sidebar %>
+    <div class="<%= content_for?(:sidebar) ? 'col-sm-9' : ''%>">
+      <%= yield %>
+    </div>
+  </div>
+<% end %>
+
+<%= render file: 'layouts/govuk_admin_template' %>


### PR DESCRIPTION
Trello: https://trello.com/c/CBBXXiS3/330-remove-the-audit-status-drop-down-on-the-reports-page

![audit-index](https://user-images.githubusercontent.com/1130010/27645575-5183a75c-5c1e-11e7-9ecc-fba10a223995.png)
![audit-report](https://user-images.githubusercontent.com/1130010/27645577-51d30f2c-5c1e-11e7-889d-9390ef65fd56.png)
![audit-show](https://user-images.githubusercontent.com/1130010/27645579-521b260e-5c1e-11e7-8534-91be457840bc.png)
