### PR TITLE
Minor lint changes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Rails.application.load_tasks
 
 namespace :lint do
   task :ruby do
-    sh "bundle exec govuk-lint-ruby --diff app config lib spec"
+    sh "bundle exec govuk-lint-ruby app config lib spec"
   end
 
   task :sass do

--- a/db/migrate/20170912052917_drop_subthemes.rb
+++ b/db/migrate/20170912052917_drop_subthemes.rb
@@ -5,7 +5,7 @@ class DropSubthemes < ActiveRecord::Migration[5.1]
       t.string "name", null: false
       t.timestamps
 
-      t.index ["theme_id", "name"], name: "index_subthemes_on_theme_id_and_name", unique: true
+      t.index %w[theme_id name], name: "index_subthemes_on_theme_id_and_name", unique: true
       t.index ["theme_id"], name: "index_subthemes_on_theme_id"
     end
   end

--- a/db/migrate/20170912052927_drop_themes.rb
+++ b/db/migrate/20170912052927_drop_themes.rb
@@ -3,7 +3,7 @@ class DropThemes < ActiveRecord::Migration[5.1]
     drop_table :themes do |t|
       t.string "name", null: false
       t.timestamps
-        
+
       t.index ["name"], name: "index_themes_on_name", unique: true
     end
   end


### PR DESCRIPTION

1. Update to use `%w` notation when defining arrays
2. Perform lint check to all the codebase.