### PR TITLE
Fix second page allocations

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -1,7 +1,7 @@
 module Audits
   class AllocationsController < BaseController
     before_action :set_default_parameters, only: :index
-    before_action :set_batch_value, only: %w(destroy create), if: -> { batch_size > content_ids.size }
+    before_action :set_batch_values, only: %w(destroy create), if: -> { batch_size > content_ids.size }
 
     decorates_assigned :content_items
 
@@ -42,11 +42,13 @@ module Audits
       params.fetch(:allocate_to)
     end
 
-    def set_batch_value
-      filter = params_to_filter
-      filter.per_page = batch_size
-
-      params[:content_ids] = FindContent.paged(filter).pluck(:content_id)
+    def set_batch_values
+      params[:content_ids] = FindContent
+                               .batch(
+                                 params_to_filter,
+                                 batch_size: batch_size,
+                                 from_page: params_to_filter.page,
+                               ).pluck(:content_id)
     end
 
     def batch_size

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -10,6 +10,18 @@ module Audits
       do_filter!(filter, scope)
     end
 
+    def self.batch(filter, from_page:, batch_size:)
+      query = query(filter)
+      scope = query.all_content_items.limit(batch_size)
+      do_filter!(filter, scope)
+
+      if from_page&.positive?
+        scope.offset(from_page * query.current_per_page - query.current_per_page)
+      else
+        scope.offset(from_page)
+      end
+    end
+
     def self.do_filter!(filter, scope)
       scope = filter.audited_policy.call(scope)
       filter.allocated_policy.call(scope, allocated_to: filter.allocated_to)

--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -16,6 +16,10 @@ module Content
       set(:per_page, per_page)
     end
 
+    def current_per_page
+      @per_page
+    end
+
     def sort(sort)
       set(:sort, sort)
     end

--- a/spec/domain/audits/find_content_spec.rb
+++ b/spec/domain/audits/find_content_spec.rb
@@ -1,0 +1,24 @@
+module Audits
+  RSpec.describe FindContent do
+    describe '#batch' do
+      let!(:content_items) { create_list(:content_item, 210) }
+
+      let(:batch_size) { 105 }
+      let(:filter) { Filter.new(sort: 'id', sort_direction: 'asc') }
+      let(:from_page) { 2 }
+
+      subject(:relation) {
+        described_class.batch(
+          filter,
+          batch_size: batch_size,
+          from_page: from_page,
+        )
+      }
+
+      it 'returns a batch of filtered content items offset from the given page' do
+        expect(relation)
+          .to match_array(content_items.sort_by(&:id)[100...205])
+      end
+    end
+  end
+end

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     let!(:books) do
       create_list(
         :content_item,
-        20,
+        60,
         primary_publishing_organisation: novelists,
       )
     end
@@ -134,28 +134,28 @@ RSpec.feature "Allocate multiple content items", type: :feature do
     let!(:paintings) do
       create_list(
         :content_item,
-        20,
+        60,
         primary_publishing_organisation: painters,
       )
     end
 
-    scenario "I can assign 26 content items to myself from both organisations" do
+    scenario "I can assign 101 content items to myself from both organisations" do
       visit audits_allocations_path
 
-      expect(page).to have_content("20 items")
+      expect(page).to have_content("60 items")
 
       page.select "Painters", from: "organisations[]"
       click_on "Apply filters"
 
       expect(page).to have_select("organisations[]", selected: %w[Novelists Painters])
-      expect(page).to have_content("40 items")
+      expect(page).to have_content("120 items")
 
       select "Me", from: "allocate_to"
-      fill_in "batch_size", with: "26"
+      fill_in "batch_size", with: "101"
       click_on "Assign"
 
-      expect(page).to have_content("26 items assigned to Jane Austen")
-      expect(page).to have_content("14 items")
+      expect(page).to have_content("101 items assigned to Jane Austen")
+      expect(page).to have_content("19 items")
     end
   end
 end


### PR DESCRIPTION
This fixes the logic we have to calculate which content items to allocate when a batch size is specified that is greater than the 100 items we display on a page and when the assignment is instigated from page 2 or greater.

We calculate an offset value which is the total number of content items that would have been displayed on all previous pages. We then assign X number of content items from there onwards.