### PR TITLE
Track user's organisation in the Audit Tool

### DIFF
--- a/app/helpers/google_tag_manager_helper.rb
+++ b/app/helpers/google_tag_manager_helper.rb
@@ -1,0 +1,7 @@
+module GoogleTagManagerHelper
+  def google_tag_manager
+    @google_tag_manager ||= GoogleAnalytics::GoogleTagManager.new(
+      current_user,
+    )
+  end
+end

--- a/app/services/google_analytics/google_tag_manager.rb
+++ b/app/services/google_analytics/google_tag_manager.rb
@@ -1,0 +1,13 @@
+module GoogleAnalytics
+  class GoogleTagManager
+    def initialize(current_user)
+      @current_user = current_user
+    end
+
+    def data_layer
+      [{
+        organisation: @current_user.organisation_slug,
+      }]
+    end
+  end
+end

--- a/app/views/application/_google_tag_manager.html.erb
+++ b/app/views/application/_google_tag_manager.html.erb
@@ -1,0 +1,3 @@
+<script>
+  dataLayer = <%= google_tag_manager.data_layer.to_json.html_safe %>;
+</script>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -13,6 +13,7 @@
 <% content_for :head do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= render "google_tag_manager" %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 <% end %>
 

--- a/spec/features/common/analytics_spec.rb
+++ b/spec/features/common/analytics_spec.rb
@@ -1,7 +1,15 @@
 RSpec.feature "Analytics", type: :feature do
+  let!(:my_organisation) do
+    create(
+      :organisation,
+      base_path: "google-tag-manager",
+    )
+  end
+
   let!(:me) do
     create(
       :user,
+      organisation: my_organisation,
     )
   end
 
@@ -23,6 +31,15 @@ RSpec.feature "Analytics", type: :feature do
           expect(select['data-tracking-id'].blank?).to be(false)
         end
       end
+    end
+  end
+
+  context "Tracking information from the server" do
+    scenario "the user's organisation is in the Google Tag Manager data layer", js: true do
+      visit audits_path
+
+      data_layer = page.evaluate_script("dataLayer")
+      expect(data_layer).to include("organisation" => "google-tag-manager")
     end
   end
 end


### PR DESCRIPTION
In order to better understand the data we are receiving from Google Tag
Manager (GTM), we would like to know the organisation of the user. This
will help us to filter out "noise" from users at Government Digital
Service (GDS). It will also help us to see how organisations work when
using the tool.

In order to track the user's organisation, this change introduces a
`<script>` tag on the Audit Tool only (ie not the Content Performance
Manager). This `<script>` tag is populated with JSON by a Rails template,
which fetches information from a helper method, where we have access to
the user's organisation from Signon.

Since we are in full control of the JSON, and it is all rendered server-
side, this method is considered safe.
inject the JSON onto the page in this way.