### PR TITLE
Allocate content to other content auditors

### DIFF
--- a/app/domain/audits/plan.rb
+++ b/app/domain/audits/plan.rb
@@ -1,46 +1,45 @@
 module Audits
   class Plan
     def self.document_type_ids
-      values.values
+      DOCUMENT_TYPES.values
     end
 
     def self.document_types
-      values
+      DOCUMENT_TYPES
     end
 
-    def self.values
-      @values ||= {
-         "Answer" => :answer,
-         "Case Study > Case Study" => :case_study,
-         "Consultation > Closed Consultation" => :closed_consultation,
-         "Consultation > Consultation Outcome" => :consultation_outcome,
-         "Publication > Corporate Report" => :corporate_report,
-         "Publication > Correspondence" => :correspondence,
-         "Publication > Decision" => :decision,
-         "Detailed Guidance > Detailed Guide" => :detailed_guide,
-         "Document Collection > Collection" => :document_collection,
-         "Publication > Form" => :form,
-         "Publication > Guidance" => :guidance,
-         "Guide" => :guide,
-         "Publication > Impact Assessment" => :impact_assessment,
-         "Publication > Independent Report" => :independent_report,
-         "Publication > International Treaty" => :international_treaty,
-         "Mainstream Browse Page" => :mainstream_browse_page,
-         "Manual" => :manual,
-         "Manual Section" => :manual_section,
-         "Publication > Map" => :map,
-         "Publication > Notice" => :notice,
-         "Consultation > Open Consultation" => :open_consultation,
-         "Publication > Policy Paper" => :policy_paper,
-         "Publication > Promotional Material" => :promotional,
-         "Publication > Regulation" => :regulation,
-         "Publication > Research And Analysis" => :research,
-         "Simple Smart Answer" => :simple_smart_answer,
-         "Smart-answer" => :smart_answer,
-         "Publication > Statutory Guidance" => :statutory_guidance,
-         "Transaction" => :transaction,
-         "Publication > Transparency Data" => :transparency,
-      }
-    end
+    DOCUMENT_TYPES = {
+      "Answer" => :answer,
+      "Case Study > Case Study" => :case_study,
+      "Consultation > Closed Consultation" => :closed_consultation,
+      "Consultation > Consultation Outcome" => :consultation_outcome,
+      "Publication > Corporate Report" => :corporate_report,
+      "Publication > Correspondence" => :correspondence,
+      "Publication > Decision" => :decision,
+      "Detailed Guidance > Detailed Guide" => :detailed_guide,
+      "Document Collection > Collection" => :document_collection,
+      "Publication > Form" => :form,
+      "Publication > Guidance" => :guidance,
+      "Guide" => :guide,
+      "Publication > Impact Assessment" => :impact_assessment,
+      "Publication > Independent Report" => :independent_report,
+      "Publication > International Treaty" => :international_treaty,
+      "Mainstream Browse Page" => :mainstream_browse_page,
+      "Manual" => :manual,
+      "Manual Section" => :manual_section,
+      "Publication > Map" => :map,
+      "Publication > Notice" => :notice,
+      "Consultation > Open Consultation" => :open_consultation,
+      "Publication > Policy Paper" => :policy_paper,
+      "Publication > Promotional Material" => :promotional,
+      "Publication > Regulation" => :regulation,
+      "Publication > Research And Analysis" => :research,
+      "Simple Smart Answer" => :simple_smart_answer,
+      "Smart-answer" => :smart_answer,
+      "Publication > Statutory Guidance" => :statutory_guidance,
+      "Transaction" => :transaction,
+      "Publication > Transparency Data" => :transparency,
+    }.freeze
+    private_constant :DOCUMENT_TYPES
   end
 end

--- a/app/domain/audits/plan.rb
+++ b/app/domain/audits/plan.rb
@@ -8,6 +8,10 @@ module Audits
       DOCUMENT_TYPES
     end
 
+    def self.auditors(exclude: nil)
+      User.all - Array(exclude)
+    end
+
     DOCUMENT_TYPES = {
       "Answer" => :answer,
       "Case Study > Case Study" => :case_study,

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -56,13 +56,19 @@ module DropdownHelper
     options_for_select(document_type_options, selected)
   end
 
-  def allocate_to_options(selected = nil)
-    allocation_options = {
-      "Me" => current_user.uid,
-      "No one" => :no_one,
-    }
+  def allocation_options_for_select(selected = nil)
+    auditors = Audits::Plan
+                 .auditors(exclude: current_user)
+                 .sort_by(&:name)
+                 .unshift(OpenStruct.new(name: "Me", uid: current_user.uid))
+                 .unshift(OpenStruct.new(name: "No one", uid: :no_one))
 
-    options_for_select(allocation_options, selected)
+    options_from_collection_for_select(
+      auditors,
+      :uid,
+      :name,
+      selected: selected,
+    )
   end
 
   class ThemeOption < SimpleDelegator

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -53,12 +53,14 @@ module DropdownHelper
     document_type_options = Audits::Plan
                               .document_types
                               .sort_by { |key, _value| key.split(/\s>\s/) }
-
     options_for_select(document_type_options, selected)
   end
 
-  def allocation_options_for_select(selected = nil)
-    allocation_options = { 'Me' => current_user.uid, 'No one' => :no_one }
+  def allocate_to_options(selected = nil)
+    allocation_options = {
+      "Me" => current_user.uid,
+      "No one" => :no_one,
+    }
 
     options_for_select(allocation_options, selected)
   end

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -1,6 +1,6 @@
 <div class="allocation-menu">
   <div class="row">
-    <div class="col-sm-8">
+    <div class="col-sm-7">
       <div class="checkbox">
         <label>
           <%= check_box_tag :select_all, nil, false %> Select all
@@ -16,7 +16,7 @@
         </div>
       <% end %>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-5">
       <div class="form-group form-inline pull-right">
         <%= label_tag :allocate_to, "Assign to" %>
         <%= select_tag "allocate_to",

--- a/spec/domain/audits/plan_spec.rb
+++ b/spec/domain/audits/plan_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Audits::Plan do
+  subject { described_class }
+
+  describe "#auditors" do
+    it "returns all content auditors" do
+      user = create :user
+
+      expect(subject.auditors).to match_array(user)
+    end
+
+    it "excludes auditors declared in the parameter list" do
+      user1 = create :user
+      user2 = create :user
+
+      expect(subject.auditors(exclude: user1)).to match_array(user2)
+    end
+  end
+end

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Content Allocation", type: :feature do
+RSpec.feature "Allocate multiple content items", type: :feature do
   around(:each) do |example|
     Feature.run_with_activated(:auditing_allocation) { example.run }
   end

--- a/spec/features/audit/allocation/allocation_spec.rb
+++ b/spec/features/audit/allocation/allocation_spec.rb
@@ -6,40 +6,6 @@ RSpec.feature "Content Allocation", type: :feature do
   let!(:content_item) { create :content_item, title: "content item 1" }
   let!(:current_user) { User.first }
 
-  scenario "Filter allocated content" do
-    another_user = create(:user)
-    another_content_item = create(:content_item, title: "content item 2")
-    create(:content_item, title: "content item 3")
-
-    create(:allocation, content_item: content_item, user: current_user)
-    create(:allocation, content_item: another_content_item, user: another_user)
-
-    visit audits_path
-
-    expect(page).to have_selector(".nav")
-    expect(page).to have_selector("#sort_by")
-
-    expect(page).to have_content("content item 1")
-    expect(page).to have_content("content item 2")
-
-    select "Me", from: "allocated_to"
-    click_on "Apply filters"
-    expect(page).to have_content("content item 1")
-    expect(page).to_not have_content("content item 2")
-
-    select "No one", from: "allocated_to"
-    click_on "Apply filters"
-    expect(page).to_not have_content("content item 1")
-    expect(page).to_not have_content("content item 2")
-    expect(page).to have_content("content item 3")
-
-    select "Anyone", from: "allocated_to"
-    click_on "Apply filters"
-    expect(page).to have_content("content item 1")
-    expect(page).to have_content("content item 2")
-    expect(page).to have_content("content item 3")
-  end
-
   scenario "Allocate content within current page" do
     second = create(:content_item, title: "content item 2")
     first = create(:content_item, title: "content item 3")
@@ -69,26 +35,6 @@ RSpec.feature "Content Allocation", type: :feature do
     expect(page).to_not have_content("content item 3")
   end
 
-  scenario "Does not change filer status after user has allocated content" do
-    item2 = create(:content_item, title: "content item 2")
-    item3 = create(:content_item, title: "content item 3")
-
-    create(:allocation, content_item: item2, user: current_user)
-
-    visit audits_allocations_path
-
-    select "No one", from: "allocated_to"
-    click_on "Apply filters"
-
-    check option: item3.content_id
-    select "Me", from: "allocate_to"
-    click_on "Go"
-
-    expect(page).to_not have_content("content item 2")
-    expect(page).to_not have_content("content item 3")
-
-    expect(page).to have_select("allocated_to", selected: "No one")
-  end
 
   scenario "Unallocate content" do
     create(:allocation, content_item: content_item, user: current_user)

--- a/spec/features/audit/allocation/allocation_spec.rb
+++ b/spec/features/audit/allocation/allocation_spec.rb
@@ -35,26 +35,6 @@ RSpec.feature "Content Allocation", type: :feature do
     expect(page).to_not have_content("content item 3")
   end
 
-
-  scenario "Unallocate content" do
-    create(:allocation, content_item: content_item, user: current_user)
-
-    visit audits_allocations_path
-
-    select "Me", from: "allocated_to"
-    click_on "Apply filters"
-    expect(page).to have_content("content item 1")
-
-
-    check option: content_item.content_id
-    select "No one", from: "allocate_to"
-    click_on "Go"
-
-    expect(page).to_not have_content("content item 1")
-    expect(page).to have_select("allocate_to", selected: "No one")
-    expect(page).to have_content("1 items unallocated")
-  end
-
   scenario 'Allocate all content within current page', :js do
     create_list(:content_item, 26)
 

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -61,4 +61,22 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
 
     expect(page).to have_select("allocated_to", selected: "No one")
   end
+
+  scenario "Filter content allocated to other content auditor" do
+    user = create(:user, name: "John Smith")
+    item1 = create :content_item, title: "content item 1"
+    create :allocation, user: user, content_item: item1
+    create :content_item, title: "content item 2"
+
+    visit audits_allocations_path
+
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+
+    select "John Smith", from: "allocated_to"
+    click_on "Apply filters"
+
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+  end
 end

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -3,16 +3,16 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     Feature.run_with_activated(:auditing_allocation) { example.run }
   end
 
-  let!(:content_item) { create :content_item, title: "content item 1" }
   let!(:current_user) { User.first }
 
   scenario "Filter allocated content" do
     another_user = create(:user)
-    another_content_item = create(:content_item, title: "content item 2")
+    item1 = create :content_item, title: "content item 1"
+    item2 = create(:content_item, title: "content item 2")
     create(:content_item, title: "content item 3")
 
-    create(:allocation, content_item: content_item, user: current_user)
-    create(:allocation, content_item: another_content_item, user: another_user)
+    create(:allocation, content_item: item1, user: current_user)
+    create(:allocation, content_item: item2, user: another_user)
 
     visit audits_path
 
@@ -41,6 +41,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
   end
 
   scenario "Does not change filer status after user has allocated content" do
+    create :content_item, title: "content item 1"
     item2 = create(:content_item, title: "content item 2")
     item3 = create(:content_item, title: "content item 3")
 

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -1,0 +1,63 @@
+RSpec.feature "Filter content by allocated content auditor", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:auditing_allocation) { example.run }
+  end
+
+  let!(:content_item) { create :content_item, title: "content item 1" }
+  let!(:current_user) { User.first }
+
+  scenario "Filter allocated content" do
+    another_user = create(:user)
+    another_content_item = create(:content_item, title: "content item 2")
+    create(:content_item, title: "content item 3")
+
+    create(:allocation, content_item: content_item, user: current_user)
+    create(:allocation, content_item: another_content_item, user: another_user)
+
+    visit audits_path
+
+    expect(page).to have_selector(".nav")
+    expect(page).to have_selector("#sort_by")
+
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+
+    select "Me", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+
+    select "No one", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to_not have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+    expect(page).to have_content("content item 3")
+
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+    expect(page).to have_content("content item 3")
+  end
+
+  scenario "Does not change filer status after user has allocated content" do
+    item2 = create(:content_item, title: "content item 2")
+    item3 = create(:content_item, title: "content item 3")
+
+    create(:allocation, content_item: item2, user: current_user)
+
+    visit audits_allocations_path
+
+    select "No one", from: "allocated_to"
+    click_on "Apply filters"
+
+    check option: item3.content_id
+    select "Me", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to_not have_content("content item 2")
+    expect(page).to_not have_content("content item 3")
+
+    expect(page).to have_select("allocated_to", selected: "No one")
+  end
+end

--- a/spec/features/audit/allocation/team_allocation_spec.rb
+++ b/spec/features/audit/allocation/team_allocation_spec.rb
@@ -1,0 +1,40 @@
+RSpec.feature "Allocate content to other content auditors", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:auditing_allocation) { example.run }
+  end
+
+  scenario "List allocation options including other content auditors" do
+    create :user, name: "John Smith"
+
+    visit audits_allocations_path
+
+    options = [
+      "Me",
+      "Anyone",
+      "No one",
+      "John Smith",
+    ]
+    expect(page).to have_select("allocated_to", options: options)
+  end
+
+  scenario "Allocate content to other content auditors" do
+    create(:user, name: "John Smith")
+    item1 = create :content_item, title: "content item 1"
+    create(:content_item, title: "content item 2")
+
+    visit audits_allocations_path
+
+    check option: item1.content_id
+
+    select "John Smith", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to have_content("1 items allocated to John Smith")
+
+    select "John Smith", from: "allocated_to"
+    click_on "Apply filters"
+
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+  end
+end

--- a/spec/features/audit/allocation/unallocate_spec.rb
+++ b/spec/features/audit/allocation/unallocate_spec.rb
@@ -1,0 +1,27 @@
+RSpec.feature "Unallocate content", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:auditing_allocation) { example.run }
+  end
+
+  let!(:content_item) { create :content_item, title: "content item 1" }
+  let!(:current_user) { User.first }
+
+  scenario "Unallocate content" do
+    create(:allocation, content_item: content_item, user: current_user)
+
+    visit audits_allocations_path
+
+    select "Me", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_content("content item 1")
+
+
+    check option: content_item.content_id
+    select "No one", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to_not have_content("content item 1")
+    expect(page).to have_select("allocate_to", selected: "No one")
+    expect(page).to have_content("1 items unallocated")
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/SiPz4wDt/427-3-show-content-allocated-to-other-content-auditors)

### User need

**As** a Content Auditor
**I need to** know what content is allocated to a user
**So that** I am able to better allocate content to users

### Includes

- Restructures allocation feature tests so scenarios are easier to find
- Allocate to other content auditors
- Filter by allocated content
