### PR TITLE
Include array parameters in allocation

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -2,6 +2,7 @@ module FilterHelper
   def filter_to_hidden_fields(*fields_to_exclude)
     filter_params = params.except(:controller, :action).except(*fields_to_exclude)
     hidden_fields = filter_params.keys.map do |key|
+      key = "#{key}[]" if params[key].is_a?(Array)
       hidden_field_tag key, filter_params.dig(key)
     end
 

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -43,6 +43,20 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     expect(page).to have_content("2 items allocated to #{current_user.name}")
   end
 
+  scenario "Allocation when filtering by organisation using filter results" do
+    create :organisation, title: "HMRC"
+
+    visit audits_allocations_path
+    select "HMRC", from: "Organisations"
+    click_on "Apply filters"
+
+    select "Me", from: "allocate_to"
+    fill_in "batch_size", with: "4"
+    click_on "Assign"
+
+    expect(page).to have_content("0 items allocated to #{current_user.name}")
+  end
+
   scenario "Allocate selecting individual items" do
     item2 = create(:content_item, title: "content item 2")
     item3 = create(:content_item, title: "content item 3")


### PR DESCRIPTION
[Trello card](https://trello.com/c/CHhqnUL4/541-allocating-more-content-than-total-count-of-the-list-is-raising-errors)

When filtering by organisations in allocation, the form with the hidden
fields that represent the params filter was not considering that 
organisations were an Array. 

So it was using the name `organisations` instead of `organisations[]`.