### PR TITLE
Filter by allocation in Reports tab

### DIFF
--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,4 +1,5 @@
 <%= form_tag audits_report_path, method: :get do %>
+  <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
   <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>

--- a/spec/features/report/allocation_spec.rb
+++ b/spec/features/report/allocation_spec.rb
@@ -1,0 +1,22 @@
+RSpec.feature "Content Allocation", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:auditing_allocation) { example.run }
+  end
+
+  scenario "Filter allocated content" do
+    current_user = User.first
+    content_item = create :content_item, title: "content item 1"
+
+    create(:allocation, content_item: content_item, user: current_user)
+
+    visit audits_report_path
+
+    select "Me", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_selector(".report-section", text: "1")
+
+    select "No one", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_selector(".report-section", text: "0")
+  end
+end


### PR DESCRIPTION
Content auditor need to filter by allocation in the `Reports` section.
They need to by able to track their progress, along with the progress
of other content auditors.

![image](https://user-images.githubusercontent.com/227328/29722330-36a4ef3c-89b8-11e7-9c2b-a56a13a01366.png)
