### PR TITLE
Extract a `guidance#show` action from AuditsController 

### DIFF
--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -36,10 +36,6 @@ module Audits
       send_data(csv, filename: "Transformation_audit_report_CSV_download.csv")
     end
 
-    def guidance
-      @body = Govspeak::Document.new(File.read("doc/guidance.md")).to_html.html_safe
-    end
-
   private
 
     def audit

--- a/app/controllers/audits/guidances_controller.rb
+++ b/app/controllers/audits/guidances_controller.rb
@@ -1,0 +1,7 @@
+module Audits
+  class GuidancesController < ApplicationController
+    def show
+      @body = Govspeak::Document.new(File.read("doc/guidance.md")).to_html
+    end
+  end
+end

--- a/app/controllers/audits/guidances_controller.rb
+++ b/app/controllers/audits/guidances_controller.rb
@@ -1,7 +1,7 @@
 module Audits
   class GuidancesController < ApplicationController
     def show
-      @body = Govspeak::Document.new(File.read("doc/guidance.md")).to_html
+      @content = Support.get
     end
   end
 end

--- a/app/domain/audits/support.rb
+++ b/app/domain/audits/support.rb
@@ -1,0 +1,7 @@
+module Audits
+  class Support
+    def self.get
+      File.read("doc/guidance.md")
+    end
+  end
+end

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -34,7 +34,7 @@
 
   <hr/>
 
-  <%= link_to "Audit question help", "/audit-guidance" %>
+  <%= link_to "Audit question help", audits_guidance_path %>
 
   <h4>Do these things need to change?</h4>
 

--- a/app/views/audits/guidances/show.html.erb
+++ b/app/views/audits/guidances/show.html.erb
@@ -1,3 +1,3 @@
 <div class="col-sm-7">
-  <%=raw @body %>
+  <%=raw Govspeak::Document.new(@content).to_html %>
 </div>

--- a/app/views/audits/guidances/show.html.erb
+++ b/app/views/audits/guidances/show.html.erb
@@ -1,3 +1,3 @@
 <div class="col-sm-7">
-  <%= @body %>
+  <%=raw @body %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,22 +3,19 @@ Rails.application.routes.draw do
 
   resources :content_items, only: %w(index show), param: :content_id
 
-  scope module: :audits do
-    resources :audits, only: %w(index guidance)
-
-    resources :content_items, only: %w(index show), param: :content_id do
+  resources :content_items, only: %w(index show), param: :content_id do
+    scope module: "audits" do
       get :audit, to: "audits#show"
       post :audit, to: "audits#save"
       patch :audit, to: "audits#save"
     end
+  end
 
-    namespace :audits do
-      get :report
-      get :export
-      get :guidance
-    end
-
-    get "audit-guidance", to: "audits#guidance"
+  namespace :audits do
+    get '/', to: "audits#index"
+    get :report, to: "audits#report"
+    get :export, to: "audits#export"
+    resource :guidance, only: :show
   end
 
   namespace :inventory do

--- a/spec/features/audit/guidance_spec.rb
+++ b/spec/features/audit/guidance_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Using guidance while auditing a content item", type: :feature do
 
     click_link("Audit question help")
 
-    expect(page).to have_current_path("/audit-guidance")
+    expect(page).to have_current_path("/audits/guidance")
     expect(page).to have_css("h1")
     expect(page).to have_content("Audit GOV.UK content")
   end


### PR DESCRIPTION
It simplifies `AuditsController` by extracting out into a single 
resource action that does not belong to the controller.  

We should be rendering the Govspeak in the view with something 
like `show.govspeak.erb` but this is something to be addressed in the
 future. [I have tracked this work on this Trello card][1]  

[1]: https://trello.com/c/g5hdNO1t/25-render-guidance-content-in-the-view



