### PR TITLE
Allow clearing of default organisation

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -9,6 +9,7 @@ module Audits
         allocated_to: :no_one,
         audit_status: Audits::Audit::NON_AUDITED,
         organisations: [current_user.organisation_content_id],
+        primary_org_only: true,
       }
 
       @content_items = FindContent.paged(filter)

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -8,6 +8,7 @@ module Audits
           @default_filter = {
             allocated_to: current_user.uid,
             audit_status: Audits::Audit::NON_AUDITED,
+            primary_org_only: true,
           }
 
           @content_items = FindContent.paged(filter)

--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -27,7 +27,6 @@ module Audits
         allocated_to: params[:allocated_to],
         audit_status: params[:audit_status],
         document_type: params[:document_type],
-        organisations: organisations,
         page: params[:page],
         sort: Sort.column(params[:sort_by]),
         sort_direction: Sort.direction(params[:sort_by]),
@@ -40,6 +39,7 @@ module Audits
     def filter_from_blankable_query_parameters
       {}.tap do |options|
         options[:primary_org_only] = primary_org_only? if params.key?(:primary)
+        options[:organisations] = organisations if params.key?(:organisations)
       end
     end
 

--- a/app/controllers/audits/reports_controller.rb
+++ b/app/controllers/audits/reports_controller.rb
@@ -5,6 +5,7 @@ module Audits
         allocated_to: current_user.uid,
         audit_status: Audits::Audit::ALL,
         organisations: [current_user.organisation_content_id],
+        primary_org_only: true,
       }
 
       @monitor = ::Audits::Monitor.new(filter)

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -1,6 +1,7 @@
 <div class="form-group" data-module="organisation-autocomplete">
   <%= label_tag :organisations %>
   <div class="organisation-select-wrapper js-organisation-select-wrapper">
+    <%= hidden_field_tag("organisations[]", [""], id: nil) %>
     <%= select_tag :organisations,
                    organisation_options_for_select(filter.organisations),
                    include_blank: true,

--- a/app/views/audits/common/_primary.html.erb
+++ b/app/views/audits/common/_primary.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group">
   <%= hidden_field_tag :primary, false, id: nil %>
-  <%= check_box_tag :primary, true, primary_org_only? %>
+  <%= check_box_tag :primary, true, filter.primary_org_only %>
   <%= label_tag :primary, "Primary organisation only" %>
 </div>

--- a/spec/features/audit/allocation/filter_spec.rb
+++ b/spec/features/audit/allocation/filter_spec.rb
@@ -132,5 +132,17 @@ RSpec.feature "Filter content by allocated content auditor", type: :feature do
 
       expect(page).to have_text("1 item")
     end
+
+    scenario "Clearing the default organisation" do
+      visit audits_allocations_path
+
+      expect(page).to have_select("organisations[]", selected: "Authors")
+      page.unselect "Authors", from: "organisations[]"
+      expect(page).to_not have_select("organisations[]", selected: "Authors")
+
+      click_on "Apply filters"
+
+      expect(page).to_not have_select("organisations[]", selected: "Authors")
+    end
   end
 end

--- a/spec/javascripts/organisation_autocomplete_spec.js
+++ b/spec/javascripts/organisation_autocomplete_spec.js
@@ -17,7 +17,7 @@ describe('Organisation autocomplete', function () {
     });
 
     it('can autocomplete', function (done) {
-      $fixture.find('input').val('minist');
+      autoCompleteTextInput().val('minist');
 
       waitForElements($fixture, 'li')
         .then(function ($lis) {
@@ -30,7 +30,7 @@ describe('Organisation autocomplete', function () {
         })
         .then(function () {
           return wait(function () {
-            return $fixture.find('input').val() === 'Ministry of Defence';
+            return autoCompleteTextInput().val() === 'Ministry of Defence';
           });
         })
         .then(function () {
@@ -60,7 +60,7 @@ describe('Organisation autocomplete', function () {
 
       wait(
         function () {
-          return !$fixture.find('input').eq(0).val();
+          return !autoCompleteTextInput().eq(0).val();
         })
         .then(function () {
           expect(numberOfOrganisations()).toBe(1);
@@ -104,7 +104,7 @@ describe('Organisation autocomplete', function () {
 
       wait(
         function () {
-          return !$fixture.find('input').eq(0).val();
+          return !autoCompleteTextInput().eq(0).val();
         })
         .then(function () {
           expect(numberOfOrganisations()).toBe(1);
@@ -175,7 +175,7 @@ describe('Organisation autocomplete', function () {
         .eq(filterIndex);
 
     var $select = $wrapper.find('select').first();
-    var $input = $wrapper.find('input').first();
+    var $input = $wrapper.find('input[type=text]').first();
 
     expect($select.val()).toBe(value);
     expect($input.val()).toBe(label);
@@ -186,16 +186,20 @@ describe('Organisation autocomplete', function () {
   }
 
   function addOrganisation() {
-    var numberOfOrganisations = $fixture.find('input').length;
+    var numberOfOrganisations = autoCompleteTextInput().length;
     var $addOrganisation = $fixture.find('.js-add-organisation');
     $addOrganisation.click();
     return wait(function () {
-      return $fixture.find('input').length === numberOfOrganisations + 1;
+      return autoCompleteTextInput().length === numberOfOrganisations + 1;
     });
   }
 
   function removeOrganisation(index) {
     var $removeOrganisation = $fixture.find('.js-remove-organisation').eq(index);
     $removeOrganisation.click();
+  }
+
+  function autoCompleteTextInput() {
+    return $fixture.find('input[type=text]');
   }
 });


### PR DESCRIPTION
This change addresses a bug we have:

1. Visit the "Allocation" page
2. The organisation filters should default to your own organisation
3. Clear the organisation filter
4. Apply filters
5. The page is still filtered by your own organisation

This is because we have no way of determining the difference between a user who has just landed on the page "cold" (ie with no filters set), or a user who has actively deselected all the organisations (or selected the blank organisation).

In order to fix this, this change moves "blankable" filters (ie filters who can override defaults when explicitly `blank` eg `[]` or `false`) into their own method, and adds a `hidden` `<input>` field to the organisations multi-select. See individual commits for further details.