### PR TITLE
Add support for title search in Audit Tool

### DIFF
--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -13,6 +13,7 @@ module Audits
         primary_org_only: primary_org_only?,
         sort_by: params[:sort_by],
         theme_id: params[:theme],
+        title: params[:query],
       )
     end
 

--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -11,7 +11,8 @@ module Audits
       :primary_org_only,
       :sort,
       :sort_direction,
-      :theme_id
+      :theme_id,
+      :title
 
     def audit_status=(value)
       @audit_status = if value.blank?

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -20,6 +20,7 @@ module Audits
         .page(filter.page)
         .per_page(filter.per_page)
         .organisations(filter.organisations, filter.primary_org_only)
+        .title(filter.title)
         .document_types(filter.document_type)
         .document_types(*Plan.document_type_ids)
         .sort(filter.sort)

--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -26,7 +26,7 @@ module Content
 
     def title(title)
       builder(verify_presence: title) do
-        @scope = @scope.where("title like ?", "%#{title}%")
+        @scope = @scope.where("lower(title) like ?", "%#{title.downcase}%")
       end
     end
 

--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,4 +1,5 @@
 <%= form_tag audits_allocations_path, method: :get do %>
+  <%= render 'audits/common/title' %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
   <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,4 +1,5 @@
 <%= form_tag audits_path, method: :get do %>
+  <%= render 'audits/common/title' %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' if Feature.active?(:auditing_allocation) %>
   <%= render 'audits/common/theme_subtheme' if Feature.active?(:filtering_themes) %>

--- a/app/views/audits/common/_title.html.erb
+++ b/app/views/audits/common/_title.html.erb
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <%= label_tag 'query', 'Search term:', class: '' %>
+  <%= text_field_tag 'query', params[:query], placeholder: 'Enter search term...', class: 'form-control' %>
+</div>

--- a/spec/domain/content/query_spec.rb
+++ b/spec/domain/content/query_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe Content::Query do
       subject.title("foo")
       expect(subject.content_items).to contain_exactly(foo)
     end
+
+    it "is not case sensitive" do
+      foo = create(:content_item, title: "barfoobaz")
+      subject.title("Foo")
+      expect(subject.content_items).to contain_exactly(foo)
+    end
   end
 
   describe "with 26 content items" do

--- a/spec/features/audit/allocation/allocation_spec.rb
+++ b/spec/features/audit/allocation/allocation_spec.rb
@@ -17,7 +17,9 @@ RSpec.feature "Content Allocation", type: :feature do
     visit audits_allocations_path
 
     expect(page).to have_selector(".nav")
+    expect(page).to have_selector("li.active", text: "Assign content")
     expect(page).to have_selector("#sort_by")
+    expect(page).to have_selector("#query")
 
     expect(page).to have_content("content item 1")
     expect(page).to have_content("content item 2")

--- a/spec/features/audit/allocation/allocation_spec.rb
+++ b/spec/features/audit/allocation/allocation_spec.rb
@@ -1,0 +1,142 @@
+RSpec.feature "Content Allocation", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:auditing_allocation) { example.run }
+  end
+
+  let!(:content_item) { create :content_item, title: "content item 1" }
+  let!(:current_user) { User.first }
+
+  scenario "Filter allocated content" do
+    another_user = create(:user)
+    another_content_item = create(:content_item, title: "content item 2")
+    create(:content_item, title: "content item 3")
+
+    create(:allocation, content_item: content_item, user: current_user)
+    create(:allocation, content_item: another_content_item, user: another_user)
+
+    visit audits_allocations_path
+
+    expect(page).to have_selector(".nav")
+    expect(page).to have_selector("#sort_by")
+
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+
+    select "Me", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+
+    select "No one", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to_not have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+    expect(page).to have_content("content item 3")
+
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_content("content item 1")
+    expect(page).to have_content("content item 2")
+    expect(page).to have_content("content item 3")
+  end
+
+  scenario "Allocate content within current page" do
+    second = create(:content_item, title: "content item 2")
+    first = create(:content_item, title: "content item 3")
+
+    visit audits_allocations_path
+
+    check option: second.content_id
+    check option: first.content_id
+
+    select "Me", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to have_content("2 items allocated to #{current_user.name}")
+
+    select "Me", from: "allocated_to"
+    click_on "Apply filters"
+
+    expect(page).to_not have_content("content item 1")
+    expect(page).to have_content("content item 2")
+    expect(page).to have_content("content item 3")
+
+    select "No one", from: "allocated_to"
+    click_on "Apply filters"
+
+    expect(page).to have_content("content item 1")
+    expect(page).to_not have_content("content item 2")
+    expect(page).to_not have_content("content item 3")
+  end
+
+  scenario "Does not change filer status after user has allocated content" do
+    item2 = create(:content_item, title: "content item 2")
+    item3 = create(:content_item, title: "content item 3")
+
+    create(:allocation, content_item: item2, user: current_user)
+
+    visit audits_allocations_path
+
+    select "No one", from: "allocated_to"
+    click_on "Apply filters"
+
+    check option: item3.content_id
+    select "Me", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to_not have_content("content item 2")
+    expect(page).to_not have_content("content item 3")
+
+    expect(page).to have_select("allocated_to", selected: "No one")
+  end
+
+  scenario "Unallocate content" do
+    create(:allocation, content_item: content_item, user: current_user)
+
+    visit audits_allocations_path
+
+    select "Me", from: "allocated_to"
+    click_on "Apply filters"
+    expect(page).to have_content("content item 1")
+
+
+    check option: content_item.content_id
+    select "No one", from: "allocate_to"
+    click_on "Go"
+
+    expect(page).to_not have_content("content item 1")
+    expect(page).to have_select("allocate_to", selected: "No one")
+    expect(page).to have_content("1 items unallocated")
+  end
+
+  scenario 'Allocate all content within current page', :js do
+    create_list(:content_item, 26)
+
+    visit audits_allocations_path
+
+    check 'Select all'
+
+    select 'Me', from: 'allocate_to'
+    click_on 'Go'
+
+    within('.alert-success') do
+      expect(page).to have_content("25 items allocated to #{current_user.name}")
+    end
+  end
+
+  scenario 'Allocate all content within all pages', :js do
+    create_list(:content_item, 26)
+
+    visit audits_allocations_path
+
+    check 'Select all'
+    check 'Select 27 items on all pages'
+
+    select 'Me', from: 'allocate_to'
+    click_on 'Go'
+
+    within('.alert-success') do
+      expect(page).to have_content("27 items allocated to #{current_user.name}")
+    end
+  end
+end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -153,6 +153,27 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     end
   end
 
+  context "filtering by title" do
+    scenario "the user enters a text in the search box and retrieves a filtered list" do
+      create :content_item, title: "some text"
+      create :content_item, title: "another text"
+
+      visit audits_path
+      fill_in "query", with: "some text"
+      click_on "Apply filters"
+
+      expect(page).to have_selector("main tbody tr", count: 1)
+    end
+
+    scenario "show the query entered by the user after filtering" do
+      visit audits_path
+      fill_in 'query', with: 'a search value'
+      click_on "Apply filters"
+
+      expect(page).to have_field(:query, with: 'a search value')
+    end
+  end
+
   scenario "themes and subthemes are in alphabetical order" do
     visit audits_path
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/7JOmgvRl/495-3-add-search-to-audit-tool)

### User need

As a Content Auditor
I want to search content by text
So that I can audit and allocate content easily

### Changes

![image](https://user-images.githubusercontent.com/227328/30030493-70e7afd4-9185-11e7-8b98-93693f2bd8df.png)
