### PR TITLE
Allocate individual content items

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -5,23 +5,29 @@ module Audits
     end
 
     def create
-      content_ids = params.fetch(:content_ids)
-      user_uid = params.fetch(:allocate_to)
+      allocation = AllocateContent.call(user_uid: user_uid, content_ids: content_ids)
 
-      if user_uid == "no_one"
-        UnallocateContent.call(content_ids: content_ids)
-      else
-        AllocateContent.call(user_uid: user_uid, content_ids: content_ids)
-      end
+      redirect_to audits_allocations_url(redirect_params), notice: allocation.message
+    end
 
-      message = "#{content_ids.length} items assigned to #{current_user.name}"
-      redirect_to audits_allocations_url(redirect_params), notice: message
+    def destroy
+      unallocation = UnallocateContent.call(content_ids: content_ids)
+
+      redirect_to audits_allocations_url(redirect_params), notice: unallocation.message
     end
 
   private
 
+    def user_uid
+      params.fetch(:allocate_to)
+    end
+
+    def content_ids
+      params.fetch(:content_ids) { [] }
+    end
+
     def redirect_params
-      params.permit(:user_uid, :audit_status, :theme, :organisations, :primary, :document_type, :content_ids, :allocate_to, :allocated_to)
+      params.permit(:user_uid, :audit_status, :theme, :organisations, :primary, :document_type, :content_ids, :allocated_to, :allocate_to)
     end
   end
 end

--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -8,10 +8,11 @@ module Audits
       content_ids = params.fetch(:content_ids)
       user_uid = params.fetch(:allocate_to)
 
-      AllocateContent.call(
-        user_uid: user_uid,
-        content_ids: content_ids
-      )
+      if user_uid == "no_one"
+        UnallocateContent.call(content_ids: content_ids)
+      else
+        AllocateContent.call(user_uid: user_uid, content_ids: content_ids)
+      end
 
       message = "#{content_ids.length} items assigned to #{current_user.name}"
       redirect_to audits_allocations_url(redirect_params), notice: message

--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -5,8 +5,8 @@ module Audits
     end
 
     def create
-      content_ids = params[:allocations][:content_ids]
-      user_uid = params[:allocations][:user_uid]
+      content_ids = params.fetch(:content_ids)
+      user_uid = params.fetch(:allocate_to)
 
       AllocateContent.call(
         user_uid: user_uid,
@@ -14,7 +14,13 @@ module Audits
       )
 
       message = "#{content_ids.length} items assigned to #{current_user.name}"
-      redirect_to audits_allocations_path, notice: message
+      redirect_to audits_allocations_url(redirect_params), notice: message
+    end
+
+  private
+
+    def redirect_params
+      params.permit(:user_uid, :audit_status, :theme, :organisations, :primary, :document_type, :content_ids, :allocate_to, :allocated_to)
     end
   end
 end

--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -1,7 +1,9 @@
 module Audits
   class AllocationsController < BaseController
+    decorates_assigned :content_items
+
     def index
-      @content_items = FindContent.paged(build_filter).decorate
+      @content_items = FindContent.paged(build_filter)
     end
 
     def create

--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -1,0 +1,20 @@
+module Audits
+  class AllocationsController < BaseController
+    def index
+      @content_items = FindContent.paged(build_filter).decorate
+    end
+
+    def create
+      content_ids = params[:allocations][:content_ids]
+      user_uid = params[:allocations][:user_uid]
+
+      AllocateContent.call(
+        user_uid: user_uid,
+        content_ids: content_ids
+      )
+
+      message = "#{content_ids.length} items assigned to #{current_user.name}"
+      redirect_to audits_allocations_path, notice: message
+    end
+  end
+end

--- a/app/domain/audits/allocate_content.rb
+++ b/app/domain/audits/allocate_content.rb
@@ -20,6 +20,21 @@ module Audits
           Allocation.create!(user: user, content_item: content_item)
         end
       end
+
+      Result.new(user, content_items)
+    end
+
+    class Result
+      attr_reader :user, :content_items
+
+      def initialize(user, content_items)
+        @user = user
+        @content_items = content_items
+      end
+
+      def message
+        "#{content_items.count} items allocated to #{user.name}"
+      end
     end
   end
 end

--- a/app/domain/audits/allocate_content.rb
+++ b/app/domain/audits/allocate_content.rb
@@ -1,0 +1,25 @@
+module Audits
+  class AllocateContent
+    def self.call(*args)
+      new(*args).call
+    end
+
+    attr_accessor :user, :content_items
+
+    def initialize(user_uid:, content_ids:)
+      self.user = User.find_by(uid: user_uid)
+      self.content_items = Content::Item.where(content_id: content_ids)
+    end
+
+    def call
+      content_items.find_each do |content_item|
+        allocation = Allocation.find_by(content_item: content_item)
+        if allocation
+          allocation.update!(user: user, content_item: content_item)
+        else
+          Allocation.create!(user: user, content_item: content_item)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/audits/allocate_content.rb
+++ b/app/domain/audits/allocate_content.rb
@@ -12,16 +12,18 @@ module Audits
     end
 
     def call
-      content_items.find_each do |content_item|
-        allocation = Allocation.find_by(content_item: content_item)
-        if allocation
-          allocation.update!(user: user, content_item: content_item)
-        else
-          Allocation.create!(user: user, content_item: content_item)
-        end
-      end
+      Allocation.transaction { create_or_update_allocation! }
 
       Result.new(user, content_items)
+    end
+
+  private
+
+    def create_or_update_allocation!
+      Allocation.where(content_item: content_items).delete_all
+      content_items.find_each do |item|
+        Allocation.create(user: user, content_item: item)
+      end
     end
 
     class Result

--- a/app/domain/audits/unallocate_content.rb
+++ b/app/domain/audits/unallocate_content.rb
@@ -12,6 +12,20 @@ module Audits
 
     def call
       Allocation.where(content_id: content_ids).delete_all
+
+      Result.new(content_ids)
+    end
+
+    class Result
+      attr_reader :content_ids
+
+      def initialize(content_ids)
+        @content_ids = content_ids
+      end
+
+      def message
+        "#{content_ids.length} items unallocated"
+      end
     end
   end
 end

--- a/app/domain/audits/unallocate_content.rb
+++ b/app/domain/audits/unallocate_content.rb
@@ -1,0 +1,17 @@
+module Audits
+  class UnallocateContent
+    def self.call(*args)
+      new(*args).call
+    end
+
+    attr_accessor :content_ids
+
+    def initialize(content_ids:)
+      self.content_ids = content_ids
+    end
+
+    def call
+      Allocation.where(content_id: content_ids).delete_all
+    end
+  end
+end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -57,10 +57,16 @@ module DropdownHelper
     )
   end
 
-  def allocation_options
+  def allocated_to_options
     options = { "Me" => current_user.uid, "No one" => :no_one }
 
     options_for_select(options, params[:allocated_to])
+  end
+
+  def allocate_to_options
+    options = { "Me" => current_user.uid, "No one" => :no_one }
+
+    options_for_select(options, params[:allocate_to])
   end
 
   class ThemeOption < SimpleDelegator

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -1,0 +1,10 @@
+module FilterHelper
+  def filter_to_hidden_fields
+    filter_params = params.except(:controller, :action)
+    hidden_fields = filter_params.keys.map do |key|
+      hidden_field_tag key, filter_params.dig(key)
+    end
+
+    hidden_fields.join.html_safe
+  end
+end

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -1,6 +1,6 @@
 module FilterHelper
-  def filter_to_hidden_fields
-    filter_params = params.except(:controller, :action)
+  def filter_to_hidden_fields(*fields_to_exclude)
+    filter_params = params.except(:controller, :action).except(*fields_to_exclude)
     hidden_fields = filter_params.keys.map do |key|
       hidden_field_tag key, filter_params.dig(key)
     end

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -1,0 +1,11 @@
+module MenuHelper
+  def navigation_link(text, url, scope)
+    status = controller.controller_name == scope ? 'active' : ''
+
+    content_tag :li, role: "presentation", class: status do
+      link_to_unless_current text, url, aria_controls: "home", role: "tab" do
+        link_to text, "#", aria_controls: "home", role: "tab"
+      end
+    end
+  end
+end

--- a/app/views/audits/allocations/_content_item.html.erb
+++ b/app/views/audits/allocations/_content_item.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= check_box_tag "allocations[content_ids][]", content_item.content_id %></td>
+  <td><%= check_box_tag "content_ids[]", content_item.content_id %></td>
   <td><%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %></td>
   <td><%= content_item.six_months_page_views %></td>
 </tr>

--- a/app/views/audits/allocations/_content_item.html.erb
+++ b/app/views/audits/allocations/_content_item.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td><%= check_box_tag "allocations[content_ids][]", content_item.content_id %></td>
+  <td><%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %></td>
+  <td><%= content_item.six_months_page_views %></td>
+</tr>

--- a/app/views/audits/allocations/_notice.html.erb
+++ b/app/views/audits/allocations/_notice.html.erb
@@ -1,0 +1,6 @@
+<% if flash[:notice] %>
+    <div class="alert alert-success" role="alert">
+      <%= flash[:notice] %>
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+<% end %>

--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,0 +1,52 @@
+<h1>Filter</h1>
+<%= form_tag submit_path, method: :get do %>
+  <div class="form-group">
+    <%= label_tag :audit_status, 'Audit status' %>
+    <%= select_tag :audit_status,
+      audit_status_options,
+      include_blank: "All",
+      class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :allocated_to, "Assigned to" %>
+    <%= select_tag :allocated_to,
+      allocation_options,
+      include_blank: "Anyone",
+      class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :theme, 'Theme' %>
+    <%= select_tag :theme,
+      theme_and_subtheme_options,
+      include_blank: "All",
+      class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :organisations, "Organisation" %>
+    <%= select_tag :organisations,
+      organisation_options,
+      include_blank: "All",
+      class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= hidden_field_tag :primary, false, id: nil %>
+    <%= check_box_tag :primary, true, primary_org_only? %>
+    <%= label_tag :primary, "Primary organisation only" %>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :document_type, 'Content type' %>
+    <%= select_tag :document_type,
+      document_type_options,
+      include_blank: "All",
+      class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
+  </div>
+<% end %>

--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -11,7 +11,7 @@
   <div class="form-group">
     <%= label_tag :allocated_to, "Assigned to" %>
     <%= select_tag :allocated_to,
-      allocation_options,
+      allocated_to_options,
       include_blank: "Anyone",
       class: "form-control" %>
   </div>

--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,4 +1,3 @@
-<h1>Filter</h1>
 <%= form_tag audits_allocations_path, method: :get do %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' %>

--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,52 +1,10 @@
 <h1>Filter</h1>
-<%= form_tag submit_path, method: :get do %>
-  <div class="form-group">
-    <%= label_tag :audit_status, 'Audit status' %>
-    <%= select_tag :audit_status,
-      audit_status_options,
-      include_blank: "All",
-      class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :allocated_to, "Assigned to" %>
-    <%= select_tag :allocated_to,
-      allocated_to_options,
-      include_blank: "Anyone",
-      class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :theme, 'Theme' %>
-    <%= select_tag :theme,
-      theme_and_subtheme_options,
-      include_blank: "All",
-      class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :organisations, "Organisation" %>
-    <%= select_tag :organisations,
-      organisation_options,
-      include_blank: "All",
-      class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= hidden_field_tag :primary, false, id: nil %>
-    <%= check_box_tag :primary, true, primary_org_only? %>
-    <%= label_tag :primary, "Primary organisation only" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :document_type, 'Content type' %>
-    <%= select_tag :document_type,
-      document_type_options,
-      include_blank: "All",
-      class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
-  </div>
+<%= form_tag audits_allocations_path, method: :get do %>
+  <%= render 'audits/common/audit_status' %>
+  <%= render 'audits/common/allocated_to' %>
+  <%= render 'audits/common/theme_subtheme' %>
+  <%= render 'audits/common/organisations' %>
+  <%= render 'audits/common/primary' %>
+  <%= render 'audits/common/document_type' %>
+  <%= render 'audits/common/submit' %>
 <% end %>

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -1,0 +1,17 @@
+<div class="allocation-menu">
+  <div class="row">
+    <div class="col-sm-8">
+    </div>
+    <div class="col-sm-4">
+      <div class="form-group form-inline pull-right">
+        <%= label_tag :allocate_to, "Assign to" %>
+        <%= select_tag "allocate_to",
+          allocate_to_options,
+          class: "form-control",
+          id: "allocate_to" %>
+        <%= filter_to_hidden_fields(:allocate_to) %>
+        <%= submit_tag "Go", class: "btn btn-default" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -38,8 +38,8 @@
       </tr>
       </thead>
       <tbody>
-      <%= render collection: @content_items, partial: 'content_item' %>
+      <%= render collection: content_items, partial: 'content_item' %>
       </tbody>
     </table>
 <% end %>
-<%= paginate @content_items, :window => 2 %>
+<%= paginate content_items, :window => 2 %>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -2,13 +2,7 @@
     <%= render 'sidebar' %>
 <% end %>
 
-<% if flash[:notice] %>
-    <div class="alert alert-success" role="alert">
-      <%= flash[:notice] %>
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    </div>
-
-<% end %>
+<%= render 'notice' %>
 
 <%= form_tag audits_allocations_path do %>
     <div class="allocation-menu">

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -5,23 +5,7 @@
 <%= render 'notice' %>
 
 <%= form_tag audits_allocations_path do %>
-    <div class="allocation-menu">
-      <div class="row">
-        <div class="col-sm-8">
-        </div>
-        <div class="col-sm-4">
-          <div class="form-group form-inline pull-right">
-            <%= label_tag :allocate_to, "Assign to" %>
-            <%= select_tag "allocate_to",
-              allocate_to_options,
-              class: "form-control",
-              id: "allocate_to" %>
-            <%= filter_to_hidden_fields(:allocate_to) %>
-            <%= submit_tag "Go", class: "btn btn-default" %>
-          </div>
-        </div>
-      </div>
-    </div>
+    <%= render 'toolbar' %>
 
     <table class="table table-bordered table-hover">
       <thead>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar do %>
-    <%= render 'sidebar', submit_path: audits_allocations_path %>
+    <%= render 'sidebar' %>
 <% end %>
 
 <% if flash[:notice] %>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :sidebar do %>
+    <%= render 'sidebar', submit_path: audits_allocations_path %>
+<% end %>
+
+<% if flash[:notice] %>
+    <div class="notice"><%= flash[:notice] %></div>
+<% end %>
+
+<%= form_tag audits_allocations_path do %>
+    <div class="allocation-menu">
+      <div class="row">
+        <div class="col-sm-8">
+        </div>
+        <div class="col-sm-4">
+          <div class="form-group form-inline pull-right">
+            <%= label_tag :allocate_to, "Assign to" %>
+            <%= select_tag "allocations[user_uid]",
+              allocation_options,
+              class: "form-control",
+              id: "allocate_to" %>
+            <%= submit_tag "Go", class: "btn btn-default" %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <table class="table table-bordered table-hover">
+      <thead>
+      <tr class="table-header">
+        <td></td>
+        <td>Title</td>
+        <td>Page views (6mth)</td>
+      </tr>
+      </thead>
+      <tbody>
+      <%= render collection: @content_items, partial: 'content_item' %>
+      </tbody>
+    </table>
+<% end %>
+<%= paginate @content_items, :window => 2 %>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -14,10 +14,11 @@
         <div class="col-sm-4">
           <div class="form-group form-inline pull-right">
             <%= label_tag :allocate_to, "Assign to" %>
-            <%= select_tag "allocations[user_uid]",
+            <%= select_tag "allocate_to",
               allocation_options,
               class: "form-control",
               id: "allocate_to" %>
+            <%= filter_to_hidden_fields %>
             <%= submit_tag "Go", class: "btn btn-default" %>
           </div>
         </div>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -18,7 +18,7 @@
               allocation_options,
               class: "form-control",
               id: "allocate_to" %>
-            <%= filter_to_hidden_fields %>
+            <%= filter_to_hidden_fields(:allocate_to) %>
             <%= submit_tag "Go", class: "btn btn-default" %>
           </div>
         </div>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -3,7 +3,11 @@
 <% end %>
 
 <% if flash[:notice] %>
-    <div class="notice"><%= flash[:notice] %></div>
+    <div class="alert alert-success" role="alert">
+      <%= flash[:notice] %>
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+
 <% end %>
 
 <%= form_tag audits_allocations_path do %>
@@ -15,7 +19,7 @@
           <div class="form-group form-inline pull-right">
             <%= label_tag :allocate_to, "Assign to" %>
             <%= select_tag "allocate_to",
-              allocation_options,
+              allocate_to_options,
               class: "form-control",
               id: "allocate_to" %>
             <%= filter_to_hidden_fields(:allocate_to) %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,55 +1,53 @@
-<div class="col-sm-3 sidebar">
-  <h1>Filter</h1>
-  <%= form_tag submit_path, method: :get do %>
+<h1>Filter</h1>
+<%= form_tag submit_path, method: :get do %>
 
-    <div class="form-group">
-      <%= label_tag :audit_status, 'Audit status' %>
-      <%= select_tag :audit_status,
-      audit_status_options,
-      include_blank: "All",
+  <div class="form-group">
+    <%= label_tag :audit_status, 'Audit status' %>
+    <%= select_tag :audit_status,
+    audit_status_options,
+    include_blank: "All",
+    class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :allocated_to, "Assigned to" %>
+    <%= select_tag :allocated_to,
+      allocation_options,
+      include_blank: "Anyone",
       class: "form-control" %>
-    </div>
+  </div>
 
-    <div class="form-group">
-      <%= label_tag :allocated_to, "Assigned to" %>
-      <%= select_tag :allocated_to,
-        allocation_options,
-        include_blank: "Anyone",
+  <div class="form-group">
+    <%= label_tag :theme, 'Theme' %>
+    <%= select_tag :theme,
+        theme_and_subtheme_options,
+        include_blank: "All",
         class: "form-control" %>
-    </div>
+  </div>
 
-    <div class="form-group">
-      <%= label_tag :theme, 'Theme' %>
-      <%= select_tag :theme,
-          theme_and_subtheme_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
+  <div class="form-group">
+    <%= label_tag :organisations, "Organisation" %>
+    <%= select_tag :organisations,
+        organisation_options,
+        include_blank: "All",
+        class: "form-control" %>
+  </div>
 
-    <div class="form-group">
-      <%= label_tag :organisations, "Organisation" %>
-      <%= select_tag :organisations,
-          organisation_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
+  <div class="form-group">
+    <%= hidden_field_tag :primary, false, id: nil %>
+    <%= check_box_tag :primary, true, primary_org_only? %>
+    <%= label_tag :primary, "Primary organisation only" %>
+  </div>
 
-    <div class="form-group">
-      <%= hidden_field_tag :primary, false, id: nil %>
-      <%= check_box_tag :primary, true, primary_org_only? %>
-      <%= label_tag :primary, "Primary organisation only" %>
-    </div>
+  <div class="form-group">
+    <%= label_tag :document_type, 'Content type' %>
+    <%= select_tag :document_type,
+        document_type_options,
+        include_blank: "All",
+        class: "form-control" %>
+  </div>
 
-    <div class="form-group">
-      <%= label_tag :document_type, 'Content type' %>
-      <%= select_tag :document_type,
-          document_type_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
-
-    <div class="form-group">
-      <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
-    </div>
-  <% end %>
-</div>
+  <div class="form-group">
+    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
+  </div>
+<% end %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -12,7 +12,7 @@
   <div class="form-group">
     <%= label_tag :allocated_to, "Assigned to" %>
     <%= select_tag :allocated_to,
-      allocation_options,
+      allocated_to_options,
       include_blank: "Anyone",
       class: "form-control" %>
   </div>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,4 +1,3 @@
-<h1>Filter</h1>
 <%= form_tag audits_path, method: :get do %>
     <%= render 'audits/common/audit_status' %>
     <%= render 'audits/common/allocated_to' %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,53 +1,10 @@
 <h1>Filter</h1>
-<%= form_tag submit_path, method: :get do %>
-
-  <div class="form-group">
-    <%= label_tag :audit_status, 'Audit status' %>
-    <%= select_tag :audit_status,
-    audit_status_options,
-    include_blank: "All",
-    class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :allocated_to, "Assigned to" %>
-    <%= select_tag :allocated_to,
-      allocated_to_options,
-      include_blank: "Anyone",
-      class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :theme, 'Theme' %>
-    <%= select_tag :theme,
-        theme_and_subtheme_options,
-        include_blank: "All",
-        class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :organisations, "Organisation" %>
-    <%= select_tag :organisations,
-        organisation_options,
-        include_blank: "All",
-        class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= hidden_field_tag :primary, false, id: nil %>
-    <%= check_box_tag :primary, true, primary_org_only? %>
-    <%= label_tag :primary, "Primary organisation only" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :document_type, 'Content type' %>
-    <%= select_tag :document_type,
-        document_type_options,
-        include_blank: "All",
-        class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
-  </div>
+<%= form_tag audits_path, method: :get do %>
+    <%= render 'audits/common/audit_status' %>
+    <%= render 'audits/common/allocated_to' %>
+    <%= render 'audits/common/theme_subtheme' %>
+    <%= render 'audits/common/organisations' %>
+    <%= render 'audits/common/primary' %>
+    <%= render 'audits/common/document_type' %>
+    <%= render 'audits/common/submit' %>
 <% end %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -3,17 +3,6 @@
   <%= render 'sidebar', submit_path: audits_path %>
 <% end %>
 
-<% content_for :header do %>
-<ul class="nav nav-tabs">
-  <li role="presentation" class="active">
-    <%= link_to "Content", "#", aria_controls: "home", role: "tab" %>
-  </li>
-  <li role="presentation">
-    <%= link_to "Report", audits_report_path(filter_params), aria_controls: "home", role: "tab" %>
-  </li>
-</ul>
-<% end %>
-
 <table class="table table-bordered table-hover">
   <thead>
   <tr class="table-header">

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -1,6 +1,6 @@
 
 <% content_for :sidebar do %>
-  <%= render 'sidebar', submit_path: audits_path %>
+  <%= render 'sidebar' %>
 <% end %>
 
 <table class="table table-bordered table-hover">

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <%= label_tag :allocated_to, "Assigned to" %>
+  <%= select_tag :allocated_to,
+    allocated_to_options,
+    include_blank: "Anyone",
+    class: "form-control" %>
+</div>

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <%= label_tag :audit_status, 'Audit status' %>
+  <%= select_tag :audit_status,
+    audit_status_options,
+    include_blank: "All",
+    class: "form-control" %>
+</div>

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <%= label_tag :document_type, 'Content type' %>
+  <%= select_tag :document_type,
+    document_type_options,
+    include_blank: "All",
+    class: "form-control" %>
+</div>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <%= label_tag :organisations, "Organisation" %>
+  <%= select_tag :organisations,
+    organisation_options,
+    include_blank: "All",
+    class: "form-control" %>
+</div>

--- a/app/views/audits/common/_primary.html.erb
+++ b/app/views/audits/common/_primary.html.erb
@@ -1,0 +1,5 @@
+<div class="form-group">
+  <%= hidden_field_tag :primary, false, id: nil %>
+  <%= check_box_tag :primary, true, primary_org_only? %>
+  <%= label_tag :primary, "Primary organisation only" %>
+</div>

--- a/app/views/audits/common/_submit.html.erb
+++ b/app/views/audits/common/_submit.html.erb
@@ -1,0 +1,3 @@
+<div class="form-group">
+  <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
+</div>

--- a/app/views/audits/common/_submit.html.erb
+++ b/app/views/audits/common/_submit.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
+  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block" %>
 </div>

--- a/app/views/audits/common/_theme_subtheme.html.erb
+++ b/app/views/audits/common/_theme_subtheme.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <%= label_tag :theme, 'Theme' %>
+  <%= select_tag :theme,
+    theme_and_subtheme_options,
+    include_blank: "All",
+    class: "form-control" %>
+</div>

--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,37 +1,8 @@
 <h1>Filter</h1>
-<%= form_tag submit_path, method: :get do %>
-
-  <div class="form-group">
-    <%= label_tag :theme, 'Theme' %>
-    <%= select_tag :theme,
-        theme_and_subtheme_options,
-        include_blank: "All",
-        class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :organisations, "Organisation" %>
-    <%= select_tag :organisations,
-        organisation_options,
-        include_blank: "All",
-        class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= hidden_field_tag :primary, false, id: nil %>
-    <%= check_box_tag :primary, true, primary_org_only? %>
-    <%= label_tag :primary, "Primary organisation only" %>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag :document_type, 'Content type' %>
-    <%= select_tag :document_type,
-        document_type_options,
-        include_blank: "All",
-        class: "form-control" %>
-  </div>
-
-  <div class="form-group">
-    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
-  </div>
+<%= form_tag audits_report_path, method: :get do %>
+    <%= render 'audits/common/theme_subtheme' %>
+    <%= render 'audits/common/organisations' %>
+    <%= render 'audits/common/primary' %>
+    <%= render 'audits/common/document_type' %>
+    <%= render 'audits/common/submit' %>
 <% end %>

--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,39 +1,37 @@
-<div class="col-sm-3 sidebar">
-  <h1>Filter</h1>
-  <%= form_tag submit_path, method: :get do %>
+<h1>Filter</h1>
+<%= form_tag submit_path, method: :get do %>
 
-    <div class="form-group">
-      <%= label_tag :theme, 'Theme' %>
-      <%= select_tag :theme,
-          theme_and_subtheme_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
+  <div class="form-group">
+    <%= label_tag :theme, 'Theme' %>
+    <%= select_tag :theme,
+        theme_and_subtheme_options,
+        include_blank: "All",
+        class: "form-control" %>
+  </div>
 
-    <div class="form-group">
-      <%= label_tag :organisations, "Organisation" %>
-      <%= select_tag :organisations,
-          organisation_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
+  <div class="form-group">
+    <%= label_tag :organisations, "Organisation" %>
+    <%= select_tag :organisations,
+        organisation_options,
+        include_blank: "All",
+        class: "form-control" %>
+  </div>
 
-    <div class="form-group">
-      <%= hidden_field_tag :primary, false, id: nil %>
-      <%= check_box_tag :primary, true, primary_org_only? %>
-      <%= label_tag :primary, "Primary organisation only" %>
-    </div>
+  <div class="form-group">
+    <%= hidden_field_tag :primary, false, id: nil %>
+    <%= check_box_tag :primary, true, primary_org_only? %>
+    <%= label_tag :primary, "Primary organisation only" %>
+  </div>
 
-    <div class="form-group">
-      <%= label_tag :document_type, 'Content type' %>
-      <%= select_tag :document_type,
-          document_type_options,
-          include_blank: "All",
-          class: "form-control" %>
-    </div>
+  <div class="form-group">
+    <%= label_tag :document_type, 'Content type' %>
+    <%= select_tag :document_type,
+        document_type_options,
+        include_blank: "All",
+        class: "form-control" %>
+  </div>
 
-    <div class="form-group">
-      <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
-    </div>
-  <% end %>
-</div>
+  <div class="form-group">
+    <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
+  </div>
+<% end %>

--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,4 +1,3 @@
-<h1>Filter</h1>
 <%= form_tag audits_report_path, method: :get do %>
     <%= render 'audits/common/theme_subtheme' %>
     <%= render 'audits/common/organisations' %>

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -2,17 +2,6 @@
   <%= render 'sidebar', submit_path: audits_report_path %>
 <% end %>
 
-<% content_for :header do %>
-  <ul class="nav nav-tabs">
-    <li role="presentation">
-      <%= link_to "Content", audits_path(filter_params), aria_controls: "home", role: "tab" %>
-    </li>
-    <li role="presentation" class="active">
-      <%= link_to "Report", "#", aria_controls: "home", role: "tab" %>
-    </li>
-  </ul>
-<% end %>
-
 <%= link_to "Export filtered audit to CSV", audits_path(filter_params, format: :csv), class: "report-export" %>
 
 <div class="report-section">

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar do %>
-  <%= render 'sidebar', submit_path: audits_report_path %>
+  <%= render 'sidebar'%>
 <% end %>
 
 <%= link_to "Export filtered audit to CSV", audits_path(filter_params, format: :csv), class: "report-export" %>

--- a/app/views/content/items/_sidebar.html.erb
+++ b/app/views/content/items/_sidebar.html.erb
@@ -1,5 +1,4 @@
 <div class="col-sm-3 sidebar">
-  <h1>Filter</h1>
   <%= form_tag content_items_path, method: :get do %>
     <div class="form-group">
       <%= label_tag 'query', 'Search term:', class: '' %>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -19,6 +19,7 @@
 <% content_for :header do %>
   <ul class="nav nav-tabs">
     <%= navigation_link "Content", audits_url(filter_params), 'audits'%>
+    <%= navigation_link "Assign content", audits_allocations_url(filter_params), 'allocations' %>
     <%= navigation_link "Report", audits_report_url(filter_params), 'reports' %>
   </ul>
 <% end %>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -31,10 +31,10 @@
     </div>
   </div>
   <div class="row">
-    <div class="<%= content_for?(:sidebar) ? 'col-sm-9' : ''%>">
     <div class="col-sm-3 sidebar">
       <%= yield :sidebar %>
     </div>
+    <div class="col-sm-9">
       <%= yield %>
     </div>
   </div>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -16,6 +16,13 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
+<% content_for :header do %>
+  <ul class="nav nav-tabs">
+    <%= navigation_link "Content", audits_url(filter_params), 'audits'%>
+    <%= navigation_link "Report", audits_report_url(filter_params), 'reports' %>
+  </ul>
+<% end %>
+
 <% content_for :content do %>
   <%= render 'application/phase_banner' %>
   <div class="row header-row">

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -31,8 +31,10 @@
     </div>
   </div>
   <div class="row">
-    <%= yield :sidebar %>
     <div class="<%= content_for?(:sidebar) ? 'col-sm-9' : ''%>">
+    <div class="col-sm-3 sidebar">
+      <%= yield :sidebar %>
+    </div>
       <%= yield %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     get '/', to: "audits#index"
     resource :report, only: :show
     resource :guidance, only: :show
+
+    post :allocations, to: "allocations#destroy", constraints: ->(req) { req.parameters["allocate_to"] == "no_one" }
     resources :allocations, only: %w(index create)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     get '/', to: "audits#index"
     resource :report, only: :show
     resource :guidance, only: :show
+    resources :allocations, only: %w(index create)
   end
 
   namespace :inventory do

--- a/spec/domain/audits/allocate_content_spec.rb
+++ b/spec/domain/audits/allocate_content_spec.rb
@@ -1,0 +1,30 @@
+module Audits
+  RSpec.describe AllocateContent do
+    let!(:user) { create :user }
+    let!(:content_item) { create :content_item, content_id: "content_id_1" }
+
+    it "creates a new allocation if content is not allocated" do
+      AllocateContent.call(
+        user_uid: user.uid,
+        content_ids: %w(content_id_1)
+      )
+
+      allocation = Allocation.first
+      expect(allocation.content_item).to eq(content_item)
+      expect(allocation.user).to eq(user)
+    end
+
+    it "updates the user if allocation is allocated to another user" do
+      another_user = create :user
+      create(:allocation, user: another_user, content_item: content_item)
+
+      AllocateContent.call(
+        user_uid: user.uid,
+        content_ids: %w(content_id_1)
+      )
+
+      expect(Allocation.count).to eq(1)
+      expect(Allocation.first.user).to eq(user)
+    end
+  end
+end

--- a/spec/domain/audits/allocate_content_spec.rb
+++ b/spec/domain/audits/allocate_content_spec.rb
@@ -26,5 +26,17 @@ module Audits
       expect(Allocation.count).to eq(1)
       expect(Allocation.first.user).to eq(user)
     end
+
+    it "Returns a message with the number of allocated items" do
+      user = create :user, name: "John Smith"
+      create :content_item, content_id: "content_id_2"
+
+      result = AllocateContent.call(
+        user_uid: user.uid,
+        content_ids: %w(content_id_1 content_id_2)
+      )
+
+      expect(result.message).to eq("2 items allocated to John Smith")
+    end
   end
 end

--- a/spec/domain/audits/allocate_content_spec.rb
+++ b/spec/domain/audits/allocate_content_spec.rb
@@ -4,38 +4,29 @@ module Audits
     let!(:content_item) { create :content_item, content_id: "content_id_1" }
 
     it "creates a new allocation if content is not allocated" do
-      AllocateContent.call(
-        user_uid: user.uid,
-        content_ids: %w(content_id_1)
-      )
+      AllocateContent.call(user_uid: user.uid, content_ids: %w(content_id_1))
 
       allocation = Allocation.first
-      expect(allocation.content_item).to eq(content_item)
-      expect(allocation.user).to eq(user)
+      expect(allocation).to have_attributes(content_item: content_item, user: user)
     end
 
     it "updates the user if allocation is allocated to another user" do
       another_user = create :user
       create(:allocation, user: another_user, content_item: content_item)
 
-      AllocateContent.call(
-        user_uid: user.uid,
-        content_ids: %w(content_id_1)
-      )
+      expect {
+        AllocateContent.call(user_uid: user.uid, content_ids: %w(content_id_1))
+      }.not_to change { Allocation.count }
 
-      expect(Allocation.count).to eq(1)
-      expect(Allocation.first.user).to eq(user)
+      allocation = Allocation.first
+      expect(allocation).to have_attributes(content_item: content_item, user: user)
     end
 
     it "Returns a message with the number of allocated items" do
-      user = create :user, name: "John Smith"
+      user.update name:  "John Smith"
       create :content_item, content_id: "content_id_2"
 
-      result = AllocateContent.call(
-        user_uid: user.uid,
-        content_ids: %w(content_id_1 content_id_2)
-      )
-
+      result = AllocateContent.call(user_uid: user.uid, content_ids: %w(content_id_1 content_id_2))
       expect(result.message).to eq("2 items allocated to John Smith")
     end
   end

--- a/spec/domain/audits/unallocate_content_spec.rb
+++ b/spec/domain/audits/unallocate_content_spec.rb
@@ -1,0 +1,18 @@
+module Audits
+  RSpec.describe UnallocateContent do
+    it "Unallocates content items" do
+      user = create :user
+      item1 = create :content_item, content_id: "content_id_1"
+      item2 = create :content_item, content_id: "content_id_2"
+
+      create(:allocation, user: user, content_item: item1)
+      create(:allocation, user: user, content_item: item2)
+
+      UnallocateContent.call(content_ids: %w(content_id_1))
+
+      expect(Allocation.count).to eq(1)
+      expect(Allocation.first.user).to eq(user)
+      expect(Allocation.first.content_item).to eq(item2)
+    end
+  end
+end

--- a/spec/domain/audits/unallocate_content_spec.rb
+++ b/spec/domain/audits/unallocate_content_spec.rb
@@ -14,5 +14,18 @@ module Audits
       expect(Allocation.first.user).to eq(user)
       expect(Allocation.first.content_item).to eq(item2)
     end
+
+    it "Returns a message with the number of unallocated items" do
+      user = create :user
+      item1 = create :content_item, content_id: "content_id_1"
+      item2 = create :content_item, content_id: "content_id_2"
+
+      create(:allocation, user: user, content_item: item1)
+      create(:allocation, user: user, content_item: item2)
+
+      result = UnallocateContent.call(content_ids: %w(content_id_1 content_id_2))
+
+      expect(result.message).to eq("2 items unallocated")
+    end
   end
 end

--- a/spec/domain/audits/unallocate_content_spec.rb
+++ b/spec/domain/audits/unallocate_content_spec.rb
@@ -1,28 +1,23 @@
 module Audits
   RSpec.describe UnallocateContent do
-    it "Unallocates content items" do
-      user = create :user
-      item1 = create :content_item, content_id: "content_id_1"
-      item2 = create :content_item, content_id: "content_id_2"
+    let(:user) { create :user }
 
+    let(:item1) { create :content_item, content_id: "content_id_1" }
+    let(:item2) { create :content_item, content_id: "content_id_2" }
+
+    before do
       create(:allocation, user: user, content_item: item1)
       create(:allocation, user: user, content_item: item2)
+    end
 
+    it "Unallocates content items" do
       UnallocateContent.call(content_ids: %w(content_id_1))
 
       expect(Allocation.count).to eq(1)
-      expect(Allocation.first.user).to eq(user)
-      expect(Allocation.first.content_item).to eq(item2)
+      expect(Allocation.first).to have_attributes(content_item: item2, user: user)
     end
 
     it "Returns a message with the number of unallocated items" do
-      user = create :user
-      item1 = create :content_item, content_id: "content_id_1"
-      item2 = create :content_item, content_id: "content_id_2"
-
-      create(:allocation, user: user, content_item: item1)
-      create(:allocation, user: user, content_item: item2)
-
       result = UnallocateContent.call(content_ids: %w(content_id_1 content_id_2))
 
       expect(result.message).to eq("2 items unallocated")

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -81,4 +81,22 @@ RSpec.feature "Content Allocation", type: :feature do
 
     expect(page).to have_select("allocated_to", selected: "No one")
   end
+
+  scenario "Unallocate content" do
+    create(:allocation, content_item: content_item, user: current_user)
+
+    visit audits_allocations_path
+
+    select "Me", from: "allocated_to"
+    click_on "Filter"
+    expect(page).to have_content("content item 1")
+
+
+    check option: content_item.content_id
+    select "No one", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to_not have_content("content item 1")
+    expect(page).to have_select("allocate_to", selected: "No one")
+  end
 end

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -15,18 +15,18 @@ RSpec.feature "Content Allocation", type: :feature do
     expect(page).to have_content("content item 2")
 
     select "Me", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to have_content("content item 1")
     expect(page).to_not have_content("content item 2")
 
     select "No one", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to_not have_content("content item 1")
     expect(page).to_not have_content("content item 2")
     expect(page).to have_content("content item 3")
 
     select "Anyone", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to have_content("content item 1")
     expect(page).to have_content("content item 2")
     expect(page).to have_content("content item 3")
@@ -47,14 +47,14 @@ RSpec.feature "Content Allocation", type: :feature do
     expect(page).to have_content("2 items allocated to #{current_user.name}")
 
     select "Me", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to_not have_content("content item 1")
     expect(page).to have_content("content item 2")
     expect(page).to have_content("content item 3")
 
     select "No one", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to have_content("content item 1")
     expect(page).to_not have_content("content item 2")
@@ -70,7 +70,7 @@ RSpec.feature "Content Allocation", type: :feature do
     visit audits_allocations_path
 
     select "No one", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
 
     check option: item3.content_id
     select "Me", from: "allocate_to"
@@ -88,7 +88,7 @@ RSpec.feature "Content Allocation", type: :feature do
     visit audits_allocations_path
 
     select "Me", from: "allocated_to"
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to have_content("content item 1")
 
 

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature "Content Allocation", type: :feature do
   let!(:content_item) { create :content_item, title: "content item 1" }
-  let(:current_user)  { User.first }
+  let!(:current_user) { User.first }
 
   scenario "Filter allocated content" do
     another_user = create(:user)
@@ -59,5 +59,26 @@ RSpec.feature "Content Allocation", type: :feature do
     expect(page).to have_content("content item 1")
     expect(page).to_not have_content("content item 2")
     expect(page).to_not have_content("content item 3")
+  end
+
+  scenario "Does not change filer status after user has allocated content" do
+    item2 = create(:content_item, title: "content item 2")
+    item3 = create(:content_item, title: "content item 3")
+
+    create(:allocation, content_item: item2, user: current_user)
+
+    visit audits_allocations_path
+
+    select "No one", from: "allocated_to"
+    click_on "Filter"
+
+    check option: item3.content_id
+    select "Me", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to_not have_content("content item 2")
+    expect(page).to_not have_content("content item 3")
+
+    expect(page).to have_select("allocated_to", selected: "No one")
   end
 end

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -1,8 +1,8 @@
 RSpec.feature "Content Allocation", type: :feature do
-  let(:content_item) { create :content_item, title: "content item 1" }
+  let!(:content_item) { create :content_item, title: "content item 1" }
+  let(:current_user)  { User.first }
 
   scenario "Filter allocated content" do
-    current_user = User.first
     another_user = create(:user)
     another_content_item = create(:content_item, title: "content item 2")
     create(:content_item, title: "content item 3")
@@ -30,5 +30,34 @@ RSpec.feature "Content Allocation", type: :feature do
     expect(page).to have_content("content item 1")
     expect(page).to have_content("content item 2")
     expect(page).to have_content("content item 3")
+  end
+
+  scenario "Allocate content within current page" do
+    second = create(:content_item, title: "content item 2")
+    first = create(:content_item, title: "content item 3")
+
+    visit audits_allocations_path
+
+    check option: second.content_id
+    check option: first.content_id
+
+    select "Me", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to have_content("2 items assigned to #{current_user.name}")
+
+    select "Me", from: "allocated_to"
+    click_on "Filter"
+
+    expect(page).to_not have_content("content item 1")
+    expect(page).to have_content("content item 2")
+    expect(page).to have_content("content item 3")
+
+    select "No one", from: "allocated_to"
+    click_on "Filter"
+
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+    expect(page).to_not have_content("content item 3")
   end
 end

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Content Allocation", type: :feature do
     select "Me", from: "allocate_to"
     click_on "Go"
 
-    expect(page).to have_content("2 items assigned to #{current_user.name}")
+    expect(page).to have_content("2 items allocated to #{current_user.name}")
 
     select "Me", from: "allocated_to"
     click_on "Filter"
@@ -98,5 +98,6 @@ RSpec.feature "Content Allocation", type: :feature do
 
     expect(page).to_not have_content("content item 1")
     expect(page).to have_select("allocate_to", selected: "No one")
+    expect(page).to have_content("1 items unallocated")
   end
 end

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     visit audits_path
     select "Audited", from: "audit_status"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to have_content("Tree felling")
     expect(page).to have_no_content("Forest management")
@@ -81,7 +81,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     visit audits_path
     select "Non Audited", from: "audit_status"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to have_no_content("Tree felling")
     expect(page).to have_content("Forest management")
@@ -94,7 +94,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
     select "HMRC", from: "organisations"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to have_content("VAT")
     expect(page).to have_no_content("Tree felling")
@@ -106,7 +106,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
     select "HMRC", from: "organisations"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to have_content("VAT")
     expect(page).to have_content("Travel insurance")
@@ -159,7 +159,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     visit audits_path
     select "All Environment", from: "theme"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     within("table") do
       expect(page).to have_content("Tree felling")
@@ -172,7 +172,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     visit audits_path
     select "Aviation", from: "theme"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     within("table") do
       expect(page).to have_content("Travel insurance")
@@ -187,7 +187,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     visit audits_path
     select "Organisation", from: "document_type"
 
-    click_on "Filter"
+    click_on "Apply filters"
 
     within("table") do
       expect(page).to have_content("HMRC")
@@ -202,7 +202,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     within(".pagination") { click_on "2" }
 
     select "Non Audited", from: "audit_status"
-    click_on "Filter"
+    click_on "Apply filters"
 
     expect(page).to have_css(".pagination .active", text: "1")
   end

--- a/spec/features/audit/navigation_spec.rb
+++ b/spec/features/audit/navigation_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Navigation", type: :feature do
 
       visit audits_path
       select "Non Audited", from: "audit_status"
-      click_on "Filter"
+      click_on "Apply filters"
 
       expect(page).to have_content(first.title)
       expect(page).to have_no_content(second.title)

--- a/spec/features/report/csv_export_spec.rb
+++ b/spec/features/report/csv_export_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Exporting a CSV from the report page" do
       visit audits_report_path
 
       select "HMRC", from: "organisations"
-      click_on "Filter"
+      click_on "Apply filters"
 
       click_link "Export filtered audit to CSV"
       expect(page).to have_no_content("Example,https://gov.uk/example")
@@ -73,7 +73,7 @@ RSpec.feature "Exporting a CSV from the report page" do
       visit audits_path
       select "Audited", from: "audit_status"
 
-      click_on "Filter"
+      click_on "Apply filters"
       expect(page).to have_content("Example 1")
       expect(page).to have_no_content("Example 2")
 

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -33,11 +33,11 @@ RSpec.feature "Reporting on audit progress" do
     expect(page).to have_content("3 Content items")
 
     select "Organisation", from: "document_type"
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to have_content("1 Content items")
 
     select "Policy", from: "document_type"
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to have_content("2 Content items")
   end
 

--- a/spec/features/report/tabs_spec.rb
+++ b/spec/features/report/tabs_spec.rb
@@ -3,7 +3,7 @@ RSpec.feature "Tabs" do
     visit audits_path
     select "Audited", from: "audit_status"
 
-    click_on "Filter"
+    click_on "Apply filters"
     expect(page).to have_select("audit_status", selected: "Audited")
 
     click_link "Report"


### PR DESCRIPTION
[Trello card](https://trello.com/c/Rcyk9UU9/429-3-allocate-content-items-within-current-page)

### User need

As a **Content Auditor**
I **need** to allocate multiple content items within a page
**So that** I am able to allocate/unallocate individual content items to users.

### Description

Add support for allocating / unallocating content Items for the current user. 
The content items are cherry-picked from the current page via checkboxes.

### Refactorings

**Top navigation**. 

The code was duplicated in reports, and audits. I have extracted 
a helper to render the links

```ruby
  def navigation_link(text, url, scope)
    status = controller.controller_name == scope ? 'active' : ''

    content_tag :li, role: "presentation", class: status do
      link_to_unless_current text, url, aria_controls: "home", role: "tab" do
        link_to text, "#", aria_controls: "home", role: "tab"
      end
    end
  end
```

**Form controls** 

Controls were duplicated across all sidebars, so I have extracted
them out into partials for:

- Audits
- Allocations
- Reports

### Before

N/A

### After

![image](https://user-images.githubusercontent.com/227328/29305356-3bf1d6a6-8190-11e7-8aa5-b221d3c755c6.png)
