### PR TITLE
Move position of 'Search' field in Audit Tool

### DIFF
--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag audits_allocations_path, method: :get do %>
+  <%= render 'audits/common/title' %>
   <%= render 'audits/common/allocated_to' %>
   <%= render 'audits/common/audit_status' %>
-  <%= render 'audits/common/title' %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag audits_path, method: :get do %>
+  <%= render 'audits/common/title' %>
   <%= render 'audits/common/allocated_to' %>
   <%= render 'audits/common/audit_status' %>
-  <%= render 'audits/common/title' %>
   <%= render 'audits/common/document_type' %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>


### PR DESCRIPTION
The 'Search' field in Audit content (tab 1) and Assign content (tab 2) is positioned
above other filter options to make it easier for users to find.