### PR TITLE
Only run code coverage reporting on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,9 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject()
+  govuk.buildProject(
+    beforeTest: {
+      govuk.setEnvar("TEST_COVERAGE", "true")
+    }
+  )
 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,8 @@
-require 'simplecov'
-SimpleCov.start 'rails'
+# Run code coverage reporting on Jenkins
+if ENV["TEST_COVERAGE"] == "true"
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
Running code coverage reporting in development can slow down running
tests, especially as the reporting runs on even single tests (as well
as the whole suite).

This change only runs the test coverage reporting if the environment
variable `TEST_COVERAGE` is `”true”`, and sets this appropriately in
the `Jenkinsfile`, so that test coverage reporting is run on Jenkins.

Test coverage can be run locally by running, for example:
`TEST_COVERAGE=true bundle exec rake`