### PR TITLE
Ensure filter defaults are applied on first interaction

### DIFF
--- a/app/controllers/audits/base_controller.rb
+++ b/app/controllers/audits/base_controller.rb
@@ -44,9 +44,9 @@ module Audits
     end
 
     def filter_params
-      request
-        .query_parameters
-        .deep_symbolize_keys
+      Audits::SerializeFilterToQueryParameters
+        .new(filter)
+        .call
     end
 
     def primary_org_only?

--- a/app/services/audits/serialize_filter_to_query_parameters.rb
+++ b/app/services/audits/serialize_filter_to_query_parameters.rb
@@ -1,0 +1,19 @@
+module Audits
+  class SerializeFilterToQueryParameters
+    def initialize(filter)
+      @filter = filter
+    end
+
+    def call
+      {
+        allocated_to: @filter.allocated_to,
+        audit_status: @filter.audit_status,
+        document_type: @filter.document_type,
+        organisations: @filter.organisations,
+        primary: @filter.primary_org_only,
+        query: @filter.title,
+        sort_by: @filter.sort_by,
+      }
+    end
+  end
+end

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
 
     expect(page).to have_content("item1")
     expect(page).to have_content("10,000")
-    expect(page).to have_link("item1", href: "/content_items/content-id/audit")
+    expect(page).to have_link("item1", href: "/content_items/content-id/audit?allocated_to=#{me.uid}&audit_status=non_audited&primary=true")
 
     expect(page).to have_content("item2")
   end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "Exporting a CSV from the report page" do
         :content_item,
         title: "Example 1",
         base_path: "/example1",
+        allocated_to: me,
       )
 
       create(
@@ -88,7 +89,7 @@ RSpec.feature "Exporting a CSV from the report page" do
         'filename="Transformation_audit_report_CSV_download.csv"',
       )
       expect(page).to have_content("Example 1")
-      expect(page).to have_content("Example 2")
+      expect(page).to have_no_content("Example 2")
     end
   end
 
@@ -97,6 +98,8 @@ RSpec.feature "Exporting a CSV from the report page" do
 
     scenario "Exporting an unfiltered audit to CSV with all the content items" do
       visit audits_report_path
+      select "Anyone", from: "allocated_to"
+      click_on "Apply filters"
       click_link "Export filtered audit to CSV"
 
       csv = CSV.parse(page.body, headers: true)

--- a/spec/services/audits/serialize_filter_to_query_parameters_spec.rb
+++ b/spec/services/audits/serialize_filter_to_query_parameters_spec.rb
@@ -1,0 +1,39 @@
+module Audits
+  RSpec.describe SerializeFilterToQueryParameters do
+    let(:allocated_to) { double }
+    let(:audit_status) { double }
+    let(:document_type) { double }
+    let(:organisations) { double }
+    let(:primary_org_only) { double }
+    let(:sort_by) { double }
+    let(:title) { double }
+
+    let(:filter) {
+      double(
+        allocated_to: allocated_to,
+        audit_status: audit_status,
+        document_type: document_type,
+        organisations: organisations,
+        primary_org_only: primary_org_only,
+        sort_by: sort_by,
+        title: title,
+      )
+    }
+
+    describe '.call' do
+      subject { described_class.new(filter).call }
+
+      it 'returns a query parameters hash' do
+        is_expected.to eq(
+          allocated_to: allocated_to,
+          audit_status: audit_status,
+          document_type: document_type,
+          organisations: organisations,
+          primary: primary_org_only,
+          query: title,
+          sort_by: sort_by,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
When you first visit one of the audit tabs, the querystring does not contain any filter state. This means default filters are only applied if you interact with an element on the page that has URLs appended with the filter defaults.

This fixes that so that the defaults are applied correctly.