### PR TITLE
Update README to reference automated app setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,13 @@
 
 This is an app that aggregates metrics from multiple sources to give easy view of content performance measurements.
 
-### Setting up the local environment
+### Setting up the application
 
-Create the test and development databases:
-
-```bash
-$ rake db:create
-```
-
-Run all migrations:
+The application contains a [setup script](./bin/setup) that will perform the
+steps required to bootstrap the application.
 
 ```bash
-$ rake db:migrate
+$ ./bin/setup
 ```
 
 ### Running the application


### PR DESCRIPTION
We have automated the steps required to setup the application in the `./bin/setup` script. We shouldn't duplicated (and potentially conflict) with them in the README instructions.