### PR TITLE
Only fetch Google Analytics for present base paths

### DIFF
--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -41,9 +41,11 @@ module GoogleAnalytics
 
       def filters(base_paths, name, operator = "EXACT")
         dimension_filter_clause = DimensionFilterClause.new
-        dimension_filter_clause.filters = base_paths.map do|base_path|
-          filter(base_path, name, operator)
-        end
+
+        dimension_filter_clause.filters = base_paths
+          .select(&:present?)
+          .map { |base_path| filter(base_path, name, operator) }
+
         [dimension_filter_clause]
       end
 

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -62,6 +62,20 @@ module GoogleAnalytics
           expect(request.as_json).to include(page_views_request)
         end
       end
+
+      context "When there are blank base paths" do
+        it "does not include them in the request" do
+          request = PageViewsRequest.new.build(
+            base_paths: ["/foo", "", nil, "/bar"],
+            start_dates: ["2017/09/18"],
+          )
+
+          filters = request.to_h[:report_requests][0][:dimension_filter_clauses][0][:filters]
+          base_paths = filters.map { |filter| filter[:expressions][0] }
+
+          expect(base_paths).to contain_exactly("/foo", "/bar")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We have some content items with `nil` base paths. Trying to fetch
analytics data for these blank base paths results in a `400 Bad Request`
when querying Google Analytics.

This change only fetches analytics data for those content items with a
base path.