### PR TITLE
Assign jobs to their own queues with different concurrencies

### DIFF
--- a/app/jobs/content/import_item_job.rb
+++ b/app/jobs/content/import_item_job.rb
@@ -1,5 +1,7 @@
 module Content
   class ImportItemJob < ApplicationJob
+    sidekiq_options queue: 'publishing_api'
+
     def run(*args)
       Importers::SingleContentItem.run(*args)
     end

--- a/app/jobs/content/import_pageviews_job.rb
+++ b/app/jobs/content/import_pageviews_job.rb
@@ -1,5 +1,7 @@
 module Content
   class ImportPageviewsJob < ApplicationJob
+    sidekiq_options queue: 'google_analytics'
+
     def run(*args)
       base_paths = args[0]
       Importers::Pageviews.run(base_paths)

--- a/config/sidekiq/google_analytics.yml
+++ b/config/sidekiq/google_analytics.yml
@@ -1,0 +1,4 @@
+---
+:concurrency:  1
+:queues:
+  - google_analytics

--- a/config/sidekiq/publishing_api.yml
+++ b/config/sidekiq/publishing_api.yml
@@ -1,0 +1,4 @@
+---
+:concurrency:  3
+:queues:
+  - publishing_api


### PR DESCRIPTION
We have different concurrency requirements for our different Sidekiq
jobs:

- The Content Item import job takes hours to run, so it needs concurrent
  runners, but not too many so that we avoid hammering the Publishing
  API.
- We keep getting [concurrency errors][errors] from Google when we query
  for analytics data, so we need to remove all concurrency from those
  jobs.

In order to have different concurrency settings, we will spin up two
separate Sidekiq processes that will each handle their own queue.

This change adds the configuration for these processes, and configures
the jobs to assign themselves to the correct queue.

Note that in a future commit, we should [remove the old `sidekiq.yml`][remove]
configuration. It is left in in this commit to avoid errors when
deploying.

Also note that neither of these jobs will run until the [corresponding
Puppet change][puppet] is merged.

[errors]: https://sentry.io/govuk/app-content-performance-manager/issues/352869156/
[remove]: https://github.com/alphagov/content-performance-manager/pull/359
[puppet]: https://github.com/alphagov/govuk-puppet/pull/6521