### PR TITLE
Return 404 for non-existent content items

### DIFF
--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -40,7 +40,7 @@ module Audits
     end
 
     def content_item
-      @content_item ||= ContentItem.find_by(content_id: params.fetch(:content_item_content_id)).decorate
+      @content_item ||= ContentItem.find_by!(content_id: params.fetch(:content_item_content_id)).decorate
     end
 
     def next_item

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -7,7 +7,7 @@ class ContentItemsController < ApplicationController
   end
 
   def show
-    @content_item = ContentItem.find_by(content_id: params[:content_id]).decorate
+    @content_item = ContentItem.find_by!(content_id: params[:content_id]).decorate
   end
 
 private


### PR DESCRIPTION
The `find_by` method returns `nil` if a model cannot be found. We then
try to run `decorate` on `nil`, which causes a `500` error. This is
incorrect, and we should return a `404`.

Using `find_by!` will instead raise an `ActiveRecord::RecordNotFound`
error, which returns a `404` status, and a default “Not Found” page.