### PR TITLE
Track allocation batch size

### DIFF
--- a/app/assets/javascripts/analytics/track-allocation-batch-size.js
+++ b/app/assets/javascripts/analytics/track-allocation-batch-size.js
@@ -1,0 +1,25 @@
+(function (Modules) {
+  "use strict";
+
+  Modules.TrackAllocationBatchSize = function () {
+    var TRACKING_ID = "allocation-batch-size";
+
+    this.start = function ($form) {
+      $form.submit(trackAllocationBatchSize);
+
+      function trackAllocationBatchSize() {
+        var trackingEvent = {
+          "event": "govuk.submit",
+          "govuk.trackingId": TRACKING_ID,
+          "govuk.value": allocationBatchSize()
+        };
+
+        dataLayer.push(trackingEvent);
+      }
+
+      function allocationBatchSize() {
+        return $form.find("[data-tracking-id=" + TRACKING_ID + "]").val();
+      }
+    };
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,3 +24,4 @@
 // --- Analytics ---
 //= require analytics/google-tag-manager
 //= require analytics/track-select-change
+//= require analytics/track-allocation-batch-size

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -2,7 +2,12 @@
   <div class="row">
     <div class="form-group form-inline pull-left">
       <%= label_tag :allocate_to, "Assign", class: "allocate" %>
-      <%= text_field_tag :batch_size, "", class: "form-control" %>
+      <%= text_field_tag :batch_size,
+          "",
+          class: "form-control",
+          data: {
+            tracking_id: "allocation-batch-size",
+          } %>
       <%= label_tag :allocate_to, "items to", class: "items"  %>
       <%= select_tag "allocate_to",
         allocation_options_for_select(params[:allocate_to]),

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -9,7 +9,7 @@
 <%= render 'notice' %>
 
 <div class="allocations" data-module="batch-selection">
-  <%= form_tag audits_allocations_path do %>
+  <%= form_tag audits_allocations_path, data: { module: "track-allocation-batch-size" } do %>
       <%= render 'toolbar' %>
       <%= render 'audits/common/counter', count: content_items.total_count  %>
 


### PR DESCRIPTION
When allocating content, we want to be able to track the number of
content items users are assigning.

This change adds a tracking module that will submit this information to
Google Tag Manager when the form is submitted.