### PR TITLE
Proxy iframes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'selectize-rails'
 gem 'turbolinks'
 gem 'uglifier'
 gem 'unicorn'
+gem 'rack-proxy'
 
 group :development do
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,8 @@ GEM
       rack (>= 0.4)
     rack-protection (2.0.0)
       rack
+    rack-proxy (0.6.1)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.2)
@@ -483,6 +485,7 @@ DEPENDENCIES
   poltergeist
   pry-rails
   puma
+  rack-proxy
   rails (~> 5.1)
   rails-controller-testing
   rspec-rails

--- a/app/forms/taxonomy_todo_form.rb
+++ b/app/forms/taxonomy_todo_form.rb
@@ -2,7 +2,7 @@ class TaxonomyTodoForm
   include ActiveModel::Model
   attr_accessor :taxonomy_todo, :terms, :user
 
-  delegate :title, :url, :description, to: :content_item
+  delegate :base_path, :title, :url, :description, to: :content_item
 
   def save
     TaxonomyTodo.transaction do
@@ -13,6 +13,10 @@ class TaxonomyTodoForm
 
   def content_item
     taxonomy_todo.content_item.decorate
+  end
+
+  def proxy_url
+    File.join(Proxies::IframeAllowingProxy::PROXY_BASE_PATH, base_path)
   end
 
   def project

--- a/app/models/proxies/iframe_allowing_proxy.rb
+++ b/app/models/proxies/iframe_allowing_proxy.rb
@@ -1,0 +1,35 @@
+# This proxy is to allow an Iframe to display content from gov.uk, which is a different domain, into this application.
+module Proxies
+  class IframeAllowingProxy < Rack::Proxy
+    PROXY_BASE_PATH = '/iframe-proxy/'.freeze
+
+    def rewrite_env(env)
+      env['HTTP_HOST'] = 'www.gov.uk:443'
+      env['SERVER_NAME'] = 'www.gov.uk'
+      env['SERVER_PORT'] = 443
+      env['SCRIPT_NAME'] = ''
+      env['REQUEST_PATH'] = env['REQUEST_URI'] = env['PATH_INFO']
+      env['rack.url_scheme'] = 'https'
+
+      # Ensure the target returns an uncompressed body so that the response can easily be rewritten
+      env.delete('HTTP_ACCEPT_ENCODING')
+      env
+    end
+
+    # Links from gov.uk are rewritten to point to the proxy
+    def rewrite_response(triplet)
+      status, headers, body = triplet
+
+      result = []
+      if headers['content-type'].any? { |header| header.include?('text/html') }
+        body.each { |body_part|
+          result << body_part.gsub(%r{href=["'](https://(www\.)?gov\.uk)?/([^'"]*)["']}, %[href="#{Proxies::IframeAllowingProxy::PROXY_BASE_PATH}\\3"])
+        }
+      else
+        result = body
+      end
+
+      [status, headers.tap { |h| h['x-frame-options'] = 'ALLOWALL' }, result]
+    end
+  end
+end

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -7,7 +7,7 @@
         <h4 class="modal-title" id="myModalLabel"><%=@todo_form.title%></h4>
       </div>
       <div class="modal-body">
-        <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="600" scrolling="yes"></iframe>
+        <iframe id='frame1' src="<%=@todo_form.proxy_url%>"  width="100%" height="600" scrolling="yes"></iframe>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -76,7 +76,7 @@
   </div>
 
   <div class="add-top-padding">
-    <iframe id='#frame' src="<%=@todo_form.url%>"  sandbox="" width="100%" height="800" scrolling="yes"></iframe>
+    <iframe id='frame2' src="<%=@todo_form.proxy_url%>"  width="100%" height="800" scrolling="yes"></iframe>
   </div>
 </div>
 
@@ -136,4 +136,5 @@
       <p><%= @todo_form.content_item.six_months_page_views %> in the last six months</p>
     </div>
   </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,4 +38,12 @@ Rails.application.routes.draw do
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end
+
+  class ProxyAccessContraint
+    def matches?(request)
+      !request.env['warden'].try(:user).nil?
+    end
+  end
+
+  mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH, constraints: ProxyAccessContraint.new
 end

--- a/spec/features/taxonomy_generation/content_preview_modal_spec.rb
+++ b/spec/features/taxonomy_generation/content_preview_modal_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.feature "Content Preview Modal", type: :feature, js: true do
+  before :each do
+    Proxies::IframeAllowingProxy::PROXY_BASE_PATH = '/iframe-proxy/'.freeze
+
+    #ignore the fact the iframe points to an invalid path
+    Capybara.raise_server_errors = false
+  end
+
   it "pops up a modal when previewing content" do
     given_theres_a_project_with_a_todo
     when_i_visit_the_taxonomy_project_page
@@ -29,7 +36,7 @@ RSpec.feature "Content Preview Modal", type: :feature, js: true do
 
   def then_a_modal_with_the_content_pops_up
     within('.modal-content') do
-      expect(page).to have_css('iframe[src="https://gov.uk/path/to/a/page.html"]')
+      expect(page).to have_css('iframe[src="/iframe-proxy/path/to/a/page.html"]')
     end
   end
 end

--- a/spec/models/proxies/iframe_allowing_proxy_spec.rb
+++ b/spec/models/proxies/iframe_allowing_proxy_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Proxies::IframeAllowingProxy do
+  before :each do
+    @proxy = Proxies::IframeAllowingProxy.new
+    @status = {}
+    @headers = {}
+    Proxies::IframeAllowingProxy::PROXY_BASE_PATH = '/iframe-proxy/'.freeze
+  end
+
+  describe '#rewrite_response' do
+    context 'the page contains html' do
+      before :each do
+        @headers['content-type'] = ['text/html; charset=utf-8']
+      end
+      it 'prepends base url to all absolute URLs - href' do
+        body = ['<tag>href="/absolute/path"</tag>']
+        expect(@proxy.rewrite_response([@status, @headers, body])[-1]).to eq(['<tag>href="/iframe-proxy/absolute/path"</tag>'])
+      end
+      it 'prepends base url to all absolute URLs - different quotes' do
+        body = ['<tag>href=\'/absolute/path\'</tag>']
+        expect(@proxy.rewrite_response([@status, @headers, body])[-1]).to eq(['<tag>href="/iframe-proxy/absolute/path"</tag>'])
+      end
+      it 'replaces gov.uk to an absolute path and prepends base url' do
+        body = ['<tag>href="https://gov.uk/absolute/path"</tag>']
+        expect(@proxy.rewrite_response([@status, @headers, body])[-1]).to eq(['<tag>href="/iframe-proxy/absolute/path"</tag>'])
+      end
+      it 'replaces www.gov.uk to an absolute path and prepends base url' do
+        body = ['<tag>href="https://www.gov.uk/absolute/path"</tag>']
+        expect(@proxy.rewrite_response([@status, @headers, body])[-1]).to eq(['<tag>href="/iframe-proxy/absolute/path"</tag>'])
+      end
+      it 'does not rewrite urls from other domains' do
+        body = ['<link href="https://assets.publishing.service.gov.uk/static/>']
+        expect(@proxy.rewrite_response([@status, @headers, body])[-1]).to eq(body)
+      end
+    end
+
+    context 'the page contains a pdf' do
+      before :each do
+        @headers['content-type'] = ['application/x-pdf']
+      end
+      it 'does not rewrite urls' do
+        body = ['<tag>href="/absolute/path"</tag>']
+        expect(@proxy.rewrite_response([@status, @headers, body])[-1]).to eq(['<tag>href="/absolute/path"</tag>'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a proxy for all www.gov.uk content, so that these pages can be displayed in an iFrame in the concept generator.

Links in the contents of the iFrame are rewritten so that they point to the proxy. 

See also: https://github.com/alphagov/content-performance-manager/pull/206

Trello: https://trello.com/c/4IT79oPH