### PR TITLE
Remove test dependency from seeder

### DIFF
--- a/lib/seeder.rb
+++ b/lib/seeder.rb
@@ -1,7 +1,6 @@
 module Seeder
   def self.seed!
     questions!
-    user!
   end
 
   def self.questions!
@@ -18,16 +17,5 @@ module Seeder
 
     Audits::FreeTextQuestion.create!(text: "URLs of similar pages")
     Audits::FreeTextQuestion.create!(text: "Notes")
-  end
-
-  def self.user!
-    return if User.any?
-
-    User.create!(
-      uid: "user-1",
-      name: "Test User",
-      organisation_slug: "government-digital-service",
-      permissions: %w(inventory_management),
-    )
   end
 end

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Navigation" do
+RSpec.feature "Navigation", type: :feature do
   context "with three items with different numbers of page views" do
     let!(:first) { create(:content_item, title: "First", six_months_page_views: 10) }
     let!(:second) { create(:content_item, title: "Second", six_months_page_views: 9) }

--- a/spec/features/inventory/inventory_spec.rb
+++ b/spec/features/inventory/inventory_spec.rb
@@ -1,5 +1,14 @@
 # rubocop:disable Style/VariableNumber
 RSpec.feature "Managing inventory" do
+  before do
+    User.first.update!(
+      uid: "user-99",
+      name: "Test User",
+      organisation_slug: "government-digital-service",
+      permissions: %w(inventory_management),
+    )
+  end
+
   def expect_active(title)
     expect(page).to have_css(".row.active", text: title)
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,8 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
     Seeder.seed! if use_truncation?
   end
+
+  config.before(type: :feature) do
+    create :user
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/ltxuNAuz/441-remove-coupling-between-seeder-and-rspec-feature-tests)

Tests should not rely on global fixtures set up in a Seeder. The more
explicit the fixtures for a test the better. In this case, it contained
an explicit role that was needed for the test 
`spec/features/inventory/inventory_spec.rb`

I have removed the seeder code to setup the user, and I have setup 
a `config.before(type: feature)` for RSpec.feature tests.