### PR TITLE
Hide organisation selection

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,7 +17,8 @@
 //= require selectize
 //= require accessible-autocomplete.min
 //= require organisation-autocomplete
-//= require batch-selection.js
+//= require batch-selection
+//= require expandable-filters
 
 // --- Analytics ---
 //= require analytics/google-tag-manager

--- a/app/assets/javascripts/expandable-filters.js
+++ b/app/assets/javascripts/expandable-filters.js
@@ -1,0 +1,36 @@
+(function (Modules) {
+  "use strict";
+
+  Modules.ExpandableFilters = function () {
+    this.start = function ($element) {
+      initialise();
+
+      function initialise() {
+        if (startCollapsed()) {
+          collapseFilters();
+        }
+
+        showExpansionButton();
+        showElement();
+      }
+
+      function startCollapsed() {
+        return !$element.data('start-expanded');
+      }
+
+      function collapseFilters() {
+        var $additional = $element.find('.js-additional-filters').first();
+        $additional.removeClass('in');
+      }
+
+      function showExpansionButton() {
+        var $expansionButton = $element.find('.js-expand-button-wrapper').first();
+        $expansionButton.removeClass('hidden');
+      }
+
+      function showElement() {
+        $element.removeClass('js-hidden');
+      }
+    };
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/organisation-autocomplete.js
+++ b/app/assets/javascripts/organisation-autocomplete.js
@@ -23,7 +23,7 @@
         return $(
           '<button type="button" ' +
           '        id="add-organisation" ' +
-          '        class="add-organisation js-add-organisation">' +
+          '        class="btn btn-link add-organisation js-add-organisation">' +
           '  Add another organisation' +
           '</button>'
         ).click(addOrganisation);

--- a/app/assets/stylesheets/_expandable_filters.scss
+++ b/app/assets/stylesheets/_expandable_filters.scss
@@ -1,0 +1,25 @@
+[data-module="expandable-filters"] {
+  .js-expand-button-wrapper {
+    .btn {
+      padding: 0;
+    }
+  }
+
+  .data-close-label {
+    display: inline;
+  }
+
+  .data-open-label {
+    display: none;
+  }
+
+  .collapsed {
+    .data-close-label {
+      display: none;
+    }
+
+    .data-open-label {
+      display: inline;
+    }
+  }
+}

--- a/app/assets/stylesheets/_javascript.scss
+++ b/app/assets/stylesheets/_javascript.scss
@@ -1,0 +1,5 @@
+.js {
+  .js-hidden {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/_organisation_select.scss
+++ b/app/assets/stylesheets/_organisation_select.scss
@@ -35,11 +35,6 @@
   }
 
   .add-organisation {
-    @extend %legend-reset;
-
-    background: none;
-    border-bottom: 1px solid $black;
-    padding: 0 2px;
-    margin: 3px;
+    padding: 0;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 // scss-lint:enable Comment
 
 @import 'govuk_admin_template';
+@import 'javascript';
 @import 'tables';
 @import 'pagination';
 @import 'phase_banner';
@@ -29,23 +30,4 @@
 @import 'organisation_select';
 @import 'allocation';
 @import 'guidance';
-
-// TODO: move any styles below to modules once more established
-
-[data-toggle] {
-
-  &[aria-expanded="true"] {
-
-    [data-close-label] {
-      display: inline;
-    }
-
-    [data-open-label] {
-      display: none;
-    }
-  }
-
-  [data-close-label] {
-    display: none;
-  }
-}
+@import 'expandable_filters';

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -2,9 +2,11 @@
   <%= render 'audits/common/title' %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/allocated_to' %>
-  <%= render 'audits/common/organisations' %>
-  <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>
+  <%= render 'components/expandable_filters', start_expanded: filter.organisations.any? do %>
+    <%= render 'audits/common/organisations' %>
+    <%= render 'audits/common/primary' %>
+  <% end %>
   <%= render 'audits/common/sort' %>
   <%= render 'audits/common/submit' %>
 <% end %>

--- a/app/views/components/_expandable_filters.html.erb
+++ b/app/views/components/_expandable_filters.html.erb
@@ -1,12 +1,19 @@
 <% start_expanded ||= false %>
 
-<div id="additionalFilters" class="collapse <%= "in" if start_expanded %>">
-  <%= yield %>
-</div>
+<div data-module="expandable-filters" data-start-expanded="<%= start_expanded -%>" class="js-hidden">
+  <div id="additionalFilters" class="js-additional-filters collapse in">
+    <%= yield %>
+  </div>
 
-<div class="form-group">
-  <a class="" role="button" data-toggle="collapse" href="#additionalFilters" aria-expanded="<%=advanced_filter_enabled? %>" aria-controls="additionalFilters">
-    <span data-open-label>More filter options</span>
-    <span data-close-label>Less filter options</span>
-  </a>
+  <div class="form-group js-expand-button-wrapper hidden">
+    <button type="button"
+            class="btn btn-link <%= "collapsed" unless start_expanded -%>"
+            data-toggle="collapse"
+            data-target="#additionalFilters"
+            aria-expanded="<%= start_expanded -%>"
+            aria-controls="additionalFilters">
+      <span class="data-open-label">More options</span>
+      <span class="data-close-label">Fewer options</span>
+    </button>
+  </div>
 </div>

--- a/app/views/components/_expandable_filters.html.erb
+++ b/app/views/components/_expandable_filters.html.erb
@@ -1,0 +1,12 @@
+<% start_expanded ||= false %>
+
+<div id="additionalFilters" class="collapse <%= "in" if start_expanded %>">
+  <%= yield %>
+</div>
+
+<div class="form-group">
+  <a class="" role="button" data-toggle="collapse" href="#additionalFilters" aria-expanded="<%=advanced_filter_enabled? %>" aria-controls="additionalFilters">
+    <span data-open-label>More filter options</span>
+    <span data-close-label>Less filter options</span>
+  </a>
+</div>

--- a/app/views/content/items/_sidebar.html.erb
+++ b/app/views/content/items/_sidebar.html.erb
@@ -22,7 +22,7 @@
       <%= label_tag :primary, "Primary organisation only" %>
     </div>
 
-    <div id="additionalFilters" class="collapse<% if advanced_filter_enabled? %> in<% end %>">
+    <%= render 'components/expandable_filters', start_expanded: advanced_filter_enabled? do %>
       <div class="form-group">
         <div class="form-group">
           <%= label_tag :taxons, "Taxons" %>
@@ -35,16 +35,10 @@
                          }%>
         </div>
       </div>
-    </div>
-    <div class="form-group">
-      <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
-    </div>
+    <% end %>
 
     <div class="form-group">
-      <a class="" role="button" data-toggle="collapse" href="#additionalFilters" aria-expanded="<%=advanced_filter_enabled? %>" aria-controls="additionalFilters">
-        <span data-open-label>More filter options</span>
-        <span data-close-label>Less filter options</span>
-      </a>
+      <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
     </div>
 
     <%= hidden_field_tag :sort, params[:sort] %>

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -129,6 +129,9 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
       scenario "using autocomplete", js: true do
         expect(page.current_url).not_to include("organisations%5B%5D=#{hmrc.content_id}")
 
+        click_on "More options"
+        expect(page).to have_selector("#organisations", visible: true)
+
         organisations_autocomplete = page.find("#organisations")
         organisations_autocomplete.send_keys("HM", :down, :enter)
 
@@ -139,6 +142,9 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
       scenario "multiple", js: true do
         expect(page.current_url).not_to include("organisations%5B%5D=#{hmrc.content_id}")
+
+        click_on "More options"
+        expect(page).to have_selector("#add-organisation", visible: true)
 
         page.find("#add-organisation").click
 

--- a/spec/features/performance/filter_spec.rb
+++ b/spec/features/performance/filter_spec.rb
@@ -73,12 +73,20 @@ RSpec.feature "Filter in content items", type: :feature do
       expect(page).to have_selector('#additionalFilters', visible: false)
     end
 
+    scenario "the user can see the additional filters if JavaScript is disabled", js: false do
+      visit "/content/items"
+
+      expect(page).to have_selector('#additionalFilters', visible: true)
+    end
+
     scenario "the user can toggle the visibility of the additional filters", js: true do
       visit "/content/items"
 
-      click_on "More filter options"
-
+      click_on "More options"
       expect(page).to have_selector('#additionalFilters', visible: true)
+
+      click_on "Fewer options"
+      expect(page).to have_selector('#additionalFilters', visible: false)
     end
 
     scenario "the user can see the additional filters if they are currently filtering by one of them", js: true do

--- a/spec/javascripts/fixtures/expandable_filters/default.html.erb
+++ b/spec/javascripts/fixtures/expandable_filters/default.html.erb
@@ -1,0 +1,1 @@
+<%= render 'components/expandable_filters' %>

--- a/spec/javascripts/fixtures/expandable_filters/start_expanded.html.erb
+++ b/spec/javascripts/fixtures/expandable_filters/start_expanded.html.erb
@@ -1,0 +1,1 @@
+<%= render 'components/expandable_filters', start_expanded: true %>

--- a/spec/javascripts/modules/expandable_filters_spec.js
+++ b/spec/javascripts/modules/expandable_filters_spec.js
@@ -1,0 +1,57 @@
+describe("Expandable filters", function () {
+  "use strict";
+
+  var $fixture;
+
+  describe("with default settings", function () {
+    beforeEach(function () {
+      fixture.load("expandable_filters/default.html.erb");
+      $fixture = $(fixture.el).find('[data-module="expandable-filters"]');
+      new GOVUKAdmin.Modules.ExpandableFilters().start($fixture);
+    });
+
+    it("starts with the options collapsed", function () {
+      expect(filters()).not.toHaveClass("in");
+    });
+
+    it("shows the expansion button", function () {
+      expect(buttonWrapper()).not.toHaveClass("hidden");
+    });
+
+    it("starts with the button collapsed", function () {
+      expect(button()).toHaveClass("collapsed")
+    });
+  });
+
+  describe("starting expanded", function () {
+    beforeEach(function () {
+      fixture.load("expandable_filters/start_expanded.html.erb");
+      $fixture = $(fixture.el).find('[data-module="expandable-filters"]');
+      new GOVUKAdmin.Modules.ExpandableFilters().start($fixture);
+    });
+
+    it("starts with the options expanded", function () {
+      expect(filters()).toHaveClass("in");
+    });
+
+    it("shows the expansion button", function () {
+      expect(buttonWrapper()).not.toHaveClass("hidden");
+    });
+
+    it("starts with the button not collapsed", function () {
+      expect(button()).not.toHaveClass("collapsed");
+    });
+  });
+
+  function buttonWrapper() {
+    return $fixture.find(".js-expand-button-wrapper").first();
+  }
+
+  function button() {
+    return $fixture.find("button").first();
+  }
+
+  function filters() {
+    return $fixture.find("#additionalFilters").first();
+  }
+});


### PR DESCRIPTION
This change is to primarily hide the organisation filters on the Audit Content view. This is achieved by modifying and improving the existing functionality in the Content Performance Manager (CPM).

The expandable filter functionality has been extracted out into its own Rails partial. Its accessibility has also been improved; notably, the component is now progressively enhanced, and will work even with JavaScript disabled.

![hide-organisations](https://user-images.githubusercontent.com/12036746/30335033-2e2ba132-97d9-11e7-87ad-4cacb7fe0e3f.gif)
