### PR TITLE
Fix failing migration

### DIFF
--- a/db/migrate/20170112173524_set_default_value_for_number_of_views.rb
+++ b/db/migrate/20170112173524_set_default_value_for_number_of_views.rb
@@ -1,5 +1,5 @@
 class SetDefaultValueForNumberOfViews < ActiveRecord::Migration[5.0]
   def up
-    ContentItem.update_all(number_of_views: 0)
+    execute "UPDATE content_items SET number_of_views = 0;"
   end
 end


### PR DESCRIPTION
Following a refactor that renamed the `ContentItem` model, this
migration no longer works.

For exactly this reason, models should not be referenced in migrations.
This change fixes the broken migration by executing raw SQL rather than
referring to the content model.