### PR TITLE
Remove unused Sidekiq config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
-worker: bundle exec sidekiq -C ./config/sidekiq.yml
 publishing-api-worker: bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
 google-analytics-worker: bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,0 @@
-# config/sidekiq.yml
----
-:concurrency:  3


### PR DESCRIPTION
We now have separate Sidekiq configuration files for our two separate
queues. We no longer need this old configuration file.

## Dependencies

- [x] https://github.com/alphagov/govuk-puppet/pull/6521
- [x] https://github.com/alphagov/govuk-puppet/pull/6526