### PR TITLE
Refactor dropdown helper

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -1,71 +1,64 @@
 module DropdownHelper
-  def theme_and_subtheme_options_for_select
-    groups = Audits::Theme.all.map do |theme|
+  def theme_and_subtheme_options_for_select(selected = nil)
+    theme_and_subtheme_options = Audits::Theme.all.map do |theme|
       options = [ThemeOption.new(theme)]
       options += theme.subthemes.map { |s| SubthemeOption.new(s) }
 
       [theme.name, options.map { |o| [o.name, o.value] }]
     end
 
-    grouped_options_for_select(groups, params[:theme])
+    grouped_options_for_select(theme_and_subtheme_options, selected)
   end
 
-  def audit_status_options_for_select
+  def audit_status_options_for_select(selected = nil)
+    audit_status_options = [
+      AuditStatusOption.new(Audits::Audit::AUDITED),
+      AuditStatusOption.new(Audits::Audit::NON_AUDITED),
+    ]
+
     options_from_collection_for_select(
-      [
-        AuditStatusOption.new(Audits::Audit::AUDITED),
-        AuditStatusOption.new(Audits::Audit::NON_AUDITED),
-      ],
+      audit_status_options,
       :value,
       :name,
-      params[:audit_status],
+      selected,
     )
   end
 
-  def taxon_options_for_select
-    options = Content::Item.all_taxons
+  def taxon_options_for_select(selected = nil)
+    taxon_options = Content::Item.all_taxons.pluck(:title, :content_id)
 
-    options_from_collection_for_select(
-      options,
-      :content_id,
-      :title,
-      selected: params["taxons"],
-    )
+    options_for_select(taxon_options, selected)
   end
 
-  def organisation_options_for_select
-    options = Content::Item.all_organisations
+  def organisation_options_for_select(selected = nil)
+    organisation_options = Content::Item
+                             .all_organisations
+                             .pluck(:title, :content_id)
 
-    options_from_collection_for_select(
-      options,
-      :content_id,
-      :title,
-      selected: params[:organisations],
-    )
+    options_for_select(organisation_options, selected)
   end
 
-  def sort_by_options_for_select
-    options = {
+  def sort_by_options_for_select(selected = nil)
+    sort_by_options = {
       "Title A-Z" => "title_asc",
       "Title Z-A" => "title_desc",
     }
 
-    options_for_select(options, params[:sort_by])
+    options_for_select(sort_by_options, selected)
   end
 
-  def document_type_options_for_select
-    options = Audits::Plan
-                .document_types
-                .sort_by { |key, _value| key.split(/\s>\s/) }
+  def document_type_options_for_select(selected = nil)
+    document_type_options = Audits::Plan
+                              .document_types
+                              .sort_by { |key, _value| key.split(/\s>\s/) }
 
-    options_for_select(options, params[:document_type])
+    options_for_select(document_type_options, selected)
   end
 
   def allocation_options_for_select(selected = nil)
-    options_for_select(
-      { 'Me' => current_user.uid, 'No one' => :no_one },
-      selected,
-    )
+    allocation_options = { 'Me' => current_user.uid, 'No one' => :no_one }
+
+    options_for_select(allocation_options, selected)
   end
 
   class ThemeOption < SimpleDelegator

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -1,5 +1,5 @@
 module DropdownHelper
-  def theme_and_subtheme_options
+  def theme_and_subtheme_options_for_select
     groups = Audits::Theme.all.map do |theme|
       options = [ThemeOption.new(theme)]
       options += theme.subthemes.map { |s| SubthemeOption.new(s) }
@@ -10,7 +10,7 @@ module DropdownHelper
     grouped_options_for_select(groups, params[:theme])
   end
 
-  def audit_status_options
+  def audit_status_options_for_select
     options_from_collection_for_select(
       [
         AuditStatusOption.new(Audits::Audit::AUDITED),
@@ -22,7 +22,7 @@ module DropdownHelper
     )
   end
 
-  def taxons_options
+  def taxon_options_for_select
     options = Content::Item.all_taxons
 
     options_from_collection_for_select(
@@ -33,7 +33,7 @@ module DropdownHelper
     )
   end
 
-  def organisation_options
+  def organisation_options_for_select
     options = Content::Item.all_organisations
 
     options_from_collection_for_select(
@@ -44,7 +44,7 @@ module DropdownHelper
     )
   end
 
-  def sort_by_options
+  def sort_by_options_for_select
     options = {
       "Title A-Z" => "title_asc",
       "Title Z-A" => "title_desc",
@@ -53,7 +53,7 @@ module DropdownHelper
     options_for_select(options, params[:sort_by])
   end
 
-  def document_type_options
+  def document_type_options_for_select
     options = Audits::Plan
                 .document_types
                 .sort_by { |key, _value| key.split(/\s>\s/) }
@@ -61,13 +61,13 @@ module DropdownHelper
     options_for_select(options, params[:document_type])
   end
 
-  def allocated_to_options
+  def allocated_to_options_for_select
     options = { "Me" => current_user.uid, "No one" => :no_one }
 
     options_for_select(options, params[:allocated_to])
   end
 
-  def allocate_to_options
+  def allocate_to_options_for_select
     options = { "Me" => current_user.uid, "No one" => :no_one }
 
     options_for_select(options, params[:allocate_to])

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -34,6 +34,8 @@ module DropdownHelper
     organisation_options = Content::Item
                              .all_organisations
                              .pluck(:title, :content_id)
+                             .map { |title, content_id| [title.squish, content_id] }
+                             .sort_by { |title, _| title }
 
     options_for_select(organisation_options, selected)
   end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -61,16 +61,11 @@ module DropdownHelper
     options_for_select(options, params[:document_type])
   end
 
-  def allocated_to_options_for_select
-    options = { "Me" => current_user.uid, "No one" => :no_one }
-
-    options_for_select(options, params[:allocated_to])
-  end
-
-  def allocate_to_options_for_select
-    options = { "Me" => current_user.uid, "No one" => :no_one }
-
-    options_for_select(options, params[:allocate_to])
+  def allocation_options_for_select(selected = nil)
+    options_for_select(
+      { 'Me' => current_user.uid, 'No one' => :no_one },
+      selected,
+    )
   end
 
   class ThemeOption < SimpleDelegator

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -20,7 +20,7 @@
       <div class="form-group form-inline pull-right">
         <%= label_tag :allocate_to, "Assign to" %>
         <%= select_tag "allocate_to",
-                       allocate_to_options_for_select,
+                       allocation_options_for_select(params[:allocate_to]),
                        class: "form-control",
                        id: "allocate_to" %>
         <%= filter_to_hidden_fields(:allocate_to) %>

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -20,9 +20,9 @@
       <div class="form-group form-inline pull-right">
         <%= label_tag :allocate_to, "Assign to" %>
         <%= select_tag "allocate_to",
-          allocate_to_options,
-          class: "form-control",
-          id: "allocate_to" %>
+                       allocate_to_options_for_select,
+                       class: "form-control",
+                       id: "allocate_to" %>
         <%= filter_to_hidden_fields(:allocate_to) %>
         <%= submit_tag "Go", class: "btn btn-default" %>
       </div>

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :allocated_to, "Assigned to" %>
   <%= select_tag :allocated_to,
-    allocated_to_options,
-    include_blank: "Anyone",
-    class: "form-control" %>
+                 allocated_to_options_for_select,
+                 include_blank: "Anyone",
+                 class: "form-control" %>
 </div>

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :allocated_to, "Assigned to" %>
   <%= select_tag :allocated_to,
-                 allocated_to_options_for_select,
+                 allocation_options_for_select(params[:allocated_to]),
                  include_blank: "Anyone",
                  class: "form-control" %>
 </div>

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :audit_status, 'Audit status' %>
   <%= select_tag :audit_status,
-                 audit_status_options_for_select,
+                 audit_status_options_for_select(params[:audit_status]),
                  include_blank: "All",
                  class: "form-control" %>
 </div>

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :audit_status, 'Audit status' %>
   <%= select_tag :audit_status,
-    audit_status_options,
-    include_blank: "All",
-    class: "form-control" %>
+                 audit_status_options_for_select,
+                 include_blank: "All",
+                 class: "form-control" %>
 </div>

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :document_type, 'Content type' %>
   <%= select_tag :document_type,
-    document_type_options,
-    include_blank: "All",
-    class: "form-control" %>
+                 document_type_options_for_select,
+                 include_blank: "All",
+                 class: "form-control" %>
 </div>

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :document_type, 'Content type' %>
   <%= select_tag :document_type,
-                 document_type_options_for_select,
+                 document_type_options_for_select(params[:document_type]),
                  include_blank: "All",
                  class: "form-control" %>
 </div>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -1,8 +1,8 @@
 <div class="form-group" data-module="organisation-autocomplete">
   <%= label_tag :organisations, "Organisation" %>
   <%= select_tag :organisations,
-    organisation_options,
-    include_blank: "",
-    id: "organisations",
-    class: "form-control" %>
+                 organisation_options_for_select,
+                 include_blank: "",
+                 id: "organisations",
+                 class: "form-control" %>
 </div>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group" data-module="organisation-autocomplete">
   <%= label_tag :organisations, "Organisation" %>
   <%= select_tag :organisations,
-                 organisation_options_for_select,
+                 organisation_options_for_select(params[:organisations]),
                  include_blank: "",
                  id: "organisations",
                  class: "form-control" %>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -2,7 +2,7 @@
   <%= label_tag :organisations, "Organisation" %>
   <%= select_tag :organisations,
                  organisation_options_for_select(params[:organisations]),
-                 include_blank: "",
+                 include_blank: true,
                  id: "organisations",
                  class: "form-control" %>
 </div>

--- a/app/views/audits/common/_sort.html.erb
+++ b/app/views/audits/common/_sort.html.erb
@@ -1,9 +1,9 @@
 <div class="form-group">
   <%= label_tag :sort_by, "Sort" %>
   <%= select_tag :sort_by,
-    sort_by_options,
-    include_blank: "Pageviews",
-    class: "form-control" %>
+                 sort_by_options_for_select,
+                 include_blank: "Pageviews",
+                 class: "form-control" %>
 </div>
 
 

--- a/app/views/audits/common/_sort.html.erb
+++ b/app/views/audits/common/_sort.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :sort_by, "Sort" %>
   <%= select_tag :sort_by,
-                 sort_by_options_for_select,
+                 sort_by_options_for_select(params[:sort_by]),
                  include_blank: "Pageviews",
                  class: "form-control" %>
 </div>

--- a/app/views/audits/common/_theme_subtheme.html.erb
+++ b/app/views/audits/common/_theme_subtheme.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :theme, 'Theme' %>
   <%= select_tag :theme,
-                 theme_and_subtheme_options_for_select,
+                 theme_and_subtheme_options_for_select(params[:theme]),
                  include_blank: "All",
                  class: "form-control" %>
 </div>

--- a/app/views/audits/common/_theme_subtheme.html.erb
+++ b/app/views/audits/common/_theme_subtheme.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :theme, 'Theme' %>
   <%= select_tag :theme,
-    theme_and_subtheme_options,
-    include_blank: "All",
-    class: "form-control" %>
+                 theme_and_subtheme_options_for_select,
+                 include_blank: "All",
+                 class: "form-control" %>
 </div>

--- a/app/views/content/items/_sidebar.html.erb
+++ b/app/views/content/items/_sidebar.html.erb
@@ -8,7 +8,7 @@
     <div class="form-group">
       <%= label_tag :organisations, "Organisation" %>
       <%= select_tag :organisations,
-                     organisation_options_for_select,
+                     organisation_options_for_select(params[:organisations]),
                      include_blank: "All",
                      class: "form-control" %>
     </div>
@@ -24,7 +24,7 @@
         <div class="form-group">
           <%= label_tag :taxons, "Taxons" %>
           <%= select_tag :taxons,
-                         taxon_options_for_select,
+                         taxon_options_for_select(params['taxons']),
                          include_blank: "All",
                          class: "form-control" %>
         </div>

--- a/app/views/content/items/_sidebar.html.erb
+++ b/app/views/content/items/_sidebar.html.erb
@@ -8,9 +8,9 @@
     <div class="form-group">
       <%= label_tag :organisations, "Organisation" %>
       <%= select_tag :organisations,
-          organisation_options,
-          include_blank: "All",
-          class: "form-control" %>
+                     organisation_options_for_select,
+                     include_blank: "All",
+                     class: "form-control" %>
     </div>
 
     <div class="form-group">
@@ -24,9 +24,9 @@
         <div class="form-group">
           <%= label_tag :taxons, "Taxons" %>
           <%= select_tag :taxons,
-              taxons_options,
-              include_blank: "All",
-              class: "form-control" %>
+                         taxon_options_for_select,
+                         include_blank: "All",
+                         class: "form-control" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
A bit of a refactoring of the dropdown helper with the aim of:

- Making the helper methods more revealing by adopting the Rails naming conventions they are specialists of
- Removing external dependency on the `params` object
- Removing duplication
- Making the code look consistent