### PR TITLE
Add multiple users support for prototyping in Heroku

### DIFF
--- a/app/views/application/_heroku.html.erb
+++ b/app/views/application/_heroku.html.erb
@@ -1,0 +1,6 @@
+<% content_for :navbar_right do %>
+  <%= form_tag audits_path, method: 'get' do %>
+    <%= select("heroku", "user_id", User.all.collect { |p| [p.name, p.id] }, { selected: session[:heroku_user_id] }) %>
+    <%= submit_tag "Go" %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 <% end %>
 
 <% content_for :content do %>
+  <%= render 'application/heroku' if Heroku.enabled?%>
   <%= render 'application/alpha_banner' %>
   <div class="row">
     <%= yield :sidebar %>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -19,6 +19,7 @@
 
 <% content_for :content do %>
   <%= render 'application/beta_banner' %>
+  <%= render 'application/heroku' if Heroku.enabled?%>
   <div class="row header-row">
     <div class="col-md-12">
       <%= yield :header %>

--- a/config/initializers/heroku.rb
+++ b/config/initializers/heroku.rb
@@ -17,4 +17,8 @@ if Heroku.enabled?
       end
     end
   end
+
+  GovukAdminTemplate.configure do |c|
+    c.show_signout = false
+  end
 end

--- a/config/initializers/heroku.rb
+++ b/config/initializers/heroku.rb
@@ -1,6 +1,7 @@
 if Heroku.enabled?
   ApplicationController.class_eval do
     before_action :force_development!
+    before_action :set_default_user
 
     def authenticate_user!
       user_id = params.dig(:heroku, :user_id)
@@ -10,6 +11,10 @@ if Heroku.enabled?
 
     def current_user
       User.find(session[:heroku_user_id])
+    end
+
+    def set_default_user
+      session[:heroku_user_id] ||= User.first.id
     end
 
     private

--- a/config/initializers/heroku.rb
+++ b/config/initializers/heroku.rb
@@ -1,19 +1,22 @@
 if Heroku.enabled?
   ApplicationController.class_eval do
-    before_action :ensure_environment
+    before_action :force_development!
 
     def authenticate_user!
+      user_id = params.dig(:heroku, :user_id)
+
+      session[:heroku_user_id] = user_id if user_id.present?
     end
 
     def current_user
-      User.last
+      User.find(session[:heroku_user_id])
     end
 
     private
 
-    def ensure_environment
+    def force_development!
       if Rails.env.production?
-        raise "This code should never run in production"
+        raise 'This code should never run in production'
       end
     end
   end

--- a/config/initializers/heroku.rb
+++ b/config/initializers/heroku.rb
@@ -11,6 +11,9 @@ if Heroku.enabled?
 
     def current_user
       User.find(session[:heroku_user_id])
+    rescue
+      session.clear
+      User.first
     end
 
     def set_default_user

--- a/config/initializers/heroku.rb
+++ b/config/initializers/heroku.rb
@@ -1,0 +1,20 @@
+if Heroku.enabled?
+  ApplicationController.class_eval do
+    before_action :ensure_environment
+
+    def authenticate_user!
+    end
+
+    def current_user
+      User.last
+    end
+
+    private
+
+    def ensure_environment
+      if Rails.env.production?
+        raise "This code should never run in production"
+      end
+    end
+  end
+end

--- a/config/initializers/heroku.rb
+++ b/config/initializers/heroku.rb
@@ -20,5 +20,6 @@ if Heroku.enabled?
 
   GovukAdminTemplate.configure do |c|
     c.show_signout = false
+    c.disable_google_analytics = true
   end
 end

--- a/doc/deploy-to-heroku.md
+++ b/doc/deploy-to-heroku.md
@@ -1,4 +1,4 @@
-# Deploy to Heroku
+# Deploy a PR to Heroku
 
 1. Install the [the Heroku Command Line Interface (CLI)][heroku-cli]
 2. [Login][login-terminal] from your terminal: you only need to do it once

--- a/lib/heroku.rb
+++ b/lib/heroku.rb
@@ -1,4 +1,8 @@
 class Heroku
+  def self.enabled?
+    Rails.env.development? && ENV['RUNNING_IN_HEROKU'].present?
+  end
+
   def self.create_users(organisation_id)
     organisation = Content::Item.find(organisation_id)
 

--- a/lib/heroku.rb
+++ b/lib/heroku.rb
@@ -6,12 +6,14 @@ class Heroku
   def self.create_users(organisation_id)
     organisation = Content::Item.find(organisation_id)
 
-    User.create!(
-      name: 'AT user',
-      email: 'uat@gds.com',
-      uid: SecureRandom.uuid,
-      organisation_slug: organisation.title.parameterize.underscore,
-      organisation_content_id: organisation.content_id,
-    )
+    10.times do |index|
+      User.create!(
+        name: "user-#{index}",
+        email: "email-#{index}@domain.gov.uk",
+        uid: "uid-#{index}",
+        organisation_slug: organisation.title.parameterize.underscore,
+        organisation_content_id: organisation.content_id,
+      )
+    end
   end
 end

--- a/lib/heroku.rb
+++ b/lib/heroku.rb
@@ -1,0 +1,13 @@
+class Heroku
+  def self.create_users(organisation_id)
+    organisation = Content::Item.find(organisation_id)
+
+    User.create!(
+      name: 'AT user',
+      email: 'uat@gds.com',
+      uid: SecureRandom.uuid,
+      organisation_slug: organisation.title.parameterize.underscore,
+      organisation_content_id: organisation.content_id,
+    )
+  end
+end

--- a/lib/heroku.rb
+++ b/lib/heroku.rb
@@ -6,7 +6,8 @@ class Heroku
   def self.create_users(organisation_id)
     organisation = Content::Item.find(organisation_id)
 
-    10.times do |index|
+    number_of_users = 10
+    number_of_users.times do |index|
       User.create!(
         name: "user-#{index}",
         email: "email-#{index}@domain.gov.uk",

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -49,6 +49,9 @@ namespace :heroku do
 
     # Creates default user
     system %{heroku run rails runner "Heroku.create_users '#{organisation.id}'" --app #{app_name}}
+
+    # Opens the application in the browser
+    system %{heroku open --app #{app_name}}
   end
 
   def content_items_file

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -44,7 +44,7 @@ namespace :heroku do
     system %{heroku pg:psql -c "DELETE FROM USERS" --app #{app_name}}
 
     # Creates default user
-    system %{heroku run rails runner "User.create!(name: 'AT user', email: 'uat@gds.com', uid: SecureRandom.uuid, organisation_slug: '#{organisation.title.parameterize.underscore}', organisation_content_id: '#{organisation.content_id}')" --app #{app_name}}
+    system %{heroku run rails runner "Heroku.create_users(#{organisation.id})" --app #{app_name}}
 
     #Import Contetn Items and Links
     system %{heroku pg:psql -c "\\COPY CONTENT_ITEMS FROM '#{content_items_file}'" --app #{app_name}}

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -16,7 +16,7 @@ namespace :heroku do
     ## Create the Heroku app
     heroku_remote = "heroku-#{app_name}"
     system %{heroku apps:create --region eu --remote #{heroku_remote} --app #{app_name}}
-    system %{heroku config:set RAILS_ENV=development RACK_ENV=development --app #{app_name}}
+    system %{heroku config:set RUNNING_IN_HEROKU=true RAILS_ENV=development RACK_ENV=development --app #{app_name}}
 
     ## Push code to Heroku
     current_branch = `git branch | grep "^\*" | cut -d" " -f2`.strip

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -33,24 +33,24 @@ namespace :heroku do
       pluck(:content_id)
     content_item_ids.push(organisation.content_id)
 
-    # Export Content Items and Links
+    ## Export Content Items and Links
     system %{psql content_performance_manager_development -c "COPY (#{content_items_query(content_item_ids)}) TO STDOUT" > '#{content_items_file}'}
     system %{psql content_performance_manager_development -c "COPY (#{links_query(content_item_ids, options)}) TO STDOUT" > '#{links_file}'}
 
-    # Clean-up data if this is a redeployment
+    ## Clean-up data if this is a redeployment
     system %{heroku pg:psql -c "DELETE FROM ALLOCATIONS" --app #{app_name}}
     system %{heroku pg:psql -c "DELETE FROM LINKS" --app #{app_name}}
     system %{heroku pg:psql -c "DELETE FROM CONTENT_ITEMS" --app #{app_name}}
     system %{heroku pg:psql -c "DELETE FROM USERS" --app #{app_name}}
 
-    #Import Contetn Items and Links
+    ## Import Content Items and Links
     system %{heroku pg:psql -c "\\COPY CONTENT_ITEMS FROM '#{content_items_file}'" --app #{app_name}}
     system %{heroku pg:psql -c "\\COPY lINKS FROM '#{links_file}'" --app #{app_name}}
 
-    # Creates default user
+    ## Creates default user
     system %{heroku run rails runner "Heroku.create_users '#{organisation.id}'" --app #{app_name}}
 
-    # Opens the application in the browser
+    ## Opens the application in the browser
     system %{heroku open --app #{app_name}}
   end
 

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -43,12 +43,12 @@ namespace :heroku do
     system %{heroku pg:psql -c "DELETE FROM CONTENT_ITEMS" --app #{app_name}}
     system %{heroku pg:psql -c "DELETE FROM USERS" --app #{app_name}}
 
-    # Creates default user
-    system %{heroku run rails runner "Heroku.create_users(#{organisation.id})" --app #{app_name}}
-
     #Import Contetn Items and Links
     system %{heroku pg:psql -c "\\COPY CONTENT_ITEMS FROM '#{content_items_file}'" --app #{app_name}}
     system %{heroku pg:psql -c "\\COPY lINKS FROM '#{links_file}'" --app #{app_name}}
+
+    # Creates default user
+    system %{heroku run rails runner "Heroku.create_users '#{organisation.id}'" --app #{app_name}}
   end
 
   def content_items_file

--- a/spec/lib/heroku_spec.rb
+++ b/spec/lib/heroku_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Heroku do
     let(:environment) { 'development' }
 
     context 'in development' do
-
       it 'returns true if `RUNNING_IN_HEROKU` is present' do
         expect(ENV).to receive(:[]).with("RUNNING_IN_HEROKU").and_return("TRUE")
 

--- a/spec/lib/heroku_spec.rb
+++ b/spec/lib/heroku_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Heroku do
+  subject { described_class }
+
+  before do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new(environment))
+  end
+
+  describe '.enabled?' do
+    let(:environment) { 'development' }
+
+    context 'in development' do
+
+      it 'returns true if `RUNNING_IN_HEROKU` is present' do
+        expect(ENV).to receive(:[]).with("RUNNING_IN_HEROKU").and_return("TRUE")
+
+        expect(described_class.enabled?).to be true
+      end
+      it 'returns false otherwise' do
+        expect(ENV).to receive(:[]).with("RUNNING_IN_HEROKU").and_return(nil)
+
+        expect(described_class.enabled?).to be false
+      end
+    end
+
+    context 'in production' do
+      let(:environment) { 'production' }
+
+      it 'returns false if `RUNNING_IN_HEROKU` is present' do
+        expect(ENV).to_not receive(:[]).with("RUNNING_IN_HEROKU")
+
+        expect(described_class.enabled?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds multiple users support in Heroku deployments

### Background

The support for login is provided by [GDS-SSO][1] which is a gem that provides everything needed to integrate with [Signon][2]

In #384, we created a `rake` task to:

1. Deploy a branch to `Heroku`
2. Populate `Heroku` with a subset of the `Content::Item`s and `Link`s (about 1000)

Once a branch is deployed to `Heroku` it runs in `development` mode, so [GDS::SSO][1] mocks [Signon][2] and [authenticates automatically to the first user of the database][3]. This means, that only one user will exist in Heroku, and we have no easy way to authenticate other users.

This PR overcomes this issue by providing a simple authentication mechanism based on an URL parameter: `heroku_user_id` and the user session. This is obviously intended to be used only in `Heroku`.

### About the solution

1. I'd rather not creating a PR to support multiple users in [GDS-SSO][1] as this would be a temporary solution that would need to change once we move to PAAS.
2. I have created a helper class `lib/heroku.rb` that detects when the code runs in Heroku: checks for the existence of the environment variable `RUNNING_IN_HEROKU` and that we are not in `production` mode.
3. I have added an initialiser `config/initializers/heroku.rb` that overrides the default security mechanisms that are in place. 
4. I've removed the login information from the admin template, and I have added support for a select combobox to choose the user.

### After

![image](https://user-images.githubusercontent.com/227328/32106843-c6a5d3ba-bb24-11e7-9288-75a1546e90af.png)


[1]: https://github.com/alphagov/gds-sso
[2]: https://github.com/alphagov/signon
[3]: https://github.com/alphagov/gds-sso/blob/82ed8e549739a5ac807565ac49123e5dffff158d/lib/gds-sso/warden_config.rb#L83