### PR TITLE
Amend tab labels

### DIFF
--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs">
-  <%= navigation_link "Content", audits_url(filter_params), 'audits'%>
+  <%= navigation_link "Audit content", audits_url(filter_params), 'audits'%>
   <%= navigation_link "Assign content", audits_allocations_url(filter_params), 'allocations' if Feature.active?(:auditing_allocation) %>
-  <%= navigation_link "Report", audits_report_url(filter_params), 'reports' %>
+  <%= navigation_link "Audit progress", audits_report_url(filter_params), 'reports' %>
 </ul>

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Exporting a CSV from the report page" do
       expect(page).to have_content("Example 1")
       expect(page).to have_no_content("Example 2")
 
-      click_link "Report"
+      click_link "Audit progress"
 
       click_link "Export filtered audit to CSV"
       expect(content_disposition).to include(

--- a/spec/features/audit/report/tabs_spec.rb
+++ b/spec/features/audit/report/tabs_spec.rb
@@ -6,9 +6,9 @@ RSpec.feature "Tabs" do
     click_on "Apply filters"
     expect(page).to have_select("audit_status", selected: "Audited")
 
-    click_link "Report"
+    click_link "Audit progress"
 
-    click_link "Content"
+    click_link "Audit content"
     expect(page).to have_select("audit_status", selected: "Audited")
   end
 end


### PR DESCRIPTION
The text for the tabs in the Audit Tool need amending to help with usability.

## Before

![screenshot-content-performance-manager staging publishing service gov uk-2017-09-08-11-56-27](https://user-images.githubusercontent.com/424772/30208753-cec29d26-948c-11e7-8168-f9fcb21b8fec.png)

## After

![screenshot-localhost-3000-2017-09-08-11-57-20](https://user-images.githubusercontent.com/424772/30208789-edfb80ea-948c-11e7-81cb-b600282a2f89.png)

