### PR TITLE
Specify paging on `FindContent`

### DIFF
--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -2,7 +2,7 @@ module Audits
   class AuditsController < BaseController
     def index
       respond_to do |format|
-        format.html { @content_items = FindContent.call(build_filter).decorate }
+        format.html { @content_items = FindContent.paged(build_filter).decorate }
         format.csv do
           send_data(
             Report.generate(build_filter, request.url),

--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -1,7 +1,7 @@
 module Audits
   class Filter
     include ActiveModel::Model
-    attr_accessor :theme_id, :page, :organisations, :document_type, :audit_status, :primary_org_only, :after
+    attr_accessor :theme_id, :page, :per_page, :organisations, :document_type, :audit_status, :primary_org_only, :after
 
     def audit_status=(value)
       @audit_status = if value.blank?

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -1,15 +1,23 @@
 module Audits
   class FindContent
-    def self.call(filter = Filter.new)
-      scope = Content::Query.new
-                .page(filter.page)
-                .organisations(filter.organisations, filter.primary_org_only)
-                .document_type(filter.document_type)
-                .after(filter.after)
-                .theme(filter.theme_id)
-                .scope
-
+    def self.paged(filter)
+      scope = query(filter).content_items
       filter.audited_policy.call(scope)
+    end
+
+    def self.all(filter)
+      scope = query(filter).all_content_items
+      filter.audited_policy.call(scope)
+    end
+
+    def self.query(filter)
+      Content::Query.new
+        .page(filter.page)
+        .per_page(filter.per_page)
+        .organisations(filter.organisations, filter.primary_org_only)
+        .document_type(filter.document_type)
+        .after(filter.after)
+        .theme(filter.theme_id)
     end
   end
 end

--- a/app/domain/audits/find_next_item.rb
+++ b/app/domain/audits/find_next_item.rb
@@ -2,9 +2,10 @@ module Audits
   class FindNextItem
     def self.call(content_item, filter)
       filter.after = content_item
-      filter.page = nil
+      filter.page = 1
+      filter.per_page = 1
 
-      FindContent.call(filter).first
+      FindContent.paged(filter).first
     end
   end
 end

--- a/app/domain/audits/monitor.rb
+++ b/app/domain/audits/monitor.rb
@@ -45,7 +45,7 @@ module Audits
   private
 
     def content_items
-      @content_items ||= FindContent.call(filter).limit(nil).offset(nil)
+      @content_items ||= FindContent.all(filter)
     end
 
     def percentage(number, out_of:)

--- a/app/domain/audits/report.rb
+++ b/app/domain/audits/report.rb
@@ -10,9 +10,8 @@ module Audits
 
     def initialize(filter, report_url)
       filter.audit_status = nil
-      filter.page = nil
 
-      self.content_items = FindContent.call(filter)
+      self.content_items = FindContent.all(filter)
       self.report_url = report_url
       self.questions = Question.order(:id).to_a
     end

--- a/spec/features/report/csv_export_spec.rb
+++ b/spec/features/report/csv_export_spec.rb
@@ -7,82 +7,98 @@ RSpec.feature "Exporting a CSV from the report page" do
     page.response_headers.fetch("Content-Disposition")
   end
 
-  let!(:hmrc) {
-    create(
-      :content_item,
-      title: "HMRC",
-      document_type: "organisation"
-    )
-  }
+  context "Two content items are in the database" do
+    let!(:hmrc) {
+      create(
+        :content_item,
+        title: "HMRC",
+        document_type: "organisation"
+      )
+    }
 
-  before do
-    example1 = create(
-      :content_item,
-      title: "Example 1",
-      base_path: "/example1",
-    )
+    before do
+      example1 = create(
+        :content_item,
+        title: "Example 1",
+        base_path: "/example1",
+      )
 
-    create(
-      :link,
-      source_content_id: example1.content_id,
-      target_content_id: hmrc.content_id,
-      link_type: "primary_publishing_organisation",
-    )
+      create(
+        :link,
+        source_content_id: example1.content_id,
+        target_content_id: hmrc.content_id,
+        link_type: "primary_publishing_organisation",
+      )
 
-    create(
-      :content_item,
-      title: "Example 2",
-      base_path: "/example2",
-    )
+      create(
+        :content_item,
+        title: "Example 2",
+        base_path: "/example2",
+      )
 
-    tax_audit = create(:audit, content_item: example1)
-    create(
-      :response,
-      question: create(:boolean_question),
-      audit: tax_audit,
-      value: "no"
-    )
+      tax_audit = create(:audit, content_item: example1)
+      create(
+        :response,
+        question: create(:boolean_question),
+        audit: tax_audit,
+        value: "no"
+      )
+    end
+
+    scenario "Exporting a csv file as an attachment" do
+      visit audits_report_path
+      click_link "Export filtered audit to CSV"
+
+      expect(content_type).to eq("text/csv")
+      expect(content_disposition).to start_with("attachment")
+      expect(content_disposition).to include(
+        'filename="Transformation_audit_report_CSV_download.csv"',
+      )
+
+      expect(page).to have_content("Title,URL")
+      expect(page).to have_content("Example 1,https://gov.uk/example1")
+    end
+
+    scenario "Applying the filters to the export" do
+      visit audits_report_path
+
+      select "HMRC", from: "organisations"
+      click_on "Filter"
+
+      click_link "Export filtered audit to CSV"
+      expect(page).to have_no_content("Example,https://gov.uk/example")
+    end
+
+    scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
+      visit audits_path
+      select "Audited", from: "audit_status"
+
+      click_on "Filter"
+      expect(page).to have_content("Example 1")
+      expect(page).to have_no_content("Example 2")
+
+      click_link "Report"
+
+      click_link "Export filtered audit to CSV"
+      expect(content_disposition).to include(
+        'filename="Transformation_audit_report_CSV_download.csv"',
+      )
+      expect(page).to have_content("Example 1")
+      expect(page).to have_content("Example 2")
+    end
   end
 
-  scenario "Exporting a csv file as an attachment" do
-    visit audits_report_path
-    click_link "Export filtered audit to CSV"
+  context "Multiple pages of content items are in the database" do
+    let!(:content_items) { create_list(:content_item, 50) }
 
-    expect(content_type).to eq("text/csv")
-    expect(content_disposition).to start_with("attachment")
-    expect(content_disposition).to include(
-      'filename="Transformation_audit_report_CSV_download.csv"',
-    )
+    scenario "Exporting an unfiltered audit to CSV with all the content items" do
+      visit audits_report_path
+      click_link "Export filtered audit to CSV"
 
-    expect(page).to have_content("Title,URL")
-    expect(page).to have_content("Example 1,https://gov.uk/example1")
-  end
+      csv = CSV.parse(page.body, headers: true)
 
-  scenario "Applying the filters to the export" do
-    visit audits_report_path
-
-    select "HMRC", from: "organisations"
-    click_on "Filter"
-
-    click_link "Export filtered audit to CSV"
-    expect(page).to have_no_content("Example,https://gov.uk/example")
-  end
-
-  scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-    visit audits_path
-    select "Audited", from: "audit_status"
-
-    click_on "Filter"
-    expect(page).to have_content("Example 1")
-    expect(page).to have_no_content("Example 2")
-
-    click_link "Report"
-
-    click_link "Export filtered audit to CSV"
-    expect(content_disposition).to include(
-      'filename="Transformation_audit_report_CSV_download.csv"',
-    )
-    expect(page).to have_content("Example 1")
-    expect(page).to have_content("Example 2")
+      number_of_metadata_rows = 1
+      expect(csv.count).to eq(content_items.count + number_of_metadata_rows)
+    end
   end
 end


### PR DESCRIPTION
Different consumers of `FindContent` need paged, or unpaged content,
depending on what the task is. For example, showing a list of content
items should be paged, but exporting a CSV should show all content
items.

This change replaces the single `FindContent#call` method with two
other methods for specifying whether the consumer wants paged content,
or all content items.

This fixes a bug with the CSV exporter, where it was only exporting
a single page of content items.