### PR TITLE
Switch default select option to 'Me'

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -43,6 +43,8 @@ module DropdownHelper
   end
 
   def allocation_options_for_select(selected = nil)
+    selected = current_user.uid if selected.nil?
+
     auditors = Audits::FindTeamAuditors
                  .call(user_uid: current_user.uid)
                  .sort_by(&:name)

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -5,6 +5,12 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
 
   let!(:current_user) { User.first }
 
+  scenario "List is unfiltered" do
+    visit audits_path
+
+    expect(page).to have_select("allocated_to", selected: "Me")
+  end
+
   scenario "Filter allocated content" do
     another_user = create(:user)
     item1 = create :content_item, title: "content item 1"

--- a/spec/features/audit/audit/navigation_spec.rb
+++ b/spec/features/audit/audit/navigation_spec.rb
@@ -69,6 +69,8 @@ RSpec.feature "Navigation", type: :feature do
       perform_audit
 
       visit audits_path
+      select "Anyone", from: "allocated_to"
+
       choose "Not audited"
       click_on "Apply filters"
 

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature "Filter Content Items to Audit", type: :feature do
   around(:each) do |example|
-    Feature.run_with_activated(:filtering_themes) { example.run }
+    Feature.run_with_activated(:filtering_themes, :auditing_allocation) { example.run }
   end
 
   # Organisations:
@@ -74,8 +74,9 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
   scenario "filtering audited content" do
     visit audits_path
-    choose "Audited"
+    select "Anyone", from: "allocated_to"
 
+    choose "Audited"
     click_on "Apply filters"
 
     expect(page).to have_content("Tree felling")
@@ -85,8 +86,9 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
   scenario "filtering for content regardless of audit status" do
     visit audits_path
-    choose "All"
+    select "Anyone", from: "allocated_to"
 
+    choose "All"
     click_on "Apply filters"
 
     expect(page).to have_content("Tree felling")
@@ -97,6 +99,8 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
   context "when showing content regardless of audit status" do
     before(:each) do
       visit audits_path
+      select "Anyone", from: "allocated_to"
+
       choose "All"
       click_on "Apply filters"
     end
@@ -233,6 +237,8 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
       create_list(:content_item, 25)
 
       visit audits_path
+      select "Anyone", from: "allocated_to"
+
       choose "All"
       click_on "Apply filters"
 

--- a/spec/features/audit/lists/sorting_spec.rb
+++ b/spec/features/audit/lists/sorting_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, title: "CCC")
 
     visit audits_path
+    select "Anyone", from: "allocated_to"
 
     select "Title A-Z", from: "sort_by"
     click_on "Apply filters"
@@ -32,6 +33,7 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, title: "CCC")
 
     visit audits_path
+    select "Anyone", from: "allocated_to"
 
     select "Title Z-A", from: "sort_by"
     click_on "Apply filters"

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature "Exporting a CSV from the report page" do
 
     scenario "Applying the filters to the export" do
       visit audits_report_path
+      select "Anyone", from: "allocated_to"
 
       select "HMRC", from: "organisations"
       click_on "Apply filters"
@@ -66,6 +67,8 @@ RSpec.feature "Exporting a CSV from the report page" do
 
     scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
       visit audits_path
+      select "Anyone", from: "allocated_to"
+
       choose "Audited"
 
       click_on "Apply filters"

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -18,6 +18,8 @@ RSpec.feature "Reporting on audit progress" do
 
     expect(page).to have_content("3 Content items")
 
+    select "Anyone", from: "allocated_to"
+
     select "Guide", from: "document_type"
     click_on "Apply filters"
     expect(page).to have_content("0 Content items")


### PR DESCRIPTION
To help users orientation of the tool, and recognise the 'audit content'
tab as their area to do work assigned to them, we change 'audited by'
default option to 'Me' when first coming onto the tool.