### PR TITLE
Fetch content IDs from the new Editions endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read('.ruby-version').chomp
 
 # GOV.UK gems and forks
 gem 'airbrake', git: 'https://github.com/alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
-gem 'gds-api-adapters'
+gem 'gds-api-adapters', '~> 47.4'
 gem 'gds-sso'
 gem 'govspeak', '~> 5.0.3'
 gem 'govuk_admin_template'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     formatador (0.2.5)
-    gds-api-adapters (47.1.3)
+    gds-api-adapters (47.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -472,7 +472,7 @@ DEPENDENCIES
   database_cleaner
   draper
   factory_girl_rails
-  gds-api-adapters
+  gds-api-adapters (~> 47.4)
   gds-sso
   google-api-client (~> 0.9)
   govspeak (~> 5.0.3)

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -8,19 +8,17 @@ RSpec.describe Clients::PublishingAPI do
 
     let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 
-    before do
-      1.upto(2) do |page|
-        publishing_api_has_content(
-          content_ids.map { |id| { content_id: id } },
-          fields: %w(content_id),
-          states: %w(published),
-          page: page,
-          per_page: page_size,
-        )
-      end
-    end
-
     it "returns all the content ids" do
+      editions = content_ids.map { |id| { "content_id" => id } }
+
+      pages = editions.each_slice(page_size).map do |page|
+        {
+          "results" => page,
+        }
+      end
+
+      allow_any_instance_of(GdsApi::PublishingApiV2).to receive(:get_paged_editions).and_return(pages)
+
       result = subject.content_ids
       expect(result).to eq(content_ids)
     end


### PR DESCRIPTION
Publishing API’s `/v2/content_items` was not a very performant endpoint
for fetching all content items.

In order to cater for this use case, the `/v2/editions` endpoint
was created.

This change updates our Publishing API client to use this new endpoint,
through the newly-exposed `get_paged_editions` method exposed in
`gds-api-adapters`.