### PR TITLE
Add counter of content items

### DIFF
--- a/app/assets/stylesheets/_allocation.scss
+++ b/app/assets/stylesheets/_allocation.scss
@@ -1,5 +1,5 @@
 .allocation-menu {
-  padding-left: 20px;
+  padding-left: 15px;
 
   input[type=text] {
     width: 60px;

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -34,3 +34,7 @@ $visited-colour: #337ab7;
     content: '\25B2'; // Up arrow
   }
 }
+
+.content-items-counter {
+  padding-bottom: 10px;
+}

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -11,6 +11,8 @@
 <div class="allocations" data-module="batch-selection">
   <%= form_tag audits_allocations_path do %>
       <%= render 'toolbar' %>
+      <%= render 'audits/common/counter', count: content_items.total_count  %>
+
       <table class="table table-bordered table-hover">
         <thead>
         <tr class="table-header">

--- a/app/views/audits/audits/_content_items.html.erb
+++ b/app/views/audits/audits/_content_items.html.erb
@@ -1,3 +1,5 @@
+<%= render 'audits/common/counter', count: content_items.total_count  %>
+
 <table class="table table-bordered table-hover">
   <thead>
   <tr class="table-header">

--- a/app/views/audits/common/_counter.html.erb
+++ b/app/views/audits/common/_counter.html.erb
@@ -1,0 +1,3 @@
+<div class="content-items-counter">
+  <strong><%= format_number content_items.total_count %> <%='item'.pluralize(content_items.total_count) %></strong>
+</div>

--- a/app/views/audits/common/_counter.html.erb
+++ b/app/views/audits/common/_counter.html.erb
@@ -1,3 +1,3 @@
 <div class="content-items-counter">
-  <strong><%= format_number content_items.total_count %> <%='item'.pluralize(content_items.total_count) %></strong>
+  <strong><%= format_number(count) %> <%="item".pluralize(count) %></strong>
 </div>

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -81,4 +81,12 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     expect(page).to have_content("content item 1")
     expect(page).to_not have_content("content item 2")
   end
+
+  scenario "Displays the number of content items" do
+    create_list :content_item, 2
+
+    visit audits_allocations_path
+
+    expect(page).to have_text("2 items")
+  end
 end

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -18,6 +18,14 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     expect(page).to have_content("item2")
   end
 
+  scenario "Displays the number of content items" do
+    create_list :content_item, 2
+
+    visit audits_path
+
+    expect(page).to have_text("2 items")
+  end
+
   scenario "List content items of auditable formats" do
     create(:content_item, document_type: "guide")
     create(:content_item, document_type: "other-format")


### PR DESCRIPTION
Supersedes #335

[Trello card](https://trello.com/c/6bCpfgfN/518-add-the-number-of-content-items-listed-in-the-allocation-tab-and-audit-content-tab)

Add the number of content items listed as a result of applying
the filter.

### Changes

![image](https://user-images.githubusercontent.com/227328/30327707-f5376064-97c4-11e7-91f0-89244e194df1.png)

![image](https://user-images.githubusercontent.com/227328/30327720-040b9b6e-97c5-11e7-8045-83c891237806.png)

