### PR TITLE
Updates to rake task to upload to heroku

### DIFF
--- a/doc/deploy-to-heroku.md
+++ b/doc/deploy-to-heroku.md
@@ -2,14 +2,14 @@
 
 1. Install the [the Heroku Command Line Interface (CLI)][heroku-cli]
 2. [Login][login-terminal] from your terminal: you only need to do it once
-3. Deploy your current branch from your VM with: 
+3. Deploy your current branch from your VM with:
 
 ```system
-rake heroku:deploy[PR-NUMBER]`
+rake heroku:deploy[IDENTIFIER]`
 ````
 
 You can also include the following optional parameters: `organisation_name`, `number_of_content_items` and  `link_types`
- 
+
 For example, to import `500` content items from `HMRC`, we would do:
 
 ```system

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,7 +2,7 @@ namespace :heroku do
   task :deploy, %i[pr_number organisation_name number_of_content_items link_types] => :environment do |_task, options|
     raise 'Invalid parameters' unless options.pr_number && options.organisation_name
     options.with_defaults(
-      link_types: %w(organisations primary_publishing_organisation),
+      link_types: %w(organisations primary_publishing_organisation topics),
       number_of_content_items: 1000,
       organisation_name: 'HM Revenue & Customs',
     )
@@ -32,6 +32,9 @@ namespace :heroku do
       limit(options.number_of_content_items).
       pluck(:content_id)
     content_item_ids.push(organisation.content_id)
+
+    # Add topics
+    content_item_ids.concat(Content::Item.where(document_type: 'topic').pluck(:content_id))
 
     ## Export Content Items and Links
     system %{psql content_performance_manager_development -c "COPY (#{content_items_query(content_item_ids)}) TO STDOUT" > '#{content_items_file}'}

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,6 +1,6 @@
 namespace :heroku do
   task :deploy, %i[pr_number organisation_name number_of_content_items link_types] => :environment do |_task, options|
-    raise 'Invalid parameters' unless options.pr_number && options.organisation_name
+    raise 'Invalid parameters' unless options.pr_number
     options.with_defaults(
       link_types: %w(organisations primary_publishing_organisation topics),
       number_of_content_items: 1000,

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,6 +1,6 @@
 namespace :heroku do
-  task :deploy, %i[pr_number organisation_name number_of_content_items link_types] => :environment do |_task, options|
-    raise 'Invalid parameters' unless options.pr_number
+  task :deploy, %i[identifier organisation_name number_of_content_items link_types] => :environment do |_task, options|
+    raise 'Invalid parameters' unless options.identifier
     options.with_defaults(
       link_types: %w(organisations primary_publishing_organisation topics),
       number_of_content_items: 1000,
@@ -11,7 +11,7 @@ namespace :heroku do
     (organisation = Content::Item.find_by(title: options.organisation_name)) || raise("Error -> Organisation not found: #{options.organisation_name}")
 
     ## Application name
-    app_name = "cpm-prototype-#{options.pr_number}"
+    app_name = "cpm-prototype-#{options.identifier}"
 
     ## Create the Heroku app
     heroku_remote = "heroku-#{app_name}"


### PR DESCRIPTION
Addresses the following changes to the rake task
to deploy a branch to Heroku

* Use an identifier instead of a `pr_number`
* Use a default for an organisation
* Upload topics to `Heroku`