### PR TITLE
Show 100 items per page

### DIFF
--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -3,7 +3,7 @@ module Content
     def initialize(scope = Content::Item.all)
       @scope = scope
       @page = 1
-      @per_page = 25
+      @per_page = 100
       @sort = :six_months_page_views
       @sort_direction = :desc
     end

--- a/spec/domain/content/query_spec.rb
+++ b/spec/domain/content/query_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe Content::Query do
     end
   end
 
-  describe "with 26 content items" do
-    let!(:content_items) { create_list(:content_item, 26) }
+  describe "with 101 content items" do
+    let!(:content_items) { create_list(:content_item, 101) }
 
-    it "defaults to the page 1 with 25 per page" do
+    it "defaults to the page 1 with 100 per page" do
       subject.sort_direction(:asc)
-      expect(subject.content_items.count).to eq 25
-      expect(subject.content_items).to match_array(content_items[0..24])
+      expect(subject.content_items.count).to eq 100
+      expect(subject.content_items).to match_array(content_items[0..99])
     end
   end
 

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -241,7 +241,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
       end
 
       scenario "Reseting page to 1 after filtering" do
-        create_list(:content_item, 25)
+        create_list(:content_item, 100)
 
         visit audits_path
         select "Anyone", from: "allocated_to"

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -43,19 +43,19 @@ RSpec.feature "List Content Items to Audit", type: :feature do
 
   describe "pagination" do
     let!(:content_items) {
-      create_list(:content_item, 30, allocated_to: me)
+      create_list(:content_item, 110, allocated_to: me)
         .sort_by(&:base_path)
         .reverse
     }
 
-    scenario "Showing 25 items on the first page" do
+    scenario "Showing 100 items on the first page" do
       visit audits_path
 
-      content_items[0..24].each do |content_item|
+      content_items[0..99].each do |content_item|
         expect(page).to have_content(content_item.title)
       end
 
-      content_items[25..29].each do |content_item|
+      content_items[100..109].each do |content_item|
         expect(page).to have_no_content(content_item.title)
       end
     end
@@ -65,11 +65,11 @@ RSpec.feature "List Content Items to Audit", type: :feature do
 
       click_link "Next →"
 
-      content_items[0..24].each do |content_item|
+      content_items[0..99].each do |content_item|
         expect(page).to have_no_content(content_item.title)
       end
 
-      content_items[25..29].each do |content_item|
+      content_items[100..109].each do |content_item|
         expect(page).to have_content(content_item.title)
       end
     end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   context "Multiple pages of content items are in the database" do
-    let!(:content_items) { create_list(:content_item, 50) }
+    let!(:content_items) { create_list(:content_item, 110) }
 
     scenario "Exporting an unfiltered audit to CSV with all the content items" do
       visit audits_report_path

--- a/spec/features/performance/content_item_list_spec.rb
+++ b/spec/features/performance/content_item_list_spec.rb
@@ -42,10 +42,10 @@ RSpec.feature "Content Items List", type: :feature do
   end
 
   scenario "Paginate through content items" do
-    FactoryGirl.create_list(:content_item, 26)
+    FactoryGirl.create_list(:content_item, 101)
 
     visit "/content/items"
-    expect(page).to have_selector("main tbody tr", count: 25)
+    expect(page).to have_selector("main tbody tr", count: 100)
 
     within(".pagination") { click_on "2" }
 


### PR DESCRIPTION
This change shows 100 items per page on both the audit and allocation pages. This is to address a user need to be able to quickly find the content they are looking for. Showing more items should reduce the amount of paging they have to do, and make it easier to find their content.