### PR TITLE
Unhide the organisations filter in the Audit content tab

### DIFF
--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -3,10 +3,8 @@
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/title' %>
   <%= render 'audits/common/document_type' %>
-  <%= render 'components/expandable_filters', start_expanded: filter.organisations.any? do %>
-    <%= render 'audits/common/organisations' %>
-    <%= render 'audits/common/primary' %>
-  <% end %>
+  <%= render 'audits/common/organisations' %>
+  <%= render 'audits/common/primary' %>
   <%= render 'audits/common/sort' %>
   <%= render 'audits/common/submit' %>
 <% end %>

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -170,7 +170,6 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
         scenario "using autocomplete", js: true do
           expect(page.current_url).not_to include("organisations%5B%5D=#{hmrc.content_id}")
 
-          click_on "More options"
           expect(page).to have_selector("#organisations", visible: :visible)
           expect(page).to have_selector("#organisations-select", visible: :hidden)
 
@@ -188,7 +187,6 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
         scenario "multiple", js: true do
           expect(page.current_url).not_to include("organisations%5B%5D=#{hmrc.content_id}")
 
-          click_on "More options"
           expect(page).to have_selector("#organisations", visible: :visible)
           expect(page).to have_selector("#organisations-select", visible: :hidden)
           expect(page).to have_selector("#add-organisation", visible: true)


### PR DESCRIPTION
The 'more options' link is removed from Audit content tab (tab 1). This
allows the 'organisations' field to be permanently visible.

Remove 'more options' call in feature test now it is not used in the
Audit content tab.