### PR TITLE
Remove logged-in constraint for iframe proxy

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,11 +37,5 @@ Rails.application.routes.draw do
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end
 
-  class ProxyAccessContraint
-    def matches?(request)
-      !request.env['warden'].try(:user).nil?
-    end
-  end
-
-  mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH, constraints: ProxyAccessContraint.new
+  mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH
 end


### PR DESCRIPTION
The iframe proxy requires that the user is logged in before serving
content. Since our Heroku deployment doesn't have a logged-in user,
this breaks the proxy.

This change removes this constraint, so the proxy should work on Heroku.