### PR TITLE
prototype: Fix counter which is currently limit to page size

### DIFF
--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs">
   <%= navigation_link "All content", audits_allocations_url, 'allocations' %>
-  <%= navigation_link "My content (#{Audits::FindContent.paged(Audits::Filter.new(allocated_to: current_user.uid, audit_status: Audits::Audit::NON_AUDITED )).count})", audits_url, 'audits'%>
+  <%= navigation_link "My content (#{Audits::FindContent.paged(Audits::Filter.new(allocated_to: current_user.uid, audit_status: Audits::Audit::NON_AUDITED, per_page: 100000 )).count})", audits_url, 'audits'%>
   <%= navigation_link "Audit progress", audits_report_url, 'reports' %>
 </ul>


### PR DESCRIPTION
[Trello card](https://trello.com/c/kmH6gRWv/632-content-allocation-number-in-my-content-tab-doesnt-go-above-100)

Quick fix for the prototype: the number of content items
listed as `My content` on the second tab is currently fixed
to the page size.

I have manually increased it to 100.000 as a way to prevent
this issue from happening again.