### PR TITLE
Add tag in concept generator when losing focus

### DIFF
--- a/app/controllers/taxonomy_todos_controller.rb
+++ b/app/controllers/taxonomy_todos_controller.rb
@@ -1,18 +1,26 @@
 class TaxonomyTodosController < ApplicationController
   def show
-    @todo_form = TaxonomyTodoForm.new(
-      taxonomy_todo: taxonomy_todo,
-      terms: taxonomy_todo.terms.order(:name).pluck(:name).join(','),
-    )
+    @todo_form = TaxonomyTodoForm.new(taxonomy_todo: taxonomy_todo)
+    if flash.key?(:taxonomy_todos_params)
+      @todo_form.terms = flash[:taxonomy_todos_params][:terms]
+      @todo_form.valid?
+    else
+      @todo_form.terms = taxonomy_todo.terms.order(:name).pluck(:name).join(',')
+    end
   end
 
   def update
-    todo_form = TaxonomyTodoForm.new(todo_params)
-    todo_form.taxonomy_todo = taxonomy_todo
-    todo_form.user = current_user
-    todo_form.save
-
-    redirect_to_next_item
+    @todo_form = TaxonomyTodoForm.new(todo_params)
+    @todo_form.taxonomy_todo = taxonomy_todo
+    @todo_form.user = current_user
+    if @todo_form.valid?
+      @todo_form.save
+      redirect_to_next_item
+    else
+      flash.alert = @todo_form.errors.full_messages.join(', ')
+      flash[:taxonomy_todos_params] = todo_params
+      redirect_to taxonomy_todo
+    end
   end
 
   def dont_know

--- a/app/forms/taxonomy_todo_form.rb
+++ b/app/forms/taxonomy_todo_form.rb
@@ -4,6 +4,8 @@ class TaxonomyTodoForm
 
   delegate :base_path, :title, :url, :description, to: :content_item
 
+  validates :terms, presence: true
+
   def save
     TaxonomyTodo.transaction do
       update_todo

--- a/app/views/taxonomy_todos/show.html.erb
+++ b/app/views/taxonomy_todos/show.html.erb
@@ -61,7 +61,8 @@
           valueField: 'name',
           labelField: 'name',
           sortField: 'name',
-          searchField: 'name'
+          searchField: 'name',
+          createOnBlur: true
         })
       </script>
     </div>

--- a/spec/controllers/taxonomy_todos_controller_spec.rb
+++ b/spec/controllers/taxonomy_todos_controller_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe TaxonomyTodosController, type: :controller do
+  include AuthenticationControllerHelpers
+  before do
+    login_as_stub_user
+    @taxonomy_todo = FactoryGirl.create(:taxonomy_todo, status: TaxonomyTodo::STATE_TODO)
+  end
+
+  describe '#show' do
+    it 'renders the show page' do
+      get :show, params: { id: @taxonomy_todo.id }
+      expect(response).to render_template(:show)
+      expect(assigns(:todo_form).errors).to be_empty
+    end
+    describe 'use flash' do
+      it 'renders the show page with errors' do
+        session['flash'] = ActionDispatch::Flash::FlashHash.new('taxonomy_todos_params' => { 'terms' => '' })
+        get :show, params: { id: @taxonomy_todo.id }
+        expect(assigns(:todo_form).errors).to_not be_empty
+      end
+      it 'renders the show page without  errors' do
+        session['flash'] = ActionDispatch::Flash::FlashHash.new('taxonomy_todos_params' => { 'terms' => 'term1, term2' })
+        get :show, params: { id: @taxonomy_todo.id }
+        expect(assigns(:todo_form).errors).to_not be_empty
+      end
+    end
+  end
+
+  describe '#update' do
+    it 'redirect to show with errors because there are no terms' do
+      put :update, params: { taxonomy_todo_form: { terms: '' }, id: @taxonomy_todo.id }
+      expect(response).to redirect_to(taxonomy_todo_path(@taxonomy_todo.id))
+      expect(flash.alert).to_not be_nil
+    end
+
+    it 'redirects to the next item' do
+      put :update, params: { taxonomy_todo_form: { terms: 'term' }, id: @taxonomy_todo.id }
+      expect(response).to redirect_to(next_taxonomy_project_path(@taxonomy_todo.taxonomy_project))
+    end
+
+    it 'saves terms to the the taxonomy' do
+      expect {
+        put :update, params: { taxonomy_todo_form: { terms: 'term1, term2' }, id: @taxonomy_todo.id }
+      }.to change { @taxonomy_todo.reload.terms.count }.by(2)
+      expect(@taxonomy_todo.terms.map(&:name)).to match_array(%w(term1 term2))
+    end
+  end
+
+  describe '#dont_know' do
+    it 'redirects to the next item' do
+      post :dont_know, params: { id: @taxonomy_todo.id }
+      expect(response).to redirect_to(next_taxonomy_project_path(@taxonomy_todo.taxonomy_project))
+    end
+    it 'changes the state of the taxonomy to from STATE_TODO to STATE_DONT_KNOW' do
+      expect {
+        post :dont_know, params: { id: @taxonomy_todo.id }
+      }.to change {
+        @taxonomy_todo.reload.status
+      }.from(TaxonomyTodo::STATE_TODO).to(TaxonomyTodo::STATE_DONT_KNOW)
+    end
+  end
+
+  describe '#not_relevant' do
+    it 'redirects to the next item' do
+      post :not_relevant, params: { id: @taxonomy_todo.id }
+      expect(response).to redirect_to(next_taxonomy_project_path(@taxonomy_todo.taxonomy_project))
+    end
+    it 'changes the state of the taxonomy to from STATE_TODO to STATE_NOT_RELEVANT' do
+      expect {
+        post :not_relevant, params: { id: @taxonomy_todo.id }
+      }.to change {
+        @taxonomy_todo.reload.status
+      }.from(TaxonomyTodo::STATE_TODO).to(TaxonomyTodo::STATE_NOT_RELEVANT)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/1aXV1MWc/33-concept-gen-too-easy-to-think-youve-added-a-term-when-you-havent

This option adds a tag when shifting focus from the input field. When entering a tag and saving without explicitly adding, will now include the tag anyway.

The terms field can no longer be empty - it will raise an error (screenshot). The buttons 'I don't know', and 'The page is not relevant...' will still allow a user to skip a page.

![screen shot 2017-07-25 at 16 42 27](https://user-images.githubusercontent.com/6050162/28580837-8f267d24-7158-11e7-8820-91b4461e8d39.png)


