### PR TITLE
Add autocomplete to term generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'puma'
 gem 'rails', '~> 5.1'
 gem 'sass-rails'
 gem 'turbolinks'
+gem 'twitter-typeahead-rails'
 gem 'uglifier'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,10 @@ GEM
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
+    twitter-typeahead-rails (0.11.1)
+      actionpack (>= 3.1)
+      jquery-rails
+      railties (>= 3.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -469,6 +473,7 @@ DEPENDENCIES
   spring-watcher-listen
   timecop
   turbolinks
+  twitter-typeahead-rails
   uglifier
   unicorn
   web-console

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,3 +12,4 @@
 //
 //= require_tree .
 //= require bootstrap-tagsinput.js
+//= require twitter/typeahead

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import 'report';
 @import 'inventory';
 @import 'bootstrap-tagsinput';
+@import 'bootstrap-tagsinput-typeahead';
 @import 'term_generation';
 
 // TODO: move any styles below to modules once more established

--- a/app/assets/stylesheets/bootstrap-tagsinput-typeahead.css
+++ b/app/assets/stylesheets/bootstrap-tagsinput-typeahead.css
@@ -1,0 +1,54 @@
+/*
+ * bootstrap-tagsinput v0.8.0
+ *
+ */
+
+.twitter-typeahead .tt-query,
+.twitter-typeahead .tt-hint {
+  margin-bottom: 0;
+}
+
+.twitter-typeahead .tt-hint
+{
+  display: none;
+}
+
+.tt-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  list-style: none;
+  font-size: 14px;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  background-clip: padding-box;
+  cursor: pointer;
+}
+
+.tt-suggestion {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.428571429;
+  color: #333333;
+  white-space: nowrap;
+}
+
+.tt-suggestion:hover,
+.tt-suggestion:focus {
+  color: #ffffff;
+  text-decoration: none;
+  outline: 0;
+  background-color: #428bca;
+}

--- a/app/assets/stylesheets/bootstrap-tagsinput.css
+++ b/app/assets/stylesheets/bootstrap-tagsinput.css
@@ -15,6 +15,7 @@
   width: 80%;
   line-height: 22px;
   cursor: text;
+  font-size: 18px;
 }
 .bootstrap-tagsinput input {
   border: none;

--- a/app/controllers/taxonomy_projects_controller.rb
+++ b/app/controllers/taxonomy_projects_controller.rb
@@ -29,6 +29,12 @@ class TaxonomyProjectsController < ApplicationController
     end
   end
 
+  def terms
+    @project = TaxonomyProject.find(params[:id])
+
+    render json: @project.terms.to_json(only: %i(name))
+  end
+
 private
 
   def taxonomy_project_params

--- a/app/controllers/taxonomy_todos_controller.rb
+++ b/app/controllers/taxonomy_todos_controller.rb
@@ -1,6 +1,9 @@
 class TaxonomyTodosController < ApplicationController
   def show
-    @todo_form = TaxonomyTodoForm.new(taxonomy_todo: taxonomy_todo)
+    @todo_form = TaxonomyTodoForm.new(
+      taxonomy_todo: taxonomy_todo,
+      terms: taxonomy_todo.terms.order(:name).pluck(:name).join(', '),
+    )
   end
 
   def update
@@ -35,6 +38,6 @@ private
   end
 
   def todo_params
-    params.require(:taxonomy_todo_form).permit(:new_terms)
+    params.require(:taxonomy_todo_form).permit(:terms)
   end
 end

--- a/app/forms/taxonomy_todo_form.rb
+++ b/app/forms/taxonomy_todo_form.rb
@@ -1,6 +1,6 @@
 class TaxonomyTodoForm
   include ActiveModel::Model
-  attr_accessor :taxonomy_todo, :new_terms, :user
+  attr_accessor :taxonomy_todo, :terms, :user
 
   delegate :title, :url, :description, to: :content_item
 
@@ -22,15 +22,11 @@ private
   end
 
   def save_terms
-    split_terms = new_terms.split(',').map(&:strip)
-
-    split_terms.each do |term_text|
-      term = Term.find_or_create_by!(
-        name: term_text,
-        taxonomy_project: taxonomy_todo.taxonomy_project
-      )
-
-      taxonomy_todo.terms << term
-    end
+    taxonomy_todo.terms =
+      terms
+        .split(',')
+        .map(&:squish)
+        .map { |term| taxonomy_todo.taxonomy_project.terms.where(name: term) }
+        .map(&:first_or_create!)
   end
 end

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -41,10 +41,29 @@
 
   <%= form_for @todo_form, url: taxonomy_todo_path(@todo_form.taxonomy_todo), method: 'put' do |f| %>
     <div class='form-group'>
-      <%= f.label :new_terms, "New terms:", class: 'control-label' %>
+      <%= f.label :terms, 'Terms', class: 'control-label' %>
       <div class='form-wrapper'>
-        <%= f.text_field :new_terms, data: { role: "tagsinput" } %>
+        <%= f.text_field :terms, value: @todo_form.terms %>
       </div>
+      <script>
+        var terms = new Bloodhound({
+          datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
+          queryTokenizer: Bloodhound.tokenizers.whitespace,
+          remote: '<%= terms_taxonomy_project_path(@todo_form.taxonomy_todo.taxonomy_project, format: 'json') %>'
+        });
+
+        terms.initialize();
+
+        $('#taxonomy_todo_form_terms').tagsinput({
+          trimValue: true,
+          typeaheadjs: {
+            name: 'terms',
+            displayKey: 'name',
+            valueKey: 'name',
+            source: terms.ttAdapter()
+          }
+        });
+      </script>
     </div>
 
     <%= f.submit "Save", class: "btn btn-success" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   resources :taxonomy_projects, path: '/taxonomy-projects', only: %w(index show new create) do
     get 'next', on: :member
+    get 'terms', on: :member, constraints: { format: 'json' }
   end
 
   resources :taxonomy_todos, only: %w(show update) do

--- a/spec/features/taxonomy_generation/generate_terms_spec.rb
+++ b/spec/features/taxonomy_generation/generate_terms_spec.rb
@@ -7,12 +7,18 @@ RSpec.feature "Generating terms", type: :feature do
     when_i_visit_the_taxonomy_project_page
     and_i_click_to_start_with_a_project
     then_i_should_see_a_page
-    when_i_submit_a_term
-    then_the_term_is_saved
+    when_i_submit_terms
+    then_the_terms_are_saved
     and_i_see_the_next_page
 
     when_i_go_to_the_project_page
     then_i_see_the_generated_terms
+
+    when_i_go_to_the_complete_todo_page
+    then_i_see_the_previously_generated_terms
+
+    when_i_submit_revised_terms
+    then_the_revised_terms_are_saved
   end
 
   it "allows users to say that they don't know" do
@@ -60,8 +66,14 @@ RSpec.feature "Generating terms", type: :feature do
     expect(page.body).to match "A Fancy Content Item"
   end
 
-  def when_i_submit_a_term
-    fill_in :taxonomy_todo_form_new_terms, with: "The First, The Second, The Third"
+  def when_i_submit_terms
+    fill_in :taxonomy_todo_form_terms, with: "The First, The Second, The Third"
+    click_on "Save"
+    @todo.reload
+  end
+
+  def when_i_submit_revised_terms
+    fill_in :taxonomy_todo_form_terms, with: "The First, The Second, The Forth"
     click_on "Save"
     @todo.reload
   end
@@ -81,9 +93,16 @@ RSpec.feature "Generating terms", type: :feature do
     expect(@todo.status).to eql(TaxonomyTodo::STATE_DONT_KNOW)
   end
 
-  def then_the_term_is_saved
+  def then_the_terms_are_saved
     expect(@todo).to be_completed
-    expect(@todo.terms.count).to eql(3)
+    expect(@todo.terms.pluck(:name))
+      .to contain_exactly('The First', 'The Second', 'The Third')
+  end
+
+  def then_the_revised_terms_are_saved
+    expect(@todo).to be_completed
+    expect(@todo.terms.pluck(:name))
+      .to contain_exactly('The First', 'The Second', 'The Forth')
   end
 
   def and_i_see_the_next_page
@@ -99,9 +118,17 @@ RSpec.feature "Generating terms", type: :feature do
     visit taxonomy_project_path(@project)
   end
 
+  def when_i_go_to_the_complete_todo_page
+    visit taxonomy_todo_path(@todo)
+  end
+
   def then_i_see_the_generated_terms
     expect(page).to have_content 'The First'
     expect(page).to have_content 'The Second'
     expect(page).to have_content 'The Third'
+  end
+
+  def then_i_see_the_previously_generated_terms
+    expect(page).to have_field('Terms', with: 'The First, The Second, The Third')
   end
 end


### PR DESCRIPTION
Adds typeahead functionality to term generation so that a user can easily search for existing terms that have been suggested for the taxonomy project.

Also allows previously completed todos to be have their terms revised.

<img width="809" alt="screen shot 2017-06-28 at 20 17 49" src="https://user-images.githubusercontent.com/2715/27655933-0c293e58-5c3f-11e7-8073-fb03fad56eca.png">

See https://trello.com/c/v256NfML