### PR TITLE
Change Audit Status filter to radio buttons

### DIFF
--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -15,11 +15,11 @@ module Audits
       :title
 
     def audit_status=(value)
-      @audit_status = if value.blank?
-                        nil
-                      else
-                        value.to_sym
-                      end
+      @audit_status = value.to_sym unless value.blank?
+    end
+
+    def audit_status
+      @audit_status || Audit::NON_AUDITED
     end
 
     def sort_by=(value)
@@ -44,9 +44,9 @@ module Audits
 
     def audited_policy
       case self.audit_status
-      when :audited
+      when Audit::AUDITED
         Policies::Audited
-      when :non_audited
+      when Audit::NON_AUDITED
         Policies::NonAudited
       else
         Policies::NoPolicy

--- a/app/domain/audits/monitor.rb
+++ b/app/domain/audits/monitor.rb
@@ -1,9 +1,8 @@
 module Audits
   class Monitor
-    attr_accessor :filter
-
     def initialize(filter)
-      self.filter = filter
+      @filter = filter
+      @filter.audit_status = Audit::ALL
     end
 
     def total_count
@@ -45,7 +44,7 @@ module Audits
   private
 
     def content_items
-      @content_items ||= FindContent.all(filter)
+      @content_items ||= FindContent.all(@filter)
     end
 
     def percentage(number, out_of:)

--- a/app/domain/audits/report.rb
+++ b/app/domain/audits/report.rb
@@ -9,7 +9,7 @@ module Audits
     attr_accessor :content_items, :report_url
 
     def initialize(filter, report_url)
-      filter.audit_status = nil
+      filter.audit_status = Audit::ALL
 
       self.content_items = FindContent.all(filter)
       self.report_url = report_url

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -10,20 +10,6 @@ module DropdownHelper
     grouped_options_for_select(theme_and_subtheme_options, selected)
   end
 
-  def audit_status_options_for_select(selected = nil)
-    audit_status_options = [
-      AuditStatusOption.new(Audits::Audit::AUDITED),
-      AuditStatusOption.new(Audits::Audit::NON_AUDITED),
-    ]
-
-    options_from_collection_for_select(
-      audit_status_options,
-      :value,
-      :name,
-      selected,
-    )
-  end
-
   def taxon_options_for_select(selected = nil)
     taxon_options = Content::Item.all_taxons.pluck(:title, :content_id)
 
@@ -85,16 +71,6 @@ module DropdownHelper
   class SubthemeOption < SimpleDelegator
     def value
       "Subtheme_#{id}"
-    end
-  end
-
-  class AuditStatusOption < SimpleDelegator
-    def name
-      to_s.titleize
-    end
-
-    def value
-      to_s
     end
   end
 end

--- a/app/helpers/radio_button_helper.rb
+++ b/app/helpers/radio_button_helper.rb
@@ -1,0 +1,16 @@
+module RadioButtonHelper
+  def audit_status_radio_button_options(selected)
+    options = [
+      { value: Audits::Audit::NON_AUDITED, label: 'Not audited' },
+      { value: Audits::Audit::AUDITED, label: 'Audited' },
+      { value: Audits::Audit::ALL, label: 'All' },
+    ]
+
+    options.map.with_index do |option, index|
+      option.merge(
+        id: "audit_status_#{option[:value]}",
+        selected: selected == option[:value].to_s || index.zero?,
+      )
+    end
+  end
+end

--- a/app/models/audits/audit.rb
+++ b/app/models/audits/audit.rb
@@ -1,5 +1,6 @@
 module Audits
   class Audit < ApplicationRecord
+    ALL = :all
     AUDITED = :audited
     NON_AUDITED = :non_audited
 

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :audit_status, 'Audit status' %>
-  <%= select_tag :audit_status,
-                 audit_status_options_for_select(params[:audit_status]),
-                 include_blank: "All",
-                 class: "form-control" %>
+
+  <%= render partial: "components/radio_button",
+             collection: audit_status_radio_button_options(params[:audit_status]),
+             as: :option %>
 </div>

--- a/app/views/components/_radio_button.html.erb
+++ b/app/views/components/_radio_button.html.erb
@@ -1,0 +1,11 @@
+<div class="radio">
+  <label for="<%= option[:id] -%>"
+         class="radio">
+    <input type="radio"
+           id="<%= option[:id] -%>"
+           name="audit_status"
+           value="<%= option[:value] -%>"
+           <%= "checked" if option[:selected] -%> />
+    <%= option[:label] %>
+  </label>
+</div>

--- a/spec/features/audit/audit/navigation_spec.rb
+++ b/spec/features/audit/audit/navigation_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Navigation", type: :feature do
       perform_audit
 
       visit audits_path
-      select "Non Audited", from: "audit_status"
+      choose "Not audited"
       click_on "Apply filters"
 
       expect(page).to have_content(first.title)

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Exporting a CSV from the report page" do
 
     scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
       visit audits_path
-      select "Audited", from: "audit_status"
+      choose "Audited"
 
       click_on "Apply filters"
       expect(page).to have_content("Example 1")

--- a/spec/features/audit/report/tabs_spec.rb
+++ b/spec/features/audit/report/tabs_spec.rb
@@ -1,14 +1,14 @@
 RSpec.feature "Tabs" do
   scenario "preserving filters across tabs" do
     visit audits_path
-    select "Audited", from: "audit_status"
+    choose "Audited"
 
     click_on "Apply filters"
-    expect(page).to have_select("audit_status", selected: "Audited")
+    expect(page).to have_checked_field("audit_status_audited")
 
     click_link "Audit progress"
 
     click_link "Audit content"
-    expect(page).to have_select("audit_status", selected: "Audited")
+    expect(page).to have_checked_field("audit_status_audited")
   end
 end


### PR DESCRIPTION
Radio buttons are more accessible, and generally more apparent than
dropdown menus. This change replaces the old `select` element with a set
of radio buttons for selecting the audit status.

This change also reorders the audit status options, and uses “Not
audited” as the default, both in the view, and in the controller.

### Before

![audit-status-before](https://user-images.githubusercontent.com/12036746/30211696-f3f915e0-9499-11e7-91ff-36ab938d230b.png)

### After

![audit-status-after](https://user-images.githubusercontent.com/12036746/30211699-f5d376ee-9499-11e7-86fd-6e54d2e8b922.png)
