### PR TITLE
Fix a bug with boolean responses in the report

### DIFF
--- a/app/models/report_row.rb
+++ b/app/models/report_row.rb
@@ -46,7 +46,7 @@ class ReportRow < ApplicationRecord
       next unless response
 
       if response.boolean?
-        format_boolean(response.passing?)
+        response.value.capitalize
       else
         response.value
       end

--- a/spec/models/report_row_spec.rb
+++ b/spec/models/report_row_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ReportRow do
   specify { expect(subject.url).to eq                     "https://gov.uk/example/path" }
   specify { expect(subject.is_work_needed).to eq          "Yes" }
   specify { expect(subject.page_views).to eq              "1,234" }
-  specify { expect(subject.response_values).to start_with %w(No No No) }
+  specify { expect(subject.response_values).to start_with %w(Yes Yes Yes) }
   specify { expect(subject.primary_organisation).to eq    "HMRC" }
   specify { expect(subject.other_organisations).to eq     "" }
   specify { expect(subject.content_type).to eq            "Travel Advice" }


### PR DESCRIPTION
The ‘Yes’ / ‘No’ value for the boolean question
columns should be based directly on the user’s
answers to these questions rather than whether we
deem the response a pass / fail.

The notion of passing/failing is only really
applicable for the ‘Is work needed?’ column.