### PR TITLE
Add Google Tag Manager script

### DIFF
--- a/app/assets/javascripts/google-tag-manager.js
+++ b/app/assets/javascripts/google-tag-manager.js
@@ -1,0 +1,5 @@
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5688L99');


### PR DESCRIPTION
This change adds a script to enable tracking with Google Tag Manager.

Notably, we have not included the `noscript` `iframe` part of the
setup, as this is for tracking users with JavaScript disabled, and
requires further configuration. We don’t need this functionality.