### PR TITLE
Remove automatic user setup from feature testing

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -62,6 +62,10 @@ FactoryGirl.define do
   end
 
   factory :user do
+    transient do
+      organisation nil
+    end
+
     sequence(:uid) { |i| "user-#{i}" }
     sequence(:name) { |i| "Test User #{i}" }
     email 'user@example.com'
@@ -71,6 +75,13 @@ FactoryGirl.define do
     trait :with_allocated_content do
       after(:create) do |user|
         create :allocation, user: user
+      end
+    end
+
+    before(:create) do |user, evaluator|
+      unless evaluator.organisation.nil?
+        user.organisation_slug = evaluator.organisation.base_path
+        user.organisation_content_id = evaluator.organisation.content_id
       end
     end
   end

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -1,6 +1,11 @@
 RSpec.feature "Allocate multiple content items", type: :feature do
   let!(:content_item) { create :content_item, title: "content item 1" }
-  let!(:current_user) { User.first }
+  let!(:me) do
+    create(
+      :user,
+      name: "Jane Austen",
+    )
+  end
 
   scenario "Allocate content within current page" do
     second = create(:content_item, title: "content item 2")
@@ -14,7 +19,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     select "Me", from: "allocate_to"
     click_on "Assign"
 
-    expect(page).to have_content("2 items allocated to #{current_user.name}")
+    expect(page).to have_content("2 items allocated to Jane Austen")
 
     select "Me", from: "allocated_to"
     click_on "Apply filters"
@@ -40,7 +45,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     fill_in "batch_size", with: "2"
     click_on "Assign"
 
-    expect(page).to have_content("2 items allocated to #{current_user.name}")
+    expect(page).to have_content("2 items allocated to Jane Austen")
   end
 
   scenario "Allocation when filtering by organisation using filter results" do
@@ -54,7 +59,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     fill_in "batch_size", with: "4"
     click_on "Assign"
 
-    expect(page).to have_content("0 items allocated to #{current_user.name}")
+    expect(page).to have_content("0 items allocated to Jane Austen")
   end
 
   scenario "Allocate selecting individual items" do
@@ -69,7 +74,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     select "Me", from: "allocate_to"
     click_on "Assign"
 
-    expect(page).to have_content("2 items allocated to #{current_user.name}")
+    expect(page).to have_content("2 items allocated to Jane Austen")
   end
 
   scenario "Allocate 0 content items" do
@@ -78,6 +83,6 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     select "Me", from: "allocate_to"
     click_on "Assign"
 
-    expect(page).to have_content("0 items allocated to #{current_user.name}")
+    expect(page).to have_content("0 items allocated to Jane Austen")
   end
 end

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -1,5 +1,9 @@
 RSpec.feature "Filter content by allocated content auditor", type: :feature do
-  let!(:current_user) { User.first }
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
 
   scenario "List is unfiltered" do
     visit audits_path
@@ -13,7 +17,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     item2 = create(:content_item, title: "content item 2")
     create(:content_item, title: "content item 3")
 
-    create(:allocation, content_item: item1, user: current_user)
+    create(:allocation, content_item: item1, user: me)
     create(:allocation, content_item: item2, user: another_user)
 
     visit audits_path
@@ -47,7 +51,7 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
     item2 = create(:content_item, title: "content item 2")
     item3 = create(:content_item, title: "content item 3")
 
-    create(:allocation, content_item: item2, user: current_user)
+    create(:allocation, content_item: item2, user: me)
 
     visit audits_allocations_path
 

--- a/spec/features/audit/allocation/unallocate_spec.rb
+++ b/spec/features/audit/allocation/unallocate_spec.rb
@@ -1,9 +1,14 @@
 RSpec.feature "Unallocate content", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   let!(:content_item) { create :content_item, title: "content item 1" }
-  let!(:current_user) { User.first }
 
   scenario "Unallocate content" do
-    create(:allocation, content_item: content_item, user: current_user)
+    create(:allocation, content_item: content_item, user: me)
 
     visit audits_allocations_path
 

--- a/spec/features/audit/audit/metadata_spec.rb
+++ b/spec/features/audit/audit/metadata_spec.rb
@@ -1,4 +1,11 @@
 RSpec.feature "Audit metadata", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+      name: "Harper Lee",
+    )
+  end
+
   let!(:content_item) do
     create(
       :content_item,
@@ -48,7 +55,7 @@ RSpec.feature "Audit metadata", type: :feature do
       document_type: "guidance",
     )
 
-    create(:audit, content_item: content_item, user: @current_user)
+    create(:audit, content_item: content_item, user: me)
 
     create_linked_content("organisations", "Home office")
     create_linked_content("topics", "Immigration")
@@ -62,7 +69,7 @@ RSpec.feature "Audit metadata", type: :feature do
 
     within("#metadata") do
       allocated_text = "Assigned to Edd the Duck Government Digital Service"
-      audited_text = "Audited 01/01/17 (less than a minute ago) by #{@current_user.name} Government Digital Service"
+      audited_text = "Audited 01/01/17 (less than a minute ago) by Harper Lee Government Digital Service"
       expect(page).to have_selector("#allocated", text: allocated_text)
       expect(page).to have_selector("#audited", text: audited_text)
       expect(page).to have_selector("#organisations", text: "Organisations Home office")

--- a/spec/features/audit/audit/navigation_spec.rb
+++ b/spec/features/audit/audit/navigation_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "Navigation", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   context "with three items with different numbers of page views" do
     let!(:first) { create(:content_item, title: "First", six_months_page_views: 10) }
     let!(:second) { create(:content_item, title: "Second", six_months_page_views: 9) }

--- a/spec/features/audit/guidance/guidance_spec.rb
+++ b/spec/features/audit/guidance/guidance_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "Using guidance while auditing a content item", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   let!(:content_item) do
     create(
       :content_item,

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "List Content Items to Audit", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   scenario "User does not see CPM feedback survey link in banner" do
     visit audits_path
 

--- a/spec/features/audit/lists/no_content_spec.rb
+++ b/spec/features/audit/lists/no_content_spec.rb
@@ -1,13 +1,25 @@
 RSpec.feature "Notifying of no content to audit", type: :feature do
+  let!(:narnia) do
+    create(
+      :organisation,
+      title: "Narnia",
+    )
+  end
+
+  let!(:me) do
+    create(
+      :user,
+      name: "C. S. Lewis",
+      organisation: narnia,
+    )
+  end
+
   around(:each) do |example|
     Feature.run_with_activated(:auditing_allocation) { example.run }
   end
 
   context "there is no content for my organisation to audit" do
     before(:each) do
-      @current_user.organisation_slug = SecureRandom.base64
-      @current_user.save
-
       visit audits_path
     end
 
@@ -41,20 +53,24 @@ RSpec.feature "Notifying of no content to audit", type: :feature do
     end
 
     context "viewing content assigned to someone else" do
-      let!(:someone_else) do
-        create(:user, organisation_slug: @current_user.organisation_slug)
+      let!(:aslan) do
+        create(
+          :user,
+          name: "Aslan",
+          organisation: narnia,
+        )
       end
 
       before(:each) do
         visit audits_path
-        select someone_else.name, from: :allocated_to
+        select "Aslan", from: :allocated_to
         click_on "Apply filters"
       end
 
       scenario "not audited content should show a banner" do
         choose "Not audited"
         click_on "Apply filters"
-        expect(page).to have_content("#{someone_else.name} has no content to audit.")
+        expect(page).to have_content("Aslan has no content to audit.")
         expect(page).to have_css(".alert")
         expect(page).to have_css(".alert a")
       end

--- a/spec/features/audit/lists/sorting_spec.rb
+++ b/spec/features/audit/lists/sorting_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "Sort content items to audit", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   scenario "Default sorting by popularity" do
     create(:content_item, six_months_page_views: 0, title: "item1")
     create(:content_item, six_months_page_views: 1234, title: "item2")

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -1,9 +1,14 @@
 RSpec.feature "Content Allocation", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   scenario "Filter allocated content" do
-    current_user = User.first
     content_item = create :content_item, title: "content item 1"
 
-    create(:allocation, content_item: content_item, user: current_user)
+    create(:allocation, content_item: content_item, user: me)
 
     visit audits_report_path
 

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "Exporting a CSV from the report page" do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   def content_type
     page.response_headers.fetch("Content-Type")
   end

--- a/spec/features/audit/report/tabs_spec.rb
+++ b/spec/features/audit/report/tabs_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "Tabs" do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   scenario "preserving filters across tabs" do
     visit audits_path
     choose "Audited"

--- a/spec/features/common/analytics_spec.rb
+++ b/spec/features/common/analytics_spec.rb
@@ -1,4 +1,10 @@
 RSpec.feature "Analytics", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   context "Tracking select elements" do
     scenario "all select elements have a data-tracking-id attribute" do
       paths_to_check = [

--- a/spec/features/taxonomy_generation/content_preview_modal_spec.rb
+++ b/spec/features/taxonomy_generation/content_preview_modal_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Content Preview Modal", type: :feature, js: true do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   before :each do
     #ignore the fact the iframe points to an invalid path
     Capybara.raise_server_errors = false

--- a/spec/features/taxonomy_generation/generate_terms_spec.rb
+++ b/spec/features/taxonomy_generation/generate_terms_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Generating terms", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   it "allows users to generate terms" do
     given_theres_a_project_with_todos
 

--- a/spec/features/taxonomy_generation/taxonomy_generation_spec.rb
+++ b/spec/features/taxonomy_generation/taxonomy_generation_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Taxonomy generation", type: :feature do
+  let!(:me) do
+    create(
+      :user,
+    )
+  end
+
   scenario "User creates a project" do
     when_i_visit_the_projects_page
     and_i_click_on_the_new_project_button

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,8 +53,4 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
-
-  config.before(type: :feature) do
-    @current_user = create :user
-  end
 end


### PR DESCRIPTION
We currently "hide" the setup of our logged-in user in a `before`
block. This can obscure logic based on the current user, and hides
the assumptions made about them.

It also makes it harder to set the current user up with - say - a
particular organisation, which may be needed for testing.

This change removes the automatic setup, forcing each feature test to
declare its own logged-in user, along with any assumptions and extra
setup required (eg a particular name, which might be checked in banner
messages, or a particular organisation, which may be used for content
or selected from dropdowns, etc.).