### PR TITLE
Use feature environment config directly

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -13,4 +13,4 @@ test:
 production:
   <<: *default
   features:
-    auditing_allocation: <%= ENV['FEATURE_AUDITING_ALLOCATION'].present? %>
+    auditing_allocation: <%= ENV['FEATURE_AUDITING_ALLOCATION'] %>


### PR DESCRIPTION
This prevents a scenario where the value of the variable could be false yet we'd still enable the toggle.