### PR TITLE
Fix column widths on audit screen

### DIFF
--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -32,7 +32,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-sm-3 sidebar">
+    <div class="<%= content_for?(:sidebar) ? 'col-sm-3' : ''%> sidebar">
       <%= yield :sidebar %>
     </div>
     <div class="col-sm-9">


### PR DESCRIPTION
Although we hide the filter options in the sidebar when viewing the audit
screen, we had lost the logic to collapse the width of that column and
there was a big gap.

## Before

![screenshot-content-performance-manager integration publishing service gov uk-2017-08-18-12-12-16](https://user-images.githubusercontent.com/424772/29456651-922fad7e-840e-11e7-9d88-7ff60ddff591.png)

## After

![screenshot-localhost-3000-2017-08-18-12-12-05](https://user-images.githubusercontent.com/424772/29456653-97e40d64-840e-11e7-82cc-4a1b9632a8f9.png)
