### PR TITLE
Look up Users' organisation titles from Content Items

### DIFF
--- a/app/decorators/audits/audit_decorator.rb
+++ b/app/decorators/audits/audit_decorator.rb
@@ -6,7 +6,6 @@ module Audits
 
     decorates_association :responses
     decorates_association :content_item
-    decorates_association :user
 
     def incomplete?
       object.new_record?

--- a/app/decorators/content/item_decorator.rb
+++ b/app/decorators/content/item_decorator.rb
@@ -58,7 +58,7 @@ class Content::ItemDecorator < Draper::Decorator
   end
 
   def auditor_org
-    allocation.user.organisation_slug.titleize
+    allocation.user.organisation&.title
   end
 
 private

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,8 +1,0 @@
-class UserDecorator < Draper::Decorator
-  delegate_all
-
-  def department
-    slug = user.organisation_slug
-    slug.titleize if slug
-  end
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,8 @@ class User < ApplicationRecord
   include GDS::SSO::User
 
   serialize :permissions, Array
+
+  def organisation
+    @organisation ||= Content::Item.find_by(content_id: organisation_content_id)
+  end
 end

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -113,7 +113,7 @@
       <% else %>
         <p><%= audit.last_updated %></p>
         <p>by <%= audit.user.name %></p>
-        <p><%= audit.user.department %></p>
+        <p><%= audit.user.organisation&.title %></p>
       <% end %>
     </div>
 

--- a/spec/features/audit/audit/audit_spec.rb
+++ b/spec/features/audit/audit/audit_spec.rb
@@ -9,7 +9,20 @@ RSpec.feature "Auditing a content item", type: :feature do
     )
   end
 
-  let!(:user) { create(:user) }
+  let!(:my_organisation) do
+    create(
+      :organisation,
+      title: "YA Authors",
+    )
+  end
+
+  let!(:me) do
+    create(
+      :user,
+      name: "Garth Nix",
+      organisation: my_organisation,
+    )
+  end
 
   def answer_question(question, answer)
     find('p', text: question)
@@ -135,5 +148,21 @@ RSpec.feature "Auditing a content item", type: :feature do
     answer_question "Is this content very similar to other pages?", "Yes"
     expect(find_field("Where should users be redirected to? (optional)").value).to eq("")
     expect(find_field("URLs of similar pages").value).to eq("")
+  end
+
+  context "a content item is assigned to me" do
+    let!(:sabriel) do
+      create(
+        :content_item,
+        allocated_to: me,
+      )
+    end
+
+    scenario "my name and organisation are shown on the content item" do
+      visit content_item_audit_path(sabriel)
+
+      expect(page).to have_content("Garth Nix")
+      expect(page).to have_content("YA Authors")
+    end
   end
 end

--- a/spec/features/audit/audit/metadata_spec.rb
+++ b/spec/features/audit/audit/metadata_spec.rb
@@ -1,8 +1,16 @@
 RSpec.feature "Audit metadata", type: :feature do
+  let!(:my_organisation) do
+    create(
+      :organisation,
+      title: "Authors",
+    )
+  end
+
   let!(:me) do
     create(
       :user,
       name: "Harper Lee",
+      organisation: my_organisation,
     )
   end
 
@@ -62,14 +70,15 @@ RSpec.feature "Audit metadata", type: :feature do
     create_linked_content("topics", "Borders")
     create_linked_content("policy_areas", "Borders and Immigration")
 
-    user = create(:user, name: "Edd the Duck")
-    create(:allocation, content_item: content_item, user: user)
+    cbbc = create(:organisation, title: "CBBC")
+    edd = create(:user, name: "Edd the Duck", organisation: cbbc)
+    create(:allocation, content_item: content_item, user: edd)
 
     visit content_item_audit_path(content_item)
 
     within("#metadata") do
-      allocated_text = "Assigned to Edd the Duck Government Digital Service"
-      audited_text = "Audited 01/01/17 (less than a minute ago) by Harper Lee Government Digital Service"
+      allocated_text = "Assigned to Edd the Duck CBBC"
+      audited_text = "Audited 01/01/17 (less than a minute ago) by Harper Lee Authors"
       expect(page).to have_selector("#allocated", text: allocated_text)
       expect(page).to have_selector("#audited", text: audited_text)
       expect(page).to have_selector("#organisations", text: "Organisations Home office")


### PR DESCRIPTION
We currently try to infer the title of a user's organisation by [`titleize`ing][1] their organisation slug. However, this doesn't work in all cases. For example, HMRC has the slug `/hm-revenue-customs`, which titleizes to "Hm Revenue Customs", when the actual title of the organisation is "HM Revenue & Customs" (note the incorrect capitalization of "HM" and the missing ampersand).

This change removes the titleization, and instead explicitly looks up the organisation title from the organisation's Content Item. This is done for both auditors and assignees.

[1]: http://api.rubyonrails.org/v5.1/classes/ActiveSupport/Inflector.html#method-i-titleize