### PR TITLE
Handle `nil` rows in Google Analytics responses

### DIFF
--- a/app/services/google_analytics/responses/page_views_response.rb
+++ b/app/services/google_analytics/responses/page_views_response.rb
@@ -8,7 +8,10 @@ module GoogleAnalytics
 
       def parse(response)
         report = response.reports.first
-        report.data.rows.map do |row|
+        # If none of the provided base paths have associated pageviews, then
+        # GA returns nil instead of an empty array
+        rows = report.data.rows || []
+        rows.map do |row|
           {
             base_path: row.dimensions.first,
             one_month_page_views: row.metrics.first.values.first.to_i,

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -40,7 +40,14 @@ RSpec.describe GoogleAnalyticsService do
       expect_any_instance_of(GoogleAnalytics::Requests::PageViewsRequest).to_not receive(:build)
 
       response = subject.page_views(base_paths)
+      expect(response).to eq([])
+    end
 
+    it 'returns an empty array if the returns rows are nil' do
+      google_response = GoogleAnalyticsFactory.build_page_views_response(nil)
+      allow(google_client).to receive(:batch_get_reports).and_return(google_response)
+
+      response = subject.page_views(%w(/a-path-with-no-pageviews))
       expect(response).to eq([])
     end
   end

--- a/spec/support/google_analytics_factory.rb
+++ b/spec/support/google_analytics_factory.rb
@@ -1,11 +1,11 @@
 module GoogleAnalyticsFactory
-  def self.build_page_views_response(responses)
+  def self.build_page_views_response(rows)
     Google::Apis::AnalyticsreportingV4::GetReportsResponse.new(
       reports: [
         Google::Apis::AnalyticsreportingV4::Report.new(
           data: Google::Apis::AnalyticsreportingV4::ReportData.new(
             rows:
-              responses.map do |response|
+              rows && rows.map do |response|
                 Google::Apis::AnalyticsreportingV4::ReportRow.new(
                   dimensions: [
                     response.fetch(:base_path)


### PR DESCRIPTION
When we fetch pageview data from Google Analytics, it returns a response
object. If none of the queried base paths have any pageviews, then
the response object's rows will be `nil`, rather than an empty array.

This case may arise if we query a batch of uncommonly-accessed documents,
such as a [batch of announcments][sentry].

In order to guard against `nil` errors, this change checks that the
`rows` field exists, and - if it isn't - will provide an empty array.

[sentry]: https://sentry.io/govuk/app-content-performance-manager/issues/353541553/events/7483935478/