### PR TITLE
Add a LinkFactory for tests

### DIFF
--- a/spec/domain/search/rules_filter_spec.rb
+++ b/spec/domain/search/rules_filter_spec.rb
@@ -4,14 +4,6 @@ RSpec.describe Search::RulesFilter do
   let(:subtheme) { create(:subtheme) }
   let(:result) { subject.apply(ContentItem.all).map(&:title) }
 
-  def node(title)
-    create(:content_item, title: title)
-  end
-
-  def edge(source, target, type)
-    create(:link, source: source, target: target, link_type: type)
-  end
-
   def rule(type, target)
     create(
       :inventory_rule,
@@ -21,24 +13,22 @@ RSpec.describe Search::RulesFilter do
     )
   end
 
-  let!(:a) { node("a") }
-  let!(:b) { node("b") }
-  let!(:c) { node("c") }
+  let!(:hmrc) { create(:content_item, title: "HMRC") }
+  let!(:raib) { create(:content_item, title: "RAIB") }
 
-  let!(:hmrc) { node("HMRC") }
-  let!(:raib) { node("RAIB") }
+  let!(:vat) { create(:content_item, title: "VAT") }
+  let!(:rail) { create(:content_item, title: "Railways") }
 
-  let!(:vat) { node("VAT") }
-  let!(:rail) { node("Railways") }
+  let!(:a) do
+    create(:content_item, title: "a", organisations: hmrc, policies: vat)
+  end
 
-  before do
-    edge(a, hmrc, "organisations")
-    edge(b, hmrc, "organisations")
-    edge(c, raib, "organisations")
+  let!(:b) do
+    create(:content_item, title: "b", organisations: hmrc, policies: rail)
+  end
 
-    edge(a, vat, "policies")
-    edge(b, rail, "policies")
-    edge(c, rail, "policies")
+  let!(:c) do
+    create(:content_item, title: "c", organisations: raib, policies: rail)
   end
 
   it "filters content items for a single inventory rule" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,12 +1,27 @@
 require_relative "../app/models/question"
+require_relative "./factories/link_factory"
 
 FactoryGirl.define do
   factory :content_item do
+    transient do
+      organisations nil
+      primary_publishing_organisation nil
+      policies nil
+      policy_areas nil
+    end
+
     sequence(:content_id) { |index| "content-id-#{index}" }
     sequence(:title) { |index| "content-item-title-#{index}" }
     sequence(:document_type) { |index| "document_type-#{index}" }
     base_path "api/content/item/path"
     public_updated_at { Time.now }
+
+    after(:create) do |content_item, evaluator|
+      LinkFactory.add_organisations(content_item, evaluator.organisations)
+      LinkFactory.add_primary_publishing_organisation(content_item, evaluator.primary_publishing_organisation)
+      LinkFactory.add_policies(content_item, evaluator.policies)
+      LinkFactory.add_policy_areas(content_item, evaluator.policy_areas)
+    end
   end
 
   factory :link do

--- a/spec/factories/link_factory.rb
+++ b/spec/factories/link_factory.rb
@@ -1,0 +1,36 @@
+class LinkFactory
+  def self.add_organisations(content_item, organisations)
+    add_links(content_item, organisations, Link::ALL_ORGS)
+  end
+
+  def self.add_primary_publishing_organisation(content_item, organisation)
+    add_link(content_item, organisation, Link::PRIMARY_ORG)
+  end
+
+  def self.add_policies(content_item, policies)
+    add_links(content_item, policies, Link::POLICIES)
+  end
+
+  def self.add_policy_areas(content_item, policy_areas)
+    add_links(content_item, policy_areas, Link::POLICY_AREAS)
+  end
+
+  def self.add_link(content_item, target, link_type)
+    return unless target
+
+    FactoryGirl.create(
+      :link,
+      source: content_item,
+      target: target,
+      link_type: link_type,
+    )
+  end
+
+  def self.add_links(content_item, targets, link_type)
+    return unless targets
+
+    [targets].flatten.each do |target|
+      add_link(content_item, target, link_type)
+    end
+  end
+end

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -5,12 +5,41 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
   # Policies:
   let!(:flying) { create(:content_item, title: "Flying abroad") }
-  let!(:insurance) { create(:content_item, title: "Travel insurance") }
+
+  let!(:insurance) do
+    create(
+      :content_item,
+      title: "Travel insurance",
+      organisations: hmrc,
+      policies: flying,
+    )
+  end
 
   # Content:
-  let!(:felling) { create(:content_item, title: "Tree felling") }
-  let!(:management) { create(:content_item, title: "Forest management") }
-  let!(:vat) { create(:content_item, title: "VAT") }
+  let!(:felling) do
+    create(
+      :content_item,
+      title: "Tree felling",
+      primary_publishing_organisation: dfe,
+      policies: management,
+    )
+  end
+
+  let!(:management) do
+    create(
+      :content_item,
+      title: "Forest management",
+    )
+  end
+
+  let!(:vat) do
+    create(
+      :content_item,
+      title: "VAT",
+      primary_publishing_organisation: hmrc,
+      organisations: hmrc,
+    )
+  end
 
   # Audit:
   let!(:audit) { create(:audit, content_item: felling) }
@@ -25,14 +54,6 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
   let!(:pollution) { create(:subtheme, theme: environment, name: "Air pollution") }
 
   before do
-    # Links:
-    create(:link, source: vat, target: hmrc, link_type: "primary_publishing_organisation")
-    create(:link, source: felling, target: dfe, link_type: "primary_publishing_organisation")
-    create(:link, source: vat, target: hmrc, link_type: "organisations")
-    create(:link, source: insurance, target: hmrc, link_type: "organisations")
-    create(:link, source: insurance, target: flying, link_type: "policies")
-    create(:link, source: felling, target: management, link_type: "policies")
-
     # Rules:
     create(:inventory_rule, subtheme: aviation, link_type: "policies", target_content_id: flying.content_id)
     create(:inventory_rule, subtheme: forestry, link_type: "policies", target_content_id: management.content_id)

--- a/spec/features/inventory/inventory_spec.rb
+++ b/spec/features/inventory/inventory_spec.rb
@@ -1,13 +1,5 @@
 # rubocop:disable Style/VariableNumber
 RSpec.feature "Managing inventory" do
-  def node(title)
-    create(:content_item, title: title)
-  end
-
-  def edge(from, to, type)
-    create(:link, source: from, target: to, link_type: type)
-  end
-
   def expect_active(title)
     expect(page).to have_css(".row.active", text: title)
   end
@@ -18,22 +10,25 @@ RSpec.feature "Managing inventory" do
   end
 
   before do
-    content_item_1 = node("Content Item 1")
-    content_item_2 = node("Content Item 2")
+    organisation_1 = create(:content_item, title: "Organisation 1")
+    organisation_2 = create(:content_item, title: "Organisation 2")
 
-    organisation_1 = node("Organisation 1")
-    organisation_2 = node("Organisation 2")
+    policy_area_1 = create(:content_item, title: "Policy Area 1")
+    policy_area_2 = create(:content_item, title: "Policy Area 2")
 
-    policy_area_1 = node("Policy Area 1")
-    policy_area_2 = node("Policy Area 2")
+    create(
+      :content_item,
+      title: "Content Item 1",
+      organisations: organisation_1,
+      policy_areas: [policy_area_1, policy_area_2],
+    )
 
-    edge(content_item_1, organisation_1, "organisations")
-    edge(content_item_2, organisation_1, "organisations")
-    edge(content_item_2, organisation_2, "organisations")
-
-    edge(content_item_1, policy_area_1, "policy_areas")
-    edge(content_item_1, policy_area_2, "policy_areas")
-    edge(content_item_2, policy_area_2, "policy_areas")
+    create(
+      :content_item,
+      title: "Content Item 2",
+      organisations: [organisation_1, organisation_2],
+      policy_areas: [policy_area_2]
+    )
   end
 
   scenario "managing inventory rules for themes and subthemes" do

--- a/spec/lib/comparison_spec.rb
+++ b/spec/lib/comparison_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe Comparison do
-  let!(:first) { create(:content_item, base_path: "/first") }
-  let!(:third) { create(:content_item, base_path: "/third") }
+  let!(:policy) { create(:content_item) }
+  let!(:first) { create(:content_item, base_path: "/first", policies: policy) }
+  let!(:third) { create(:content_item, base_path: "/third", policies: policy) }
 
   before do
-    policy = create(:content_item)
-
     create(
       :theme,
       name: "Transport",
@@ -22,9 +21,6 @@ RSpec.describe Comparison do
         ),
       ],
     )
-
-    create(:link, source: first, target: policy, link_type: "policies")
-    create(:link, source: third, target: policy, link_type: "policies")
   end
 
   let(:fixture) { "#{Rails.root}/spec/fixtures/transport.csv" }

--- a/spec/models/report_row_spec.rb
+++ b/spec/models/report_row_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ReportRow do
       six_months_page_views: 1234,
       content_id: "id123",
       publishing_app: "whitehall",
+      primary_publishing_organisation: hmrc,
     )
   end
 
@@ -21,15 +22,6 @@ RSpec.describe ReportRow do
   end
 
   let!(:hmrc) { create(:content_item, title: "HMRC") }
-
-  let!(:hmrc_link) do
-    create(
-      :link,
-      source: content_item,
-      target: hmrc,
-      link_type: "primary_publishing_organisation",
-    )
-  end
 
   subject { described_class.precompute(content_item) }
 
@@ -57,10 +49,7 @@ RSpec.describe ReportRow do
     before do
       aaib = create(:content_item, title: "AAIB")
       maib = create(:content_item, title: "MAIB")
-
-      create(:link, source: content_item, target: aaib, link_type: "organisations")
-      create(:link, source: content_item, target: hmrc, link_type: "organisations")
-      create(:link, source: content_item, target: maib, link_type: "organisations")
+      LinkFactory.add_organisations(content_item, [aaib, hmrc, maib])
     end
 
     specify { expect(subject.primary_organisation).to eq "HMRC" }


### PR DESCRIPTION
When creating links between Content Items, we previously had to make
the two content items and then also create a Link object between them.

This change allows for links to be implicitly created by passing
the linked content item(s) into the factory method of the parent
content item.