### PR TITLE
Fix next link for audit show page (take 2) [SEAL IGNORE]

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -10,16 +10,22 @@ class AuditsController < ApplicationController
 
   def show
     audit.questions = audit.template.questions if audit.new_record?
-    next_item
+    compute_next_item_and_page
   end
 
   def save
     audit.user = current_user
+    # Compute the next_item before updating the audit. As the
+    # next_content_item functionality depends on finding the current
+    # item in the search, if updating the audit removes the current
+    # item from the search, this can mean that the next item can't be
+    # found.
+    compute_next_item_and_page
     updated = audit.update(audit_params)
 
-    if next_item && updated
+    if @next_item && updated
       flash.notice = "Saved successfully and continued to next item."
-      redirect_to content_item_audit_path(next_item, filter_params)
+      redirect_to content_item_audit_path(@next_item, @next_link_filter_params)
     elsif updated
       flash.now.notice = "Saved successfully."
       render :show
@@ -59,8 +65,34 @@ private
     @content_items ||= search.content_items.decorate
   end
 
-  def next_item
-    @next_item ||= content_items.next_item(content_item)
+  def compute_next_item_and_page
+    # Get a list of ContentItem ids for everything on the current
+    # page, and also the first element on the next page so that
+    # advancing between pages is possible
+    content_item_ids = content_items.object.limit(
+      content_items.object.limit_value + 1
+    ).pluck(:id)
+
+    current_item_index = content_item_ids.index(content_item.id)
+
+    # Give up if the current item can't be found
+    return unless current_item_index
+
+    next_item_index = current_item_index + 1
+    @next_item = ContentItem.find_by(id: content_item_ids[next_item_index])
+    @next_link_filter_params = filter_params.deep_dup
+
+    if next_item_index >= search.per_page
+      # Adjust the page parameter, so that it reflects the current
+      # position of this next item. Without adjusting this, the Next
+      # link on the next item page won't work, as the scope of the
+      # search will be the current page.
+      page_param = filter_params[:page]
+      current_page = page_param.nil? ? 1 : page_param.to_i
+      @next_link_filter_params[:page] = current_page + 1
+    end
+
+    nil
   end
 
   def search

--- a/app/domain/search/sort.rb
+++ b/app/domain/search/sort.rb
@@ -16,7 +16,13 @@ class Search
     end
 
     def apply(scope)
-      scope.order(sort_query)
+      # Sorting by id guarrentees a deterministic order in the case
+      # where the other sort criteria don't differ between the items
+      # being sorted. This is critical to ensure that the user
+      # experience is consistent in terms of the order items are
+      # displayed, and that features provided by PostgreSQL like ORDER
+      # and OFFSET work.
+      scope.order("#{sort_query}, content_items.id")
     end
 
   private

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -34,12 +34,6 @@ class ContentItem < ApplicationRecord
       .joins("join (#{nested.to_sql}) x on target_content_id = content_id")
   end
 
-  def self.next_item(current_item)
-    ids = pluck(:id)
-    index = ids.index(current_item.id)
-    all[index + 1] if index
-  end
-
   def self.document_type_counts
     all
       .select(:document_type, "count(1) as count")

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -17,7 +17,7 @@
 
   <nav class="prev-next-links">
     <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
-    <%= link_to "Next", content_item_audit_path(@next_item, filter_params), class: "next-item" if @next_item %>
+    <%= link_to "Next", content_item_audit_path(@next_item, @next_link_filter_params), class: "next-item" if @next_item %>
   </nav>
 
   <h2><%= link_to @content_item.title, @content_item.url, target: :_blank %></h2>

--- a/spec/domain/search/sort_spec.rb
+++ b/spec/domain/search/sort_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Search::Sort do
       scope = double
       sort = Search::Sort.new(:identifier, :sort_query)
 
-      expect(scope).to receive(:order).with(:sort_query)
+      expect(scope).to receive(:order).with("sort_query, content_items.id")
       sort.apply(scope)
     end
   end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -8,47 +8,6 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
-  describe ".next_item" do
-    let!(:content_items) { FactoryGirl.create_list(:content_item, 5) }
-
-    it "returns the next item given the current item" do
-      result = ContentItem.all.next_item(content_items[0])
-      expect(result).to eq(content_items[1])
-
-      result = ContentItem.all.next_item(content_items[1])
-      expect(result).to eq(content_items[2])
-
-      result = ContentItem.all.next_item(content_items[2])
-      expect(result).to eq(content_items[3])
-
-      result = ContentItem.all.next_item(content_items[3])
-      expect(result).to eq(content_items[4])
-    end
-
-    it "returns nil if there's no next item" do
-      result = ContentItem.all.next_item(content_items[4])
-      expect(result).to be_nil
-    end
-
-    it "returns nil if the current item isn't in the scope" do
-      result = ContentItem.offset(1).next_item(ContentItem.first)
-      expect(result).to be_nil
-    end
-
-    it "is based on the filtered, ordered scope" do
-      scope = ContentItem.limit(3).offset(1).order("id desc")
-
-      result = scope.next_item(content_items[3])
-      expect(result).to eq(content_items[2])
-
-      result = scope.next_item(content_items[2])
-      expect(result).to eq(content_items[1])
-
-      result = scope.next_item(content_items[1])
-      expect(result).to be_nil
-    end
-  end
-
   describe ".targets_of" do
     let!(:a) { FactoryGirl.create(:content_item) }
     let!(:b) { FactoryGirl.create(:content_item) }


### PR DESCRIPTION
See comment in #198 

Trello: https://trello.com/c/B8YQWsfv/308-possible-bug-if-you-click-the-last-item-on-a-list-page-you-dont-get-a-next-link