### PR TITLE
Hide theme filtering except for dev and testing

### DIFF
--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag audits_allocations_path, method: :get do %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
-  <%= render 'audits/common/theme_subtheme' %>
+  <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag audits_path, method: :get do %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
-  <%= render 'audits/common/theme_subtheme' %>
+  <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag audits_report_path, method: :get do %>
-  <%= render 'audits/common/theme_subtheme' %>
+  <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -15,4 +15,4 @@ production:
   <<: *default
   features:
     auditing_allocation: <%= ENV['FEATURE_AUDITING_ALLOCATION'] %>
-    filtering_themes: false
+    filtering_themes: <%= ENV['FEATURE_AUDITING_THEME_FILTERING'] %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3,6 +3,7 @@
 default: &default
   features:
     auditing_allocation: true
+    filtering_themes: true
 
 development:
   <<: *default
@@ -14,3 +15,4 @@ production:
   <<: *default
   features:
     auditing_allocation: <%= ENV['FEATURE_AUDITING_ALLOCATION'] %>
+    filtering_themes: false


### PR DESCRIPTION
We are currently planning to do away with Themes. We want to hide the
filtering of Themes and Subthemes, however this may come back in use in
the future. Am leaving this feature active on dev and test so that the
code remains exercised in our feature tests.