### PR TITLE
Fix persistence of sort by filter

### DIFF
--- a/app/domain/audits/filter.rb
+++ b/app/domain/audits/filter.rb
@@ -31,7 +31,7 @@ module Audits
     end
 
     def sort_by
-      Sort.combine(@sort, @sort_direction)
+      Sort.combine(sort, sort_direction)
     end
 
     def allocated_policy

--- a/spec/domain/audits/filter_spec.rb
+++ b/spec/domain/audits/filter_spec.rb
@@ -1,0 +1,9 @@
+module Audits
+  RSpec.describe Filter do
+    context 'with sort criteria' do
+      subject { described_class.new(sort: 'foo', sort_direction: 'asc') }
+
+      it { is_expected.to have_attributes(sort_by: 'foo_asc') }
+    end
+  end
+end


### PR DESCRIPTION
The sort by filter was not being persisted due to a regression within the Filter class.
Our Filter object is a struct and so we need to use the accessor methods not instance variables.