### PR TITLE
Only use decorated models in our view code

### DIFF
--- a/app/controllers/content/items_controller.rb
+++ b/app/controllers/content/items_controller.rb
@@ -1,13 +1,14 @@
 class Content::ItemsController < ApplicationController
+  decorates_assigned :content_item, :content_items
   helper_method :filter_params, :primary_org_only?
 
   def index
     @metrics = Performance::MetricBuilder.new.run_collection(search.all_content_items)
-    @content_items = search.content_items.decorate
+    @content_items = search.content_items
   end
 
   def show
-    @content_item = Content::Item.find_by!(content_id: params[:content_id]).decorate
+    @content_item = Content::Item.find_by!(content_id: params[:content_id])
   end
 
 private

--- a/app/decorators/audits/audit_decorator.rb
+++ b/app/decorators/audits/audit_decorator.rb
@@ -8,6 +8,10 @@ module Audits
     decorates_association :content_item
     decorates_association :user
 
+    def incomplete?
+      object.new_record?
+    end
+
     def last_updated
       h.format_datetime(updated_at)
     end

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -22,8 +22,8 @@
   </tr>
   </thead>
   <tbody>
-  <%= render collection: @content_items, partial: 'content_item' %>
+  <%= render collection: content_items, partial: 'content_item' %>
   </tbody>
 </table>
 
-<%= paginate @content_items, :window => 2 %>
+<%= paginate content_items, :window => 2 %>

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -17,18 +17,18 @@
 
   <nav class="prev-next-links">
     <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
-    <%= link_to "Next", content_item_audit_path(@next_item, filter_params), class: "next-item" if @next_item %>
+    <%= link_to "Next", content_item_audit_path(next_content_item, filter_params), class: "next-item" if next_content_item %>
   </nav>
 
-  <h2><%= link_to @content_item.title, @content_item.url, target: :_blank %></h2>
+  <h2><%= link_to content_item.title, content_item.url, target: :_blank %></h2>
 
   <p class="description">
-    <%= @audit.content_item.description %>
+    <%= content_item.description %>
   </p>
 
-  <%if @audit.content_item.whitehall_url %>
+  <%if content_item.whitehall_url %>
     <p>
-      <%= link_to "Open in Whitehall Publisher", @audit.content_item.whitehall_url %>
+      <%= link_to "Open in Whitehall Publisher", content_item.whitehall_url %>
     </p>
   <% end %>
 
@@ -38,7 +38,7 @@
 
   <h4>Do these things need to change?</h4>
 
-  <%= form_for [@audit.content_item, @audit], url: content_item_audit_path(filter_params) do |form| %>
+  <%= form_for [content_item, audit], url: content_item_audit_path(filter_params) do |form| %>
     <%= form.fields_for :responses do |builder| %>
       <% response = builder.object %>
       <% question = response.question %>
@@ -60,54 +60,54 @@
     <div id="audited">
       <h4>Audited</h4>
 
-      <% if @audit.new_record? %>
+      <% if audit.incomplete? %>
         <p>Not audited yet</p>
       <% else %>
-        <p><%= @audit.last_updated %></p>
-        <p>by <%= @audit.user.name %></p>
-        <p><%= @audit.user.department %></p>
+        <p><%= audit.last_updated %></p>
+        <p>by <%= audit.user.name %></p>
+        <p><%= audit.user.department %></p>
       <% end %>
     </div>
 
     <div id="organisations">
       <h4>Organisations</h4>
-      <p><%= @audit.content_item.organisations %></p>
+      <p><%= content_item.organisations %></p>
     </div>
 
     <div id="last-updated">
       <h4>Last major update</h4>
-      <p><%= @audit.content_item.last_updated %></p>
+      <p><%= content_item.last_updated %></p>
     </div>
 
     <div id="content-type">
       <h4>Content type</h4>
-      <p><%= @audit.content_item.document_type %></p>
+      <p><%= content_item.document_type %></p>
     </div>
 
     <div id="guidance">
       <h4>Guidance</h4>
-      <p><%= @audit.content_item.guidance %></p>
+      <p><%= content_item.guidance %></p>
     </div>
 
     <div id="topics">
       <h4>Topics</h4>
-      <p><%= @audit.content_item.topics %></p>
+      <p><%= content_item.topics %></p>
     </div>
 
     <div id="policy-areas">
       <h4>Policy areas</h4>
-      <p><%= @audit.content_item.policy_areas %></p>
+      <p><%= content_item.policy_areas %></p>
     </div>
 
     <div id="withdrawn">
       <h4>Withdrawn</h4>
-      <p><%= @audit.content_item.withdrawn %></p>
+      <p><%= content_item.withdrawn %></p>
     </div>
 
     <div id="pageviews">
       <h4>Unique pageviews</h4>
-      <p><%= @audit.content_item.one_month_page_views %> in the last month</p>
-      <p><%= @audit.content_item.six_months_page_views %> in the last six months</p>
+      <p><%= content_item.one_month_page_views %> in the last month</p>
+      <p><%= content_item.six_months_page_views %> in the last six months</p>
     </div>
   </div>
 </div>

--- a/app/views/content/items/index.html.erb
+++ b/app/views/content/items/index.html.erb
@@ -16,8 +16,8 @@
     </tr>
   </thead>
   <tbody>
-    <%= render @content_items %>
+    <%= render content_items %>
   </tbody>
 </table>
 
-<%= paginate @content_items, :window => 2 %>
+<%= paginate content_items, :window => 2 %>

--- a/app/views/content/items/show.html.erb
+++ b/app/views/content/items/show.html.erb
@@ -1,51 +1,51 @@
-<h1><%= @content_item.title %></h1>
+<h1><%= content_item.title %></h1>
 
 <table class="table table-bordered">
   <tbody>
     <tr>
       <td>Description</td>
-      <td><%= @content_item.description %></td>
+      <td><%= content_item.description %></td>
     </tr>
     <tr>
       <td>Page on GOV.UK</td>
-      <td><%= link_to @content_item.title, @content_item.url %></td>
+      <td><%= link_to content_item.title, content_item.url %></td>
     </tr>
     <tr>
       <td>Type of document</td>
-      <td><%= @content_item.document_type %></td>
+      <td><%= content_item.document_type %></td>
     </tr>
     <tr>
       <td>Page views (last month)</td>
-      <td><%= number_with_delimiter @content_item.one_month_page_views %></td>
+      <td><%= number_with_delimiter content_item.one_month_page_views %></td>
     </tr>
     <tr>
       <td>Page views (6 months)</td>
-      <td><%= number_with_delimiter @content_item.six_months_page_views %></td>
+      <td><%= number_with_delimiter content_item.six_months_page_views %></td>
     </tr>
     <tr>
       <td>Last major update</td>
       <td>
-        <%= @content_item.last_updated %>
+        <%= content_item.last_updated %>
       </td>
     </tr>
     <tr>
       <td>Support contacts</td>
       <td>
-        <%= @content_item.feedex_link %>
+        <%= content_item.feedex_link %>
       </td>
     </tr>
     <tr>
       <td>Organisation</td>
       <td>
-        <%= @content_item.organisation_links %>
+        <%= content_item.organisation_links %>
       </td>
     </tr>
     <tr>
       <td>Number of pdfs</td>
-      <td><%= number_with_delimiter @content_item.number_of_pdfs %></td>
+      <td><%= number_with_delimiter content_item.number_of_pdfs %></td>
     </tr>
       <td>Topics (new taxonomy)</td>
-      <td><%= @content_item.taxons_as_string %></td>
+      <td><%= content_item.taxons_as_string %></td>
     </tr>
   </tbody>
 </table>

--- a/spec/controllers/content/items_controller_spec.rb
+++ b/spec/controllers/content/items_controller_spec.rb
@@ -34,10 +34,6 @@ RSpec.describe Content::ItemsController, type: :controller do
       expect(assigns(:content_item)).to eq(content_item)
     end
 
-    it "decorates the content item" do
-      expect(assigns(:content_item)).to be_decorated
-    end
-
     it "renders the :show template" do
       expect(subject).to render_template(:show)
     end


### PR DESCRIPTION
We decorate our models so that they can be used in our view code. Our controller shouldn't depend on any behavior added through decoration.

The `decorates_assigned` helper from https://github.com/drapergem/draper creates a helper method that we should reference exclusively in our view code.