### PR TITLE
Refactor filtering feature tests into declarative style

### DIFF
--- a/app/assets/javascripts/organisation-autocomplete.js
+++ b/app/assets/javascripts/organisation-autocomplete.js
@@ -24,7 +24,7 @@
           '<button type="button" ' +
           '        id="add-organisation" ' +
           '        class="btn btn-link add-organisation js-add-organisation"' +
-          '        data-test="add-organisation">' +
+          '        data-test-id="add-organisation">' +
           '  Add another organisation' +
           '</button>'
         ).click(addOrganisation);

--- a/app/assets/javascripts/organisation-autocomplete.js
+++ b/app/assets/javascripts/organisation-autocomplete.js
@@ -23,7 +23,8 @@
         return $(
           '<button type="button" ' +
           '        id="add-organisation" ' +
-          '        class="btn btn-link add-organisation js-add-organisation">' +
+          '        class="btn btn-link add-organisation js-add-organisation"' +
+          '        data-test="add-organisation">' +
           '  Add another organisation' +
           '</button>'
         ).click(addOrganisation);

--- a/app/views/audits/audits/_content_item.html.erb
+++ b/app/views/audits/audits/_content_item.html.erb
@@ -1,8 +1,8 @@
 <tr>
-  <td data-test="title">
+  <td data-test-id="title">
     <%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %>
   </td>
-  <td data-test="page-views">
+  <td data-test-id="page-views">
     <%= content_item.six_months_page_views %>
   </td>
 </tr>

--- a/app/views/audits/audits/_content_item.html.erb
+++ b/app/views/audits/audits/_content_item.html.erb
@@ -1,4 +1,8 @@
 <tr>
-  <td><%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %></td>
-  <td><%= content_item.six_months_page_views %></td>
+  <td data-test="title">
+    <%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %>
+  </td>
+  <td data-test="page-views">
+    <%= content_item.six_months_page_views %>
+  </td>
 </tr>

--- a/app/views/audits/audits/_content_items.html.erb
+++ b/app/views/audits/audits/_content_items.html.erb
@@ -1,6 +1,6 @@
 <%= render 'audits/common/counter', count: content_items.total_count  %>
 
-<table class="table table-bordered table-hover" data-test="filter-list">
+<table class="table table-bordered table-hover" data-test-id="filter-list">
   <thead>
   <tr class="table-header">
     <td>Title</td>

--- a/app/views/audits/audits/_content_items.html.erb
+++ b/app/views/audits/audits/_content_items.html.erb
@@ -1,6 +1,6 @@
 <%= render 'audits/common/counter', count: content_items.total_count  %>
 
-<table class="table table-bordered table-hover filter-list">
+<table class="table table-bordered table-hover" data-test="filter-list">
   <thead>
   <tr class="table-header">
     <td>Title</td>
@@ -8,7 +8,7 @@
   </tr>
   </thead>
   <tbody>
-  <%= render collection: content_items, partial: "content_item", class: "filter-list" %>
+  <%= render collection: content_items, partial: "content_item" %>
   </tbody>
 </table>
 

--- a/app/views/audits/audits/_content_items.html.erb
+++ b/app/views/audits/audits/_content_items.html.erb
@@ -1,6 +1,6 @@
 <%= render 'audits/common/counter', count: content_items.total_count  %>
 
-<table class="table table-bordered table-hover">
+<table class="table table-bordered table-hover filter-list">
   <thead>
   <tr class="table-header">
     <td>Title</td>
@@ -8,7 +8,7 @@
   </tr>
   </thead>
   <tbody>
-  <%= render collection: content_items, partial: 'content_item' %>
+  <%= render collection: content_items, partial: "content_item", class: "filter-list" %>
   </tbody>
 </table>
 

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -5,5 +5,6 @@
                  class: "form-control",
                  data: {
                    tracking_id: "allocated-to",
+                   test: "allocated-to"
                  } %>
 </div>

--- a/app/views/audits/common/_allocated_to.html.erb
+++ b/app/views/audits/common/_allocated_to.html.erb
@@ -5,6 +5,6 @@
                  class: "form-control",
                  data: {
                    tracking_id: "allocated-to",
-                   test: "allocated-to"
+                   test_id: "allocated-to"
                  } %>
 </div>

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group audit-status">
   <%= label_tag :audit_status, 'Audit status' %>
 
   <%= render partial: "components/radio_button",

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group" data-test="audit-status">
+<div class="form-group" data-test-id="audit-status">
   <%= label_tag :audit_status, 'Audit status' %>
 
   <%= render partial: "components/radio_button",

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group audit-status">
+<div class="form-group" data-test="audit-status">
   <%= label_tag :audit_status, 'Audit status' %>
 
   <%= render partial: "components/radio_button",

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -3,7 +3,7 @@
   <%= select_tag :document_type,
                  document_type_options_for_select(params[:document_type]),
                  include_blank: "All",
-                 class: "form-control",
+                 class: "form-control document-type",
                  data: {
                    tracking_id: "document-type",
                  }%>

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -6,6 +6,6 @@
                  class: "form-control",
                  data: {
                    tracking_id: "document-type",
-                   test: "document-type"
+                   test_id: "document-type"
                  }%>
 </div>

--- a/app/views/audits/common/_document_type.html.erb
+++ b/app/views/audits/common/_document_type.html.erb
@@ -3,8 +3,9 @@
   <%= select_tag :document_type,
                  document_type_options_for_select(params[:document_type]),
                  include_blank: "All",
-                 class: "form-control document-type",
+                 class: "form-control",
                  data: {
                    tracking_id: "document-type",
+                   test: "document-type"
                  }%>
 </div>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -1,14 +1,15 @@
 <div class="form-group" data-module="organisation-autocomplete">
   <%= label_tag :organisations %>
-  <div class="organisation-select-wrapper js-organisation-select-wrapper">
+  <div class="organisation-select-wrapper js-organisation-select-wrapper" data-test="organisations">
     <%= hidden_field_tag("organisations[]", [""], id: nil) %>
     <%= select_tag :organisations,
                    organisation_options_for_select(params[:organisations]),
                    include_blank: true,
                    multiple: true,
-                   class: "form-control organisation-select js-organisation-select",
+                   class: "form-control js-organisation-select",
                    data: {
                        tracking_id: "organisations",
+                       test: "organisations-select"
                    } %>
   </div>
 </div>

--- a/app/views/audits/common/_organisations.html.erb
+++ b/app/views/audits/common/_organisations.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group" data-module="organisation-autocomplete">
   <%= label_tag :organisations %>
-  <div class="organisation-select-wrapper js-organisation-select-wrapper" data-test="organisations">
+  <div class="organisation-select-wrapper js-organisation-select-wrapper" data-test-id="organisations">
     <%= hidden_field_tag("organisations[]", [""], id: nil) %>
     <%= select_tag :organisations,
                    organisation_options_for_select(params[:organisations]),
@@ -9,7 +9,7 @@
                    class: "form-control js-organisation-select",
                    data: {
                        tracking_id: "organisations",
-                       test: "organisations-select"
+                       test_id: "organisations-select"
                    } %>
   </div>
 </div>

--- a/app/views/audits/common/_primary.html.erb
+++ b/app/views/audits/common/_primary.html.erb
@@ -1,5 +1,5 @@
-<div class="form-group" data-test="primary-orgs">
+<div class="form-group" data-test-id="primary-orgs">
   <%= hidden_field_tag :primary, false, id: nil %>
   <%= check_box_tag :primary, true, params[:primary] == 'true' %>
-  <%= label_tag :primary, "Primary organisation only", data: { test: "primary-orgs-label" } %>
+  <%= label_tag :primary, "Primary organisation only", data: { test_id: "primary-orgs-label" } %>
 </div>

--- a/app/views/audits/common/_primary.html.erb
+++ b/app/views/audits/common/_primary.html.erb
@@ -1,5 +1,5 @@
-<div class="form-group primary-orgs">
+<div class="form-group" data-test="primary-orgs">
   <%= hidden_field_tag :primary, false, id: nil %>
   <%= check_box_tag :primary, true, params[:primary] == 'true' %>
-  <%= label_tag :primary, "Primary organisation only" %>
+  <%= label_tag :primary, "Primary organisation only", data: { test: "primary-orgs-label" } %>
 </div>

--- a/app/views/audits/common/_primary.html.erb
+++ b/app/views/audits/common/_primary.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group primary-orgs">
   <%= hidden_field_tag :primary, false, id: nil %>
   <%= check_box_tag :primary, true, params[:primary] == 'true' %>
   <%= label_tag :primary, "Primary organisation only" %>

--- a/app/views/audits/common/_sort.html.erb
+++ b/app/views/audits/common/_sort.html.erb
@@ -6,7 +6,7 @@
                  class: "form-control",
                  data: {
                    tracking_id: "sort-by",
-                   test: "sort-by"
+                   test_id: "sort-by"
                  }%>
 </div>
 

--- a/app/views/audits/common/_sort.html.erb
+++ b/app/views/audits/common/_sort.html.erb
@@ -3,7 +3,7 @@
   <%= select_tag :sort_by,
                  sort_by_options_for_select(params[:sort_by]),
                  include_blank: "Page views",
-                 class: "form-control",
+                 class: "form-control sort-by",
                  data: {
                    tracking_id: "sort-by",
                  }%>

--- a/app/views/audits/common/_sort.html.erb
+++ b/app/views/audits/common/_sort.html.erb
@@ -3,9 +3,10 @@
   <%= select_tag :sort_by,
                  sort_by_options_for_select(params[:sort_by]),
                  include_blank: "Page views",
-                 class: "form-control sort-by",
+                 class: "form-control",
                  data: {
                    tracking_id: "sort-by",
+                   test: "sort-by"
                  }%>
 </div>
 

--- a/app/views/audits/common/_submit.html.erb
+++ b/app/views/audits/common/_submit.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block", data: { test: "apply-filters" } %>
+  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block", data: { test_id: "apply-filters" } %>
 </div>

--- a/app/views/audits/common/_submit.html.erb
+++ b/app/views/audits/common/_submit.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block" %>
+  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block apply-filters" %>
 </div>

--- a/app/views/audits/common/_submit.html.erb
+++ b/app/views/audits/common/_submit.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block apply-filters" %>
+  <%= submit_tag 'Apply filters', name: 'filter', class: "btn btn-default btn-block", data: { test: "apply-filters" } %>
 </div>

--- a/app/views/audits/common/_title.html.erb
+++ b/app/views/audits/common/_title.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group">
   <%= label_tag 'query', 'Search', class: '' %>
-  <%= text_field_tag 'query', params[:query], class: 'form-control', data: { test: "search" } %>
+  <%= text_field_tag 'query', params[:query], class: 'form-control', data: { test_id: "search" } %>
 </div>

--- a/app/views/audits/common/_title.html.erb
+++ b/app/views/audits/common/_title.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group">
   <%= label_tag 'query', 'Search', class: '' %>
-  <%= text_field_tag 'query', params[:query], class: 'form-control' %>
+  <%= text_field_tag 'query', params[:query], class: 'form-control', data: { test: "search" } %>
 </div>

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -95,30 +95,13 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_does_not_show_content_of_other_type
   end
 
-  context "With some organisations and documents set up" do
-    context "when showing content regardless of audit status" do
-      scenario "Reseting page to 1 after filtering" do
-        create_list(:content_item, 100)
-
-        given_content_belonging_to_departments
-        when_i_go_to_filter_content_to_audit
-
-        @filter_audit_list.filter_form do |form|
-          form.allocated_to.select "Anyone"
-          form.audit_status.choose "All"
-          form.apply_filters.click
-        end
-
-        @filter_audit_list.pagination.click_on "2"
-
-        @filter_audit_list.filter_form do |form|
-          form.audit_status.choose "Not audited"
-          form.apply_filters.click
-        end
-
-        expect(page).to have_css(".pagination .active", text: "1")
-      end
-    end
+  scenario "Reseting page to 1 after filtering" do
+    given_101_content_items
+    when_i_go_to_filter_content_to_audit
+    and_filter_by_all_content_allocated_to_anyone
+    and_i_click_to_the_second_page_of_results
+    and_i_change_the_filters_to_not_audited
+    then_the_list_goes_down_to_one_page
   end
 
 private
@@ -411,5 +394,24 @@ private
 
   def and_does_not_show_content_of_other_type
     expect(@filter_audit_list.list).to have_no_content("Flying to countries abroad")
+  end
+
+  def given_101_content_items
+    create_list(:content_item, 101)
+  end
+
+  def and_i_click_to_the_second_page_of_results
+    @filter_audit_list.pagination.click_on "2"
+  end
+
+  def and_i_change_the_filters_to_not_audited
+    @filter_audit_list.filter_form do |form|
+      form.audit_status.choose "Not audited"
+      form.apply_filters.click
+    end
+  end
+
+  def then_the_list_goes_down_to_one_page
+    expect(page).to have_css(".pagination .active", text: "1")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -45,22 +45,15 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     the_primary_orgs_checkbox_is_toggled_by_the_label
   end
 
+  scenario "organisation options are in alphabetical order" do
+    given_content_belonging_to_departments
+    when_i_go_to_filter_content_to_audit
+    the_organisation_filter_options_are_alphabetical
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
       context "filtering by organisation" do
-        scenario "organisations are in alphabetical order" do
-          given_content_belonging_to_departments
-          when_i_go_to_filter_content_to_audit
-
-          @filter_audit_list.filter_form.wait_until_organisations_visible
-
-          within(@filter_audit_list.filter_form.organisations) do
-            options = page.all("option")
-
-            expect(options.map(&:text)).to eq ["", "DFE", "HMRC"]
-          end
-        end
-
         scenario "using autocomplete", js: true do
           given_content_belonging_to_departments
           when_i_go_to_filter_content_to_audit
@@ -353,5 +346,15 @@ private
 
   def and_the_list_does_not_show_content_for_other_orgs
     expect(@filter_audit_list.list).to have_no_content("Tree felling")
+  end
+
+  def the_organisation_filter_options_are_alphabetical
+    @filter_audit_list.filter_form do |form|
+      within(form.organisations) do
+        options = page.all("option")
+
+        expect(options.map(&:text)).to eq ["", "DFE", "HMRC"]
+      end
+    end
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -11,22 +11,22 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     given_content_belonging_to_departments
     when_viewing_content_to_audit
     and_filtering_to_audited_content_allocated_to_anyone
-    then_the_filter_list_shows_audited_item
-    and_the_list_does_not_show_unaudited_content
+    then_the_filtered_list_shows_audited_content
+    and_the_filtered_list_does_not_show_unaudited_content
   end
 
   scenario "filtering for content regardless of audit status" do
     given_content_belonging_to_departments
     when_viewing_content_to_audit
     and_filtering_by_all_content_allocated_to_anyone
-    then_the_list_shows_all_content
+    then_the_filtered_list_shows_all_content
   end
 
   scenario "filtering by primary organisation" do
     given_content_belonging_to_departments
     when_viewing_content_to_audit
     and_filtering_to_all_content_for_anyone_belonging_to_a_primary_org
-    then_the_list_shows_primary_org_content
+    then_the_filtered_list_shows_primary_org_content
     and_does_not_show_other_department_content
   end
 
@@ -34,7 +34,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     given_content_belonging_to_departments
     when_viewing_content_to_audit
     and_filtering_to_non_primary_orgs
-    then_the_list_shows_content_for_org
+    then_the_filtered_list_shows_content_for_org
     and_the_list_does_not_show_content_for_other_orgs
   end
 
@@ -54,7 +54,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     given_content_belonging_to_departments
     when_viewing_content_to_audit
     and_part_of_an_org_name_is_typed_in_the_organisations_filter_field
-    then_the_field_is_filled_with_the_suggestion_i_chose
+    then_the_field_is_filled_with_the_suggestion_chosen
     and_when_applying_the_filters
     then_the_option_is_still_set
     and_the_url_contains_the_filter_option_in_query_param
@@ -74,7 +74,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     given_content_with_known_titles
     when_viewing_content_to_audit
     and_searching_by_title_within_all_content_assigned_to_anyone
-    then_the_list_shows_the_one_item_matching
+    then_the_filtered_list_shows_the_one_content_matching
     and_does_not_show_other_content_that_do_not_match
   end
 
@@ -90,8 +90,8 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_one_of_the_content_is_guidance
     when_viewing_content_to_audit
     and_filtering_by_guide_type_from_all_content_allocated_to_anyone
-    then_the_list_shows_content_for_that_type
-    and_does_not_show_content_of_other_type
+    then_the_filtered_list_shows_content_for_that_type
+    and_does_not_show_content_of_other_types
   end
 
   scenario "Reseting page to 1 after filtering" do
@@ -100,7 +100,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_filtering_by_all_content_allocated_to_anyone
     and_clicking_to_the_second_page_of_results
     and_changing_the_filters_to_not_audited
-    then_the_list_goes_down_to_one_page
+    then_the_filtered_list_goes_down_to_one_page
   end
 
 private
@@ -223,14 +223,14 @@ private
     expect(@audit_content_page.filter_form.audit_status).to have_checked_field("audit_status_audited")
   end
 
-  def then_the_filter_list_shows_audited_item
+  def then_the_filtered_list_shows_audited_content
     @audits_filter_list = ContentAuditTool.new.audits_filter_list
     listing = @audits_filter_list.filter_listings.first
 
     expect(listing.title).to have_text("Tree felling")
   end
 
-  def and_the_list_does_not_show_unaudited_content
+  def and_the_filtered_list_does_not_show_unaudited_content
     @audits_filter_list.filter_listings.each do |listing|
       expect(listing.title).to have_no_text("Forest management")
     end
@@ -247,7 +247,7 @@ private
     expect(@audit_content_page.filter_form.audit_status).to have_checked_field("audit_status_all")
   end
 
-  def then_the_list_shows_all_content
+  def then_the_filtered_list_shows_all_content
     expect(@audit_content_page).to have_content("VAT")
     expect(@audit_content_page).to have_content("Tree felling")
     expect(@audit_content_page).to have_content("Forest management")
@@ -263,7 +263,7 @@ private
     end
   end
 
-  def then_the_list_shows_primary_org_content
+  def then_the_filtered_list_shows_primary_org_content
     @audits_filter_list = ContentAuditTool.new.audits_filter_list
     listing = @audits_filter_list.filter_listings.first
 
@@ -286,7 +286,7 @@ private
     end
   end
 
-  def then_the_list_shows_content_for_org
+  def then_the_filtered_list_shows_content_for_org
     @audits_filter_list = ContentAuditTool.new.audits_filter_list
 
     expect(@audits_filter_list.filter_listings.size).to eq(2)
@@ -325,7 +325,7 @@ private
     end
   end
 
-  def then_the_field_is_filled_with_the_suggestion_i_chose
+  def then_the_field_is_filled_with_the_suggestion_chosen
     @audit_content_page.filter_form do |form|
       expect(form).to have_field("Organisations", with: "HMRC")
     end
@@ -389,7 +389,7 @@ private
     end
   end
 
-  def then_the_list_shows_the_one_item_matching
+  def then_the_filtered_list_shows_the_one_content_matching
     @audits_filter_list = ContentAuditTool.new.audits_filter_list
 
     expect(@audits_filter_list).to have_filter_listings
@@ -422,7 +422,7 @@ private
     end
   end
 
-  def then_the_list_shows_content_for_that_type
+  def then_the_filtered_list_shows_content_for_that_type
     @audits_filter_list = ContentAuditTool.new.audits_filter_list
     @audits_filter_list.wait_for_filter_listings
 
@@ -432,7 +432,7 @@ private
     expect(listing.title.text).to eq("HMRC")
   end
 
-  def and_does_not_show_content_of_other_type
+  def and_does_not_show_content_of_other_types
     @audits_filter_list = ContentAuditTool.new.audits_filter_list
     @audits_filter_list.filter_listings.each do |listing|
       expect(listing.title.text).not_to eq("Flying to countries abroad")
@@ -455,7 +455,7 @@ private
     end
   end
 
-  def then_the_list_goes_down_to_one_page
+  def then_the_filtered_list_goes_down_to_one_page
     expect(page).to have_css(".pagination .active", text: "1")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -32,25 +32,16 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_does_not_show_other_department_content
   end
 
+  scenario "filtering by primary and non-primary organisation" do
+    given_content_belonging_to_departments
+    when_i_go_to_filter_content_to_audit
+    and_i_filter_to_non_primary_orgs
+    then_the_list_shows_content_for_org
+    and_the_list_does_not_show_content_for_other_orgs
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
-      scenario "filtering by organisation" do
-        given_content_belonging_to_departments
-        when_i_go_to_filter_content_to_audit
-
-        @filter_audit_list.filter_form do |form|
-          form.allocated_to.select "Anyone"
-          form.audit_status.choose "All"
-          form.primary_orgs.uncheck "Primary organisation only"
-          form.organisations.select "HMRC"
-          form.apply_filters.click
-        end
-
-        expect(@filter_audit_list.list).to have_content("VAT")
-        expect(@filter_audit_list.list).to have_content("Travel insurance")
-        expect(@filter_audit_list.list).to have_no_content("Tree felling")
-      end
-
       scenario "toggling the primary org checkbox by clicking its label" do
         filter_audit_list = ContentAuditTool.new.filter_audit_list_page
         filter_audit_list.load
@@ -340,6 +331,25 @@ private
   end
 
   def and_does_not_show_other_department_content
+    expect(@filter_audit_list.list).to have_no_content("Tree felling")
+  end
+
+  def and_i_filter_to_non_primary_orgs
+    @filter_audit_list.filter_form do |form|
+      form.allocated_to.select "Anyone"
+      form.audit_status.choose "All"
+      form.primary_orgs.uncheck "Primary organisation only"
+      form.organisations.select "HMRC"
+      form.apply_filters.click
+    end
+  end
+
+  def then_the_list_shows_content_for_org
+    expect(@filter_audit_list.list).to have_content("VAT")
+    expect(@filter_audit_list.list).to have_content("Travel insurance")
+  end
+
+  def and_the_list_does_not_show_content_for_other_orgs
     expect(@filter_audit_list.list).to have_no_content("Tree felling")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -17,23 +17,14 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_the_list_does_not_show_unaudited_content
   end
 
+  scenario "filtering for content regardless of audit status" do
+    given_content_belonging_to_departments
+    when_i_go_to_filter_content_to_audit
+    and_filter_by_all_content_allocated_to_anyone
+    then_the_list_shows_all_content
+  end
+
   context "With some organisations and documents set up" do
-    scenario "filtering for content regardless of audit status" do
-      given_content_belonging_to_departments
-      when_i_go_to_filter_content_to_audit
-
-      @filter_audit_list.filter_form do |form|
-        form.allocated_to.select "Anyone"
-        form.audit_status.choose "All"
-
-        form.apply_filters.click
-      end
-
-      expect(@filter_audit_list).to have_content("Tree felling")
-      expect(@filter_audit_list).to have_content("Forest management")
-      expect(@filter_audit_list.filter_form.audit_status).to have_checked_field("audit_status_all")
-    end
-
     context "when showing content regardless of audit status" do
       scenario "filtering by primary organisation" do
         given_content_belonging_to_departments
@@ -327,5 +318,22 @@ private
 
   def and_the_list_does_not_show_unaudited_content
     expect(@filter_audit_list.list).to have_no_content("Forest management")
+  end
+
+  def and_filter_by_all_content_allocated_to_anyone
+    @filter_audit_list.filter_form do |form|
+      form.allocated_to.select "Anyone"
+      form.audit_status.choose "All"
+
+      form.apply_filters.click
+    end
+
+    expect(@filter_audit_list.filter_form.audit_status).to have_checked_field("audit_status_all")
+  end
+
+  def then_the_list_shows_all_content
+    expect(@filter_audit_list).to have_content("VAT")
+    expect(@filter_audit_list).to have_content("Tree felling")
+    expect(@filter_audit_list).to have_content("Forest management")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -1,6 +1,4 @@
 RSpec.feature "Filter Content Items to Audit", type: :feature do
-  let!(:me) { create(:user) }
-
   scenario "List filters by my unaudited content by default" do
     given_i_have_unaudited_content
     when_i_go_to_filter_content_to_audit
@@ -41,6 +39,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
   end
 
   scenario "toggling the primary org checkbox by clicking its label" do
+    given_i_am_an_audit_tool_user
     when_i_go_to_filter_content_to_audit
     the_primary_orgs_checkbox_is_toggled_by_the_label
   end
@@ -106,7 +105,13 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
 
 private
 
+  def given_i_am_an_audit_tool_user
+    create(:user)
+  end
+
   def given_i_have_unaudited_content
+    me = create(:user)
+
     create(
       :content_item,
       title: "The Famous Five",
@@ -348,6 +353,7 @@ private
   end
 
   def given_content_with_known_titles
+    create :user
     create :content_item, title: "some text"
     create :content_item, title: "another text"
   end
@@ -397,6 +403,7 @@ private
   end
 
   def given_101_content_items
+    create :user
     create_list(:content_item, 101)
   end
 

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -1,115 +1,115 @@
 RSpec.feature "Filter Content Items to Audit", type: :feature do
   scenario "List filters by my unaudited content by default" do
-    given_i_have_unaudited_content
-    when_i_go_to_filter_content_to_audit
-    and_we_filter_to_unaudited_content_allocated_to_me_by_default
+    given_unaudited_content
+    when_viewing_content_to_audit
+    and_filtering_to_unaudited_content_allocated_to_me_by_default
     then_the_filtered_list_shows_content_allocated_to_me
-    and_we_do_not_show_unaudited_content_not_allocated_to_me
+    and_unaudited_content_not_allocated_to_me_is_not_shown
   end
 
   scenario "filtering audited content" do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
-    and_i_filter_to_audited_content_allocated_to_anyone
+    when_viewing_content_to_audit
+    and_filtering_to_audited_content_allocated_to_anyone
     then_the_filter_list_shows_audited_item
     and_the_list_does_not_show_unaudited_content
   end
 
   scenario "filtering for content regardless of audit status" do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
-    and_filter_by_all_content_allocated_to_anyone
+    when_viewing_content_to_audit
+    and_filtering_by_all_content_allocated_to_anyone
     then_the_list_shows_all_content
   end
 
   scenario "filtering by primary organisation" do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
-    and_i_filter_to_all_content_for_anyone_belonging_to_a_primary_org
+    when_viewing_content_to_audit
+    and_filtering_to_all_content_for_anyone_belonging_to_a_primary_org
     then_the_list_shows_primary_org_content
     and_does_not_show_other_department_content
   end
 
   scenario "filtering by primary and non-primary organisation" do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
-    and_i_filter_to_non_primary_orgs
+    when_viewing_content_to_audit
+    and_filtering_to_non_primary_orgs
     then_the_list_shows_content_for_org
     and_the_list_does_not_show_content_for_other_orgs
   end
 
   scenario "toggling the primary org checkbox by clicking its label" do
-    given_i_am_an_audit_tool_user
-    when_i_go_to_filter_content_to_audit
+    given_an_audit_tool_user
+    when_viewing_content_to_audit
     the_primary_orgs_checkbox_is_toggled_by_the_label
   end
 
   scenario "organisation options are in alphabetical order" do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
+    when_viewing_content_to_audit
     the_organisation_filter_options_are_alphabetical
   end
 
   scenario "using organisation filter option autocomplete", js: true do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
-    and_i_type_part_of_an_org_name_in_the_organisations_filter_field
+    when_viewing_content_to_audit
+    and_part_of_an_org_name_is_typed_in_the_organisations_filter_field
     then_the_field_is_filled_with_the_suggestion_i_chose
-    and_when_we_apply_the_filters
+    and_when_applying_the_filters
     then_the_option_is_still_set
     and_the_url_contains_the_filter_option_in_query_param
   end
 
   scenario "multiple", js: true do
     given_content_belonging_to_departments
-    when_i_go_to_filter_content_to_audit
-    and_i_type_part_of_two_org_names_in_the_organisations_filter_field
+    when_viewing_content_to_audit
+    and_part_of_two_org_names_are_typed_in_the_organisations_filter_field
     then_there_are_fields_filled_with_the_suggestions_chosen
-    and_when_we_apply_the_filters
+    and_when_applying_the_filters
     then_the_options_are_still_set
     and_the_url_contains_the_filter_options_in_query_params
   end
 
   scenario "filtering by title" do
     given_content_with_known_titles
-    when_i_go_to_filter_content_to_audit
-    and_i_search_by_title_within_all_content_assigned_to_anyone
+    when_viewing_content_to_audit
+    and_searching_by_title_within_all_content_assigned_to_anyone
     then_the_list_shows_the_one_item_matching
     and_does_not_show_other_content_that_do_not_match
   end
 
   scenario "show the query entered by the user after filtering" do
     given_content_with_known_titles
-    when_i_go_to_filter_content_to_audit
-    and_i_search_by_title_within_all_content_assigned_to_anyone
+    when_viewing_content_to_audit
+    and_searching_by_title_within_all_content_assigned_to_anyone
     then_the_search_box_still_shows_the_search_query
   end
 
   scenario "filtering by content type" do
     given_content_belonging_to_departments
     and_one_of_the_content_is_guidance
-    when_i_go_to_filter_content_to_audit
-    and_filter_by_guide_type_from_all_content_allocated_to_anyone
+    when_viewing_content_to_audit
+    and_filtering_by_guide_type_from_all_content_allocated_to_anyone
     then_the_list_shows_content_for_that_type
     and_does_not_show_content_of_other_type
   end
 
   scenario "Reseting page to 1 after filtering" do
     given_101_content_items
-    when_i_go_to_filter_content_to_audit
-    and_filter_by_all_content_allocated_to_anyone
-    and_i_click_to_the_second_page_of_results
-    and_i_change_the_filters_to_not_audited
+    when_viewing_content_to_audit
+    and_filtering_by_all_content_allocated_to_anyone
+    and_clicking_to_the_second_page_of_results
+    and_changing_the_filters_to_not_audited
     then_the_list_goes_down_to_one_page
   end
 
 private
 
-  def given_i_am_an_audit_tool_user
+  def given_an_audit_tool_user
     create(:user)
   end
 
-  def given_i_have_unaudited_content
+  def given_unaudited_content
     me = create(:user)
 
     create(
@@ -132,12 +132,12 @@ private
     create(:audit, content_item: wishing_chair, user: me)
   end
 
-  def when_i_go_to_filter_content_to_audit
+  def when_viewing_content_to_audit
     @filter_audit_list = ContentAuditTool.new.filter_audit_list_page
     @filter_audit_list.load
   end
 
-  def and_we_filter_to_unaudited_content_allocated_to_me_by_default
+  def and_filtering_to_unaudited_content_allocated_to_me_by_default
     @filter_audit_list.filter_form do |form|
       expect(form).to have_select("allocated_to", selected: "Me")
       expect(form.audit_status).to have_checked_field("Not audited")
@@ -148,7 +148,7 @@ private
     expect(@filter_audit_list).to have_list(text: "The Famous Five")
   end
 
-  def and_we_do_not_show_unaudited_content_not_allocated_to_me
+  def and_unaudited_content_not_allocated_to_me_is_not_shown
     expect(@filter_audit_list.list).to have_no_content("The Secret Seven")
     expect(@filter_audit_list.list).to have_no_content("The Wishing Chair")
   end
@@ -207,7 +207,7 @@ private
     create(:audit, content_item: felling)
   end
 
-  def and_i_filter_to_audited_content_allocated_to_anyone
+  def and_filtering_to_audited_content_allocated_to_anyone
     @filter_audit_list.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "Audited"
@@ -226,7 +226,7 @@ private
     expect(@filter_audit_list.list).to have_no_content("Forest management")
   end
 
-  def and_filter_by_all_content_allocated_to_anyone
+  def and_filtering_by_all_content_allocated_to_anyone
     @filter_audit_list.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
@@ -243,7 +243,7 @@ private
     expect(@filter_audit_list).to have_content("Forest management")
   end
 
-  def and_i_filter_to_all_content_for_anyone_belonging_to_a_primary_org
+  def and_filtering_to_all_content_for_anyone_belonging_to_a_primary_org
     @filter_audit_list.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
@@ -261,7 +261,7 @@ private
     expect(@filter_audit_list.list).to have_no_content("Tree felling")
   end
 
-  def and_i_filter_to_non_primary_orgs
+  def and_filtering_to_non_primary_orgs
     @filter_audit_list.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
@@ -290,7 +290,7 @@ private
     end
   end
 
-  def and_i_type_part_of_an_org_name_in_the_organisations_filter_field
+  def and_part_of_an_org_name_is_typed_in_the_organisations_filter_field
     expect(@filter_audit_list.url).not_to include("organisations%5B%5D=#{@hmrc.content_id}")
 
     @filter_audit_list.filter_form do |form|
@@ -309,7 +309,7 @@ private
     end
   end
 
-  def and_when_we_apply_the_filters
+  def and_when_applying_the_filters
     @filter_audit_list.filter_form do |form|
       form.apply_filters.click
     end
@@ -325,7 +325,7 @@ private
     expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
   end
 
-  def and_i_type_part_of_two_org_names_in_the_organisations_filter_field
+  def and_part_of_two_org_names_are_typed_in_the_organisations_filter_field
     @filter_audit_list.filter_form do |form|
       form.wait_until_organisations_visible
       form.add_organisations.click
@@ -358,7 +358,7 @@ private
     create :content_item, title: "another text"
   end
 
-  def and_i_search_by_title_within_all_content_assigned_to_anyone
+  def and_searching_by_title_within_all_content_assigned_to_anyone
     @filter_audit_list.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
@@ -384,7 +384,7 @@ private
     @hmrc.update!(document_type: "guide")
   end
 
-  def and_filter_by_guide_type_from_all_content_allocated_to_anyone
+  def and_filtering_by_guide_type_from_all_content_allocated_to_anyone
     @filter_audit_list.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
@@ -407,11 +407,11 @@ private
     create_list(:content_item, 101)
   end
 
-  def and_i_click_to_the_second_page_of_results
+  def and_clicking_to_the_second_page_of_results
     @filter_audit_list.pagination.click_on "2"
   end
 
-  def and_i_change_the_filters_to_not_audited
+  def and_changing_the_filters_to_not_audited
     @filter_audit_list.filter_form do |form|
       form.audit_status.choose "Not audited"
       form.apply_filters.click

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -51,33 +51,19 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     the_organisation_filter_options_are_alphabetical
   end
 
+  scenario "using organisation filter option autocomplete", js: true do
+    given_content_belonging_to_departments
+    when_i_go_to_filter_content_to_audit
+    and_i_type_part_of_an_org_name_in_the_organisations_filter_field
+    then_the_field_is_filled_with_the_suggestion_i_chose
+    and_when_we_apply_the_filters
+    then_the_option_is_still_set
+    and_the_url_contains_the_filter_option_in_query_param
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
       context "filtering by organisation" do
-        scenario "using autocomplete", js: true do
-          given_content_belonging_to_departments
-          when_i_go_to_filter_content_to_audit
-
-          expect(@filter_audit_list.url).not_to include("organisations%5B%5D=#{@hmrc.content_id}")
-
-          @filter_audit_list.filter_form do |form|
-            form.wait_until_organisations_visible
-
-            expect(form).to have_organisations_input(visible: :visible)
-            expect(form).to have_organisations_select(visible: :hidden)
-
-            form.organisations_input.send_keys("HM", :down, :enter)
-
-            expect(form).to have_field("Organisations", with: "HMRC")
-
-            form.apply_filters.click
-
-            expect(form).to have_selector("option[selected][value=\"#{@hmrc.content_id}\"]", visible: :hidden)
-          end
-
-          expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
-        end
-
         scenario "multiple", js: true do
           given_content_belonging_to_departments
           when_i_go_to_filter_content_to_audit
@@ -356,5 +342,40 @@ private
         expect(options.map(&:text)).to eq ["", "DFE", "HMRC"]
       end
     end
+  end
+
+  def and_i_type_part_of_an_org_name_in_the_organisations_filter_field
+    expect(@filter_audit_list.url).not_to include("organisations%5B%5D=#{@hmrc.content_id}")
+
+    @filter_audit_list.filter_form do |form|
+      form.wait_until_organisations_visible
+
+      expect(form).to have_organisations_input(visible: :visible)
+      expect(form).to have_organisations_select(visible: :hidden)
+
+      form.organisations_input.send_keys("HM", :down, :enter)
+    end
+  end
+
+  def then_the_field_is_filled_with_the_suggestion_i_chose
+    @filter_audit_list.filter_form do |form|
+      expect(form).to have_field("Organisations", with: "HMRC")
+    end
+  end
+
+  def and_when_we_apply_the_filters
+    @filter_audit_list.filter_form do |form|
+      form.apply_filters.click
+    end
+  end
+
+  def then_the_option_is_still_set
+    @filter_audit_list.filter_form do |form|
+      expect(form).to have_selector("option[selected][value=\"#{@hmrc.content_id}\"]", visible: :hidden)
+    end
+  end
+
+  def and_the_url_contains_the_filter_option_in_query_param
+    expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -61,31 +61,18 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_the_url_contains_the_filter_option_in_query_param
   end
 
+  scenario "multiple", js: true do
+    given_content_belonging_to_departments
+    when_i_go_to_filter_content_to_audit
+    and_i_type_part_of_two_org_names_in_the_organisations_filter_field
+    then_there_are_fields_filled_with_the_suggestions_chosen
+    and_when_we_apply_the_filters
+    then_the_options_are_still_set
+    and_the_url_contains_the_filter_options_in_query_params
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
-      context "filtering by organisation" do
-        scenario "multiple", js: true do
-          given_content_belonging_to_departments
-          when_i_go_to_filter_content_to_audit
-
-          @filter_audit_list.filter_form do |form|
-            form.wait_until_organisations_visible
-            form.add_organisations.click
-
-            page.find_all("#organisations")[1].send_keys("DF", :down, :enter)
-            page.find_all("#organisations")[0].send_keys("HM", :down, :enter)
-
-            expect(@filter_audit_list).to have_field("Organisations", with: "DFE")
-            expect(@filter_audit_list).to have_field("Organisations", with: "HMRC")
-
-            form.apply_filters.click
-
-            expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@dfe.content_id}")
-            expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
-          end
-        end
-      end
-
       context "filtering by title" do
         scenario "the user enters a text in the search box and retrieves a filtered list" do
           given_content_belonging_to_departments
@@ -376,6 +363,33 @@ private
   end
 
   def and_the_url_contains_the_filter_option_in_query_param
+    expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
+  end
+
+  def and_i_type_part_of_two_org_names_in_the_organisations_filter_field
+    @filter_audit_list.filter_form do |form|
+      form.wait_until_organisations_visible
+      form.add_organisations.click
+
+      page.find_all("#organisations")[1].send_keys("DF", :down, :enter)
+      page.find_all("#organisations")[0].send_keys("HM", :down, :enter)
+    end
+  end
+
+  def then_there_are_fields_filled_with_the_suggestions_chosen
+    expect(@filter_audit_list).to have_field("Organisations", with: "DFE")
+    expect(@filter_audit_list).to have_field("Organisations", with: "HMRC")
+  end
+
+  def then_the_options_are_still_set
+    @filter_audit_list.filter_form do |form|
+      expect(form).to have_selector("option[selected][value=\"#{@hmrc.content_id}\"]", visible: :hidden)
+      expect(form).to have_selector("option[selected][value=\"#{@dfe.content_id}\"]", visible: :hidden)
+    end
+  end
+
+  def and_the_url_contains_the_filter_options_in_query_params
+    expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@dfe.content_id}")
     expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -133,28 +133,28 @@ private
   end
 
   def when_viewing_content_to_audit
-    @filter_audit_list = ContentAuditTool.new.filter_audit_list_page
-    @filter_audit_list.load
+    @audit_content_page = ContentAuditTool.new.audit_content_page
+    @audit_content_page.load
   end
 
   def and_filtering_to_unaudited_content_allocated_to_me_by_default
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       expect(form).to have_select("allocated_to", selected: "Me")
       expect(form.audit_status).to have_checked_field("Not audited")
     end
   end
 
   def then_the_filtered_list_shows_content_allocated_to_me
-    expect(@filter_audit_list).to have_list(text: "The Famous Five")
+    expect(@audit_content_page).to have_list(text: "The Famous Five")
   end
 
   def and_unaudited_content_not_allocated_to_me_is_not_shown
-    expect(@filter_audit_list.list).to have_no_content("The Secret Seven")
-    expect(@filter_audit_list.list).to have_no_content("The Wishing Chair")
+    expect(@audit_content_page.list).to have_no_content("The Secret Seven")
+    expect(@audit_content_page.list).to have_no_content("The Wishing Chair")
   end
 
   def the_primary_orgs_checkbox_is_toggled_by_the_label
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       expect(form).to have_primary_orgs_label
       expect(form).to have_primary_orgs
 
@@ -208,43 +208,43 @@ private
   end
 
   def and_filtering_to_audited_content_allocated_to_anyone
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "Audited"
 
       form.apply_filters.click
     end
 
-    expect(@filter_audit_list.filter_form.audit_status).to have_checked_field("audit_status_audited")
+    expect(@audit_content_page.filter_form.audit_status).to have_checked_field("audit_status_audited")
   end
 
   def then_the_filter_list_shows_audited_item
-    expect(@filter_audit_list.list).to have_content("Tree felling")
+    expect(@audit_content_page.list).to have_content("Tree felling")
   end
 
   def and_the_list_does_not_show_unaudited_content
-    expect(@filter_audit_list.list).to have_no_content("Forest management")
+    expect(@audit_content_page.list).to have_no_content("Forest management")
   end
 
   def and_filtering_by_all_content_allocated_to_anyone
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
 
       form.apply_filters.click
     end
 
-    expect(@filter_audit_list.filter_form.audit_status).to have_checked_field("audit_status_all")
+    expect(@audit_content_page.filter_form.audit_status).to have_checked_field("audit_status_all")
   end
 
   def then_the_list_shows_all_content
-    expect(@filter_audit_list).to have_content("VAT")
-    expect(@filter_audit_list).to have_content("Tree felling")
-    expect(@filter_audit_list).to have_content("Forest management")
+    expect(@audit_content_page).to have_content("VAT")
+    expect(@audit_content_page).to have_content("Tree felling")
+    expect(@audit_content_page).to have_content("Forest management")
   end
 
   def and_filtering_to_all_content_for_anyone_belonging_to_a_primary_org
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
       form.primary_orgs.check "Primary organisation only"
@@ -254,15 +254,15 @@ private
   end
 
   def then_the_list_shows_primary_org_content
-    expect(@filter_audit_list.list).to have_content("VAT")
+    expect(@audit_content_page.list).to have_content("VAT")
   end
 
   def and_does_not_show_other_department_content
-    expect(@filter_audit_list.list).to have_no_content("Tree felling")
+    expect(@audit_content_page.list).to have_no_content("Tree felling")
   end
 
   def and_filtering_to_non_primary_orgs
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
       form.primary_orgs.uncheck "Primary organisation only"
@@ -272,16 +272,16 @@ private
   end
 
   def then_the_list_shows_content_for_org
-    expect(@filter_audit_list.list).to have_content("VAT")
-    expect(@filter_audit_list.list).to have_content("Travel insurance")
+    expect(@audit_content_page.list).to have_content("VAT")
+    expect(@audit_content_page.list).to have_content("Travel insurance")
   end
 
   def and_the_list_does_not_show_content_for_other_orgs
-    expect(@filter_audit_list.list).to have_no_content("Tree felling")
+    expect(@audit_content_page.list).to have_no_content("Tree felling")
   end
 
   def the_organisation_filter_options_are_alphabetical
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       within(form.organisations) do
         options = page.all("option")
 
@@ -291,9 +291,9 @@ private
   end
 
   def and_part_of_an_org_name_is_typed_in_the_organisations_filter_field
-    expect(@filter_audit_list.url).not_to include("organisations%5B%5D=#{@hmrc.content_id}")
+    expect(@audit_content_page.url).not_to include("organisations%5B%5D=#{@hmrc.content_id}")
 
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.wait_until_organisations_visible
 
       expect(form).to have_organisations_input(visible: :visible)
@@ -304,29 +304,29 @@ private
   end
 
   def then_the_field_is_filled_with_the_suggestion_i_chose
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       expect(form).to have_field("Organisations", with: "HMRC")
     end
   end
 
   def and_when_applying_the_filters
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.apply_filters.click
     end
   end
 
   def then_the_option_is_still_set
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       expect(form).to have_selector("option[selected][value=\"#{@hmrc.content_id}\"]", visible: :hidden)
     end
   end
 
   def and_the_url_contains_the_filter_option_in_query_param
-    expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
+    expect(@audit_content_page.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
   end
 
   def and_part_of_two_org_names_are_typed_in_the_organisations_filter_field
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.wait_until_organisations_visible
       form.add_organisations.click
 
@@ -336,20 +336,20 @@ private
   end
 
   def then_there_are_fields_filled_with_the_suggestions_chosen
-    expect(@filter_audit_list).to have_field("Organisations", with: "DFE")
-    expect(@filter_audit_list).to have_field("Organisations", with: "HMRC")
+    expect(@audit_content_page).to have_field("Organisations", with: "DFE")
+    expect(@audit_content_page).to have_field("Organisations", with: "HMRC")
   end
 
   def then_the_options_are_still_set
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       expect(form).to have_selector("option[selected][value=\"#{@hmrc.content_id}\"]", visible: :hidden)
       expect(form).to have_selector("option[selected][value=\"#{@dfe.content_id}\"]", visible: :hidden)
     end
   end
 
   def and_the_url_contains_the_filter_options_in_query_params
-    expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@dfe.content_id}")
-    expect(@filter_audit_list.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
+    expect(@audit_content_page.current_url).to include("organisations%5B%5D=#{@dfe.content_id}")
+    expect(@audit_content_page.current_url).to include("organisations%5B%5D=#{@hmrc.content_id}")
   end
 
   def given_content_with_known_titles
@@ -359,7 +359,7 @@ private
   end
 
   def and_searching_by_title_within_all_content_assigned_to_anyone
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
       form.search.set "some text"
@@ -368,16 +368,16 @@ private
   end
 
   def then_the_list_shows_the_one_item_matching
-    expect(@filter_audit_list).to have_listing count: 1
-    expect(@filter_audit_list).to have_listing(text: "some text")
+    expect(@audit_content_page).to have_listing count: 1
+    expect(@audit_content_page).to have_listing(text: "some text")
   end
 
   def and_does_not_show_other_content_that_do_not_match
-    expect(@filter_audit_list.list).to have_no_content("another text")
+    expect(@audit_content_page.list).to have_no_content("another text")
   end
 
   def then_the_search_box_still_shows_the_search_query
-    expect(@filter_audit_list).to have_field(:query, with: 'some text')
+    expect(@audit_content_page).to have_field(:query, with: 'some text')
   end
 
   def and_one_of_the_content_is_guidance
@@ -385,7 +385,7 @@ private
   end
 
   def and_filtering_by_guide_type_from_all_content_allocated_to_anyone
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.allocated_to.select "Anyone"
       form.audit_status.choose "All"
       form.document_type.select "Guide"
@@ -395,11 +395,11 @@ private
   end
 
   def then_the_list_shows_content_for_that_type
-    expect(@filter_audit_list.list).to have_content("HMRC")
+    expect(@audit_content_page.list).to have_content("HMRC")
   end
 
   def and_does_not_show_content_of_other_type
-    expect(@filter_audit_list.list).to have_no_content("Flying to countries abroad")
+    expect(@audit_content_page.list).to have_no_content("Flying to countries abroad")
   end
 
   def given_101_content_items
@@ -408,11 +408,11 @@ private
   end
 
   def and_clicking_to_the_second_page_of_results
-    @filter_audit_list.pagination.click_on "2"
+    @audit_content_page.pagination.click_on "2"
   end
 
   def and_changing_the_filters_to_not_audited
-    @filter_audit_list.filter_form do |form|
+    @audit_content_page.filter_form do |form|
       form.audit_status.choose "Not audited"
       form.apply_filters.click
     end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -145,12 +145,17 @@ private
   end
 
   def then_the_filtered_list_shows_content_allocated_to_me
-    expect(@audit_content_page).to have_list(text: "The Famous Five")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+
+    listing = @audits_filter_list.filter_listings.first
+    expect(listing.title).to have_text("The Famous Five")
   end
 
   def and_unaudited_content_not_allocated_to_me_is_not_shown
-    expect(@audit_content_page.list).to have_no_content("The Secret Seven")
-    expect(@audit_content_page.list).to have_no_content("The Wishing Chair")
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title).to have_no_text("The Secret Seven")
+      expect(listing.title).to have_no_text("The Wishing Chair")
+    end
   end
 
   def the_primary_orgs_checkbox_is_toggled_by_the_label
@@ -219,11 +224,16 @@ private
   end
 
   def then_the_filter_list_shows_audited_item
-    expect(@audit_content_page.list).to have_content("Tree felling")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+    listing = @audits_filter_list.filter_listings.first
+
+    expect(listing.title).to have_text("Tree felling")
   end
 
   def and_the_list_does_not_show_unaudited_content
-    expect(@audit_content_page.list).to have_no_content("Forest management")
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title).to have_no_text("Forest management")
+    end
   end
 
   def and_filtering_by_all_content_allocated_to_anyone
@@ -254,11 +264,16 @@ private
   end
 
   def then_the_list_shows_primary_org_content
-    expect(@audit_content_page.list).to have_content("VAT")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+    listing = @audits_filter_list.filter_listings.first
+
+    expect(listing.title).to have_text("VAT")
   end
 
   def and_does_not_show_other_department_content
-    expect(@audit_content_page.list).to have_no_content("Tree felling")
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title).to have_no_text("Tree felling")
+    end
   end
 
   def and_filtering_to_non_primary_orgs
@@ -272,12 +287,19 @@ private
   end
 
   def then_the_list_shows_content_for_org
-    expect(@audit_content_page.list).to have_content("VAT")
-    expect(@audit_content_page.list).to have_content("Travel insurance")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+
+    expect(@audits_filter_list.filter_listings.size).to eq(2)
+
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title.text).to eq("VAT").or eq("Travel insurance")
+    end
   end
 
   def and_the_list_does_not_show_content_for_other_orgs
-    expect(@audit_content_page.list).to have_no_content("Tree felling")
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title).to have_no_content("Tree felling")
+    end
   end
 
   def the_organisation_filter_options_are_alphabetical
@@ -368,12 +390,18 @@ private
   end
 
   def then_the_list_shows_the_one_item_matching
-    expect(@audit_content_page).to have_listing count: 1
-    expect(@audit_content_page).to have_listing(text: "some text")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+
+    expect(@audits_filter_list).to have_filter_listings
+    expect(@audits_filter_list.filter_listings.size).to eq(1)
+    listing = @audits_filter_list.filter_listings.first
+    expect(listing.title).to have_text("some text")
   end
 
   def and_does_not_show_other_content_that_do_not_match
-    expect(@audit_content_page.list).to have_no_content("another text")
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title).to have_no_text("another text")
+    end
   end
 
   def then_the_search_box_still_shows_the_search_query
@@ -395,11 +423,20 @@ private
   end
 
   def then_the_list_shows_content_for_that_type
-    expect(@audit_content_page.list).to have_content("HMRC")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+    @audits_filter_list.wait_for_filter_listings
+
+    expect(@audits_filter_list.filter_listings.size).to eq(1)
+
+    listing = @audits_filter_list.filter_listings.first
+    expect(listing.title.text).to eq("HMRC")
   end
 
   def and_does_not_show_content_of_other_type
-    expect(@audit_content_page.list).to have_no_content("Flying to countries abroad")
+    @audits_filter_list = ContentAuditTool.new.audits_filter_list
+    @audits_filter_list.filter_listings.each do |listing|
+      expect(listing.title.text).not_to eq("Flying to countries abroad")
+    end
   end
 
   def given_101_content_items

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_the_url_contains_the_filter_options_in_query_params
   end
 
-  scenario "searching by title" do
+  scenario "filtering by title" do
     given_content_with_known_titles
     when_i_go_to_filter_content_to_audit
     and_i_search_by_title_within_all_content_assigned_to_anyone
@@ -79,42 +79,24 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_does_not_show_other_content_that_do_not_match
   end
 
+  scenario "show the query entered by the user after filtering" do
+    given_content_with_known_titles
+    when_i_go_to_filter_content_to_audit
+    and_i_search_by_title_within_all_content_assigned_to_anyone
+    then_the_search_box_still_shows_the_search_query
+  end
+
+  scenario "filtering by content type" do
+    given_content_belonging_to_departments
+    and_one_of_the_content_is_guidance
+    when_i_go_to_filter_content_to_audit
+    and_filter_by_guide_type_from_all_content_allocated_to_anyone
+    then_the_list_shows_content_for_that_type
+    and_does_not_show_content_of_other_type
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
-      context "filtering by title" do
-        scenario "show the query entered by the user after filtering" do
-          given_content_belonging_to_departments
-          when_i_go_to_filter_content_to_audit
-
-          @filter_audit_list.filter_form do |form|
-            form.allocated_to.select "Anyone"
-            form.audit_status.choose "All"
-            form.search.set "a search value"
-            form.apply_filters.click
-          end
-
-          expect(@filter_audit_list).to have_field(:query, with: 'a search value')
-        end
-      end
-
-      scenario "filtering by content type" do
-        given_content_belonging_to_departments
-        when_i_go_to_filter_content_to_audit
-
-        @hmrc.update!(document_type: "guide")
-
-        @filter_audit_list.filter_form do |form|
-          form.allocated_to.select "Anyone"
-          form.audit_status.choose "All"
-          form.document_type.select "Guide"
-
-          form.apply_filters.click
-        end
-
-        expect(@filter_audit_list.list).to have_content("HMRC")
-        expect(@filter_audit_list.list).to have_no_content("Flying to countries abroad")
-      end
-
       scenario "Reseting page to 1 after filtering" do
         create_list(:content_item, 100)
 
@@ -403,5 +385,31 @@ private
 
   def and_does_not_show_other_content_that_do_not_match
     expect(@filter_audit_list.list).to have_no_content("another text")
+  end
+
+  def then_the_search_box_still_shows_the_search_query
+    expect(@filter_audit_list).to have_field(:query, with: 'some text')
+  end
+
+  def and_one_of_the_content_is_guidance
+    @hmrc.update!(document_type: "guide")
+  end
+
+  def and_filter_by_guide_type_from_all_content_allocated_to_anyone
+    @filter_audit_list.filter_form do |form|
+      form.allocated_to.select "Anyone"
+      form.audit_status.choose "All"
+      form.document_type.select "Guide"
+
+      form.apply_filters.click
+    end
+  end
+
+  def then_the_list_shows_content_for_that_type
+    expect(@filter_audit_list.list).to have_content("HMRC")
+  end
+
+  def and_does_not_show_content_of_other_type
+    expect(@filter_audit_list.list).to have_no_content("Flying to countries abroad")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -24,28 +24,16 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     then_the_list_shows_all_content
   end
 
+  scenario "filtering by primary organisation" do
+    given_content_belonging_to_departments
+    when_i_go_to_filter_content_to_audit
+    and_i_filter_to_all_content_for_anyone_belonging_to_a_primary_org
+    then_the_list_shows_primary_org_content
+    and_does_not_show_other_department_content
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
-      scenario "filtering by primary organisation" do
-        given_content_belonging_to_departments
-        when_i_go_to_filter_content_to_audit
-
-        @filter_audit_list.filter_form do |form|
-          form.allocated_to.select "Anyone"
-          form.audit_status.choose "All"
-          form.apply_filters.click
-
-          expect(form.primary_orgs).to have_checked_field
-
-          form.organisations.select "HMRC"
-          # select "HMRC", from: "Organisations"
-          form.apply_filters.click
-        end
-
-        expect(@filter_audit_list.list).to have_content("VAT")
-        expect(@filter_audit_list.list).to have_no_content("Tree felling")
-      end
-
       scenario "filtering by organisation" do
         given_content_belonging_to_departments
         when_i_go_to_filter_content_to_audit
@@ -335,5 +323,23 @@ private
     expect(@filter_audit_list).to have_content("VAT")
     expect(@filter_audit_list).to have_content("Tree felling")
     expect(@filter_audit_list).to have_content("Forest management")
+  end
+
+  def and_i_filter_to_all_content_for_anyone_belonging_to_a_primary_org
+    @filter_audit_list.filter_form do |form|
+      form.allocated_to.select "Anyone"
+      form.audit_status.choose "All"
+      form.primary_orgs.check "Primary organisation only"
+      form.organisations.select "HMRC"
+      form.apply_filters.click
+    end
+  end
+
+  def then_the_list_shows_primary_org_content
+    expect(@filter_audit_list.list).to have_content("VAT")
+  end
+
+  def and_does_not_show_other_department_content
+    expect(@filter_audit_list.list).to have_no_content("Tree felling")
   end
 end

--- a/spec/features/audit/lists/filter_spec.rb
+++ b/spec/features/audit/lists/filter_spec.rb
@@ -40,24 +40,13 @@ RSpec.feature "Filter Content Items to Audit", type: :feature do
     and_the_list_does_not_show_content_for_other_orgs
   end
 
+  scenario "toggling the primary org checkbox by clicking its label" do
+    when_i_go_to_filter_content_to_audit
+    the_primary_orgs_checkbox_is_toggled_by_the_label
+  end
+
   context "With some organisations and documents set up" do
     context "when showing content regardless of audit status" do
-      scenario "toggling the primary org checkbox by clicking its label" do
-        filter_audit_list = ContentAuditTool.new.filter_audit_list_page
-        filter_audit_list.load
-
-        filter_audit_list.filter_form do |form|
-          expect(form).to have_primary_orgs_label
-          expect(form).to have_primary_orgs
-
-          form.primary_orgs_label.click
-          expect(form.primary_orgs).not_to have_checked_field
-
-          form.primary_orgs_label.click
-          expect(form.primary_orgs).to have_checked_field
-        end
-      end
-
       context "filtering by organisation" do
         scenario "organisations are in alphabetical order" do
           given_content_belonging_to_departments
@@ -237,6 +226,19 @@ private
   def and_we_do_not_show_unaudited_content_not_allocated_to_me
     expect(@filter_audit_list.list).to have_no_content("The Secret Seven")
     expect(@filter_audit_list.list).to have_no_content("The Wishing Chair")
+  end
+
+  def the_primary_orgs_checkbox_is_toggled_by_the_label
+    @filter_audit_list.filter_form do |form|
+      expect(form).to have_primary_orgs_label
+      expect(form).to have_primary_orgs
+
+      form.primary_orgs_label.click
+      expect(form.primary_orgs).not_to have_checked_field
+
+      form.primary_orgs_label.click
+      expect(form.primary_orgs).to have_checked_field
+    end
   end
 
   def given_content_belonging_to_departments

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,4 +56,8 @@ RSpec.configure do |config|
   end
 end
 
+SitePrism.configure do |config|
+  config.use_implicit_waits = true
+end
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -5,7 +5,7 @@ class ContentAuditTool
     AuditContentItemPage.new
   end
 
-  def filter_audit_list_page
-    FilterAuditListPage.new
+  def audit_content_page
+    AuditContentPage.new
   end
 end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -4,4 +4,8 @@ class ContentAuditTool
   def audit_content_item
     AuditContentItemPage.new
   end
+
+  def filter_audit_list_page
+    FilterAuditListPage.new
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -8,4 +8,8 @@ class ContentAuditTool
   def audit_content_page
     AuditContentPage.new
   end
+
+  def audits_filter_list
+    AuditsFilterList.new
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -4,17 +4,17 @@ class AuditContentPage < SitePrism::Page
   set_url "/audits"
 
   section :filter_form, "form" do
-    element :search, "[data-test=search]"
-    element :allocated_to, "[data-test=allocated-to]"
-    element :audit_status, "[data-test=audit-status]"
-    element :organisations, "[data-test=organisations]"
-    element :organisations_select, "[data-test=organisations-select]"
-    element :organisations_input, "[data-test=organisations] input"
-    element :add_organisations, "[data-test=add-organisation]"
-    element :primary_orgs_label, "[data-test=primary-orgs-label]"
-    element :primary_orgs, "[data-test=primary-orgs]"
-    element :document_type, "[data-test=document-type]"
-    element :apply_filters, "[data-test=apply-filters]"
+    element :search, "[data-test-id=search]"
+    element :allocated_to, "[data-test-id=allocated-to]"
+    element :audit_status, "[data-test-id=audit-status]"
+    element :organisations, "[data-test-id=organisations]"
+    element :organisations_select, "[data-test-id=organisations-select]"
+    element :organisations_input, "[data-test-id=organisations] input"
+    element :add_organisations, "[data-test-id=add-organisation]"
+    element :primary_orgs_label, "[data-test-id=primary-orgs-label]"
+    element :primary_orgs, "[data-test-id=primary-orgs]"
+    element :document_type, "[data-test-id=document-type]"
+    element :apply_filters, "[data-test-id=apply-filters]"
   end
 
   element :pagination, ".pagination"

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -17,7 +17,5 @@ class AuditContentPage < SitePrism::Page
     element :apply_filters, "[data-test=apply-filters]"
   end
 
-  element :list, "[data-test=filter-list]"
-  element :listing, "[data-test=filter-list] tbody tr"
   element :pagination, ".pagination"
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -4,20 +4,20 @@ class AuditContentPage < SitePrism::Page
   set_url "/audits"
 
   section :filter_form, "form" do
-    element :search, ".search"
-    element :allocated_to, ".allocated-to"
-    element :audit_status, ".audit-status"
-    element :document_type, ".document-type"
-    element :organisations, ".organisation-select-wrapper"
-    element :organisations_select, "#organisations-select"
-    element :organisations_input, "#organisations"
-    element :add_organisations, ".add-organisation"
-    element :primary_orgs_label, "label[for='primary']"
-    element :primary_orgs, ".primary-orgs"
-    element :apply_filters, ".apply-filters"
+    element :search, "[data-test=search]"
+    element :allocated_to, "[data-test=allocated-to]"
+    element :audit_status, "[data-test=audit-status]"
+    element :organisations, "[data-test=organisations]"
+    element :organisations_select, "[data-test=organisations-select]"
+    element :organisations_input, "[data-test=organisations] input"
+    element :add_organisations, "[data-test=add-organisation]"
+    element :primary_orgs_label, "[data-test=primary-orgs-label]"
+    element :primary_orgs, "[data-test=primary-orgs]"
+    element :document_type, "[data-test=document-type]"
+    element :apply_filters, "[data-test=apply-filters]"
   end
 
-  element :list, ".filter-list"
-  element :listing, ".filter-list tbody tr"
+  element :list, "[data-test=filter-list]"
+  element :listing, "[data-test=filter-list] tbody tr"
   element :pagination, ".pagination"
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -1,6 +1,6 @@
 require "site_prism/page"
 
-class FilterAuditListPage < SitePrism::Page
+class AuditContentPage < SitePrism::Page
   set_url "/audits"
 
   section :filter_form, "form" do

--- a/spec/support/pages/audit/content_audit_tool/audit_listing_section.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_listing_section.rb
@@ -1,6 +1,6 @@
 require "site_prism/page"
 
 class AuditListingSection < SitePrism::Section
-  element :title, "[data-test=title] a"
-  element :page_views, "[data-test=page-views]"
+  element :title, "[data-test-id=title] a"
+  element :page_views, "[data-test-id=page-views]"
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_listing_section.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_listing_section.rb
@@ -1,0 +1,6 @@
+require "site_prism/page"
+
+class AuditListingSection < SitePrism::Section
+  element :title, "[data-test=title] a"
+  element :page_views, "[data-test=page-views]"
+end

--- a/spec/support/pages/audit/content_audit_tool/audits_filter_list.rb
+++ b/spec/support/pages/audit/content_audit_tool/audits_filter_list.rb
@@ -1,5 +1,5 @@
 require "site_prism/page"
 
 class AuditsFilterList < SitePrism::Page
-  sections :filter_listings, AuditListingSection, "[data-test=filter-list] tbody tr"
+  sections :filter_listings, AuditListingSection, "[data-test-id=filter-list] tbody tr"
 end

--- a/spec/support/pages/audit/content_audit_tool/audits_filter_list.rb
+++ b/spec/support/pages/audit/content_audit_tool/audits_filter_list.rb
@@ -1,0 +1,5 @@
+require "site_prism/page"
+
+class AuditsFilterList < SitePrism::Page
+  sections :filter_listings, AuditListingSection, "[data-test=filter-list] tbody tr"
+end

--- a/spec/support/pages/audit/content_audit_tool/audits_filter_list.rb
+++ b/spec/support/pages/audit/content_audit_tool/audits_filter_list.rb
@@ -1,5 +1,6 @@
 require "site_prism/page"
 
 class AuditsFilterList < SitePrism::Page
-  sections :filter_listings, AuditListingSection, "[data-test-id=filter-list] tbody tr"
+  element :list, "table[data-test-id=filter-list] tbody"
+  sections :listings, AuditListingSection, "table[data-test-id=filter-list] tbody tr"
 end

--- a/spec/support/pages/audit/content_audit_tool/filter_audit_list_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/filter_audit_list_page.rb
@@ -1,0 +1,23 @@
+require "site_prism/page"
+
+class FilterAuditListPage < SitePrism::Page
+  set_url "/audits"
+
+  section :filter_form, "form" do
+    element :search, ".search"
+    element :allocated_to, ".allocated-to"
+    element :audit_status, ".audit-status"
+    element :document_type, ".document-type"
+    element :organisations, ".organisation-select-wrapper"
+    element :organisations_select, "#organisations-select"
+    element :organisations_input, "#organisations"
+    element :add_organisations, ".add-organisation"
+    element :primary_orgs_label, "label[for='primary']"
+    element :primary_orgs, ".primary-orgs"
+    element :apply_filters, ".apply-filters"
+  end
+
+  element :list, ".filter-list"
+  element :listing, ".filter-list tbody tr"
+  element :pagination, ".pagination"
+end


### PR DESCRIPTION
- Refactors the feature specs for filtering by using a semantic DSL for describing the filter page elements using the Page Object Model pattern.
- Changes the style the feature specs are written in to add clear separation between the Arrange, Act, Assert parts of the test.

See:
  - https://docs.publishing.service.gov.uk/manual/testing.html
  - https://martinfowler.com/bliki/PageObject.html
  - https://robots.thoughtbot.com/better-acceptance-tests-with-page-objects
  - https://github.com/natritmeyer/site_prism
  - https://about.futurelearn.com/blog/how-we-write-readable-feature-tests-with-rspec