### PR TITLE
Open Audit guidance in a new tab

### DIFF
--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -26,7 +26,7 @@
 
   <hr/>
 
-  <%= link_to "Audit guidance", audits_guidance_path %>
+  <%= link_to "Audit guidance", audits_guidance_path, target: "_blank", rel: "noopener noreferrer" %>
 
   <% if audit.errors.any? %>
     <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
Trello: https://trello.com/c/TBU1L09N/614-1-open-guidance-in-a-new-tab

- Audit guidance opens in a new browser tab
- The link has a `rel="noopener noreferrer"` attribute to avoid a
vulnerability for the `target: "_blank”` attribute
(https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimat
ed-vulnerability-ever/)