### PR TITLE
Fix markdown links in heroku documentation

### DIFF
--- a/doc/deploy-to-heroku.md
+++ b/doc/deploy-to-heroku.md
@@ -19,6 +19,7 @@ rake heroku:deploy[10,"HM Revenue & Customs",500]
 ### Heroku limit
 
 [Heroku has a limit of 1000 rows][heroku-limit] in a database, so we have hardcoded the script to only import that many objects. This limit covers content items, links and other rows such as allocations that we would need for testing.
+
 [heroku-cli]: https://devcenter.heroku.com/articles/heroku-cli
 [login-terminal]: https://devcenter.heroku.com/articles/heroku-cli#getting-started
 [heroku-limit]: https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier

--- a/doc/deploy-to-heroku.md
+++ b/doc/deploy-to-heroku.md
@@ -18,7 +18,7 @@ rake heroku:deploy[10,"HM Revenue & Customs",500]
 
 ### Heroku limit
 
-[Heroku has a limit of 1000 rows][heroku-limit] in a database, so we have hardcoded the script to only import that many objects. This limit covers content items, links and other rows such as allocations that we would need for testing.
+[Heroku has a limit of 10000 rows][heroku-limit] in a database, so we have hardcoded the script to only import that many objects. This limit covers content items, links and other rows such as allocations that we would need for testing.
 
 [heroku-cli]: https://devcenter.heroku.com/articles/heroku-cli
 [login-terminal]: https://devcenter.heroku.com/articles/heroku-cli#getting-started


### PR DESCRIPTION
**Minor changes**:

* Add a blank line between the links and the last paragraph
so links are render propertly
* Updates the limit of Heroku database rows to 10.000

### Before

![image](https://user-images.githubusercontent.com/227328/32051228-b9613e44-ba4b-11e7-9ae3-9534f523ef8c.png)

### After

![image](https://user-images.githubusercontent.com/227328/32051093-3a4250c6-ba4b-11e7-94d5-22fb5b92338c.png)

