### PR TITLE
Switch from id to content-id in URLs

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -51,7 +51,7 @@ private
   end
 
   def content_item
-    @content_item ||= ContentItem.find(params.fetch(:content_item_id)).decorate
+    @content_item ||= ContentItem.find_by(content_id: params.fetch(:content_item_content_id)).decorate
   end
 
   def content_items

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -15,7 +15,7 @@ class ContentItemsController < ApplicationController
   end
 
   def show
-    @content_item = ContentItem.find(params[:id]).decorate
+    @content_item = ContentItem.find_by(content_id: params[:content_id]).decorate
   end
 
 private

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -16,6 +16,10 @@ class ContentItem < ApplicationRecord
 
   attr_accessor :details
 
+  def to_param
+    content_id
+  end
+
   def self.targets_of(link_type:, scope_to_count: all)
     sql = scope_to_count.to_sql.presence
     sql ||= "select * from content_items where id = -1"

--- a/app/views/content_items/_content_item.html.erb
+++ b/app/views/content_items/_content_item.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to content_item.title, content_item_path(id: content_item.id) %></td>
+  <td><%= link_to content_item.title, content_item_path(content_item) %></td>
   <td><%= content_item.document_type %></td>
   <td><%= number_with_delimiter content_item.one_month_page_views %></td>
   <td><%= number_with_delimiter content_item.six_months_page_views %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'content_items#index'
 
-  resources :content_items, only: %w(index show) do
+  resources :content_items, only: %w(index show), param: :content_id do
     get :audit, to: "audits#show"
     post :audit, to: "audits#save"
     patch :audit, to: "audits#save"

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ContentItemsController, type: :controller do
     let(:content_item) { create(:content_item) }
 
     before do
-      get :show, params: { id: content_item.id }
+      get :show, params: { content_id: content_item.content_id }
     end
 
     it "returns http success" do

--- a/spec/features/audit/list_content_items_to_audit_spec.rb
+++ b/spec/features/audit/list_content_items_to_audit_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     expect(page).to have_content("All about flooding.")
     expect(page).to have_content("All about gardening.")
     expect(page).to have_content("1,234")
-    expect(page).to have_link("All about gardening.", href: "/content_items/#{content_item_2.id}/audit")
+    expect(page).to have_link("All about gardening.", href: "/content_items/#{content_item_2.content_id}/audit")
   end
 
   scenario "Default sorting by popularity" do

--- a/spec/features/audit/metadata_spec.rb
+++ b/spec/features/audit/metadata_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Audit metadata", type: :feature do
   end
 
   scenario "showing minimal metadata next to the audit quesionnaire" do
-    visit content_item_audit_path(content_item)
+    visit content_item_audit_path(content_item.content_id)
 
     within("#metadata") do
       expect(page).to have_selector("#audited", text: "Not audited yet")
@@ -65,7 +65,7 @@ RSpec.feature "Audit metadata", type: :feature do
       expect(page).to have_selector("#guidance", text: "Yes")
       expect(page).to have_selector("#topics", text: "Borders, Immigration")
       expect(page).to have_selector("#policy-areas", text: "Borders and Immigration")
-#      expect(page).to have_selector("#withdrawn", text: "No")
+      expect(page).to have_selector("#withdrawn", text: "No")
       expect(page).to have_selector("#pageviews", text: "1,234 in the last month")
       expect(page).to have_selector("#pageviews", text: "12,345 in the last six months")
     end

--- a/spec/features/audit/metadata_spec.rb
+++ b/spec/features/audit/metadata_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Audit metadata", type: :feature do
   end
 
   scenario "showing minimal metadata next to the audit quesionnaire" do
-    visit content_item_audit_path(content_item.content_id)
+    visit content_item_audit_path(content_item)
 
     within("#metadata") do
       expect(page).to have_selector("#audited", text: "Not audited yet")

--- a/spec/features/performance/content_item_spec.rb
+++ b/spec/features/performance/content_item_spec.rb
@@ -4,12 +4,12 @@ RSpec.feature "Content Item Details", type: :feature do
   end
 
   scenario "the user clicks on the view content item link and is redirected to the content item show page" do
-    create :content_item, id: 1, title: "content item title"
+    create :content_item, content_id: "content-id-1", title: "content item title"
 
     visit "/content_items"
     click_on "content item title"
 
-    expected_path = "/content_items/1"
+    expected_path = "/content_items/content-id-1"
     expect(current_path).to eq(expected_path)
   end
 
@@ -21,7 +21,7 @@ RSpec.feature "Content Item Details", type: :feature do
       description: "a-description",
       public_updated_at: 2.months.ago,)
 
-    visit "/content_items/#{content_item.id}"
+    visit "/content_items/#{content_item.content_id}"
     expect(page).to have_text("a-title")
     expect(page).to have_link("a-title", href: "https://gov.uk/content/1/path")
     expect(page).to have_text("Guidance")
@@ -32,7 +32,7 @@ RSpec.feature "Content Item Details", type: :feature do
   scenario "Renders the number of PDFs" do
     content_item = create :content_item, number_of_pdfs: 99
 
-    visit "/content_items/#{content_item.id}"
+    visit "/content_items/#{content_item.content_id}"
 
     expect(page).to have_text("99")
   end
@@ -46,7 +46,7 @@ RSpec.feature "Content Item Details", type: :feature do
     create(:link, source: content, target: taxonomy1, link_type: "taxons")
     create(:link, source: content, target: taxonomy2, link_type: "taxons")
 
-    visit "/content_items/#{content.id}"
+    visit "/content_items/#{content.content_id}"
 
     expect(page).to have_text('Education, Health')
   end
@@ -54,7 +54,7 @@ RSpec.feature "Content Item Details", type: :feature do
   scenario "Renders stats for Google Analytics" do
     content_item = create :content_item, one_month_page_views: 77
 
-    visit "/content_items/#{content_item.id}"
+    visit "/content_items/#{content_item.content_id}"
 
     expect(page).to have_text("77")
   end
@@ -62,7 +62,7 @@ RSpec.feature "Content Item Details", type: :feature do
   scenario "Renders feedex details" do
     content_item = create :content_item, base_path: '/the-base-path'
 
-    visit "/content_items/#{content_item.id}"
+    visit "/content_items/#{content_item.content_id}"
 
     feedex_link = "http://support.dev.gov.uk/anonymous_feedback?path=/the-base-path"
     expect(page).to have_link('View feedback on FeedEx', href: feedex_link)
@@ -77,7 +77,7 @@ RSpec.feature "Content Item Details", type: :feature do
     create(:link, source: content, target: organisation1, link_type: "organisations")
     create(:link, source: content, target: organisation2, link_type: "organisations")
 
-    visit "/content_items/#{content.id}"
+    visit "/content_items/#{content.content_id}"
 
     expect(page).to have_text('Education, Health')
   end
@@ -85,7 +85,7 @@ RSpec.feature "Content Item Details", type: :feature do
   scenario "Renders when an item has not been published" do
     content_item = create :content_item, public_updated_at: nil
 
-    visit "/content_items/#{content_item.id}"
+    visit "/content_items/#{content_item.content_id}"
 
     expect(page).to have_text("Never")
   end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
+  describe ".to_param" do
+    let!(:content_item) { build(:content_item, content_id: "content-id-1") }
+
+    it "returns the content id" do
+      expect(content_item.to_param).to eq("content-id-1")
+    end
+  end
+
   describe ".next_item" do
     let!(:content_items) { create_list(:content_item, 5) }
 


### PR DESCRIPTION
We refer to content items by their content_item_id in most GOV.UK apps so we should be consistent. Here we’ve switched the param in the URL path to be for the content-id instead of id when referring to content items.