### PR TITLE
Add controller action to guidance controller

### DIFF
--- a/app/controllers/audits/guidances_controller.rb
+++ b/app/controllers/audits/guidances_controller.rb
@@ -1,5 +1,7 @@
 module Audits
   class GuidancesController < BaseController
     layout "audits/guidances"
+
+    def show; end
   end
 end


### PR DESCRIPTION
Being explicit about the controller action provides the reader context
about what the controller does. In this case, it is obvious now that 
the view to open would be: 

`/view/audits/guidances/show.html.erb`