### PR TITLE
Do not override GA attributes when importing

### DIFF
--- a/app/domain/content/importers/single_content_item.rb
+++ b/app/domain/content/importers/single_content_item.rb
@@ -37,11 +37,15 @@ module Content
         attributes = content_item
           .attributes
           .symbolize_keys
-          .except(:id, :created_at, :updated_at)
+          .except(
+            :created_at,
+            :id,
+            :one_month_page_views,
+            :six_months_page_views,
+            :updated_at,
+          )
 
-        existing.attributes = attributes
-
-        existing.save!
+        existing.update! attributes
       else
         content_item.save!
       end

--- a/spec/domain/content/importers/single_content_item_spec.rb
+++ b/spec/domain/content/importers/single_content_item_spec.rb
@@ -81,6 +81,20 @@ module Content
           .and change { content_item.reload.linked_organisations.to_a }.from([]).to([org1, org2])
           .and change { content_item.reload.number_of_pdfs }.from(0).to(10)
       end
+
+      it "does not override `six_months_page_views` attributes" do
+        content_item.update!(six_months_page_views: 1000)
+
+        expect { subject.run(content_id, locale) }
+          .to_not change(content_item.reload, :six_months_page_views)
+      end
+
+      it "does not override `one_month_page_views` attributes" do
+        content_item.update!(one_month_page_views: 1000)
+
+        expect { subject.run(content_id, locale) }
+          .to_not change(content_item.reload, :one_month_page_views)
+      end
     end
 
     context "when the links already exists, and the Publishing API is unchanged" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/IbdaeX3i/490-do-not-override-ga-attributes-when-importing-content-items)

We are currently overwriting the GA attributes that are stored in the
Content::Item. We plan to move those attributes out of Content::Item
soon, but in the meantime we should skip them from the importing process.

This issue has raised because the GA data in integration is different 
thank in production.