### PR TITLE
Enable hide-theme feature toggle in development

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -3,7 +3,7 @@
 default: &default
   features:
     auditing_allocation: true
-    filtering_themes: true
+    filtering_themes: false
 
 development:
   <<: *default

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -1,4 +1,8 @@
 RSpec.feature "Filter Content Items to Audit", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:filtering_themes) { example.run }
+  end
+
   # Organisations:
   let!(:hmrc) { create(:organisation, title: "HMRC") }
   let!(:dfe) { create(:organisation, title: "DFE") }


### PR DESCRIPTION
This toggle is disabled in production. It seems that we are going to 
remove theme filtering from the Audit Tool, so it feels better to not
show the filter in development as well.