### PR TITLE
Fix allocate/unallocate when nothing is selected

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -28,7 +28,7 @@ module Audits
       if params[:select_all_pages]
         FindContent.all(build_filter).pluck(:content_id)
       else
-        params[:content_ids]
+        params.fetch(:content_ids, [])
       end
     end
 

--- a/spec/features/audit/allocation/allocation_spec.rb
+++ b/spec/features/audit/allocation/allocation_spec.rb
@@ -141,4 +141,22 @@ RSpec.feature "Content Allocation", type: :feature do
       expect(page).to have_content("27 items allocated to #{current_user.name}")
     end
   end
+
+  scenario "Allocate 0 content items" do
+    visit audits_allocations_path
+
+    select "Me", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to have_content("0 items allocated to #{current_user.name}")
+  end
+
+  scenario "Unallocate 0 content items" do
+    visit audits_allocations_path
+
+    select "No one", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to have_content("0 items unallocated")
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/nIYtldbE/491-fix-empty-allocations-issue)

We are getting server errors when the user is trying to allocate or
unallocated an empty selection of content items. To fix it we just need
to use a default (empty array) when nothing is selected.

### After

![image](https://user-images.githubusercontent.com/227328/29976813-47215cf8-8f33-11e7-909c-26dac6588e98.png)

![image](https://user-images.githubusercontent.com/227328/29976832-54c8e3a8-8f33-11e7-85eb-ad3dcaa6720f.png)
