### PR TITLE
Let users clear the first organisation filter with an “X” button

### DIFF
--- a/app/assets/javascripts/organisation-autocomplete.js
+++ b/app/assets/javascripts/organisation-autocomplete.js
@@ -104,7 +104,12 @@
       }
 
       function clearAutocompleteAndSelect($organisationSelectWrapper) {
-        $organisationSelectWrapper.find('input').val('');
+        var $input = $organisationSelectWrapper.find('input');
+        $input.val('');
+        // Changing the value will expand the autocomplete, but without focus, meaning that
+        // it won't close if you click outside it. Here we manually focus and blur it, so
+        // the options don't display
+        $input.click().focus().blur();
         // Clearing the input doesn't reset the select, so we have to reset it manually.
         // See: https://github.com/alphagov/accessible-autocomplete/issues/220
         $organisationSelectWrapper.find('select').val('');

--- a/app/assets/stylesheets/_organisation_select.scss
+++ b/app/assets/stylesheets/_organisation_select.scss
@@ -9,16 +9,6 @@
     position: relative;
     margin-bottom: 6px;
 
-    &:only-of-type {
-      .autocomplete__wrapper {
-        width: 100%;
-      }
-
-      .remove-organisation {
-        display: none;
-      }
-    }
-
     .autocomplete__wrapper {
       width: 85%;
     }


### PR DESCRIPTION
We currently hide the “X” remove organisation button if there is only
one organisation filter. However, users cannot clear this selection, so
we should add this functionality back.

This change unhides the “X” button if there is only one organisation,
and fixes a bug that means clearing the input opens the options
without being able to dismiss them.