### PR TITLE
Fix database schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,13 +50,13 @@ ActiveRecord::Schema.define(version: 20170626153519) do
   end
 
   create_table "content_items_organisations", id: false, force: :cascade do |t|
-    t.bigint "content_item_id", null: false
-    t.bigint "organisation_id", null: false
+    t.integer "content_item_id", null: false
+    t.integer "organisation_id", null: false
   end
 
   create_table "content_items_taxons", id: false, force: :cascade do |t|
-    t.bigint "content_item_id", null: false
-    t.bigint "taxon_id", null: false
+    t.integer "content_item_id", null: false
+    t.integer "taxon_id", null: false
     t.index ["content_item_id"], name: "index_content_items_taxons_on_content_item_id"
     t.index ["taxon_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true
   end


### PR DESCRIPTION
Running the `./bin/setup` application setup script causes schema changes. We should be tracking these.