### PR TITLE
[WIP] Fix - Precompute Report Rows

### DIFF
--- a/app/domain/audits/report.rb
+++ b/app/domain/audits/report.rb
@@ -39,9 +39,11 @@ module Audits
 
     def rows
       @rows ||= content_items
-        .joins(:report_row)
+        .includes(:audit)
+        .includes(:linked_primary_publishing_organisation)
+        .includes(:linked_organisations)
         .unscope(:order)
-        .pluck(:data)
+        .map { |item| ReportRow.new(item).to_h }
     end
 
     def report_timestamp

--- a/app/models/audits/report_row.rb
+++ b/app/models/audits/report_row.rb
@@ -1,16 +1,15 @@
 module Audits
-  class ReportRow < ApplicationRecord
+  class ReportRow
     include FormatHelper
 
-    belongs_to :content_item, primary_key: :content_id, foreign_key: :content_id,
-               class_name: 'Content::Item'
+    attr_reader :content_item
 
-    def self.precompute(content_item)
-      find_or_initialize_by(content_item: content_item).precompute
+    def initialize(content_item)
+      @content_item = content_item
     end
 
-    def precompute
-      self.data = {
+    def to_h
+      {
         "Title" => title,
         "URL" => url,
         "Is work needed?" => is_work_needed,
@@ -31,9 +30,6 @@ module Audits
         "Last major update" => last_major_update,
         "Whitehall URL" => whitehall_url,
       }
-
-      save!
-      self
     end
 
     def title


### PR DESCRIPTION
Trello: https://trello.com/c/wSruwud5/627-csv-export-broken

The CSV export was broken due to an unexpected Array object instead of
a Hash, returned by the Audits::Report `rows` method.

A new method of retrieving reports rows was introduced, but this is not
supported by the old values anymore.

This fix aims to set data for all the item involved in the reports
generations, triggering their `after_save` callbacks.