### PR TITLE
Fix no filters on csv

### DIFF
--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -13,7 +13,7 @@
   </ul>
 <% end %>
 
-<%= link_to "Export filtered audit to CSV", audits_path(filter_params, format: :csv), class: "report-export" %>
+<%= link_to "Export filtered audit to CSV", audits_path(params: filter_params, format: :csv), class: "report-export" %>
 
 <div class="report-section">
   <h3><%= format_number(@monitor.total_count) %></h3>

--- a/spec/features/report/csv_export_spec.rb
+++ b/spec/features/report/csv_export_spec.rb
@@ -66,7 +66,8 @@ RSpec.feature "Exporting a CSV from the report page" do
       click_on "Filter"
 
       click_link "Export filtered audit to CSV"
-      expect(page).to have_no_content("Example,https://gov.uk/example")
+      expect(page).to have_content("Example 1,https://gov.uk/example1")
+      expect(page).to have_no_content("Example 2,https://gov.uk/example2")
     end
 
     scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do


### PR DESCRIPTION
Query parameters were not set on the link for exporting a list of content items to CSV. Hence users were always exporting the entire 300k of content items to CSV.