### PR TITLE
Remove taxonomy and organisations tables

### DIFF
--- a/db/migrate/20170824145426_drop_organisations.rb
+++ b/db/migrate/20170824145426_drop_organisations.rb
@@ -1,0 +1,12 @@
+class DropOrganisations < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :organisations do |t|
+      t.string "slug"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.string "title"
+      t.string "content_id"
+      t.index ["slug"], name: "index_organisations_on_slug", unique: true
+    end
+  end
+end

--- a/db/migrate/20170824145545_drop_organisations_items_join_table.rb
+++ b/db/migrate/20170824145545_drop_organisations_items_join_table.rb
@@ -1,0 +1,5 @@
+class DropOrganisationsItemsJoinTable < ActiveRecord::Migration[5.1]
+  def change
+    drop_join_table :content_items, :organisations
+  end
+end

--- a/db/migrate/20170824145959_drop_taxons_items_join_table.rb
+++ b/db/migrate/20170824145959_drop_taxons_items_join_table.rb
@@ -1,0 +1,8 @@
+class DropTaxonsItemsJoinTable < ActiveRecord::Migration[5.1]
+  def change
+    drop_join_table :content_items, :taxons do |t|
+      t.index [:content_item_id]
+      t.index [:taxon_id, :content_item_id], name: "index_content_item_taxonomies", unique: true
+    end
+  end
+end

--- a/db/migrate/20170824150019_drop_taxons.rb
+++ b/db/migrate/20170824150019_drop_taxons.rb
@@ -1,0 +1,10 @@
+class DropTaxons < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :taxons do |t|
+      t.string :content_id
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170824145545) do
+ActiveRecord::Schema.define(version: 20170824150019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,13 +67,6 @@ ActiveRecord::Schema.define(version: 20170824145545) do
     t.index ["content_item_id"], name: "index_content_items_groups_on_content_item_id"
     t.index ["group_id", "content_item_id"], name: "index_group_content_items", unique: true
     t.index ["group_id"], name: "index_content_items_groups_on_group_id"
-  end
-
-  create_table "content_items_taxons", id: false, force: :cascade do |t|
-    t.bigint "content_item_id", null: false
-    t.bigint "taxon_id", null: false
-    t.index ["content_item_id"], name: "index_content_items_taxons_on_content_item_id"
-    t.index ["taxon_id", "content_item_id"], name: "index_content_item_taxonomies", unique: true
   end
 
   create_table "groups", id: :serial, force: :cascade do |t|
@@ -163,13 +156,6 @@ ActiveRecord::Schema.define(version: 20170824145545) do
     t.index ["taxonomy_todo_id"], name: "index_taxonomy_todos_terms_on_taxonomy_todo_id"
     t.index ["term_id", "taxonomy_todo_id"], name: "index_terms_taxonomy_todos", unique: true
     t.index ["term_id"], name: "index_taxonomy_todos_terms_on_term_id"
-  end
-
-  create_table "taxons", id: :serial, force: :cascade do |t|
-    t.string "content_id"
-    t.string "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "terms", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170810074052) do
+ActiveRecord::Schema.define(version: 20170824145545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,11 +69,6 @@ ActiveRecord::Schema.define(version: 20170810074052) do
     t.index ["group_id"], name: "index_content_items_groups_on_group_id"
   end
 
-  create_table "content_items_organisations", id: false, force: :cascade do |t|
-    t.bigint "content_item_id", null: false
-    t.bigint "organisation_id", null: false
-  end
-
   create_table "content_items_taxons", id: false, force: :cascade do |t|
     t.bigint "content_item_id", null: false
     t.bigint "taxon_id", null: false
@@ -109,15 +104,6 @@ ActiveRecord::Schema.define(version: 20170810074052) do
     t.index ["link_type"], name: "index_links_on_link_type"
     t.index ["source_content_id"], name: "index_links_on_source_content_id"
     t.index ["target_content_id"], name: "index_links_on_target_content_id"
-  end
-
-  create_table "organisations", id: :serial, force: :cascade do |t|
-    t.string "slug"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "title"
-    t.string "content_id"
-    t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
   create_table "questions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
[Trello card](https://trello.com/c/743QsKG5/475-remove-taxons-and-orgnisations-model-no-longer-in-use)

We no longer use `Organisations` and `Taxons` so we are 
removing them from the database. 

We have not done it so far because we wanted to be able to 
rollback to use them at any moment.