### PR TITLE
Limit Sidekiq retries and only log final failure

### DIFF
--- a/app/domain/content/importers/all_content_items.rb
+++ b/app/domain/content/importers/all_content_items.rb
@@ -10,7 +10,7 @@ module Content
       content_items = content_items_service.fetch_all_with_default_locale_only
 
       content_items.each do |content_item|
-        ImportItemJob.perform_later(content_item[:content_id], content_item[:locale])
+        ImportItemJob.perform_async(content_item[:content_id], content_item[:locale])
       end
     end
   end

--- a/app/domain/content/importers/all_google_analytics_metrics.rb
+++ b/app/domain/content/importers/all_google_analytics_metrics.rb
@@ -8,7 +8,8 @@ module Content
 
     def run
       Content::Item.find_in_batches(batch_size: batch_size) do |content_items|
-        ImportPageviewsJob.perform_later(content_items)
+        base_paths = content_items.map(&:base_path)
+        ImportPageviewsJob.perform_async(base_paths)
       end
     end
   end

--- a/app/domain/content/importers/pageviews.rb
+++ b/app/domain/content/importers/pageviews.rb
@@ -8,9 +8,7 @@ module Content
       @google_analytics_service = GoogleAnalyticsService.new
     end
 
-    def run(content_items)
-      base_paths = content_items.pluck(:base_path)
-
+    def run(base_paths)
       results = @google_analytics_service.page_views(base_paths)
       results.each do |result|
         content_item = Content::Item.find_by(base_path: result[:base_path])

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,9 @@
-class ApplicationJob < ActiveJob::Base
+class ApplicationJob
+  include Sidekiq::Worker
+
+  # Retry for ~12 hours with exponential backoff, according to the default Sidekiq formula:
+  # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
+  MAX_RETRIES = 14
+
+  sidekiq_options retry: MAX_RETRIES
 end

--- a/app/jobs/content/import_pageviews_job.rb
+++ b/app/jobs/content/import_pageviews_job.rb
@@ -1,8 +1,8 @@
 module Content
   class ImportPageviewsJob < ApplicationJob
     def perform(*args)
-      content_items = args[0]
-      Importers::Pageviews.run(content_items)
+      base_paths = args[0]
+      Importers::Pageviews.run(base_paths)
     end
   end
 end

--- a/spec/domain/content/importers/all_content_items_spec.rb
+++ b/spec/domain/content/importers/all_content_items_spec.rb
@@ -11,8 +11,8 @@ module Content
 
     describe '#run' do
       it 'creates a job for each content item to import' do
-        expect(ImportItemJob).to receive(:perform_later).with("id-123", "en")
-        expect(ImportItemJob).to receive(:perform_later).with("id-456", "cy")
+        expect(ImportItemJob).to receive(:perform_async).with("id-123", "en")
+        expect(ImportItemJob).to receive(:perform_async).with("id-456", "cy")
 
         subject.run
       end

--- a/spec/domain/content/importers/all_google_analytics_metrics_spec.rb
+++ b/spec/domain/content/importers/all_google_analytics_metrics_spec.rb
@@ -3,7 +3,8 @@ module Content
     describe "#run" do
       it "creates a job to import pageviews for content items" do
         content_items = [create(:content_item)]
-        expect(ImportPageviewsJob).to receive(:perform_later).with(content_items)
+        base_paths = content_items.map(&:base_path)
+        expect(ImportPageviewsJob).to receive(:perform_async).with(base_paths)
 
         subject.run
       end
@@ -12,7 +13,7 @@ module Content
         create_list(:content_item, 2)
         subject.batch_size = 1
 
-        expect(ImportPageviewsJob).to receive(:perform_later).twice
+        expect(ImportPageviewsJob).to receive(:perform_async).twice
 
         subject.run
       end

--- a/spec/jobs/content/import_pageviews_job_spec.rb
+++ b/spec/jobs/content/import_pageviews_job_spec.rb
@@ -12,7 +12,7 @@ module Content
         ]
       )
 
-      subject.perform([content_item])
+      subject.perform(['/the-base-path'])
 
       content_item.reload
       expect(content_item.one_month_page_views).to eq(88)


### PR DESCRIPTION
We previously used Sidekiq's default retry behaviour, which is an
exponential backoff strategy limited to 25 retries, which will span
approximately three weeks.

Since our jobs rerun daily, we do not need to keep retrying beyond one
day at the most.

This change therefore limits the number of retries to 14, which is
approximately 12 hours according to the formula documented in [the
Sidekiq documentation](https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry):

```
(retry_count ** 4) + 15 + (rand(30) * (retry_count + 1))
```

Further, our jobs are highly dependent on external parties' APIs. We do
not need to log errors that are beyond our control (for example,
timeouts).

This being the case, this change also updates the Airbrake configuration
to ignore all errors whose `retry_count` is below the maximum retries.

In order to achieve these changes, the workers must now use the
`Sidekiq::Worker` mixin, rather than extending `ActiveJob::Base`,
because `ActiveJob::Base` does not allow configuration of
`sidekiq` options, as noted in [the documentation](https://github.com/mperham/sidekiq/wiki/Active-Job).