### PR TITLE
Fix showing items belonging to "Me" as default

### DIFF
--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -7,6 +7,7 @@ module Audits
       Filter.new(
         allocated_to: params[:allocated_to],
         audit_status: params[:audit_status],
+        current_user_id: current_user.uid,
         document_type: params[:document_type],
         organisations: params[:organisations],
         page: params[:page],

--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -4,6 +4,7 @@ module Audits
     attr_accessor :after,
       :allocated_to,
       :audit_status,
+      :current_user_id,
       :document_type,
       :organisations,
       :page,
@@ -19,7 +20,7 @@ module Audits
     end
 
     def audit_status
-      @audit_status || Audit::NON_AUDITED
+      @audit_status || Audit::ALLOCATED_TO
     end
 
     def sort_by=(value)
@@ -33,10 +34,13 @@ module Audits
     end
 
     def allocated_policy
-      if allocated_to == 'no_one'
-        Policies::Unallocated
-      elsif allocated_to.blank?
+      if allocated_to.blank?
+        @allocated_to = current_user_id
+        Policies::Allocated
+      elsif allocated_to == 'anyone'
         Policies::NoPolicy
+      elsif allocated_to == 'no_one'
+        Policies::Unallocated
       else
         Policies::Allocated
       end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -48,8 +48,9 @@ module DropdownHelper
     auditors = Audits::FindTeamAuditors
                  .call(user_uid: current_user.uid)
                  .sort_by(&:name)
-                 .unshift(OpenStruct.new(name: "Me", uid: current_user.uid))
                  .unshift(OpenStruct.new(name: "No one", uid: :no_one))
+                 .unshift(OpenStruct.new(name: "Anyone", uid: :anyone))
+                 .unshift(OpenStruct.new(name: "Me", uid: current_user.uid))
 
     auditors.delete(current_user)
     options_from_collection_for_select(

--- a/app/models/audits/audit.rb
+++ b/app/models/audits/audit.rb
@@ -3,6 +3,7 @@ module Audits
     ALL = :all
     AUDITED = :audited
     NON_AUDITED = :non_audited
+    ALLOCATED_TO = :allocated_to
 
     belongs_to :content_item, primary_key: :content_id, foreign_key: :content_id,
                class_name: 'Content::Item'

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -2,6 +2,5 @@
   <%= label_tag :allocated_to, "Assigned to" %>
   <%= select_tag :allocated_to,
                  allocation_options_for_select(params[:allocated_to]),
-                 include_blank: "Anyone",
                  class: "form-control" %>
 </div>

--- a/spec/domain/report_spec.rb
+++ b/spec/domain/report_spec.rb
@@ -1,14 +1,13 @@
 module Audits
   RSpec.describe Report do
-    before do
-      create(:content_item, title: "Example")
-    end
+    let!(:example_content) { create(:content_item, title: "Example") }
+    let!(:current_user) { create(:user, uid: 1) }
 
     after do
       ActiveRecord.enable
     end
 
-    subject! { described_class.new(Filter.new, "http://example.com") }
+    subject! { described_class.new(Filter.new(current_user_id: current_user.uid), "http://example.com") }
 
     let(:csv) { subject.generate }
     let(:lines) { csv.split("\n") }
@@ -25,6 +24,7 @@ module Audits
     end
 
     it "outputs a row for each content item" do
+      create(:allocation, content_item: example_content, user: current_user)
       expect(data.third).to start_with("", "", "Example")
     end
 

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     second = create(:content_item, title: "content item 2")
     first = create(:content_item, title: "content item 3")
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check option: second.content_id
     check option: first.content_id
@@ -38,7 +38,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
   scenario 'Allocate all content within current page', :js do
     create_list(:content_item, 26)
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check 'Select all'
 
@@ -53,7 +53,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
   scenario 'Allocate all content within all pages', :js do
     create_list(:content_item, 26)
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check 'Select all'
     check 'Select 27 items on all pages'

--- a/spec/features/audit/allocation/allocation_spec.rb
+++ b/spec/features/audit/allocation/allocation_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Content Allocation", type: :feature do
     create(:allocation, content_item: content_item, user: current_user)
     create(:allocation, content_item: another_content_item, user: another_user)
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     expect(page).to have_selector(".nav")
     expect(page).to have_selector("li.active", text: "Assign content")
@@ -46,7 +46,7 @@ RSpec.feature "Content Allocation", type: :feature do
     second = create(:content_item, title: "content item 2")
     first = create(:content_item, title: "content item 3")
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check option: second.content_id
     check option: first.content_id
@@ -114,7 +114,7 @@ RSpec.feature "Content Allocation", type: :feature do
   scenario 'Allocate all content within current page', :js do
     create_list(:content_item, 26)
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check 'Select all'
 
@@ -129,7 +129,7 @@ RSpec.feature "Content Allocation", type: :feature do
   scenario 'Allocate all content within all pages', :js do
     create_list(:content_item, 26)
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check 'Select all'
     check 'Select 27 items on all pages'

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -5,10 +5,21 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
 
   let!(:current_user) { User.first }
 
-  scenario "List is unfiltered" do
+  scenario "Default view is 'Allocated to Me' and there is no allocated content" do
     visit audits_path
 
     expect(page).to have_select("allocated_to", selected: "Me")
+    expect(page).to have_no_content("An item to be audited")
+  end
+
+  scenario "Default view is 'Allocated to Me' and there is allocated content" do
+    content_item = create(:content_item, title: "An item to be audited")
+    create(:allocation, content_item: content_item, user: current_user)
+
+    visit audits_path
+
+    expect(page).to have_select("allocated_to", selected: "Me")
+    expect(page).to have_content("An item to be audited")
   end
 
   scenario "Filter allocated content" do
@@ -20,7 +31,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     create(:allocation, content_item: item1, user: current_user)
     create(:allocation, content_item: item2, user: another_user)
 
-    visit audits_path
+    visit audits_path(allocated_to: "anyone")
 
     expect(page).to have_selector(".nav")
     expect(page).to have_selector("#sort_by")
@@ -74,7 +85,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     create :allocation, user: user, content_item: item1
     create :content_item, title: "content item 2"
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     expect(page).to have_content("content item 1")
     expect(page).to have_content("content item 2")

--- a/spec/features/audit/allocation/team_allocation_spec.rb
+++ b/spec/features/audit/allocation/team_allocation_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Allocate content to other content auditors", type: :feature do
     create :content_item, title: "content item 1", content_id: "content-id-1"
     create :content_item, title: "content item 2"
 
-    visit audits_allocations_path
+    visit audits_allocations_path(allocated_to: "anyone")
 
     check option: "content-id-1"
 

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -64,17 +64,16 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
   end
 
   scenario "List not audited by default" do
-    visit audits_path
-    expect(page).to have_selector(".nav")
+    visit audits_path(allocated_to: "anyone", audit_status: "non_audited")
 
+    expect(page).to have_selector(".nav")
     expect(page).to have_no_content("Tree felling")
     expect(page).to have_content("Forest management")
     expect(page).to have_checked_field("audit_status_non_audited")
   end
 
   scenario "filtering audited content" do
-    visit audits_path
-    select "Anyone", from: "allocated_to"
+    visit audits_path(allocated_to: "anyone")
 
     choose "Audited"
     click_on "Apply filters"

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -9,11 +9,11 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id")
     create(:content_item, title: "item2")
 
-    visit audits_path
+    visit audits_path(allocated_to: "anyone")
 
     expect(page).to have_content("item1")
     expect(page).to have_content("10,000")
-    expect(page).to have_link("item1", href: "/content_items/content-id/audit")
+    expect(page).to have_link("item1", href: "/content_items/content-id/audit?allocated_to=anyone")
 
     expect(page).to have_content("item2")
   end
@@ -22,7 +22,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     create(:content_item, document_type: "guide")
     create(:content_item, document_type: "other-format")
 
-    visit audits_path
+    visit audits_path(allocated_to: "anyone")
 
     expect(page).to have_css("main tbody tr", count: 1)
   end
@@ -35,7 +35,8 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     }
 
     scenario "Showing 25 items on the first page" do
-      visit audits_path
+      content_items.sort_by!(&:title)
+      visit audits_path(allocated_to: "anyone", sort_by: "title_asc")
 
       content_items[0..24].each do |content_item|
         expect(page).to have_content(content_item.title)
@@ -47,7 +48,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     end
 
     scenario "Showing the second page of items" do
-      visit audits_path
+      visit audits_path(allocated_to: "anyone")
 
       click_link "Next →"
 
@@ -61,8 +62,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     end
 
     scenario "Clicking 'Next' on content items" do
-      visit audits_path
-
+      visit audits_path(allocated_to: "anyone")
       click_link content_items[0].title
 
       (content_items.count - 1).times do |index|

--- a/spec/features/audit/lists/sorting_spec.rb
+++ b/spec/features/audit/lists/sorting_spec.rb
@@ -3,7 +3,7 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, six_months_page_views: 0, title: "item1")
     create(:content_item, six_months_page_views: 1234, title: "item2")
 
-    visit audits_path
+    visit audits_path(allocated_to: "anyone")
 
     rows = page.all('main tbody tr')
     expect(rows[0].text).to match("item2")

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     end
 
     scenario "Exporting a csv file as an attachment" do
-      visit audits_report_path
+      visit audits_report_path(allocated_to: "anyone")
       click_link "Export filtered audit to CSV"
 
       expect(content_type).to eq("text/csv")
@@ -90,7 +90,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     let!(:content_items) { create_list(:content_item, 50) }
 
     scenario "Exporting an unfiltered audit to CSV with all the content items" do
-      visit audits_report_path
+      visit audits_report_path(allocated_to: "anyone")
       click_link "Export filtered audit to CSV"
 
       csv = CSV.parse(page.body, headers: true)

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Reporting on audit progress" do
   end
 
   scenario "Displaying the number of items included in the audit" do
-    visit audits_report_path
+    visit audits_report_path(allocated_to: "anyone")
     expect(page).to have_selector(".nav")
 
     expect(page).to have_content("3 Content items")
@@ -30,7 +30,7 @@ RSpec.feature "Reporting on audit progress" do
   end
 
   scenario "Displaying the number of items audited/not audited" do
-    visit audits_report_path
+    visit audits_report_path(allocated_to: "anyone")
 
     expect(page).to have_content("Items audited 2 67%")
     expect(page).to have_content("Items still to audit 1 33%")
@@ -38,7 +38,7 @@ RSpec.feature "Reporting on audit progress" do
   end
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
-    visit audits_report_path
+    visit audits_report_path(allocated_to: "anyone")
 
     expect(page).to have_content("Items that need improvement 1 50%")
     expect(page).to have_content("Items that don't need improvement 1 50%")


### PR DESCRIPTION
When default filtering for allocation was switched from "Anyone" to
"Me", the default view of items should have displayed content items
for the current user.