### PR TITLE
Add override to running code coverage

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,6 @@
 require_relative "./lib/guard/lint"
 
-guard :rspec, cmd: 'bundle exec spring rspec' do
+guard :rspec, cmd: 'NO_COVERAGE=true bundle exec spring rspec' do
   watch('spec/spec_helper.rb')                        { "spec" }
   watch('spec/rails_helper.rb')                       { "spec" }
   watch('config/routes.rb')                           { "spec/routing" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,5 @@
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' unless ENV["NO_COVERAGE"]
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
We don't always want to generate the coverage report when we are
running the tests locally during development, as it slows down the tests.

The coverage report will not be generated when running guard. Running
default rake or just rspec will still generate the report, but these can
be overridden with an additional env var.

```
NO_COVERAGE=true bundle exec rspec
```

We can even alias this.