### PR TITLE
Add Airbrake config

### DIFF
--- a/config/airbrake.rb
+++ b/config/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find_uri('errbit')
+
+  Airbrake.configure do |config|
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative 'airbrake'
+
 module ContentPerformanceManager
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
This change sets up Airbrake to report errors to Errbit. The config has been copied from `content-tagger`.

A test error has been posted to Errbit on integration here: https://errbit.integration.publishing.service.gov.uk/apps/587e4d6b65786365af130000/problems/5977657e65786354b9530000

A test Sidekiq error is here:
https://errbit.integration.publishing.service.gov.uk/apps/587e4d6b65786365af130000/problems/59776def65786362a6680000
