### PR TITLE
Fetch Content Items with Locale

### DIFF
--- a/app/domain/content/importers/all_content_items.rb
+++ b/app/domain/content/importers/all_content_items.rb
@@ -7,10 +7,10 @@ module Content
     end
 
     def run
-      content_ids = content_items_service.content_ids
+      content_items = content_items_service.fetch_all_with_default_locale_only
 
-      content_ids.each do |content_id|
-        ImportContentItemJob.perform_later(content_id)
+      content_items.each do |content_item|
+        ImportContentItemJob.perform_later(content_item[:content_id], content_item[:locale])
       end
     end
   end

--- a/app/domain/content/importers/single_content_item.rb
+++ b/app/domain/content/importers/single_content_item.rb
@@ -11,8 +11,8 @@ module Content
       self.metric_builder = Performance::MetricBuilder.new
     end
 
-    def run(content_id)
-      content_item = content_items_service.fetch(content_id)
+    def run(content_id, locale)
+      content_item = content_items_service.fetch(content_id, locale)
       links = content_items_service.links(content_id)
 
       set_metrics(content_item)

--- a/app/jobs/content/import_content_item_job.rb
+++ b/app/jobs/content/import_content_item_job.rb
@@ -1,8 +1,7 @@
 module Content
   class ImportContentItemJob < ApplicationJob
     def perform(*args)
-      content_id = args[0]
-      Importers::SingleContentItem.run(content_id)
+      Importers::SingleContentItem.run(*args)
     end
   end
 end

--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -15,20 +15,19 @@ module Clients
       @per_page = 700
     end
 
-    def content_ids
+    def fetch_all(fields)
       publishing_api
         .get_paged_editions(
-          fields: %w[content_id],
+          fields: fields,
           states: %w[published],
           per_page: @per_page,
         )
         .map { |response| normalise(response).fetch(:results) }
         .flatten
-        .map { |result| result.fetch(:content_id) }
     end
 
-    def fetch(content_id)
-      normalise(publishing_api.get_content(content_id))
+    def fetch(content_id, locale)
+      normalise(publishing_api.get_content(content_id, locale: locale))
     end
 
     def links(content_id)

--- a/db/migrate/20170804092444_add_locale_to_content_items.rb
+++ b/db/migrate/20170804092444_add_locale_to_content_items.rb
@@ -1,0 +1,11 @@
+class AddLocaleToContentItems < ActiveRecord::Migration[5.1]
+  def up
+    add_column :content_items, :locale, :string
+    ActiveRecord::Base.connection.execute("UPDATE content_items SET locale = 'en'")
+    change_column_null :content_items, :locale, false
+  end
+
+  def down
+    remove_column :content_items, :locale
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170728202520) do
+ActiveRecord::Schema.define(version: 20170804092444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20170728202520) do
     t.integer "number_of_pdfs", default: 0
     t.integer "six_months_page_views", default: 0
     t.string "publishing_app"
+    t.string "locale", null: false
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true
     t.index ["title"], name: "index_content_items_on_title"
   end
@@ -50,13 +51,13 @@ ActiveRecord::Schema.define(version: 20170728202520) do
   end
 
   create_table "content_items_organisations", id: false, force: :cascade do |t|
-    t.bigint "content_item_id", null: false
-    t.bigint "organisation_id", null: false
+    t.integer "content_item_id", null: false
+    t.integer "organisation_id", null: false
   end
 
   create_table "content_items_taxons", id: false, force: :cascade do |t|
-    t.bigint "content_item_id", null: false
-    t.bigint "taxon_id", null: false
+    t.integer "content_item_id", null: false
+    t.integer "taxon_id", null: false
     t.index ["content_item_id"], name: "index_content_items_taxons_on_content_item_id"
     t.index ["taxon_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true
   end

--- a/spec/controllers/taxonomy_projects_controller_spec.rb
+++ b/spec/controllers/taxonomy_projects_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe TaxonomyProjectsController, type: :controller do
       @project = TaxonomyProject.create
     end
     it 'redirects to the next todo' do
-      todo = @project.taxonomy_todos.create(content_item: ContentItem.create)
+      todo = @project.taxonomy_todos.create(content_item: create(:content_item))
       get :next, params: { id: @project.id }
       expect(response).to redirect_to(todo)
     end

--- a/spec/domain/content/importers/all_content_items_spec.rb
+++ b/spec/domain/content/importers/all_content_items_spec.rb
@@ -2,14 +2,17 @@ module Content
   RSpec.describe Importers::AllContentItems do
     before do
       allow(subject.content_items_service)
-        .to receive(:content_ids)
-              .and_return(%w(id-123 id-456))
+        .to receive(:fetch_all_with_default_locale_only)
+          .and_return([
+            { content_id: "id-123", locale: "en" },
+            { content_id: "id-456", locale: "cy" },
+          ])
     end
 
     describe '#run' do
       it 'creates a job for each content item to import' do
-        expect(ImportContentItemJob).to receive(:perform_later).with("id-123")
-        expect(ImportContentItemJob).to receive(:perform_later).with("id-456")
+        expect(ImportContentItemJob).to receive(:perform_later).with("id-123", "en")
+        expect(ImportContentItemJob).to receive(:perform_later).with("id-456", "cy")
 
         subject.run
       end

--- a/spec/domain/term_generation/term_generation_spec.rb
+++ b/spec/domain/term_generation/term_generation_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe TermGeneration::TaxonomyProjectBuilder do
         yyy
     EOCSV
 
-    ContentItem.create(content_id: 'xxx')
-    ContentItem.create(content_id: 'yyy')
+    create(:content_item, content_id: 'xxx')
+    create(:content_item, content_id: 'yyy')
     stub_request(:get, @url).to_return(body: csv)
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     sequence(:document_type) { |index| "document_type-#{index}" }
     sequence(:base_path) { |index| "api/content/item/path-%04i" % index }
     public_updated_at { Time.now }
+    locale { "en" }
 
     after(:create) do |content_item, evaluator|
       LinkFactory.add_organisations(content_item, evaluator.organisations)

--- a/spec/features/import_spec.rb
+++ b/spec/features/import_spec.rb
@@ -5,9 +5,9 @@ RSpec.feature "Import a single content item", type: :feature do
 
   it "creates jobs to import a single content items" do
     publishing_api_has_links(content_id: "id-123", links: { organisation: ["org-123"] })
-    publishing_api_has_item(content_id: "id-123", title: "title")
+    publishing_api_has_item(build(:content_item, content_id: "id-123", title: "title"))
 
-    expect { Content::ImportContentItemJob.new.perform("id-123") }
+    expect { Content::ImportContentItemJob.new.perform("id-123", "en") }
       .to change(ContentItem, :count).by(1)
       .and change(Link, :count).by(1)
   end

--- a/spec/jobs/content/import_content_item_job_spec.rb
+++ b/spec/jobs/content/import_content_item_job_spec.rb
@@ -1,8 +1,8 @@
 module Content
   RSpec.describe ImportContentItemJob, type: :job do
     it "calls the single content item importer" do
-      expect(Importers::SingleContentItem).to receive(:run).with("id-123")
-      subject.perform("id-123")
+      expect(Importers::SingleContentItem).to receive(:run).with(content_id: "id-123", locale: "en")
+      subject.perform(content_id: "id-123", locale: "en")
     end
   end
 end

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -3,24 +3,35 @@ RSpec.describe Clients::PublishingAPI do
 
   subject { Clients::PublishingAPI.new }
 
-  describe "#content_ids" do
-    let(:page_size) { 700 }
+  describe "#all_content_items" do
+    describe "multiple pages of 'en' content items" do
+      let(:page_size) { 700 }
 
-    let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
+      let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 
-    it "returns all the content ids" do
-      editions = content_ids.map { |id| { "content_id" => id } }
+      it "returns all the content ids and locales" do
+        editions = content_ids.map { |id| { "content_id" => id, "locale" => "en" } }
 
-      pages = editions.each_slice(page_size).map do |page|
-        {
-          "results" => page,
-        }
+        pages = editions.each_slice(page_size).map do |page|
+          {
+            "results" => page,
+          }
+        end
+
+        allow_any_instance_of(GdsApi::PublishingApiV2)
+          .to receive(:get_paged_editions)
+            .with(
+              fields: %[content_id locale],
+              states: %w[published],
+              per_page: page_size,
+            )
+            .and_return(pages)
+
+        result = subject.fetch_all(%[content_id locale])
+        expect(result).to eq(
+          editions.map(&:deep_symbolize_keys)
+        )
       end
-
-      allow_any_instance_of(GdsApi::PublishingApiV2).to receive(:get_paged_editions).and_return(pages)
-
-      result = subject.content_ids
-      expect(result).to eq(content_ids)
     end
   end
 
@@ -32,7 +43,7 @@ RSpec.describe Clients::PublishingAPI do
     end
 
     it "fetches a content item by content id" do
-      result = subject.fetch("id-123")
+      result = subject.fetch("id-123", "en")
       expect(result).to eq(content_item)
     end
   end


### PR DESCRIPTION
Some content items (approx. 1,600) do not have an “en” locale, which is
the assumed default when querying the Publishing API.

Asking for one of these content items by content ID, but without a valid
locale will result (correctly) in a 404 error from the Publishing API.

In order to address this, when fetching all content IDs from the
`/v2/editions` endpoint, we will also fetch the corresponding locales.
If the “en” locale is present, we use that by default. If it is not
present, we take the first arbitrary locale, so that the content item
is definitely included in the database.

We currently only accept one locale to avoid the race condition of
updating two content items with the same content ID at the same time.