### PR TITLE
Update guide styling

### DIFF
--- a/app/assets/stylesheets/_guidance.scss
+++ b/app/assets/stylesheets/_guidance.scss
@@ -1,0 +1,3 @@
+.guidance {
+  font-size: 19px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@
 @import 'term_generation';
 @import 'accessible-autocomplete';
 @import 'allocation';
+@import 'guidance';
 
 // TODO: move any styles below to modules once more established
 

--- a/app/views/audits/guidances/show.html.erb
+++ b/app/views/audits/guidances/show.html.erb
@@ -1,3 +1,3 @@
-<div class="col-sm-7">
+<div class="col-sm-8">
   <%=raw Govspeak::Document.new(@content).to_html %>
 </div>

--- a/app/views/audits/guidances/show.html.erb
+++ b/app/views/audits/guidances/show.html.erb
@@ -1,3 +1,3 @@
-<div class="col-sm-8">
+<div class="col-sm-8 guidance">
   <%=raw Govspeak::Document.new(@content).to_html %>
 </div>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -27,7 +27,7 @@
     <div class="<%= content_for?(:sidebar) ? 'col-sm-3' : ''%> sidebar">
       <%= yield :sidebar %>
     </div>
-    <div class="col-sm-9">
+    <div class="<%= content_for?(:sidebar) ? 'col-sm-9' : ''%>">
       <%= yield %>
     </div>
   </div>


### PR DESCRIPTION
This change makes a couple of styling changes, primarily affecting the guidance, but also affecting the default page width of the audit tool:

- Default page to "full-width" (12 columns) if there is no sidebar present
- Increase guidance page width to 2/3 width
- Increase guidance copy font size to 19px

## Before

![guidance-before](https://user-images.githubusercontent.com/12036746/30318371-d86ee4f4-97a4-11e7-8397-a6b79a8fc878.png)

## After

![guidance-after](https://user-images.githubusercontent.com/12036746/30318377-dc208fda-97a4-11e7-940c-61f24b4859e8.png)
