### PR TITLE
Fixes report issue with items needing improvement

### DIFF
--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -40,13 +40,13 @@
       <table class="table">
         <tr>
           <td class="col-md-6">Items that need improvement</td>
-          <td class="col-md-3"><%= format_number(@monitor.passing_count) %></td>
-          <td class="col-md-3"><%= format_percentage(@monitor.passing_percentage) %></td>
+          <td class="col-md-3"><%= format_number(@monitor.not_passing_count) %></td>
+          <td class="col-md-3"><%= format_percentage(@monitor.not_passing_percentage) %></td>
         </tr>
         <tr>
           <td class="col-md-6">Items that don't need improvement</td>
-          <td class="col-md-3"><%= format_number(@monitor.not_passing_count) %></td>
-          <td class="col-md-3"><%= format_percentage(@monitor.not_passing_percentage) %></td>
+          <td class="col-md-3"><%= format_number(@monitor.passing_count) %></td>
+          <td class="col-md-3"><%= format_percentage(@monitor.passing_percentage) %></td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
[Trello card](https://trello.com/c/X1B3nJY3/492-fix-report-view-items-needing-improvement)

The number of items not needing improvement is showing up incorrect:
When checking how many items have been marked as not needing improvement, 
users recognised that the information was incorrect.


