### PR TITLE
Remove `js-hidden` class

### DIFF
--- a/app/assets/javascripts/expandable-filters.js
+++ b/app/assets/javascripts/expandable-filters.js
@@ -29,7 +29,7 @@
       }
 
       function showElement() {
-        $element.removeClass('js-hidden');
+        $element.removeClass('if-js-hide');
       }
     };
   };

--- a/app/assets/stylesheets/_javascript.scss
+++ b/app/assets/stylesheets/_javascript.scss
@@ -1,5 +1,0 @@
-.js {
-  .js-hidden {
-    display: none;
-  }
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,7 +18,6 @@
 // scss-lint:enable Comment
 
 @import 'govuk_admin_template';
-@import 'javascript';
 @import 'tables';
 @import 'pagination';
 @import 'phase_banner';

--- a/app/views/components/_expandable_filters.html.erb
+++ b/app/views/components/_expandable_filters.html.erb
@@ -1,6 +1,6 @@
 <% start_expanded ||= false %>
 
-<div data-module="expandable-filters" data-start-expanded="<%= start_expanded -%>" class="js-hidden">
+<div data-module="expandable-filters" data-start-expanded="<%= start_expanded -%>" class="if-js-hide">
   <div id="additionalFilters" class="js-additional-filters collapse in">
     <%= yield %>
   </div>


### PR DESCRIPTION
The `govuk_admin_template` already has [a class for hiding elements on
JavaScript-enabled devices](https://github.com/alphagov/govuk_admin_template/blob/340e2e341b28783d9ee44a60ce4a0cf07af81c3b/app/assets/stylesheets/govuk_admin_template/_toggles.scss#L15-L17).

This change removes our own implementation of this, and uses the
built-in class instead.