### PR TITLE
Present all organisation users in dropdowns

### DIFF
--- a/app/domain/audits/find_team_auditors.rb
+++ b/app/domain/audits/find_team_auditors.rb
@@ -12,7 +12,6 @@ module Audits
 
     def call
       User
-        .joins("INNER JOIN allocations ON allocations.uid = users.uid")
         .where(organisation_slug: user.organisation_slug)
         .distinct
         .to_a

--- a/spec/domain/audits/find_team_auditors_spec.rb
+++ b/spec/domain/audits/find_team_auditors_spec.rb
@@ -10,12 +10,5 @@ module Audits
 
       expect(subject.call(user_uid: user_uid)).to match_array(user)
     end
-
-    it "returns only users with content allocated" do
-      create :user, organisation_slug: "organisation_slug"
-
-      users = subject.call(user_uid: user_uid)
-      expect(users).to match_array([user])
-    end
   end
 end

--- a/spec/features/audit/allocation/team_allocation_spec.rb
+++ b/spec/features/audit/allocation/team_allocation_spec.rb
@@ -10,10 +10,9 @@ RSpec.feature "Allocate content to other content auditors", type: :feature do
     create :allocation, user: current_user
   end
 
-  scenario "List content auditors of same organisation with content assigned" do
+  scenario "List content auditors of same organisation" do
     create :user, :with_allocated_content, name: "John Smith", organisation_slug: organisation_slug
     create :user, :with_allocated_content, name: "Arthur Johnson", organisation_slug: organisation_slug
-    create :user, organisation_slug: organisation_slug
 
     visit audits_allocations_path
 


### PR DESCRIPTION
When picking colleagues from dropdowns, we currently only show users
with content allocated to them. This can make for a confusing user
experience when trying to - for example - allocate content to users
who have never had content allocated to them, or when trying to view
content allocated to that user.

This change removes that restriction. The users in our database are only
the users who have logged into the application, which will also be
restricted by Signon permissions. This will naturally limit the number
of other users presented in the dropdowns, so it is assumed that we
do not need to restrict users in this way.