### PR TITLE
Show only auditable formats

### DIFF
--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -20,7 +20,7 @@ module Audits
         .page(filter.page)
         .per_page(filter.per_page)
         .organisations(filter.organisations, filter.primary_org_only)
-        .document_type(filter.document_type)
+        .document_types(filter.document_type)
         .sort(filter.sort)
         .sort_direction(filter.sort_direction)
         .after(filter.after)

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -21,6 +21,7 @@ module Audits
         .per_page(filter.per_page)
         .organisations(filter.organisations, filter.primary_org_only)
         .document_types(filter.document_type)
+        .document_types(*Plan.document_type_ids)
         .sort(filter.sort)
         .sort_direction(filter.sort_direction)
         .after(filter.after)

--- a/app/domain/audits/plan.rb
+++ b/app/domain/audits/plan.rb
@@ -1,0 +1,46 @@
+module Audits
+  class Plan
+    def self.document_type_ids
+      values.values
+    end
+
+    def self.document_types
+      values
+    end
+
+    def self.values
+      @values ||= {
+         "Answer" => :answer,
+         "Case Study > Case Study" => :case_study,
+         "Consultation > Closed Consultation" => :closed_consultation,
+         "Consultation > Consultation Outcome" => :consultation_outcome,
+         "Publication > Corporate Report" => :corporate_report,
+         "Publication > Correspondence" => :correspondence,
+         "Publication > Decision" => :decision,
+         "Detailed Guidance > Detailed Guide" => :detailed_guide,
+         "Document Collection > Collection" => :document_collection,
+         "Publication > Form" => :form,
+         "Publication > Guidance" => :guidance,
+         "Guide" => :guide,
+         "Publication > Impact Assessment" => :impact_assessment,
+         "Publication > Independent Report" => :independent_report,
+         "Publication > International Treaty" => :international_treaty,
+         "Mainstream Browse Page" => :mainstream_browse_page,
+         "Manual" => :manual,
+         "Manual Section" => :manual_section,
+         "Publication > Map" => :map,
+         "Publication > Notice" => :notice,
+         "Consultation > Open Consultation" => :open_consultation,
+         "Publication > Policy Paper" => :policy_paper,
+         "Publication > Promotional Material" => :promotional,
+         "Publication > Regulation" => :regulation,
+         "Publication > Research And Analysis" => :research,
+         "Simple Smart Answer" => :simple_smart_answer,
+         "Smart-answer" => :smart_answer,
+         "Publication > Statutory Guidance" => :statutory_guidance,
+         "Transaction" => :transaction,
+         "Publication > Transparency Data" => :transparency,
+      }
+    end
+  end
+end

--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -30,9 +30,12 @@ module Content
       end
     end
 
-    def document_type(document_type)
-      builder(verify_presence: document_type) do
-        @scope = @scope.where(document_type: document_type)
+    def document_types(*document_types)
+      document_types.compact!
+      document_types.reject!(&:empty?)
+
+      builder(verify_presence: document_types) do
+        @scope = @scope.where(document_type: document_types)
       end
     end
 
@@ -161,6 +164,7 @@ module Content
 
     def builder(verify_presence:)
       yield if verify_presence.present?
+
       self
     end
   end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -54,16 +54,11 @@ module DropdownHelper
   end
 
   def document_type_options
-    options = Content::Item
-      .all_document_types
-      .map { |option| DocumentTypeOption.new(option) }
+    options = Audits::Plan
+                .document_types
+                .sort_by { |key, _value| key.split(/\s>\s/) }
 
-    options_from_collection_for_select(
-      options,
-      :value,
-      :name,
-      params[:document_type],
-    )
+    options_for_select(options, params[:document_type])
   end
 
   def allocated_to_options
@@ -91,16 +86,6 @@ module DropdownHelper
   class SubthemeOption < SimpleDelegator
     def value
       "Subtheme_#{id}"
-    end
-  end
-
-  class DocumentTypeOption < SimpleDelegator
-    def name
-      document_type.titleize
-    end
-
-    def value
-      document_type
     end
   end
 

--- a/spec/domain/content/query_spec.rb
+++ b/spec/domain/content/query_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Content::Query do
 
     it "can filter by document type" do
       travel_advice = create(:content_item, document_type: "travel_advice")
-      subject.document_type("travel_advice")
+      subject.document_types("travel_advice")
       expect(subject.content_items).to contain_exactly(travel_advice)
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
     sequence(:content_id) { |index| "content-id-%04i" % index }
     sequence(:title) { |index| "content-item-title-#{index}" }
-    sequence(:document_type) { |index| "document_type-#{index}" }
+    document_type { Audits::Plan.document_type_ids.sample }
     sequence(:base_path) { |index| "api/content/item/path-%04i" % index }
     public_updated_at { Time.now }
     locale { "en" }

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -198,10 +198,10 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
   end
 
   scenario "filtering by document type" do
-    hmrc.update!(document_type: "organisation")
+    hmrc.update!(document_type: "guide")
 
     visit audits_path
-    select "Organisation", from: "document_type"
+    select "Guide", from: "document_type"
 
     click_on "Apply filters"
 

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -18,6 +18,15 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     expect(page).to have_content("item2")
   end
 
+  scenario "List content items of auditable formats" do
+    create(:content_item, document_type: "guide")
+    create(:content_item, document_type: "other-format")
+
+    visit audits_path
+
+    expect(page).to have_css("main tbody tr", count: 1)
+  end
+
   describe "pagination" do
     let!(:content_items) {
       create_list(:content_item, 30)

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,10 +1,7 @@
 RSpec.feature "Reporting on audit progress" do
-  # Organisations:
-  let!(:hmrc) { create(:content_item, title: "HMRC", document_type: "organisation") }
-
-  # Policies:
-  let!(:flying) { create(:content_item, title: "Flying abroad", document_type: "policy") }
-  let!(:insurance) { create(:content_item, title: "Travel insurance", document_type: "policy") }
+  let!(:content_item) { create(:content_item, document_type: "transaction") }
+  let!(:flying) { create(:content_item, document_type: "transaction") }
+  let!(:insurance) { create(:content_item, document_type: "transaction") }
 
   before do
     create(:passing_audit, content_item: flying)
@@ -21,13 +18,13 @@ RSpec.feature "Reporting on audit progress" do
 
     expect(page).to have_content("3 Content items")
 
-    select "Organisation", from: "document_type"
+    select "Guide", from: "document_type"
     click_on "Apply filters"
-    expect(page).to have_content("1 Content items")
+    expect(page).to have_content("0 Content items")
 
-    select "Policy", from: "document_type"
+    select "Transaction", from: "document_type"
     click_on "Apply filters"
-    expect(page).to have_content("2 Content items")
+    expect(page).to have_content("3 Content items")
   end
 
   scenario "Displaying the number of items audited/not audited" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/Affxvnkf/467-2-only-show-auditable-formats-in-the-audit-tool)

Depends on #307 

Not all formats are auditable by content auditors, so we need to exclude
them. We have decided to define a `Plan` and audit that determines what
subset of content items are auditable.

As of now, we are only excluding by format (document type), but in the
long run we plan to extend the plan definition with subscriptions and
individual content items.

### Changes

![image](https://user-images.githubusercontent.com/227328/29858486-8429f36a-8d55-11e7-9f72-5e04d156dbe9.png)

