### PR TITLE
Show/hide textbox based on answers to related question

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require cable
 //= require namespaces
 //= require selectize
+//= require show-free-text-question
 //= require accessible-autocomplete.min
 //= require organisation-autocomplete
 //= require batch-selection

--- a/app/assets/javascripts/show-free-text-question.js
+++ b/app/assets/javascripts/show-free-text-question.js
@@ -1,0 +1,27 @@
+(function (Modules) {
+  "use strict";
+
+  Modules.ShowFreeTextQuestion = function () {
+    this.start = function($element) {
+      var $textBox = $element.find('.js-free-text-question');
+      addEventListener();
+
+      function addEventListener() {
+        var $yesRadio = $element.find('.js-yes-radio');
+        var $noRadio = $element.find('.js-no-radio');
+
+        $yesRadio.click(showTextBox);
+        $noRadio.click(hideTextBox);
+      }
+
+      function showTextBox() {
+        $textBox.removeClass('if-js-hide');
+      }
+
+      function hideTextBox () {
+        $textBox.addClass('if-js-hide');
+      }
+    }
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -24,11 +24,10 @@ $next-link-colour: #000000;
   margin-bottom: 1.5em;
 }
 
-.question {
-  &.is-there-content-out-of-date {
-    margin-top: 4em;
-  }
+.t-reformat {
+  margin-bottom: 2em;
 }
+
 
 .free-text-question {
   &.redirect-or-combine-with-url {

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -24,12 +24,8 @@ $next-link-colour: #000000;
   margin-bottom: 1.5em;
 }
 
-.t-reformat {
-  margin-bottom: 2em;
-}
-
-.t-redirect-urls,
-.t-similar-urls {
+.redirect-urls,
+.similar-urls {
   margin-left: 0;
   padding-left: 2em;
   border-left: solid 2px;

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -28,7 +28,8 @@ $next-link-colour: #000000;
   margin-bottom: 2em;
 }
 
-.t-redirect-urls {
+.t-redirect-urls,
+.t-similar-urls {
   margin-left: 0;
   padding-left: 2em;
   border-left: solid 2px;
@@ -37,11 +38,6 @@ $next-link-colour: #000000;
   label {
     font-weight: normal;
   }
-}
-
-.ur-ls-of-similar-pages {
-  border-left: solid;
-  padding-left: 2em;
 }
 
 .btn-success {

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -28,18 +28,20 @@ $next-link-colour: #000000;
   margin-bottom: 2em;
 }
 
+.t-redirect-urls {
+  margin-left: 0;
+  padding-left: 2em;
+  border-left: solid 2px;
+  margin-bottom: 1.5em;
 
-.free-text-question {
-  &.redirect-or-combine-with-url {
-    textarea {
-      height: 2em;
-    }
+  label {
+    font-weight: normal;
   }
+}
 
-  &.ur-ls-of-similar-pages {
-    border-left: solid;
-    padding-left: 2em;
-  }
+.ur-ls-of-similar-pages {
+  border-left: solid;
+  padding-left: 2em;
 }
 
 .btn-success {

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -61,6 +61,7 @@ module Audits
             notes
             outdated
             redundant
+            redirect_urls
             reformat
             similar
             similar_urls

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -29,12 +29,17 @@ module Audits
     end
 
     def save
-      @content_item = Content::Item.find_by!(content_id: params.fetch(:content_item_content_id))
-      @next_content_item = FindNextItem.call(@content_item, filter)
-      @audit = Audit.find_or_initialize_by(content_item: @content_item)
-      @audit.user = current_user
+      result = Audits::SaveAudit.call(
+        attributes: audit_params,
+        content_id: params.fetch(:content_item_content_id),
+        user_uid: current_user.uid
+      )
 
-      if @audit.update(audit_params)
+      @content_item = result.content_item
+      @next_content_item = FindNextItem.call(@content_item, filter)
+      @audit = result.audit
+
+      if result.success
         if @next_content_item
           flash.notice = "Saved successfully and continued to next item."
           redirect_to content_item_audit_path(@next_content_item, filter_params)

--- a/app/domain/audits/save_audit.rb
+++ b/app/domain/audits/save_audit.rb
@@ -1,0 +1,55 @@
+module Audits
+  class SaveAudit
+    def self.call(*args)
+      new(*args).call
+    end
+
+    attr_accessor :attributes, :audit, :content_item, :success, :user
+
+    def attributes=(attribute)
+      @attributes = attribute.to_h
+    end
+
+    def initialize(attributes:, content_id:, user_uid:)
+      self.attributes = attributes
+      self.content_item = Content::Item.find_by!(content_id: content_id)
+      self.audit = Audits::Audit.find_or_initialize_by(content_item: content_item)
+      self.user = User.find_by(uid: user_uid)
+    end
+
+    def call
+      audit.content_item = content_item
+      audit.user = user
+
+      clear_redirect_urls_if_not_redundant
+      clear_similar_urls_if_not_similar
+      success = audit.update(attributes)
+
+      Result.new(
+        audit,
+        content_item,
+        success
+      )
+    end
+
+    class Result
+      attr_reader :audit, :content_item, :success
+
+      def initialize(audit, content_item, success)
+        @audit = audit
+        @content_item = content_item
+        @success = success
+      end
+    end
+
+  private
+
+    def clear_redirect_urls_if_not_redundant
+      attributes["redirect_urls"] = "" unless ActiveModel::Type::Boolean.new.cast(attributes["redundant"])
+    end
+
+    def clear_similar_urls_if_not_similar
+      attributes["similar_urls"] = "" unless ActiveModel::Type::Boolean.new.cast(attributes["similar"])
+    end
+  end
+end

--- a/app/views/audits/audits/_boolean_question.html.erb
+++ b/app/views/audits/audits/_boolean_question.html.erb
@@ -4,12 +4,12 @@
   </div>
   <div class="col-sm-4">
     <div class="pull-right">
-      <%= form.label "#{attribute}_true", class: "radio-inline" do %>
+      <%= form.label "#{attribute}_true", class: "radio-inline js-yes-radio" do %>
         <%= form.radio_button attribute, true %>
         Yes
       <% end %>
 
-      <%= form.label "#{attribute}_false", class: "radio-inline" do %>
+      <%= form.label "#{attribute}_false", class: "radio-inline js-no-radio" do %>
         <%= form.radio_button attribute, false %>
         No
       <% end %>

--- a/app/views/audits/audits/_boolean_question.html.erb
+++ b/app/views/audits/audits/_boolean_question.html.erb
@@ -1,4 +1,4 @@
-<div class="row t-<%= attribute.to_s.dasherize %>">
+<div class="row <%= attribute.to_s.dasherize %>">
   <div class="col-sm-8">
     <p><%= question %></p>
   </div>

--- a/app/views/audits/audits/_free_text_question.html.erb
+++ b/app/views/audits/audits/_free_text_question.html.erb
@@ -1,4 +1,4 @@
-<div class="row t-<%= attribute.to_s.dasherize %>">
+<div class="row <% unless related_question_answered %>if-js-hide<% end %> t-<%= attribute.to_s.dasherize %> js-free-text-question">
   <div class="col-sm-12">
     <%= form.label attribute, question %>
     <%= form.text_area attribute, class: 'form-control' %>

--- a/app/views/audits/audits/_free_text_question.html.erb
+++ b/app/views/audits/audits/_free_text_question.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row t-<%= attribute.to_s.dasherize %>">
   <div class="col-sm-12">
     <%= form.label attribute, question %>
     <%= form.text_area attribute, class: 'form-control' %>

--- a/app/views/audits/audits/_free_text_question.html.erb
+++ b/app/views/audits/audits/_free_text_question.html.erb
@@ -1,4 +1,4 @@
-<div class="row <% unless related_question_answered %>if-js-hide<% end %> t-<%= attribute.to_s.dasherize %> js-free-text-question">
+<div class="row <% unless related_question_answered %>if-js-hide<% end %> <%= attribute.to_s.dasherize %> js-free-text-question">
   <div class="col-sm-12">
     <%= form.label attribute, question %>
     <%= form.text_area attribute, class: 'form-control' %>

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -74,6 +74,10 @@
                attribute: :redundant,
                question: 'Should the content be removed?' %>
 
+    <%= render 'free_text_question', form: form,
+               attribute: :redirect_urls,
+               question: 'Where should users be redirected to? (optional)' %>
+
     <%= render 'boolean_question', form: form,
                attribute: :similar,
                question: 'Is this content very similar to other pages?' %>

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -70,25 +70,32 @@
                attribute: :outdated,
                question: 'Is the content out of date?' %>
 
-    <%= render 'boolean_question', form: form,
-               attribute: :redundant,
-               question: 'Should the content be removed?' %>
+    <div data-module="show-free-text-question">
+      <%= render 'boolean_question', form: form,
+                 attribute: :redundant,
+                 question: 'Should the content be removed?' %>
 
-    <%= render 'free_text_question', form: form,
-               attribute: :redirect_urls,
-               question: 'Where should users be redirected to? (optional)' %>
+      <%= render 'free_text_question', form: form,
+                 attribute: :redirect_urls,
+                 question: 'Where should users be redirected to? (optional)',
+                 related_question_answered: audit.redundant %>
+    </div>
 
-    <%= render 'boolean_question', form: form,
-               attribute: :similar,
-               question: 'Is this content very similar to other pages?' %>
+    <div data-module="show-free-text-question">
+      <%= render 'boolean_question', form: form,
+                 attribute: :similar,
+                 question: 'Is this content very similar to other pages?' %>
 
-    <%= render 'free_text_question', form: form,
-               attribute: :similar_urls,
-               question: 'URLs of similar pages' %>
+      <%= render 'free_text_question', form: form,
+                 attribute: :similar_urls,
+                 question: 'URLs of similar pages',
+                 related_question_answered: audit.similar %>
+    </div>
 
     <%= render 'free_text_question', form: form,
                attribute: :notes,
-               question: 'Notes' %>
+               question: 'Notes',
+               related_question_answered: {} %>
 
     <%= form.submit "Save", class: "btn btn-success" %>
   <% end %>

--- a/db/migrate/20170909211813_add_redirect_urls_to_audits.rb
+++ b/db/migrate/20170909211813_add_redirect_urls_to_audits.rb
@@ -1,0 +1,5 @@
+class AddRedirectUrlsToAudits < ActiveRecord::Migration[5.1]
+  def change
+    add_column :audits, :redirect_urls, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20170912052927) do
     t.boolean "similar"
     t.text "similar_urls"
     t.text "notes"
+    t.text "redirect_urls"
     t.index ["content_id"], name: "index_audits_on_content_id", unique: true
     t.index ["uid"], name: "index_audits_on_uid"
   end

--- a/spec/domain/audits/save_audit_spec.rb
+++ b/spec/domain/audits/save_audit_spec.rb
@@ -1,0 +1,66 @@
+module Audits
+  RSpec.describe SaveAudit do
+    let!(:user) { create :user }
+    let!(:content_item) { create :content_item, title: "A title" }
+    let!(:attributes) { attributes_for :audit }
+
+    it "creates a new audit" do
+      result = SaveAudit.call(
+        attributes: attributes,
+        content_id: content_item.content_id,
+        user_uid: user.uid
+      )
+
+      expect(result.audit).to have_attributes(change_title: false)
+      expect(result.content_item.title).to eq("A title")
+      expect(result.success).to eq(true)
+    end
+
+    it "clears the redirect_urls field when redundant is set to no" do
+      redundant_content_item = create(:content_item)
+      audit_with_redirect_urls = create(
+        :failing_audit,
+        content_item: redundant_content_item,
+        redirect_urls: "http://www.example.com"
+      )
+
+      expect(Audits::Audit.find(audit_with_redirect_urls.id).redirect_urls).to eq("http://www.example.com")
+
+      attributes[:redundant] = false
+      attributes[:redirect_urls] = "http://www.example.com"
+
+      result = SaveAudit.call(
+        attributes: attributes,
+        content_id: redundant_content_item.content_id,
+        user_uid: user.uid
+      )
+
+      expect(result.audit).to eq(audit_with_redirect_urls)
+      expect(result.audit.redirect_urls).to be_empty
+      expect(Audits::Audit.find(audit_with_redirect_urls.id).redirect_urls).to be_empty
+    end
+
+    it "clears the similar content URLs when not similar to others" do
+      similar_content_item = create(:content_item)
+      audit_with_similar_content = create(
+        :failing_audit,
+        content_item: similar_content_item,
+        similar_urls: "http://www.similar.com"
+      )
+
+      expect(Audits::Audit.find(audit_with_similar_content.id).similar_urls).to eq("http://www.similar.com")
+
+      attributes[:similar] = false
+      attributes[:similar_urls] = "http://www.similar.com"
+
+      result = SaveAudit.call(
+        attributes: attributes,
+        content_id: similar_content_item.content_id,
+        user_uid: user.uid
+      )
+
+      expect(result.audit).to eq(audit_with_similar_content)
+      expect(result.audit.similar_urls).to be_empty
+    end
+  end
+end

--- a/spec/features/audit/audit/audit_spec.rb
+++ b/spec/features/audit/audit/audit_spec.rb
@@ -47,7 +47,11 @@ RSpec.feature "Auditing a content item", type: :feature do
     answer_question "Attachments", "Yes"
     answer_question "Document type", "No"
     answer_question "Is the content out of date?", "Yes"
+
     answer_question "Should the content be removed?", "Yes"
+    expect(page).to have_content("Where should users be redirected to? (optional)")
+    fill_in "Where should users be redirected to? (optional)", with: "http://www.example.com"
+
     answer_question "Is this content very similar to other pages?", "Yes"
     fill_in "URLs of similar pages", with: "something"
 
@@ -61,6 +65,7 @@ RSpec.feature "Auditing a content item", type: :feature do
     expect_answer "Document type", "No"
     expect_answer "Is the content out of date?", "Yes"
     expect_answer "Should the content be removed?", "Yes"
+    expect(find_field("Where should users be redirected to? (optional)").value).to eq("http://www.example.com")
     expect_answer "Is this content very similar to other pages?", "Yes"
     expect(find_field("URLs of similar pages").value).to eq("something")
     expect(find_field("Notes").value).to eq("something")

--- a/spec/features/audit/audit/audit_spec.rb
+++ b/spec/features/audit/audit/audit_spec.rb
@@ -85,19 +85,26 @@ RSpec.feature "Auditing a content item", type: :feature do
     expect_answer "Is the content out of date?", "Yes"
   end
 
-  scenario "clicking on yes and no buttons for similar content questions", js: true do
+  scenario "clicking on yes and no buttons for redundant/similar content questions", js: true do
     visit content_item_audit_path(content_item)
 
-    expect(page).to have_no_content('Where should users be redirected to? (optional)')
+    expect(page).to have_no_content("Where should users be redirected to? (optional)")
+    expect(page).to have_no_content("URLs of similar pages")
 
     answer_question "Should the content be removed?", "Yes"
-    expect(page).to have_content('Where should users be redirected to? (optional)')
+    expect(page).to have_content("Where should users be redirected to? (optional)")
 
     answer_question "Should the content be removed?", "No"
-    expect(page).to have_no_content('Where should users be redirected to? (optional)')
+    expect(page).to have_no_content("Where should users be redirected to? (optional)")
+
+    answer_question "Is this content very similar to other pages?", "Yes"
+    expect(page).to have_content("URLs of similar pages")
+
+    answer_question "Is this content very similar to other pages?", "No"
+    expect(page).to have_no_content("URLs of similar pages")
   end
 
-  scenario "filling in and saving questions for similar content", js: true do
+  scenario "filling in and saving questions for redundant content", js: true do
     visit content_item_audit_path(content_item)
 
     answer_question "Title", "No"
@@ -110,19 +117,25 @@ RSpec.feature "Auditing a content item", type: :feature do
     answer_question "Should the content be removed?", "Yes"
     fill_in "Where should users be redirected to? (optional)", with: "http://www.example.com"
     answer_question "Is this content very similar to other pages?", "Yes"
-    fill_in "URLs of similar pages", with: "something"
+    fill_in "URLs of similar pages", with: "http://www.example.com"
 
     click_on "Save"
 
-    expect(page).to have_content('Where should users be redirected to? (optional)')
+    expect(page).to have_content("Where should users be redirected to? (optional)")
     expect(find_field("Where should users be redirected to? (optional)").value).to eq("http://www.example.com")
+    expect(page).to have_content("URLs of similar pages")
+    expect(find_field("URLs of similar pages").value).to eq("http://www.example.com")
 
     answer_question "Should the content be removed?", "No"
+    answer_question "Is this content very similar to other pages?", "No"
     click_on "Save"
 
     expect(page).to have_no_content('Where should users be redirected to? (optional)')
+    expect(page).to have_no_content("URLs of similar pages")
 
     answer_question "Should the content be removed?", "Yes"
+    answer_question "Is this content very similar to other pages?", "Yes"
     expect(find_field("Where should users be redirected to? (optional)").value).to eq("")
+    expect(find_field("URLs of similar pages").value).to eq("")
   end
 end

--- a/spec/features/audit/audit/audit_spec.rb
+++ b/spec/features/audit/audit/audit_spec.rb
@@ -84,4 +84,45 @@ RSpec.feature "Auditing a content item", type: :feature do
     expect_answer "Document type", "No"
     expect_answer "Is the content out of date?", "Yes"
   end
+
+  scenario "clicking on yes and no buttons for similar content questions", js: true do
+    visit content_item_audit_path(content_item)
+
+    expect(page).to have_no_content('Where should users be redirected to? (optional)')
+
+    answer_question "Should the content be removed?", "Yes"
+    expect(page).to have_content('Where should users be redirected to? (optional)')
+
+    answer_question "Should the content be removed?", "No"
+    expect(page).to have_no_content('Where should users be redirected to? (optional)')
+  end
+
+  scenario "filling in and saving questions for similar content", js: true do
+    visit content_item_audit_path(content_item)
+
+    answer_question "Title", "No"
+    answer_question "Summary", "Yes"
+    answer_question "Page detail", "No"
+    fill_in "Notes", with: "something"
+    answer_question "Attachments", "Yes"
+    answer_question "Document type", "No"
+    answer_question "Is the content out of date?", "Yes"
+    answer_question "Should the content be removed?", "Yes"
+    fill_in "Where should users be redirected to? (optional)", with: "http://www.example.com"
+    answer_question "Is this content very similar to other pages?", "Yes"
+    fill_in "URLs of similar pages", with: "something"
+
+    click_on "Save"
+
+    expect(page).to have_content('Where should users be redirected to? (optional)')
+    expect(find_field("Where should users be redirected to? (optional)").value).to eq("http://www.example.com")
+
+    answer_question "Should the content be removed?", "No"
+    click_on "Save"
+
+    expect(page).to have_no_content('Where should users be redirected to? (optional)')
+
+    answer_question "Should the content be removed?", "Yes"
+    expect(find_field("Where should users be redirected to? (optional)").value).to eq("")
+  end
 end

--- a/spec/javascripts/fixtures/show-free-text-question.html
+++ b/spec/javascripts/fixtures/show-free-text-question.html
@@ -1,0 +1,15 @@
+<div data-module="show-free-text-question">
+  <label class="js-yes-radio" for="audits_audit_redundant_true">
+    <input type="radio" value="true" id="audits_audit_redundant_true">
+    Yes
+  </label>
+  <label class="js-no-radio" for="audits_audit_redundant_false">
+    <input type="radio" value="false" id="audits_audit_redundant_false">
+    No
+  </label>
+
+  <div class="if-js-hide js-free-text-question">
+    <label for="audits_audit_redirect_urls"></label>
+    <textarea class="form-control" id="audits_audit_redirect_urls"></textarea>
+  </div>
+</div>

--- a/spec/javascripts/modules/show_free_text_question_spec.js
+++ b/spec/javascripts/modules/show_free_text_question_spec.js
@@ -1,0 +1,40 @@
+describe('A show free text question textbox module', function() {
+  'use strict';
+
+  var showFreeTextQuestion,
+      $element,
+      yesRadio,
+      noRadio,
+      textBox;
+
+  beforeEach(function() {
+    showFreeTextQuestion = new GOVUKAdmin.Modules.ShowFreeTextQuestion();
+    this.fixtures = fixture.load('show-free-text-question.html');
+
+    $element = $(':first-child', fixture.el);
+    yesRadio = $element.find('.js-yes-radio');
+    noRadio = $element.find('.js-no-radio');
+    textBox = $element.find('.js-free-text-question');
+
+    showFreeTextQuestion.start($element);
+  });
+
+  describe('when "yes" radio is chosen', function() {
+    it('removes the if-js-hide class from the free text question', function(){
+      expect(textBox).toHaveClass('if-js-hide');
+
+      yesRadio.click();
+      expect(textBox).not.toHaveClass('if-js-hide');
+    });
+  });
+
+  describe('when "no" radio is chosen', function () {
+    it('adds the if-js-hide class onto the free text question', function () {
+      textBox.removeClass('if-js-hide');
+      expect(textBox).not.toHaveClass('if-js-hide');
+
+      noRadio.click();
+      expect(textBox).toHaveClass('if-js-hide');
+    })
+  });
+});


### PR DESCRIPTION
We only want to give the user fields to provide more detail if they answer `Yes` to a question.

If the user answers `Yes` to:

* `Should the content be removed?`, they are presented with a textbox for `Where should users be redirected to? (optional)`
* `Is this content very similar to other pages?`, they are presented with a textbox for `URLs of similar pages`

Answering `No` to either question will hide the textboxes.

## Before
![screenshot-content-performance-manager publishing service gov uk-2017-09-15-19-24-15-196](https://user-images.githubusercontent.com/424772/30497688-a81ecd88-9a4b-11e7-898f-aefe65a80c47.png)

## After 
![screenshot-localhost-3000-2017-09-15-19-24-48-478](https://user-images.githubusercontent.com/424772/30497707-bb589bf4-9a4b-11e7-9985-33763001cace.png)
![screenshot-localhost-3000-2017-09-15-19-25-09-877](https://user-images.githubusercontent.com/424772/30497711-bf4aef46-9a4b-11e7-81c9-a623342b1ae7.png)

