### PR TITLE
Fetch content after another content item

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'unicorn'
 gem 'rack-proxy'
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,13 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (7.1.2.1)
       execjs
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     bindex (0.5.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
@@ -84,6 +90,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.6.1)
+    debug_inspector (0.0.3)
     declarative (0.0.9)
     declarative-option (0.1.0)
     diff-lcs (1.3)
@@ -97,6 +104,7 @@ GEM
       activesupport (~> 5.0)
       request_store (~> 1.0)
     erubi (1.6.1)
+    erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -467,6 +475,8 @@ PLATFORMS
 DEPENDENCIES
   active_record_disabler
   airbrake!
+  better_errors
+  binding_of_caller
   byebug
   capybara
   database_cleaner

--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -91,8 +91,8 @@ module Content
       @scope
         .order(
           @sort => @sort_direction,
-          # Finally sort by base path (which is unique) to stabilise sort order
-          :base_path => :asc,
+          # Finally sort by Content ID (which is unique) to stabilise sort order
+          :content_id => @sort_direction,
         )
         .page(@page)
         .per(@per_page)

--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -87,15 +87,17 @@ module Content
       end
     end
 
+    def after(content_item)
+      builder(verify_presence: content_item) do
+        @after = content_item
+      end
+    end
+
     def scope
-      @scope
-        .order(
-          @sort => @sort_direction,
-          # Finally sort by Content ID (which is unique) to stabilise sort order
-          :content_id => @sort_direction,
-        )
-        .page(@page)
-        .per(@per_page)
+      scope = @scope.clone
+      scope = apply_ordering(scope)
+      scope = apply_pagination(scope)
+      apply_after(scope)
     end
 
     def content_items
@@ -120,6 +122,35 @@ module Content
       )
 
       @scope = filter.apply(@scope)
+    end
+
+    def apply_ordering(scope)
+      scope.order(
+        @sort => @sort_direction,
+        # Finally sort by Content ID (which is unique) to stabilise sort order
+        :content_id => @sort_direction,
+      )
+    end
+
+    def apply_pagination(scope)
+      scope.page(@page).per(@per_page)
+    end
+
+    def apply_after(scope)
+      return scope unless @after
+
+      sort_field = ContentItem.arel_table[@sort]
+      content_id_field = ContentItem.arel_table[:content_id]
+
+      comparison = @sort_direction == :asc ? :gt : :lt
+
+      scope.where(
+        sort_field.send(comparison, @after[@sort])
+          .or(
+            sort_field.eq(@after[@sort])
+              .and(content_id_field.send(comparison, @after[:content_id]))
+          )
+      )
     end
 
     def set(instance_variable, value)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -20,12 +20,6 @@ class ContentItem < ApplicationRecord
     content_id
   end
 
-  def self.next_item(current_item)
-    ids = pluck(:id)
-    index = ids.index(current_item.id)
-    all[index + 1] if index
-  end
-
   def guidance?
     document_type == "guidance"
   end

--- a/spec/domain/content/query_spec.rb
+++ b/spec/domain/content/query_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Content::Query do
     let!(:content_items) { create_list(:content_item, 26) }
 
     it "defaults to the page 1 with 25 per page" do
+      subject.sort_direction(:asc)
       expect(subject.content_items.count).to eq 25
       expect(subject.content_items).to match_array(content_items[0..24])
     end

--- a/spec/domain/content/query_spec.rb
+++ b/spec/domain/content/query_spec.rb
@@ -144,8 +144,51 @@ RSpec.describe Content::Query do
     let!(:content_item_3) { create(:content_item, six_months_page_views: 1) }
     let!(:content_item_4) { create(:content_item, six_months_page_views: 9) }
 
-    it "defaults to six month page views descending" do
-      expect(subject.content_items.pluck(:six_months_page_views)).to match_array [9, 3, 3, 1]
+    describe "with default sort" do
+      it "sorts by six month page views descending" do
+        expect(subject.content_items).to contain_exactly(
+          content_item_4,
+          content_item_2,
+          content_item_1,
+          content_item_3,
+        )
+      end
+    end
+
+    describe "picking content items after another item" do
+      describe "sorting by six month page views" do
+        before do
+          subject.sort(:six_months_page_views)
+        end
+
+        it "returns the correct results when sorted in descending order" do
+          subject
+            .sort_direction(:desc)
+            .after(content_item_1)
+          expect(subject.content_items).to contain_exactly(content_item_3)
+        end
+
+        it "returns the correct results when sorted in ascending order" do
+          subject
+            .sort_direction(:asc)
+            .after(content_item_1)
+          expect(subject.content_items).to contain_exactly(content_item_2, content_item_4)
+        end
+
+        it "returns nothing after the last result" do
+          subject
+            .sort_direction(:desc)
+            .after(content_item_3)
+          expect(subject.content_items).to be_empty
+        end
+
+        it "returns everything after the first result" do
+          subject
+            .sort_direction(:desc)
+            .after(content_item_4)
+          expect(subject.content_items).to contain_exactly(content_item_2, content_item_1, content_item_3)
+        end
+      end
     end
   end
 end

--- a/spec/domain/content/sort_spec.rb
+++ b/spec/domain/content/sort_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe 'sorting' do
   describe "sorting" do
     context "by page views (6 months)" do
       before do
-        create(:content_item, six_months_page_views: 0, base_path: '/b')
-        create(:content_item, six_months_page_views: 0, base_path: '/a')
-        create(:content_item, six_months_page_views: 0, base_path: '/c')
-        create(:content_item, six_months_page_views: 999, base_path: '/z')
+        create(:content_item, six_months_page_views: 0, content_id: 'b')
+        create(:content_item, six_months_page_views: 0, content_id: 'a')
+        create(:content_item, six_months_page_views: 0, content_id: 'c')
+        create(:content_item, six_months_page_views: 999, content_id: 'z')
 
         query.sort(:six_months_page_views)
       end
@@ -24,7 +24,7 @@ RSpec.describe 'sorting' do
 
       it "breaks ties on ascending base path" do
         query.sort_direction(:asc)
-        expect(query.content_items.pluck(:base_path)).to contain_exactly('/a', '/b', '/c', '/z')
+        expect(query.content_items.pluck(:content_id)).to contain_exactly('a', 'b', 'c', 'z')
       end
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
       policy_areas nil
     end
 
-    sequence(:content_id) { |index| "content-id-#{index}" }
+    sequence(:content_id) { |index| "content-id-%04i" % index }
     sequence(:title) { |index| "content-item-title-#{index}" }
     sequence(:document_type) { |index| "document_type-#{index}" }
     sequence(:base_path) { |index| "api/content/item/path-%04i" % index }

--- a/spec/features/audit/list_content_items_to_audit_spec.rb
+++ b/spec/features/audit/list_content_items_to_audit_spec.rb
@@ -1,6 +1,9 @@
 RSpec.feature "List Content Items to Audit", type: :feature do
-  let!(:content_item_1) { create(:content_item, title: "All about flooding.") }
-  let!(:content_item_2) { create(:content_item, title: "All about gardening.") }
+  let!(:content_items) {
+    create_list(:content_item, 30)
+      .sort_by(&:base_path)
+      .reverse
+  }
 
   scenario "User does not see CPM feedback survey link in banner" do
     visit audits_path
@@ -9,24 +12,64 @@ RSpec.feature "List Content Items to Audit", type: :feature do
   end
 
   scenario "List Content Items to Audit" do
-    content_item_1.update!(six_months_page_views: 1234)
+    content_items[0].update!(six_months_page_views: 1234)
 
     visit audits_path
 
-    expect(page).to have_content("All about flooding.")
-    expect(page).to have_content("All about gardening.")
+    expect(page).to have_content(content_items[0].title)
+    expect(page).to have_content(content_items[1].title)
     expect(page).to have_content("1,234")
-    expect(page).to have_link("All about gardening.", href: "/content_items/#{content_item_2.content_id}/audit")
+    expect(page).to have_link(content_items[1].title, href: "/content_items/#{content_items[1].content_id}/audit")
   end
 
   scenario "Default sorting by popularity" do
-    content_item_1.update!(six_months_page_views: 0)
-    content_item_2.update!(six_months_page_views: 1234)
+    content_items[0].update!(six_months_page_views: 0)
+    content_items[1].update!(six_months_page_views: 1234)
 
     visit audits_path
 
     rows = page.all('main tbody tr')
-    expect(rows[0].text).to match("All about gardening.")
-    expect(rows[1].text).to match("All about flooding.")
+    expect(rows[0].text).to match(content_items[1].title)
+    expect(rows[1].text).to match(content_items[0].title)
+  end
+
+  scenario "Showing 25 items on the first page" do
+    visit audits_path
+
+    content_items[0..24].each do |content_item|
+      expect(page).to have_content(content_item.title)
+    end
+
+    content_items[25..29].each do |content_item|
+      expect(page).to have_no_content(content_item.title)
+    end
+  end
+
+  scenario "Showing the second page of items" do
+    visit audits_path
+
+    click_link "Next →"
+
+    content_items[0..24].each do |content_item|
+      expect(page).to have_no_content(content_item.title)
+    end
+
+    content_items[25..29].each do |content_item|
+      expect(page).to have_content(content_item.title)
+    end
+  end
+
+  scenario "Clicking 'Next' on content items" do
+    visit audits_path
+
+    click_link content_items[0].title
+
+    (content_items.count - 1).times do |index|
+      expect(page).to have_content(content_items[index].title)
+      click_link "Next"
+    end
+
+    expect(page).to have_content(content_items.last.title)
+    expect(page).to have_no_content "Next"
   end
 end

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Navigation" do
-  let!(:first) { create(:content_item, title: "First", six_months_page_views: 3) }
-  let!(:second) { create(:content_item, title: "Second", six_months_page_views: 2) }
-  let!(:third) { create(:content_item, title: "Third", six_months_page_views: 1) }
+  let!(:first) { create(:content_item, title: "First", six_months_page_views: 10) }
+  let!(:second) { create(:content_item, title: "Second", six_months_page_views: 9) }
+  let!(:third) { create(:content_item, title: "Third", six_months_page_views: 8) }
 
   scenario "navigating between audits and the index page" do
     visit audits_path(some_filter: "value")

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -1,44 +1,110 @@
 RSpec.feature "Navigation" do
-  let!(:first) { create(:content_item, title: "First", six_months_page_views: 10) }
-  let!(:second) { create(:content_item, title: "Second", six_months_page_views: 9) }
-  let!(:third) { create(:content_item, title: "Third", six_months_page_views: 8) }
+  context "with three items with different numbers of page views" do
+    let!(:first) { create(:content_item, title: "First", six_months_page_views: 10) }
+    let!(:second) { create(:content_item, title: "Second", six_months_page_views: 9) }
+    let!(:third) { create(:content_item, title: "Third", six_months_page_views: 8) }
 
-  scenario "navigating between audits and the index page" do
-    visit audits_path(some_filter: "value")
-    click_link "First"
+    scenario "navigating between audits and the index page" do
+      visit audits_path(some_filter: "value")
+      click_link "First"
 
-    expected = content_item_audit_path(first, some_filter: "value")
-    expect(current_url).to end_with(expected)
+      expected = content_item_audit_path(first, some_filter: "value")
+      expect(current_url).to end_with(expected)
 
-    click_link "Next"
+      click_link "Next"
 
-    expected = content_item_audit_path(second, some_filter: "value")
-    expect(current_url).to end_with(expected)
+      expected = content_item_audit_path(second, some_filter: "value")
+      expect(current_url).to end_with(expected)
 
-    click_link "Next"
+      click_link "Next"
 
-    expected = content_item_audit_path(third, some_filter: "value")
-    expect(current_url).to end_with(expected)
+      expected = content_item_audit_path(third, some_filter: "value")
+      expect(current_url).to end_with(expected)
 
-    expect(page).to have_no_link("Next")
+      expect(page).to have_no_link("Next")
 
-    click_link "< All items"
+      click_link "< All items"
 
-    expected = audits_path(some_filter: "value")
-    expect(current_url).to end_with(expected)
+      expected = audits_path(some_filter: "value")
+      expect(current_url).to end_with(expected)
+    end
+
+    scenario "returning to the first page of the index" do
+      visit content_item_audit_path(first, some_filter: "value", page: "123")
+      click_link "< All items"
+
+      expected = audits_path(some_filter: "value")
+      expect(current_url).to end_with(expected)
+    end
+
+    scenario "continuing to next item on save" do
+      visit content_item_audit_path(first, some_filter: "value")
+
+      perform_audit
+
+      expected = content_item_audit_path(second, some_filter: "value")
+      expect(current_url).to end_with(expected)
+
+      expect(page).to have_content("Success: Saved successfully and continued to next item.")
+    end
+
+    scenario "not continuing to next item if fails to save" do
+      visit content_item_audit_path(first, some_filter: "value")
+
+      click_on "Save"
+
+      expected = content_item_audit_path(first, some_filter: "value")
+      expect(current_url).to end_with(expected)
+
+      expect(page).to have_content("Warning: Mandatory field missing")
+
+      click_on "Next"
+
+      expected = content_item_audit_path(second, some_filter: "value")
+      expect(current_url).to end_with(expected)
+    end
+
+    scenario "continuing to the next unadited item on save" do
+      visit content_item_audit_path(second)
+      perform_audit
+
+      visit audits_path
+      select "Non Audited", from: "audit_status"
+      click_on "Filter"
+
+      expect(page).to have_content(first.title)
+      expect(page).to have_no_content(second.title)
+      expect(page).to have_content(third.title)
+
+      click_link first.title
+      perform_audit
+      expect(current_url).to include(content_item_audit_path(third))
+    end
   end
 
-  scenario "returning to the first page of the index" do
-    visit content_item_audit_path(first, some_filter: "value", page: "123")
-    click_link "< All items"
+  context "when there are multiple pages of content items" do
+    let!(:content_items) {
+      create_list(:content_item, 30)
+        .sort_by(&:base_path)
+        .reverse
+    }
 
-    expected = audits_path(some_filter: "value")
-    expect(current_url).to end_with(expected)
+    scenario "Clicking 'Next' to navigate between individual content items" do
+      visit audits_path
+
+      click_link content_items[0].title
+
+      (content_items.count - 1).times do |index|
+        expect(page).to have_content(content_items[index].title)
+        click_link "Next"
+      end
+
+      expect(page).to have_content(content_items.last.title)
+      expect(page).to have_no_content "Next"
+    end
   end
 
-  scenario "continuing to next item on save" do
-    visit content_item_audit_path(first, some_filter: "value")
-
+  def perform_audit
     within("#question-1") { choose "No" }
     within("#question-2") { choose "No" }
     within("#question-3") { choose "No" }
@@ -49,45 +115,5 @@ RSpec.feature "Navigation" do
     within("#question-8") { choose "No" }
 
     click_on "Save"
-
-    expected = content_item_audit_path(second, some_filter: "value")
-    expect(current_url).to end_with(expected)
-
-    expect(page).to have_content("Success: Saved successfully and continued to next item.")
-  end
-
-  scenario "not continuing to next item if fails to save" do
-    visit content_item_audit_path(first, some_filter: "value")
-
-    click_on "Save"
-
-    expected = content_item_audit_path(first, some_filter: "value")
-    expect(current_url).to end_with(expected)
-
-    expect(page).to have_content("Warning: Mandatory field missing")
-
-    click_on "Next"
-
-    expected = content_item_audit_path(second, some_filter: "value")
-    expect(current_url).to end_with(expected)
-  end
-
-  context "when on the second page of content items" do
-    before do
-      create_list(:content_item, 25, six_months_page_views: 2)
-
-      create(:content_item, title: "Penultimate item", six_months_page_views: 1)
-      create(:content_item, title: "Last item", six_months_page_views: 0)
-
-      visit audits_path(page: 2)
-    end
-
-    scenario "continuing to the next item from the audit page" do
-      click_link "Penultimate item"
-      click_on "Next"
-
-      expect(page).to have_content("Last item")
-      expect(page).to have_no_link "Next"
-    end
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -16,47 +16,6 @@ RSpec.describe ContentItem, type: :model do
     end
   end
 
-  describe ".next_item" do
-    let!(:content_items) { create_list(:content_item, 5) }
-
-    it "returns the next item given the current item" do
-      result = ContentItem.all.next_item(content_items[0])
-      expect(result).to eq(content_items[1])
-
-      result = ContentItem.all.next_item(content_items[1])
-      expect(result).to eq(content_items[2])
-
-      result = ContentItem.all.next_item(content_items[2])
-      expect(result).to eq(content_items[3])
-
-      result = ContentItem.all.next_item(content_items[3])
-      expect(result).to eq(content_items[4])
-    end
-
-    it "returns nil if there's no next item" do
-      result = ContentItem.all.next_item(content_items[4])
-      expect(result).to be_nil
-    end
-
-    it "returns nil if the current item isn't in the scope" do
-      result = ContentItem.offset(1).next_item(ContentItem.first)
-      expect(result).to be_nil
-    end
-
-    it "is based on the filtered, ordered scope" do
-      scope = ContentItem.limit(3).offset(1).order("id desc")
-
-      result = scope.next_item(content_items[3])
-      expect(result).to eq(content_items[2])
-
-      result = scope.next_item(content_items[2])
-      expect(result).to eq(content_items[1])
-
-      result = scope.next_item(content_items[1])
-      expect(result).to be_nil
-    end
-  end
-
   describe "#url" do
     it "returns a url to a content item on gov.uk" do
       content_item = build(:content_item, base_path: "/api/content/item/path/1")


### PR DESCRIPTION
This change adds the ability to fetch the content item after a given
content item, according to the sort criteria provided in a query.

This is particularly useful when trying to pick the “next” item when
viewing a single content item.

The previous approach to this used the list of content items on a page,
but that approach breaks when viewing the last item on a page.

## Dependencies

- [x] https://github.com/alphagov/content-performance-manager/pull/251