### PR TITLE
Set the app_home_path in the audit layout

### DIFF
--- a/app/views/layouts/audit.html.erb
+++ b/app/views/layouts/audit.html.erb
@@ -6,6 +6,10 @@
   Content Audit Tool
 <% end %>
 
+<% content_for :app_home_path do %>
+  <%= audits_path %>
+<% end %>
+
 <% content_for :head do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
To link to the audits page, rather than taking users in to the CPM
side of the application.