### PR TITLE
Rake task to build term generation report

### DIFF
--- a/app/domain/term_generation/rate_of_discovery.rb
+++ b/app/domain/term_generation/rate_of_discovery.rb
@@ -1,0 +1,46 @@
+module TermGeneration
+  module RateOfDiscovery
+    WINDOW_SIZE = 50
+
+    # Calculate the moving-window average of the absolute change
+    # in new term discovery for a project. Aims to give insight
+    # into the expected reward of reviewing a single extra page.
+
+    def self.calculate(project)
+      results = []
+
+      # Keeps track of previously seen unique terms.
+      terms = Set.new
+
+      # Iterate over previously completed Todos in completion order.
+      project_todos(project).each do |todo|
+        # Note how many terms have been encountered thus far.
+        count_of_previously_found_terms = terms.size
+
+        # Add the terms from this Todo to the set of all terms.
+        terms.merge Set.new(todo.terms)
+
+        # Record the absolute change in number of terms encountered for this Todo.
+        results << {
+          count_of_new_terms: terms.size - count_of_previously_found_terms
+        }
+
+        # Our window is the last 50 results.
+        moving_window = results.last(WINDOW_SIZE)
+
+        # Calculate the absolute change in terms found over the course of the window.
+        total_change = moving_window.sum { |r| r[:count_of_new_terms] }
+
+        # Average the result. Expected values are roughly between 0.3 and 1.5
+        results[-1][:moving_average] = total_change.to_f / moving_window.size
+      end
+
+      # Return an array of floating point values.
+      results.map { |r| r[:moving_average] }
+    end
+
+    def self.project_todos(project)
+      project.taxonomy_todos.done.order(completed_at: :asc).includes(:terms)
+    end
+  end
+end

--- a/lib/tasks/term_generation/calculate_project_statistics.rake
+++ b/lib/tasks/term_generation/calculate_project_statistics.rake
@@ -1,0 +1,17 @@
+namespace :term_generation do
+  desc "Create a CSV of term generation project Rate of Discovery statistics"
+  task :create_project_statistics_csv, [:project_id] => :environment do |_, args|
+    project = TaxonomyProject.find(args.project_id)
+    data = TermGeneration::RateOfDiscovery.calculate(project)
+    filename = "tmp/#{project.name.parameterize}.csv"
+
+    CSV.open(filename, "wb") do |csv|
+      csv << %w[count moving_average]
+      data.each_with_index do |datum, index|
+        csv << [index, datum]
+      end
+    end
+
+    puts "Written #{data.length} stats to #{filename}"
+  end
+end

--- a/spec/domain/term_generation/rate_of_discovery_spec.rb
+++ b/spec/domain/term_generation/rate_of_discovery_spec.rb
@@ -1,0 +1,27 @@
+require 'ostruct'
+
+RSpec.describe TermGeneration::RateOfDiscovery do
+  subject { described_class }
+
+  describe ".calculate" do
+    let(:result) { subject.calculate(project) }
+    let(:project) { double }
+
+    let(:project_todos) do
+      (0..9).map do |i|
+        OpenStruct.new(terms: (0..i).to_a.map(&:to_s))
+      end
+    end
+
+    before do
+      allow(subject)
+        .to receive(:project_todos)
+        .with(project)
+        .and_return(project_todos)
+    end
+
+    it "performs the calculation" do
+      expect(result).to eql Array.new(10) { 1.0 }
+    end
+  end
+end


### PR DESCRIPTION
Rake task and calculator function to generate and save a CSV for the "rate of return of page review"

[Trello](https://trello.com/c/x6GUpctA/173-generate-graph-showing-rate-of-term-generation-for-coming-to-the-uk)