### PR TITLE
Audit select all on all pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'govuk_sidekiq'
 gem 'plek'
 
 # Third party gems
+gem 'activerecord-import'
 gem 'draper'
 gem 'feature'
 gem 'google-api-client', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       activemodel (= 5.1.2)
       activesupport (= 5.1.2)
       arel (~> 8.0)
+    activerecord-import (0.19.1)
+      activerecord (>= 3.2)
     activesupport (5.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -475,6 +477,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_disabler
+  activerecord-import
   airbrake!
   better_errors
   binding_of_caller

--- a/app/assets/javascripts/select-all.js
+++ b/app/assets/javascripts/select-all.js
@@ -2,9 +2,7 @@
   "use strict";
 
   Modules.SelectAll = function () {
-    var that = this;
-
-    that.start = function (element) {
+    this.start = function (element) {
       function addEventListener() {
         var selectAll = element.find('#select_all');
 

--- a/app/assets/javascripts/select-all.js
+++ b/app/assets/javascripts/select-all.js
@@ -5,12 +5,22 @@
     this.start = function (element) {
       function addEventListener() {
         var selectAll = element.find('#select_all');
+        var selectAllPages = element.find('#select_all_pages');
+        var selectAllPagesContainer = selectAllPages.closest('.if-js-hide');
 
         if (selectAll != undefined) {
           selectAll.on('change', function (e) {
             var checked = selectAll.prop('checked');
             var checkboxes = $('.select-content-item');
             checkboxes.prop('checked', checked);
+
+            if (selectAllPages != undefined) {
+              selectAllPages.prop('checked', false);
+            }
+
+            if (selectAllPagesContainer != undefined) {
+              selectAllPagesContainer.toggleClass('if-js-hide', !checked);
+            }
           });
         }
       }

--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -25,7 +25,11 @@ module Audits
     end
 
     def content_ids
-      params.fetch(:content_ids) { [] }
+      if params[:select_all_pages]
+        FindContent.all(build_filter).pluck(:content_id)
+      else
+        params[:content_ids]
+      end
     end
 
     def redirect_params

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -1,11 +1,20 @@
 <div class="allocation-menu">
   <div class="row">
-    <div class="col-sm-8">
-      <div class="checkbox" data-module="select-all">
+    <div class="col-sm-8" data-module="select-all">
+      <div class="checkbox">
         <label>
           <%= check_box_tag :select_all, nil, false %> Select all
         </label>
       </div>
+      <% if select_all_pages > 1 %>
+        <div class="checkbox if-js-hide">
+          <label>
+            <%= check_box_tag :select_all_pages, nil, false %>
+            Select <%= number_with_delimiter(select_all_count) %> items
+            on all pages
+          </label>
+        </div>
+      <% end %>
     </div>
     <div class="col-sm-4">
       <div class="form-group form-inline pull-right">

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -5,8 +5,9 @@
 <%= render 'notice' %>
 
 <%= form_tag audits_allocations_path do %>
-    <%= render 'toolbar' %>
-
+    <%= render 'toolbar',
+               select_all_count: content_items.total_count,
+               select_all_pages: content_items.total_pages %>
     <table class="table table-bordered table-hover">
       <thead>
       <tr class="table-header">

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -106,7 +106,7 @@ RSpec.feature "Content Allocation", type: :feature do
   end
 
   scenario 'Allocate all content within current page', :js do
-    create_list(:content_item, 100)
+    create_list(:content_item, 26)
 
     visit audits_allocations_path
 

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -119,4 +119,20 @@ RSpec.feature "Content Allocation", type: :feature do
       expect(page).to have_content("25 items allocated to #{current_user.name}")
     end
   end
+
+  scenario 'Allocate all content within all pages', :js do
+    create_list(:content_item, 26)
+
+    visit audits_allocations_path
+
+    check 'Select all'
+    check 'Select 27 items on all pages'
+
+    select 'Me', from: 'allocate_to'
+    click_on 'Go'
+
+    within('.alert-success') do
+      expect(page).to have_content("27 items allocated to #{current_user.name}")
+    end
+  end
 end


### PR DESCRIPTION
Allows all content items that match the current filters to be allocated, regardless of pagination.

I've added a dependency on https://github.com/zdennis/activerecord-import so that we can handle the potential to create thousands of allocation database records in a single trip to the server. This will need more serious consideration if the prototype tests well.

I've refactored the allocation service to use IDs and not objects to avoid hitting the database.

One potential UX improvement that we could introduce is to keep the checkboxes checked on subsequent pages if the user checks the "Select X items on all pages" then navigates to another page.