### PR TITLE
[WIP] Change tab defaults

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -22,6 +22,13 @@ module Audits
 
   private
 
+    def default_filter
+      {
+        allocated_to: :no_one,
+        audit_status: Audit::NON_AUDITED,
+      }
+    end
+
     def user_uid
       params.fetch(:allocate_to)
     end

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -41,6 +41,13 @@ module Audits
 
   private
 
+    def default_filter
+      {
+        allocated_to: current_user.uid,
+        audit_status: Audit::NON_AUDITED,
+      }
+    end
+
     def audit_params
       params
         .require(:audits_audit)

--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -4,6 +4,16 @@ module Audits
     helper_method :filter, :filter_params, :primary_org_only?
 
     def filter(override = {})
+      options = default_filter
+        .merge(query_string_filter)
+        .merge(override)
+
+      Filter.new(options)
+    end
+
+  private
+
+    def query_string_filter
       options = {
         allocated_to: params[:allocated_to],
         audit_status: params[:audit_status],
@@ -13,12 +23,16 @@ module Audits
         primary_org_only: primary_org_only?,
         sort_by: params[:sort_by],
         title: params[:query],
-      }.merge(override)
+      }
 
-      Filter.new(options)
+      options.delete_if do |_, v|
+        v == "" || v.nil?
+      end
     end
 
-  private
+    def default_filter
+      {}
+    end
 
     def filter_params
       request

--- a/app/controllers/audits/reports_controller.rb
+++ b/app/controllers/audits/reports_controller.rb
@@ -3,5 +3,14 @@ module Audits
     def show
       @monitor = ::Audits::Monitor.new(filter)
     end
+
+  private
+
+    def default_filter
+      {
+        allocated_to: current_user.uid,
+        audit_status: Audit::ALL,
+      }
+    end
   end
 end

--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -14,12 +14,12 @@ module Audits
       :theme_id,
       :title
 
-    def audit_status=(value)
-      @audit_status = value.to_sym unless value.blank?
+    def audit_status
+      @audit_status&.to_sym
     end
 
-    def audit_status
-      @audit_status || Audit::NON_AUDITED
+    def allocated_to
+      @allocated_to&.to_s
     end
 
     def sort_by=(value)
@@ -27,15 +27,19 @@ module Audits
         raise "Invalid value: #{value}" unless value =~ /\A[a-z]+_(asc|desc)\z/
 
         values = value.split("_")
-        self.sort = values[0]
-        self.sort_direction = values[1]
+        @sort = values[0]
+        @sort_direction = values[1]
       end
+    end
+
+    def sort_by
+      "#{sort}_#{sort_direction}"
     end
 
     def allocated_policy
       if allocated_to == 'no_one'
         Policies::Unallocated
-      elsif allocated_to.blank?
+      elsif allocated_to == 'anyone'
         Policies::NoPolicy
       else
         Policies::Allocated

--- a/app/domain/audits/monitor.rb
+++ b/app/domain/audits/monitor.rb
@@ -2,7 +2,6 @@ module Audits
   class Monitor
     def initialize(filter)
       @filter = filter
-      @filter.audit_status = Audit::ALL
     end
 
     def total_count

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -32,8 +32,6 @@ module DropdownHelper
   end
 
   def allocation_options_for_select(selected = nil)
-    selected = current_user.uid if selected.nil?
-
     allocation_options = FindOrganisationUsers
                            .call(organisation_slug: current_user.organisation_slug)
                            .pluck(:name, :uid)
@@ -41,8 +39,9 @@ module DropdownHelper
                            .reject { |_, uid| uid == current_user.uid }
                            .sort_by { |name, _| name }
                            .unshift(
-                             ['No one', :no_one],
                              ['Me', current_user.uid],
+                             ['Anyone', :anyone],
+                             ['No one', :no_one],
                            )
 
     options_for_select(allocation_options, selected)

--- a/app/helpers/radio_button_helper.rb
+++ b/app/helpers/radio_button_helper.rb
@@ -9,7 +9,7 @@ module RadioButtonHelper
     options.map.with_index do |option, index|
       option.merge(
         id: "audit_status_#{option[:value]}",
-        selected: selected == option[:value].to_s || index.zero?,
+        selected: selected == option[:value] || index.zero?,
       )
     end
   end

--- a/app/views/audits/audits/_no_content_to_audit.html.erb
+++ b/app/views/audits/audits/_no_content_to_audit.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </p>
     <p>
-      <%= link_to "Assign content", audits_allocations_url(filter_params) %>
+      <%= link_to "Assign content", audits_allocations_url %>
     </p>
   </div>
 <% end %>

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -1,8 +1,7 @@
 <div class="form-group">
   <%= label_tag :allocated_to, "Assigned to" %>
   <%= select_tag :allocated_to,
-                 allocation_options_for_select(params[:allocated_to]),
-                 include_blank: "Anyone",
+                 allocation_options_for_select(filter.allocated_to),
                  class: "form-control",
                  data: {
                    tracking_id: "allocated-to",

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -2,6 +2,6 @@
   <%= label_tag :audit_status, 'Audit status' %>
 
   <%= render partial: "components/radio_button",
-             collection: audit_status_radio_button_options(params[:audit_status]),
+             collection: audit_status_radio_button_options(filter.audit_status),
              as: :option %>
 </div>

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag :document_type, 'Content type' %>
   <%= select_tag :document_type,
-                 document_type_options_for_select(params[:document_type]),
+                 document_type_options_for_select(filter.document_type),
                  include_blank: "All",
                  class: "form-control",
                  data: {

--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs">
-  <%= navigation_link "Audit content", audits_url(filter_params), 'audits'%>
-  <%= navigation_link "Assign content", audits_allocations_url(filter_params), 'allocations' %>
-  <%= navigation_link "Audit progress", audits_report_url(filter_params), 'reports' %>
+  <%= navigation_link "Audit content", audits_url, 'audits'%>
+  <%= navigation_link "Assign content", audits_allocations_url, 'allocations' %>
+  <%= navigation_link "Audit progress", audits_report_url, 'reports' %>
 </ul>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -2,7 +2,7 @@
   <%= label_tag :organisations %>
   <div class="organisation-select-wrapper js-organisation-select-wrapper">
     <%= select_tag :organisations,
-                   organisation_options_for_select(params[:organisations]),
+                   organisation_options_for_select(filter.organisations),
                    include_blank: true,
                    multiple: true,
                    class: "form-control organisation-select js-organisation-select",

--- a/app/views/audits/common/_sort.html.erb
+++ b/app/views/audits/common/_sort.html.erb
@@ -1,12 +1,10 @@
 <div class="form-group">
   <%= label_tag :sort_by, "Sort" %>
   <%= select_tag :sort_by,
-                 sort_by_options_for_select(params[:sort_by]),
+                 sort_by_options_for_select(filter.sort_by),
                  include_blank: "Pageviews",
                  class: "form-control",
                  data: {
                    tracking_id: "sort-by",
                  }%>
 </div>
-
-

--- a/app/views/audits/common/_title.html.erb
+++ b/app/views/audits/common/_title.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group">
   <%= label_tag 'query', 'Search term:', class: '' %>
-  <%= text_field_tag 'query', params[:query], placeholder: 'Enter search term...', class: 'form-control' %>
+  <%= text_field_tag 'query', filter.title, placeholder: 'Enter search term...', class: 'form-control' %>
 </div>

--- a/spec/domain/report_spec.rb
+++ b/spec/domain/report_spec.rb
@@ -8,7 +8,7 @@ module Audits
       ActiveRecord.enable
     end
 
-    subject! { described_class.new(Filter.new, "http://example.com") }
+    subject! { described_class.new(build(:filter), "http://example.com") }
 
     let(:csv) { subject.generate }
     let(:lines) { csv.split("\n") }
@@ -24,8 +24,10 @@ module Audits
       end
     end
 
-    it "outputs a row for each content item" do
-      expect(data.third).to start_with("", "", "Example")
+    describe "reporting on all content" do
+      it "outputs a row for each content item" do
+        expect(data.third).to start_with("", "", "Example")
+      end
     end
 
     it "doesn't execute N+1 queries" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,6 +3,7 @@ require_relative "./factories/link_factory"
 FactoryGirl.define do
   factory :content_item, class: Content::Item do
     transient do
+      allocated_to nil
       organisations nil
       primary_publishing_organisation nil
       policies nil
@@ -21,6 +22,7 @@ FactoryGirl.define do
       LinkFactory.add_primary_publishing_organisation(content_item, evaluator.primary_publishing_organisation)
       LinkFactory.add_policies(content_item, evaluator.policies)
       LinkFactory.add_policy_areas(content_item, evaluator.policy_areas)
+      create(:allocation, content_item: content_item, user: evaluator.allocated_to) unless evaluator.allocated_to.nil?
     end
 
     factory :organisation do
@@ -91,5 +93,10 @@ FactoryGirl.define do
         group.content_items << create(:content_item)
       end
     end
+  end
+
+  factory :filter, class: Audits::Filter do
+    allocated_to 'anyone'
+    audit_status :all
   end
 end

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -22,11 +22,6 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     expect(page).to have_selector("#sort_by")
 
     expect(page).to have_content("content item 1")
-    expect(page).to have_content("content item 2")
-
-    select "Me", from: "allocated_to"
-    click_on "Apply filters"
-    expect(page).to have_content("content item 1")
     expect(page).to_not have_content("content item 2")
 
     select "No one", from: "allocated_to"
@@ -72,7 +67,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
 
     visit audits_allocations_path
 
-    expect(page).to have_content("content item 1")
+    expect(page).to have_no_content("content item 1")
     expect(page).to have_content("content item 2")
 
     select "John Smith", from: "allocated_to"

--- a/spec/features/audit/audit/navigation_spec.rb
+++ b/spec/features/audit/audit/navigation_spec.rb
@@ -1,8 +1,31 @@
 RSpec.feature "Navigation", type: :feature do
   context "with three items with different numbers of page views" do
-    let!(:first) { create(:content_item, title: "First", six_months_page_views: 10) }
-    let!(:second) { create(:content_item, title: "Second", six_months_page_views: 9) }
-    let!(:third) { create(:content_item, title: "Third", six_months_page_views: 8) }
+    let!(:first) do
+      create(
+        :content_item,
+        title: "First",
+        six_months_page_views: 10,
+        allocated_to: @current_user,
+      )
+    end
+
+    let!(:second) do
+      create(
+        :content_item,
+        title: "Second",
+        six_months_page_views: 9,
+        allocated_to: @current_user,
+      )
+    end
+
+    let!(:third) do
+      create(
+        :content_item,
+        title: "Third",
+        six_months_page_views: 8,
+        allocated_to: @current_user,
+      )
+    end
 
     scenario "navigating between audits and the index page" do
       visit audits_path(some_filter: "value")
@@ -86,7 +109,7 @@ RSpec.feature "Navigation", type: :feature do
 
   context "when there are multiple pages of content items" do
     let!(:content_items) {
-      create_list(:content_item, 30)
+      create_list(:content_item, 30, allocated_to: @current_user)
         .sort_by(&:base_path)
         .reverse
     }

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -48,6 +48,9 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     visit audits_path
     expect(page).to have_selector(".nav")
 
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
+
     expect(page).to have_no_content("Tree felling")
     expect(page).to have_content("Forest management")
     expect(page).to have_checked_field("audit_status_non_audited")

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -6,20 +6,20 @@ RSpec.feature "List Content Items to Audit", type: :feature do
   end
 
   scenario "List Content Items to Audit" do
-    create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id")
-    create(:content_item, title: "item2")
+    content_item1 = create(:content_item, six_months_page_views: 10_000, allocated_to: @current_user)
+    content_item2 = create(:content_item, allocated_to: @current_user)
 
     visit audits_path
 
-    expect(page).to have_content("item1")
+    expect(page).to have_content(content_item1.title)
     expect(page).to have_content("10,000")
-    expect(page).to have_link("item1", href: "/content_items/content-id/audit")
+    expect(page).to have_link(content_item1.title, href: "/content_items/#{content_item1.content_id}/audit")
 
-    expect(page).to have_content("item2")
+    expect(page).to have_content(content_item2.title)
   end
 
   scenario "Displays the number of content items" do
-    create_list :content_item, 2
+    create_list(:content_item, 2, allocated_to: @current_user)
 
     visit audits_path
 
@@ -27,8 +27,8 @@ RSpec.feature "List Content Items to Audit", type: :feature do
   end
 
   scenario "List content items of auditable formats" do
-    create(:content_item, document_type: "guide")
-    create(:content_item, document_type: "other-format")
+    create(:content_item, document_type: "guide", allocated_to: @current_user)
+    create(:content_item, document_type: "other-format", allocated_to: @current_user)
 
     visit audits_path
 
@@ -37,7 +37,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
 
   describe "pagination" do
     let!(:content_items) {
-      create_list(:content_item, 30)
+      create_list(:content_item, 30, allocated_to: @current_user)
         .sort_by(&:base_path)
         .reverse
     }

--- a/spec/features/audit/lists/no_content_spec.rb
+++ b/spec/features/audit/lists/no_content_spec.rb
@@ -23,6 +23,9 @@ RSpec.feature "Notifying of no content to audit", type: :feature do
         expect(page).to have_content("You have no content to audit.")
         expect(page).to have_css(".alert")
         expect(page).to have_css(".alert a")
+        within(".alert") do
+          expect(page).to have_link("Assign content", href: "http://www.example.com/audits/allocations")
+        end
       end
 
       scenario "audited content should not show a banner" do

--- a/spec/features/audit/lists/sorting_spec.rb
+++ b/spec/features/audit/lists/sorting_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Sort content items to audit", type: :feature do
   scenario "Default sorting by popularity" do
-    create(:content_item, six_months_page_views: 0, title: "item1")
-    create(:content_item, six_months_page_views: 1234, title: "item2")
+    create(:content_item, six_months_page_views: 0, title: "item1", allocated_to: @current_user)
+    create(:content_item, six_months_page_views: 1234, title: "item2", allocated_to: @current_user)
 
     visit audits_path
 

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -41,6 +41,9 @@ RSpec.feature "Exporting a CSV from the report page" do
 
     scenario "Exporting a csv file as an attachment" do
       visit audits_report_path
+      select "Anyone", from: "allocated_to"
+      click_on "Apply filters"
+
       click_link "Export filtered audit to CSV"
 
       expect(content_type).to eq("text/csv")
@@ -91,6 +94,9 @@ RSpec.feature "Exporting a CSV from the report page" do
 
     scenario "Exporting an unfiltered audit to CSV with all the content items" do
       visit audits_report_path
+      select "Anyone", from: "allocated_to"
+      click_on "Apply filters"
+
       click_link "Export filtered audit to CSV"
 
       csv = CSV.parse(page.body, headers: true)

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -67,26 +67,6 @@ RSpec.feature "Exporting a CSV from the report page" do
       expect(page).to have_content("Example 1,https://gov.uk/example1")
       expect(page).to have_no_content("Example 2,https://gov.uk/example2")
     end
-
-    scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-      visit audits_path
-      select "Anyone", from: "allocated_to"
-
-      choose "Audited"
-
-      click_on "Apply filters"
-      expect(page).to have_content("Example 1")
-      expect(page).to have_no_content("Example 2")
-
-      click_link "Audit progress"
-
-      click_link "Export filtered audit to CSV"
-      expect(content_disposition).to include(
-        'filename="Transformation_audit_report_CSV_download.csv"',
-      )
-      expect(page).to have_content("Example 1")
-      expect(page).to have_content("Example 2")
-    end
   end
 
   context "Multiple pages of content items are in the database" do

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -14,11 +14,10 @@ RSpec.feature "Reporting on audit progress" do
 
   scenario "Displaying the number of items included in the audit" do
     visit audits_report_path
-    expect(page).to have_selector(".nav")
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
 
     expect(page).to have_content("3 Content items")
-
-    select "Anyone", from: "allocated_to"
 
     select "Guide", from: "document_type"
     click_on "Apply filters"
@@ -31,6 +30,8 @@ RSpec.feature "Reporting on audit progress" do
 
   scenario "Displaying the number of items audited/not audited" do
     visit audits_report_path
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
 
     expect(page).to have_content("Items audited 2 67%")
     expect(page).to have_content("Items still to audit 1 33%")
@@ -39,6 +40,8 @@ RSpec.feature "Reporting on audit progress" do
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
     visit audits_report_path
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
 
     expect(page).to have_content("Items that need improvement 1 50%")
     expect(page).to have_content("Items that don't need improvement 1 50%")

--- a/spec/features/audit/report/tabs_spec.rb
+++ b/spec/features/audit/report/tabs_spec.rb
@@ -1,14 +1,21 @@
 RSpec.feature "Tabs" do
-  scenario "preserving filters across tabs" do
+  scenario "reset filters on each tab" do
     visit audits_path
-    choose "Audited"
+    expect(page).to have_select("allocated_to", selected: "Me")
 
+    choose "Audited"
+    select "Anyone", from: "allocated_to"
     click_on "Apply filters"
-    expect(page).to have_checked_field("audit_status_audited")
+    expect(page).to have_select("allocated_to", selected: "Anyone")
+
+    click_on "Assign content"
+    expect(page).to have_select("allocated_to", selected: "No one")
 
     click_link "Audit progress"
+    expect(page).to have_select("allocated_to", selected: "Me")
 
+    select "Anyone", from: "allocated_to"
     click_link "Audit content"
-    expect(page).to have_checked_field("audit_status_audited")
+    expect(page).to have_select("allocated_to", selected: "Me")
   end
 end

--- a/spec/javascripts/fixtures/organisation_autocomplete/none_selected.html.erb
+++ b/spec/javascripts/fixtures/organisation_autocomplete/none_selected.html.erb
@@ -1,4 +1,8 @@
 <%
+  def filter
+    OpenStruct.new
+  end
+
   def organisation_options_for_select(selected = nil)
     organisation_options = [
       ["Cabinet Office", "cabinet-office"],

--- a/spec/javascripts/fixtures/organisation_autocomplete/one_selected.html.erb
+++ b/spec/javascripts/fixtures/organisation_autocomplete/one_selected.html.erb
@@ -1,4 +1,8 @@
 <%
+  def filter
+    OpenStruct.new
+  end
+
   def organisation_options_for_select(selected = nil)
     selected = 'ministry-of-defence'
     organisation_options = [

--- a/spec/javascripts/fixtures/organisation_autocomplete/two_selected.html.erb
+++ b/spec/javascripts/fixtures/organisation_autocomplete/two_selected.html.erb
@@ -1,4 +1,8 @@
 <%
+  def filter
+    OpenStruct.new
+  end
+
   def organisation_options_for_select(selected = nil)
     selected = ['cabinet-office', 'ministry-of-defence']
     organisation_options = [


### PR DESCRIPTION
The state of a user's filtering is currently shared between all three tabs of the Audit Tool, which is done by persisting the query string when changing tabs.

However, we now want to change the filters in each view, tailoring them to the task that is to be performed on that tab. As such, we want different default values when loading each tab, and we should stop sharing the filter state when switching tabs.

In order to do this, this change removes all notion of defaults and blank values from the `filter` class, and moves the defaults up into the controllers.

The sidebar filter values are also driven by the `filter` object, rather than the query parameters, which are not indicative of the current state of the filter (since they may be blank, but a default filter will apply).