### PR TITLE
Fix Organisation Links on Content Items

### DIFF
--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -11,7 +11,7 @@ class ContentItemDecorator < Draper::Decorator
 
   def organisation_links
     names = object.linked_organisations.collect do |organisation|
-      helpers.link_to(organisation.title, helpers.content_item_path(organisation.id))
+      helpers.link_to(organisation.title, helpers.content_item_path(organisation.content_id))
     end
 
     names.join(', ').html_safe

--- a/spec/features/performance/content_item_spec.rb
+++ b/spec/features/performance/content_item_spec.rb
@@ -80,6 +80,9 @@ RSpec.feature "Content Item Details", type: :feature do
     visit "/content_items/#{content.content_id}"
 
     expect(page).to have_text('Education, Health')
+
+    click_link "Education"
+    expect(page).to have_text('Education')
   end
 
   scenario "Renders when an item has not been published" do


### PR DESCRIPTION
Since we changed paths to use Content IDs, the organisations presented
on a Content Item have had broken links, because they still use the
ID.

This change fixes them to use the Content IDs, and adds a feature test.