### PR TITLE
Only process Google Analytics for truthy base paths

### DIFF
--- a/app/domain/content/importers/all_google_analytics_metrics.rb
+++ b/app/domain/content/importers/all_google_analytics_metrics.rb
@@ -8,7 +8,9 @@ module Content
 
     def run
       Content::Item.find_in_batches(batch_size: batch_size) do |content_items|
-        base_paths = content_items.map(&:base_path)
+        base_paths = content_items
+          .map(&:base_path)
+          .select(&:present?)
         ImportPageviewsJob.perform_async(base_paths)
       end
     end

--- a/app/services/google_analytics/requests/page_views_request.rb
+++ b/app/services/google_analytics/requests/page_views_request.rb
@@ -43,7 +43,6 @@ module GoogleAnalytics
         dimension_filter_clause = DimensionFilterClause.new
 
         dimension_filter_clause.filters = base_paths
-          .select(&:present?)
           .map { |base_path| filter(base_path, name, operator) }
 
         [dimension_filter_clause]

--- a/app/services/google_analytics_service.rb
+++ b/app/services/google_analytics_service.rb
@@ -5,6 +5,8 @@ class GoogleAnalyticsService
 
   def page_views(base_paths)
     raise "base_paths isn't an array" unless base_paths.is_a?(Array)
+    base_paths = base_paths.select(&:present?)
+    return [] if base_paths.empty?
 
     request = GoogleAnalytics::Requests::PageViewsRequest.new.build(
       base_paths: base_paths,

--- a/spec/domain/content/importers/all_google_analytics_metrics_spec.rb
+++ b/spec/domain/content/importers/all_google_analytics_metrics_spec.rb
@@ -17,6 +17,15 @@ module Content
 
         subject.run
       end
+
+      it "ignores nil basepaths" do
+        create(:content_item, base_path: '/base-path')
+        create(:content_item, base_path: nil)
+
+        expect(ImportPageviewsJob).to receive(:perform_async).with(['/base-path'])
+
+        subject.run
+      end
     end
   end
 end

--- a/spec/services/google_analytics/requests/page_views_request_spec.rb
+++ b/spec/services/google_analytics/requests/page_views_request_spec.rb
@@ -62,20 +62,6 @@ module GoogleAnalytics
           expect(request.as_json).to include(page_views_request)
         end
       end
-
-      context "When there are blank base paths" do
-        it "does not include them in the request" do
-          request = PageViewsRequest.new.build(
-            base_paths: ["/foo", "", nil, "/bar"],
-            start_dates: ["2017/09/18"],
-          )
-
-          filters = request.to_h[:report_requests][0][:dimension_filter_clauses][0][:filters]
-          base_paths = filters.map { |filter| filter[:expressions][0] }
-
-          expect(base_paths).to contain_exactly("/foo", "/bar")
-        end
-      end
     end
   end
 end

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -33,5 +33,15 @@ RSpec.describe GoogleAnalyticsService do
         }
       ])
     end
+
+    it 'does not process arrays consisting solely of nil values' do
+      base_paths = [nil, nil]
+
+      expect_any_instance_of(GoogleAnalytics::Requests::PageViewsRequest).to_not receive(:build)
+
+      response = subject.page_views(base_paths)
+
+      expect(response).to eq([])
+    end
   end
 end


### PR DESCRIPTION
When requesting the Google Analytics data for a `nil` base path, we
surprisingly get results.

We are currently creating a filter in `page_views_request` by ignoring
all `nil` base paths, but in the corner case where **all** base paths
are `nil`, this results in an empty filter (ie **all** results are
returned!).

Processing all results then also results in the return of every single
path processed by GA, which includes paths who have no content item.
This in itself results in attempting to fetch a non-existent content
item, which is `nil`, and causes a `NoMethodError` when trying to call
`update!` on it, as seen in [this error report][sentry].

This change makes a couple of remedial actions. First of all, we no
longer filter out blank base paths when creating a filter. The behaviour
of creating an empty filter is confusing, so instead we should fail
loudly instead of swallowing the error at this low level.

Instead, the guard for `nil` base paths is moved up to the service layer
in `GoogleAnalyticsService`, which should be responsible for cleansing
the input it receives.

A second guard is also added at the layer above the service, in the
`AllGoogleAnalyticsMetrics` importer.

Note that here we **do not** check for the presence of a content item
when trying to retrieve it by base path. We expect to **never** try
to retrieve a content item with a non-existent base path, so we should
not swallow that error, and should indeed continue to fail loudly as we
have done in this case.

[sentry]: https://sentry.io/govuk/app-content-performance-manager/issues/353542557/events/7483853175/