### PR TITLE
Add test for allocating content from multiple organisations

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -1,7 +1,6 @@
 module FilterHelper
   def filter_to_hidden_fields
     hidden_fields = filter.to_h.each_with_object([]) do |(key, value), fields|
-      # TODO: Test for multi-org filtering
       if value.is_a?(Array)
         value.each do |array_element|
           fields << hidden_field_tag("#{key}[]", array_element)

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -114,4 +114,48 @@ RSpec.feature "Allocate multiple content items", type: :feature do
       expect(page).to have_content("You did not select any content to be assigned")
     end
   end
+
+  context "There are lots of content items belonging to two organisations" do
+    let!(:painters) do
+      create(
+        :organisation,
+        title: "Painters",
+      )
+    end
+
+    let!(:books) do
+      create_list(
+        :content_item,
+        20,
+        primary_publishing_organisation: novelists,
+      )
+    end
+
+    let!(:paintings) do
+      create_list(
+        :content_item,
+        20,
+        primary_publishing_organisation: painters,
+      )
+    end
+
+    scenario "I can assign 26 content items to myself from both organisations" do
+      visit audits_allocations_path
+
+      expect(page).to have_content("20 items")
+
+      page.select "Painters", from: "organisations[]"
+      click_on "Apply filters"
+
+      expect(page).to have_select("organisations[]", selected: %w[Novelists Painters])
+      expect(page).to have_content("40 items")
+
+      select "Me", from: "allocate_to"
+      fill_in "batch_size", with: "26"
+      click_on "Assign"
+
+      expect(page).to have_content("26 items assigned to Jane Austen")
+      expect(page).to have_content("14 items")
+    end
+  end
 end


### PR DESCRIPTION
We recently [fixed a bug][change] where allocating to organisations
wasn't working because the organisations are an array.

This change adds test coverage for that case, which we didn't previously
have.

[change]: https://github.com/alphagov/content-performance-manager/commit/311e4c805cf7992b277fb06d07a8c9946474e3ef#diff-a1d9a8be563b9698e6c917b6b4de816c