### PR TITLE
Show assigned auditor

### DIFF
--- a/app/decorators/content/item_decorator.rb
+++ b/app/decorators/content/item_decorator.rb
@@ -53,6 +53,14 @@ class Content::ItemDecorator < Draper::Decorator
     object.document_type.titleize
   end
 
+  def auditor
+    allocation.user.name
+  end
+
+  def auditor_org
+    allocation.user.organisation_slug.titleize
+  end
+
 private
 
   def titles(content_items)

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -96,9 +96,9 @@
   <div id="metadata" class="audit-metadata">
     <div id="allocated">
       <h4>Assigned to</h4>
-      <% if content_item&.allocation&.user&.name %>
-        <p><%= content_item&.allocation&.user&.name %></p>
-        <p><%= content_item.allocation&.user&.organisation_slug.titleize %></p>
+      <% if content_item.allocation %>
+        <p><%= content_item.auditor %></p>
+        <p><%= content_item.auditor_org %></p>
      <% else %>
         <p>No one</p>
       <% end %>

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -94,6 +94,15 @@
 
 <div class="col-sm-4">
   <div id="metadata" class="audit-metadata">
+    <div id="allocated">
+      <h4>Assigned to</h4>
+      <% if content_item&.allocation&.user&.name %>
+        <p><%= content_item&.allocation&.user&.name %></p>
+        <p><%= content_item.allocation&.user&.organisation_slug.titleize %></p>
+     <% else %>
+        <p>No one</p>
+      <% end %>
+    </div>
     <div id="audited">
       <h4>Audited</h4>
 

--- a/spec/features/audit/metadata_spec.rb
+++ b/spec/features/audit/metadata_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Audit metadata", type: :feature do
     visit content_item_audit_path(content_item)
 
     within("#metadata") do
+      expect(page).to have_selector("#allocated", text: "Assigned to No one")
       expect(page).to have_selector("#audited", text: "Not audited yet")
       expect(page).to have_selector("#organisations", text: "None")
       expect(page).to have_selector("#last-updated", text: "Never")
@@ -54,10 +55,15 @@ RSpec.feature "Audit metadata", type: :feature do
     create_linked_content("topics", "Borders")
     create_linked_content("policy_areas", "Borders and Immigration")
 
+    user = create(:user, name: "Edd the Duck")
+    create(:allocation, content_item: content_item, user: user)
+
     visit content_item_audit_path(content_item)
 
     within("#metadata") do
+      allocated_text = "Assigned to Edd the Duck Government Digital Service"
       audited_text = "Audited 01/01/17 (less than a minute ago) by Test User Government Digital Service"
+      expect(page).to have_selector("#allocated", text: allocated_text)
       expect(page).to have_selector("#audited", text: audited_text)
       expect(page).to have_selector("#organisations", text: "Organisations Home office")
       expect(page).to have_selector("#last-updated", text: "03/01/17 (2 days ago)")


### PR DESCRIPTION
When a content item is allocated to a person to audit, it needs to be reflected on the audit screen who it is.