### PR TITLE
Add filter to query content by allocation

### DIFF
--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -11,6 +11,7 @@ module Audits
         document_type: params[:document_type],
         audit_status: params[:audit_status],
         primary_org_only: primary_org_only?,
+        allocated_to: params[:allocated_to],
       )
     end
 

--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -1,7 +1,15 @@
 module Audits
   class Filter
     include ActiveModel::Model
-    attr_accessor :theme_id, :page, :per_page, :organisations, :document_type, :audit_status, :primary_org_only, :after, :allocated_to
+    attr_accessor :after,
+      :allocated_to,
+      :audit_status,
+      :document_type,
+      :organisations,
+      :page,
+      :per_page,
+      :primary_org_only,
+      :theme_id,
 
     def audit_status=(value)
       @audit_status = if value.blank?

--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -1,7 +1,7 @@
 module Audits
   class Filter
     include ActiveModel::Model
-    attr_accessor :theme_id, :page, :per_page, :organisations, :document_type, :audit_status, :primary_org_only, :after
+    attr_accessor :theme_id, :page, :per_page, :organisations, :document_type, :audit_status, :primary_org_only, :after, :allocated_to
 
     def audit_status=(value)
       @audit_status = if value.blank?
@@ -9,6 +9,16 @@ module Audits
                       else
                         value.to_sym
                       end
+    end
+
+    def allocated_policy
+      if allocated_to == 'no_one'
+        Policies::NonAllocated
+      elsif allocated_to.blank?
+        Policies::AllocatedAndNonAllocated
+      else
+        Policies::Allocated
+      end
     end
 
     def audited_policy

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -2,12 +2,17 @@ module Audits
   class FindContent
     def self.paged(filter)
       scope = query(filter).content_items
-      filter.audited_policy.call(scope)
+      do_filter!(filter, scope)
     end
 
     def self.all(filter)
       scope = query(filter).all_content_items
-      filter.audited_policy.call(scope)
+      do_filter!(filter, scope)
+    end
+
+    def self.do_filter!(filter, scope)
+      scope = filter.audited_policy.call(scope)
+      filter.allocated_policy.call(scope, allocated_to: filter.allocated_to)
     end
 
     def self.query(filter)

--- a/app/domain/audits/policies/allocated.rb
+++ b/app/domain/audits/policies/allocated.rb
@@ -1,0 +1,9 @@
+module Audits
+  module Policies
+    class Allocated
+      def self.call(scope, allocated_to:)
+        scope.joins(:allocation).where('allocations.user_id = ?', allocated_to)
+      end
+    end
+  end
+end

--- a/app/domain/audits/policies/allocated_and_non_allocated.rb
+++ b/app/domain/audits/policies/allocated_and_non_allocated.rb
@@ -1,0 +1,9 @@
+module Audits
+  module Policies
+    class AllocatedAndNonAllocated
+      def self.call(scope, allocated_to: nil) # rubocop:disable Lint/UnusedMethodArgument
+        scope
+      end
+    end
+  end
+end

--- a/app/domain/audits/policies/non_allocated.rb
+++ b/app/domain/audits/policies/non_allocated.rb
@@ -1,0 +1,9 @@
+module Audits
+  module Policies
+    class NonAllocated
+      def self.call(scope, allocated_to: nil) # rubocop:disable Lint/UnusedMethodArgument
+        scope.where.not(id: Allocation.select(:content_item_id))
+      end
+    end
+  end
+end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -57,6 +57,12 @@ module DropdownHelper
     )
   end
 
+  def allocation_options
+    options = { "Me" => current_user.id, "No one" => :no_one }
+
+    options_for_select(options, params[:allocated_to])
+  end
+
   class ThemeOption < SimpleDelegator
     def name
       "All #{super}"

--- a/app/models/audits/allocation.rb
+++ b/app/models/audits/allocation.rb
@@ -1,0 +1,6 @@
+module Audits
+  class Allocation < ApplicationRecord
+    belongs_to :user
+    belongs_to :content_item
+  end
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,8 @@
 class ContentItem < ApplicationRecord
   has_one :audit, primary_key: :content_id, foreign_key: :content_id, class_name: "Audits::Audit"
+  has_one :allocation, class_name: "Audits::Allocation"
   has_one :report_row, primary_key: :content_id, foreign_key: :content_id, class_name: "Audits::ReportRow"
+
   has_many :links, primary_key: :content_id, foreign_key: :source_content_id
 
   after_save { Audits::ReportRow.precompute(self) }

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -11,6 +11,14 @@
     </div>
 
     <div class="form-group">
+      <%= label_tag :allocated_to, "Assigned to" %>
+      <%= select_tag :allocated_to,
+        allocation_options,
+        include_blank: "Anyone",
+        class: "form-control" %>
+    </div>
+
+    <div class="form-group">
       <%= label_tag :theme, 'Theme' %>
       <%= select_tag :theme,
           theme_and_subtheme_options,

--- a/db/migrate/20170810074052_create_allocations.rb
+++ b/db/migrate/20170810074052_create_allocations.rb
@@ -1,0 +1,10 @@
+class CreateAllocations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :allocations do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :content_item, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170804092444) do
+ActiveRecord::Schema.define(version: 20170810074052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "allocations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "content_item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_item_id"], name: "index_allocations_on_content_item_id"
+    t.index ["user_id"], name: "index_allocations_on_user_id"
+  end
 
   create_table "audits", id: :serial, force: :cascade do |t|
     t.string "content_id", null: false
@@ -195,6 +204,8 @@ ActiveRecord::Schema.define(version: 20170804092444) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "allocations", "content_items"
+  add_foreign_key "allocations", "users"
   add_foreign_key "taxonomy_todos", "content_items"
   add_foreign_key "taxonomy_todos", "taxonomy_projects"
 end

--- a/spec/domain/audits/policies/allocated_and_non_allocated_spec.rb
+++ b/spec/domain/audits/policies/allocated_and_non_allocated_spec.rb
@@ -1,0 +1,15 @@
+module Audits
+  RSpec.describe Policies::AllocatedAndNonAllocated do
+    subject { described_class }
+
+    let(:user) { create :user }
+    let(:unallocated) { create(:content_item) }
+
+    it "returns non-allocated content" do
+      create :allocation, user: user, content_item: create(:content_item)
+
+      scope = ContentItem.all
+      expect(subject.call(scope)).to match_array(ContentItem.all)
+    end
+  end
+end

--- a/spec/domain/audits/policies/allocated_spec.rb
+++ b/spec/domain/audits/policies/allocated_spec.rb
@@ -1,0 +1,17 @@
+module Audits
+  RSpec.describe Policies::Allocated do
+    subject { described_class }
+
+    let(:user) { create :user }
+    let(:unallocated) { create(:content_item) }
+
+    it "returns content allocated to a user" do
+      allocated = create(:content_item)
+      create :allocation, user: user, content_item: allocated
+
+      scope = ContentItem.all
+      expect(subject.call(scope, allocated_to: user.id)).to match_array(allocated)
+      expect(subject.call(scope, allocated_to: create(:user).id)).to be_empty
+    end
+  end
+end

--- a/spec/domain/audits/policies/non_allocated_spec.rb
+++ b/spec/domain/audits/policies/non_allocated_spec.rb
@@ -1,0 +1,15 @@
+module Audits
+  RSpec.describe Policies::NonAllocated do
+    subject { described_class }
+
+    let(:user) { create :user }
+    let(:unallocated) { create(:content_item) }
+
+    it "returns non-allocated content" do
+      create :allocation, user: user, content_item: create(:content_item)
+
+      scope = ContentItem.all
+      expect(subject.call(scope)).to match_array(unallocated)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -64,6 +64,9 @@ FactoryGirl.define do
     sequence(:target_content_id) { |i| "target-content-id-#{i}" }
   end
 
+  factory :allocation, class: Audits::Allocation do
+  end
+
   factory :theme, class: Audits::Theme do
     sequence(:name) { |i| "Theme #{i}" }
   end

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -1,0 +1,34 @@
+RSpec.feature "Content Allocation", type: :feature do
+  let(:content_item) { create :content_item, title: "content item 1" }
+
+  scenario "Filter allocated content" do
+    current_user = User.first
+    another_user = create(:user)
+    another_content_item = create(:content_item, title: "content item 2")
+    create(:content_item, title: "content item 3")
+
+    create(:allocation, content_item: content_item, user: current_user)
+    create(:allocation, content_item: another_content_item, user: another_user)
+
+    visit audits_path
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+
+    select "Me", from: "allocated_to"
+    click_on "Filter"
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+
+    select "No one", from: "allocated_to"
+    click_on "Filter"
+    expect(page).to_not have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+    expect(page).to have_content("content item 3")
+
+    select "Anyone", from: "allocated_to"
+    click_on "Filter"
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+    expect(page).to have_content("content item 3")
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/dOMctS8m/426-3-show-content-allocated-to-myself)

Supports content filtering by allocation. We will be able to list all 
content items that are assigned to myself, that has not been
assigned, or complete ignore the filter. 

I have split the PR in two commits because although the 
domain layer should remain the same, the UI is under user 
research.
 
```ruby
  filter = Filter.new(allocated_to: params[:allocated_to])
  result = Audits::FindContent.all(filter)
```
### Before

![image](https://user-images.githubusercontent.com/227328/29169877-24c8e4ee-7dce-11e7-9a76-8ce3f7a58301.png)


### After

![image](https://user-images.githubusercontent.com/227328/29169845-065394c8-7dce-11e7-9589-47766c466859.png)
