### PR TITLE
Remove model for Groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,9 +1,0 @@
-class Group < ApplicationRecord
-  validates :slug, uniqueness: true
-  validates :slug, :name, :group_type, presence: true
-
-  belongs_to :parent, class_name: 'Group', foreign_key: :parent_group_id, optional: true
-  has_many :children, class_name: 'Group', foreign_key: :parent_group_id
-
-  has_and_belongs_to_many :content_items
-end

--- a/db/migrate/20170824142643_drop_groups.rb
+++ b/db/migrate/20170824142643_drop_groups.rb
@@ -1,0 +1,12 @@
+class DropGroups < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :groups do |t|
+      t.string :slug
+      t.string :name
+      t.string :group_type
+      t.integer :parent_group_id, foreign_key: true, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170824143605_drop_join_table_groups_content_items.rb
+++ b/db/migrate/20170824143605_drop_join_table_groups_content_items.rb
@@ -1,0 +1,9 @@
+class DropJoinTableGroupsContentItems < ActiveRecord::Migration[5.1]
+  def change
+    drop_join_table :groups, :content_items do |t|
+      t.index [:content_item_id]
+      t.index [:group_id]
+      t.index [:group_id, :content_item_id], name: "index_group_content_items", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,23 +61,6 @@ ActiveRecord::Schema.define(version: 20170824150019) do
     t.index ["title"], name: "index_content_items_on_title"
   end
 
-  create_table "content_items_groups", id: false, force: :cascade do |t|
-    t.bigint "group_id", null: false
-    t.bigint "content_item_id", null: false
-    t.index ["content_item_id"], name: "index_content_items_groups_on_content_item_id"
-    t.index ["group_id", "content_item_id"], name: "index_group_content_items", unique: true
-    t.index ["group_id"], name: "index_content_items_groups_on_group_id"
-  end
-
-  create_table "groups", id: :serial, force: :cascade do |t|
-    t.string "slug"
-    t.string "name"
-    t.string "group_type"
-    t.integer "parent_group_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "inventory_rules", force: :cascade do |t|
     t.bigint "subtheme_id"
     t.string "link_type", null: false


### PR DESCRIPTION
[Trello card](https://trello.com/c/wWeN72af/474-remove-groups)

Groups are no longer in use. We rely on subscription rules to group
content items. 

There are no Groups in production, so I am confident that deleting them
won’t have an impact in the tool.