### PR TITLE
Do not order Content Items in CSV reports

### DIFF
--- a/app/domain/audits/report.rb
+++ b/app/domain/audits/report.rb
@@ -44,7 +44,10 @@ module Audits
     end
 
     def rows
-      content_items.joins(:report_row).pluck(:data)
+      content_items
+        .joins(:report_row)
+        .unscope(:order)
+        .pluck(:data)
     end
 
     def report_timestamp


### PR DESCRIPTION
Ordering Content Items approximately doubles the length of time required
to execute the query.

When selecting a large number of columns, as we do for generating a
report, this can slow down the query enough to cause `504` Gateway
Timeout errors.

This change removes the ordering from CSV report queries in order to
speed up its performance and prevent `504` errors.