### PR TITLE
Hide theme filter options temporarily

### DIFF
--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag audits_allocations_path, method: :get do %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
-  <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
+  <%#<%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag audits_path, method: :get do %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
-  <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
+  <%#<%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag audits_report_path, method: :get do %>
-  <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
+  <%#<%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3,7 +3,6 @@
 default: &default
   features:
     auditing_allocation: true
-    filtering_themes: true
 
 development:
   <<: *default
@@ -15,4 +14,3 @@ production:
   <<: *default
   features:
     auditing_allocation: <%= ENV['FEATURE_AUDITING_ALLOCATION'] %>
-    filtering_themes: <%= ENV['FEATURE_AUDITING_THEME_FILTERING'] %>

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     end
   end
 
-  scenario "themes and subthemes are in alphabetical order" do
+  skip scenario "themes and subthemes are in alphabetical order" do
     visit audits_path
 
     within("#theme") do
@@ -155,7 +155,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     end
   end
 
-  scenario "filtering by theme" do
+  skip scenario "filtering by theme" do
     visit audits_path
     select "All Environment", from: "theme"
 
@@ -168,7 +168,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     end
   end
 
-  scenario "filtering by subtheme" do
+  skip scenario "filtering by subtheme" do
     visit audits_path
     select "Aviation", from: "theme"
 


### PR DESCRIPTION
This is a temporary fix where partials are commented out and associated
tests are skipped. Follow up PRs to do this properly will come
imminently.