### PR TITLE
Log certain Sidekiq errors only on their final retry

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,36 @@
+require 'gds_api/exceptions'
+require 'google/apis/analyticsreporting_v4'
+
 class ApplicationJob
   include Sidekiq::Worker
+
+  # List of errors to retry without alerting Sentry until their final retry
+  ERRORS_TO_RETRY_WITHOUT_ALERTS = [
+    Google::Apis::ServerError,
+    Google::Apis::TransmissionError,
+    GdsApi::HTTPBadGateway,
+    GdsApi::TimedOutException,
+  ].freeze
 
   # Retry for ~12 hours with exponential backoff, according to the default Sidekiq formula:
   # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
   MAX_RETRIES = 14
 
   sidekiq_options retry: MAX_RETRIES
+
+  sidekiq_retries_exhausted do |_message, error|
+    GovukError.notify(error.cause) if error.is_a?(RetryableError)
+  end
+
+  def perform(*args)
+    run(*args)
+  rescue *ERRORS_TO_RETRY_WITHOUT_ALERTS
+    raise RetryableError
+  end
+
+  def run(*_args)
+    raise NotImplementedError
+  end
+
+  class RetryableError < StandardError; end
 end

--- a/app/jobs/content/import_item_job.rb
+++ b/app/jobs/content/import_item_job.rb
@@ -1,6 +1,6 @@
 module Content
   class ImportItemJob < ApplicationJob
-    def perform(*args)
+    def run(*args)
       Importers::SingleContentItem.run(*args)
     end
   end

--- a/app/jobs/content/import_pageviews_job.rb
+++ b/app/jobs/content/import_pageviews_job.rb
@@ -1,6 +1,6 @@
 module Content
   class ImportPageviewsJob < ApplicationJob
-    def perform(*args)
+    def run(*args)
       base_paths = args[0]
       Importers::Pageviews.run(base_paths)
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative 'raven'
+
 module ContentPerformanceManager
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/raven.rb
+++ b/config/raven.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.excluded_exceptions << "ApplicationJob::RetryableError"
+end


### PR DESCRIPTION
Some of our Sidekiq errors arise from interactions with 3rd party APIs,
and failures beyond our control are to be expected from time to time.
We do not want to be notified every time we get one of these errors;
we just want to be notified the final time the job fails.

This change updates our `ApplicationJob` to perform its tasks inside a
block that will be rescued when certain errors raise. It will then
re-raise a `RetryableError`, which will be ignored by Sentry.

When the retries on a job are exhausted, the error will finally be sent
to Sentry.

Raven is Sentry's API offering. Documentation on the Ruby implementation
can be found [here][raven].

We thought about solving this using Raven's `should_capture` method,
which would enable us to filter errors base on arbitrary conditions,
but that would have require some error parsing. The approach taken here
is more explicit about the expected errors, and requires fewer moving
parts.

[raven]: https://docs.sentry.io/clients/ruby/