### PR TITLE
Remove tabs from auditing page

### DIFF
--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -2,6 +2,10 @@
     <%= render 'sidebar' %>
 <% end %>
 
+<% content_for :header do %>
+    <%= render 'audits/common/navigation' %>
+<% end %>
+
 <%= render 'notice' %>
 
 <%= form_tag audits_allocations_path do %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -3,6 +3,10 @@
   <%= render 'sidebar' %>
 <% end %>
 
+<% content_for :header do %>
+    <%= render 'audits/common/navigation' %>
+<% end %>
+
 <table class="table table-bordered table-hover">
   <thead>
   <tr class="table-header">

--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,0 +1,5 @@
+<ul class="nav nav-tabs">
+  <%= navigation_link "Content", audits_url(filter_params), 'audits'%>
+  <%= navigation_link "Assign content", audits_allocations_url(filter_params), 'allocations' if Feature.active?(:auditing_allocation) %>
+  <%= navigation_link "Report", audits_report_url(filter_params), 'reports' %>
+</ul>

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -2,6 +2,10 @@
   <%= render 'sidebar'%>
 <% end %>
 
+<% content_for :header do %>
+    <%= render 'audits/common/navigation' %>
+<% end %>
+
 <%= link_to "Export filtered audit to CSV", audits_path(params: filter_params, format: :csv), class: "report-export" %>
 
 <div class="report-section">

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -16,10 +16,6 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
-<% content_for :header do %>
-    <%= render 'audits/common/navigation' %>
-<% end %>
-
 <% content_for :content do %>
   <%= render 'application/phase_banner' %>
   <div class="row header-row">

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -17,11 +17,7 @@
 <% end %>
 
 <% content_for :header do %>
-  <ul class="nav nav-tabs">
-    <%= navigation_link "Content", audits_url(filter_params), 'audits'%>
-    <%= navigation_link "Assign content", audits_allocations_url(filter_params), 'allocations' if Feature.active?(:auditing_allocation) %>
-    <%= navigation_link "Report", audits_report_url(filter_params), 'reports' %>
-  </ul>
+    <%= render 'audits/common/navigation' %>
 <% end %>
 
 <% content_for :content do %>

--- a/spec/features/audit/allocation_spec.rb
+++ b/spec/features/audit/allocation_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature "Content Allocation", type: :feature do
     create(:allocation, content_item: another_content_item, user: another_user)
 
     visit audits_path
+
+    expect(page).to have_selector(".nav")
+
     expect(page).to have_content("content item 1")
     expect(page).to have_content("content item 2")
 

--- a/spec/features/audit/audit_spec.rb
+++ b/spec/features/audit/audit_spec.rb
@@ -26,6 +26,9 @@ RSpec.feature "Auditing a content item", type: :feature do
 
   scenario "auditing a content item" do
     visit content_item_audit_path(content_item)
+
+    expect(page).to_not have_selector(".nav")
+
     expect(page).to have_link("Flooding", href: "https://gov.uk/flooding")
     expect(page).to have_content("All about flooding.")
 

--- a/spec/features/audit/filter_spec.rb
+++ b/spec/features/audit/filter_spec.rb
@@ -61,6 +61,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
   scenario "List all content items (audited and not audited)" do
     visit audits_path
+    expect(page).to have_selector(".nav")
 
     expect(page).to have_content("Tree felling")
     expect(page).to have_content("Forest management")

--- a/spec/features/report/progress_spec.rb
+++ b/spec/features/report/progress_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature "Reporting on audit progress" do
 
   scenario "Displaying the number of items included in the audit" do
     visit audits_report_path
+    expect(page).to have_selector(".nav")
+
     expect(page).to have_content("3 Content items")
 
     select "Organisation", from: "document_type"


### PR DESCRIPTION
[Trello card](https://trello.com/c/TgrBQW9b/473-dont-show-tabs-on-audit-screen)

Remove the navigation bar from the audit page.
It explicitly renders the partial for the navigation
only on the desired templates.
