### PR TITLE
Display a message when no unaudited content is assigned

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -5,7 +5,7 @@ module Audits
     decorates_assigned :content_items
 
     def index
-      @content_items = FindContent.paged(build_filter)
+      @content_items = FindContent.paged(filter)
     end
 
     def create
@@ -28,7 +28,7 @@ module Audits
 
     def set_batch_value
       params[:content_ids] = FindContent
-                               .paged(build_filter(per_page: batch_size))
+                               .paged(filter(per_page: batch_size))
                                .pluck(:content_id)
     end
 

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -4,10 +4,10 @@ module Audits
 
     def index
       respond_to do |format|
-        format.html { @content_items = FindContent.paged(build_filter) }
+        format.html { @content_items = FindContent.paged(filter) }
         format.csv do
           send_data(
-            Report.generate(build_filter, request.url),
+            Report.generate(filter, request.url),
             filename: "Transformation_audit_report_CSV_download.csv"
           )
         end
@@ -16,13 +16,13 @@ module Audits
 
     def show
       @content_item = Content::Item.find_by!(content_id: params.fetch(:content_item_content_id))
-      @next_content_item = FindNextItem.call(@content_item, build_filter)
+      @next_content_item = FindNextItem.call(@content_item, filter)
       @audit = Audit.find_or_initialize_by(content_item: @content_item)
     end
 
     def save
       @content_item = Content::Item.find_by!(content_id: params.fetch(:content_item_content_id))
-      @next_content_item = FindNextItem.call(@content_item, build_filter)
+      @next_content_item = FindNextItem.call(@content_item, filter)
       @audit = Audit.find_or_initialize_by(content_item: @content_item)
       @audit.user = current_user
 

--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -1,9 +1,9 @@
 module Audits
   class BaseController < ApplicationController
     layout "audits"
-    helper_method :filter_params, :primary_org_only?
+    helper_method :filter, :filter_params, :primary_org_only?
 
-    def build_filter(override = {})
+    def filter(override = {})
       options = {
         allocated_to: params[:allocated_to],
         audit_status: params[:audit_status],
@@ -15,7 +15,7 @@ module Audits
         title: params[:query],
       }.merge(override)
 
-      Filter.new options
+      Filter.new(options)
     end
 
   private

--- a/app/controllers/audits/reports_controller.rb
+++ b/app/controllers/audits/reports_controller.rb
@@ -1,7 +1,7 @@
 module Audits
   class ReportsController < BaseController
     def show
-      @monitor = ::Audits::Monitor.new(build_filter)
+      @monitor = ::Audits::Monitor.new(filter)
     end
   end
 end

--- a/app/helpers/allocation_message_helper.rb
+++ b/app/helpers/allocation_message_helper.rb
@@ -1,0 +1,17 @@
+module AllocationMessageHelper
+  def show_allocation_message?
+    filter.audit_status == Audits::Audit::NON_AUDITED && filtered_to_specific_user?
+  end
+
+  def filtered_to_specific_user?
+    filtered_to_current_user? || filtered_user.present?
+  end
+
+  def filtered_to_current_user?
+    filter.allocated_to == current_user.uid
+  end
+
+  def filtered_user
+    @filtered_user ||= User.find_by(uid: filter.allocated_to)
+  end
+end

--- a/app/views/audits/audits/_content_items.html.erb
+++ b/app/views/audits/audits/_content_items.html.erb
@@ -1,0 +1,13 @@
+<table class="table table-bordered table-hover">
+  <thead>
+  <tr class="table-header">
+    <td>Title</td>
+    <td>Page views (6mth)</td>
+  </tr>
+  </thead>
+  <tbody>
+  <%= render collection: content_items, partial: 'content_item' %>
+  </tbody>
+</table>
+
+<%= paginate content_items, :window => 2 %>

--- a/app/views/audits/audits/_no_content_to_audit.html.erb
+++ b/app/views/audits/audits/_no_content_to_audit.html.erb
@@ -1,0 +1,14 @@
+<% if show_allocation_message? %>
+  <div class="alert alert-info" role="alert">
+    <p>
+      <% if filtered_to_current_user? %>
+        You have no content to audit.
+      <% elsif filtered_to_specific_user? %>
+        <%= filtered_user.name %> has no content to audit.
+      <% end %>
+    </p>
+    <p>
+      <%= link_to "Assign content", audits_allocations_url(filter_params) %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -7,4 +7,5 @@
     <%= render 'audits/common/navigation' %>
 <% end %>
 
+<%= render "no_content_to_audit" if content_items.empty? %>
 <%= render "content_items", locals: { content_items: content_items } if content_items.any? %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -7,16 +7,4 @@
     <%= render 'audits/common/navigation' %>
 <% end %>
 
-<table class="table table-bordered table-hover">
-  <thead>
-  <tr class="table-header">
-    <td>Title</td>
-    <td>Page views (6mth)</td>
-  </tr>
-  </thead>
-  <tbody>
-  <%= render collection: content_items, partial: 'content_item' %>
-  </tbody>
-</table>
-
-<%= paginate content_items, :window => 2 %>
+<%= render "content_items", locals: { content_items: content_items } if content_items.any? %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,7 +63,7 @@ FactoryGirl.define do
 
   factory :user do
     sequence(:uid) { |i| "user-#{i}" }
-    name 'Test User'
+    sequence(:name) { |i| "Test User #{i}" }
     email 'user@example.com'
     permissions { ['signin'] }
     organisation_slug "government-digital-service"

--- a/spec/features/audit/audit/metadata_spec.rb
+++ b/spec/features/audit/audit/metadata_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Audit metadata", type: :feature do
       document_type: "guidance",
     )
 
-    create(:audit, content_item: content_item)
+    create(:audit, content_item: content_item, user: @current_user)
 
     create_linked_content("organisations", "Home office")
     create_linked_content("topics", "Immigration")
@@ -62,7 +62,7 @@ RSpec.feature "Audit metadata", type: :feature do
 
     within("#metadata") do
       allocated_text = "Assigned to Edd the Duck Government Digital Service"
-      audited_text = "Audited 01/01/17 (less than a minute ago) by Test User Government Digital Service"
+      audited_text = "Audited 01/01/17 (less than a minute ago) by #{@current_user.name} Government Digital Service"
       expect(page).to have_selector("#allocated", text: allocated_text)
       expect(page).to have_selector("#audited", text: audited_text)
       expect(page).to have_selector("#organisations", text: "Organisations Home office")

--- a/spec/features/audit/lists/no_content_spec.rb
+++ b/spec/features/audit/lists/no_content_spec.rb
@@ -1,0 +1,89 @@
+RSpec.feature "Notifying of no content to audit", type: :feature do
+  around(:each) do |example|
+    Feature.run_with_activated(:auditing_allocation) { example.run }
+  end
+
+  context "there is no content for my organisation to audit" do
+    before(:each) do
+      @current_user.organisation_slug = SecureRandom.base64
+      @current_user.save
+
+      visit audits_path
+    end
+
+    context "viewing content assigned to me" do
+      before(:each) do
+        select "Me", from: :allocated_to
+        click_on "Apply filters"
+      end
+
+      scenario "not audited content should show a banner" do
+        choose "Not audited"
+        click_on "Apply filters"
+        expect(page).to have_content("You have no content to audit.")
+        expect(page).to have_css(".alert")
+        expect(page).to have_css(".alert a")
+      end
+
+      scenario "audited content should not show a banner" do
+        choose "Audited"
+        click_on "Apply filters"
+        expect(page).to have_no_content("You have no content to audit.")
+        expect(page).to have_no_css(".alert")
+      end
+
+      scenario "all content should not show a banner" do
+        choose "All"
+        click_on "Apply filters"
+        expect(page).to have_no_content("You have no content to audit.")
+        expect(page).to have_no_css(".alert")
+      end
+    end
+
+    context "viewing content assigned to someone else" do
+      let!(:someone_else) do
+        create(:user, organisation_slug: @current_user.organisation_slug)
+      end
+
+      before(:each) do
+        visit audits_path
+        select someone_else.name, from: :allocated_to
+        click_on "Apply filters"
+      end
+
+      scenario "not audited content should show a banner" do
+        choose "Not audited"
+        click_on "Apply filters"
+        expect(page).to have_content("#{someone_else.name} has no content to audit.")
+        expect(page).to have_css(".alert")
+        expect(page).to have_css(".alert a")
+      end
+    end
+
+    context "viewing content assigned to no one" do
+      before(:each) do
+        select "No one", from: :allocated_to
+        click_on "Apply filters"
+      end
+
+      scenario "not audited content should show a banner" do
+        choose "Not audited"
+        click_on "Apply filters"
+        expect(page).to have_no_css(".alert")
+      end
+    end
+
+    context "viewing content assigned to anyone" do
+      before(:each) do
+        select "Anyone", from: :allocated_to
+        click_on "Apply filters"
+      end
+
+      scenario "not audited content should show a banner" do
+        choose "Not audited"
+        click_on "Apply filters"
+        expect(page).to have_no_css(".alert")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,6 @@ RSpec.configure do |config|
   end
 
   config.before(type: :feature) do
-    create :user
+    @current_user = create :user
   end
 end


### PR DESCRIPTION
In order to help users orientate themselves on the site, this change
adds a message that explicitly tells them if they are filtering by
“Not audited” content (the default), but no content has been assigned
that is not audited.

A message is shown regardless of whose allocations are being viewed,
but the message is only shown on the “Audit content” tab, and notably
_not_ the “Assign content” tab. This is because the “Assign content”
tab will have a default view that will probably default to showing all
unassigned, unaudited content, and having no content there will be a
rare case.

Also notably, the change does _not_ show a message for “Audited”
content either - so if a user has not yet audited any content, the user
will be presented with a blank table.

## Screenshots

![me-no-content](https://user-images.githubusercontent.com/12036746/30221135-0ae147da-94ba-11e7-8296-94934a73fd17.png)

![someone-else-no-content](https://user-images.githubusercontent.com/12036746/30221164-1d054dc6-94ba-11e7-8e14-32416bafff07.png)
