### PR TITLE
Update `Go` button label to `Assign`

### DIFF
--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -12,7 +12,7 @@
             tracking_id: "allocate-to",
         } %>
       <%= filter_to_hidden_fields(:allocate_to, :batch_size) %>
-      <%= submit_tag "Go", class: "btn btn-default" %>
+      <%= submit_tag "Assign", class: "btn btn-default" %>
     </div>
   </div>
 </div>

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     check option: first.content_id
 
     select "Me", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("2 items allocated to #{current_user.name}")
 
@@ -38,7 +38,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
 
     select "Me", from: "allocate_to"
     fill_in "batch_size", with: "2"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("2 items allocated to #{current_user.name}")
   end
@@ -53,7 +53,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     check option: item3.content_id
 
     select "Me", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("2 items allocated to #{current_user.name}")
   end
@@ -62,7 +62,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     visit audits_allocations_path
 
     select "Me", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("0 items allocated to #{current_user.name}")
   end

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
 
     check option: item3.content_id
     select "Me", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to_not have_content("content item 2")
     expect(page).to_not have_content("content item 3")

--- a/spec/features/audit/allocation/team_allocation_spec.rb
+++ b/spec/features/audit/allocation/team_allocation_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Allocate content to other content auditors", type: :feature do
     check option: "content-id-1"
 
     select "John Smith", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("1 items allocated to John Smith")
 

--- a/spec/features/audit/allocation/unallocate_spec.rb
+++ b/spec/features/audit/allocation/unallocate_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Unallocate content", type: :feature do
 
     check option: content_item.content_id
     select "No one", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to_not have_content("content item 1")
     expect(page).to have_select("allocate_to", selected: "No one")
@@ -28,7 +28,7 @@ RSpec.feature "Unallocate content", type: :feature do
 
     select "No one", from: "allocate_to"
     fill_in "batch_size", with: "2"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("2 items unallocated")
   end
@@ -43,7 +43,7 @@ RSpec.feature "Unallocate content", type: :feature do
     check option: item3.content_id
 
     select "No one", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("2 items unallocated")
   end
@@ -52,7 +52,7 @@ RSpec.feature "Unallocate content", type: :feature do
     visit audits_allocations_path
 
     select "No one", from: "allocate_to"
-    click_on "Go"
+    click_on "Assign"
 
     expect(page).to have_content("0 items unallocated")
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/PVt9GRm1/534-rename-go-button-label-to-assign)

Update the label of the allocation button to `Go`
This was requested as part of the design in #329 
but I forgot to update the label.