### PR TITLE
Refactor report feature tests

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -2,8 +2,8 @@ module MenuHelper
   def navigation_link(text, url, scope, data_test)
     status = controller.controller_name == scope ? 'active' : ''
 
-    content_tag :li, role: "presentation", class: status, data: { test: data_test } do
-      link_to_unless_current text, url, aria_controls: "home", role: "tab" do
+    content_tag :li, role: "presentation", class: status do
+      link_to_unless_current text, url, aria_controls: "home", role: "tab", data: { test: data_test } do
         link_to text, "#", aria_controls: "home", role: "tab"
       end
     end

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -1,8 +1,8 @@
 module MenuHelper
-  def navigation_link(text, url, scope)
+  def navigation_link(text, url, scope, data_test)
     status = controller.controller_name == scope ? 'active' : ''
 
-    content_tag :li, role: "presentation", class: status do
+    content_tag :li, role: "presentation", class: status, data: { test: data_test } do
       link_to_unless_current text, url, aria_controls: "home", role: "tab" do
         link_to text, "#", aria_controls: "home", role: "tab"
       end

--- a/app/views/audits/common/_audit_status.html.erb
+++ b/app/views/audits/common/_audit_status.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group" data-test="audit-status">
   <%= label_tag :audit_status, 'Audit status' %>
 
   <%= render partial: "components/radio_button",

--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs">
-  <%= navigation_link "Audit content", audits_url, 'audits'%>
-  <%= navigation_link "Assign content", audits_allocations_url, 'allocations' %>
-  <%= navigation_link "Audit progress", audits_report_url, 'reports' %>
+  <%= navigation_link "Audit content", audits_url, 'audits', "audit_content_tab" %>
+  <%= navigation_link "Assign content", audits_allocations_url, 'allocations', "assign_content_tab" %>
+  <%= navigation_link "Audit progress", audits_report_url, 'reports', "audit_progress_tab" %>
 </ul>

--- a/app/views/audits/reports/_progress_bar.html.erb
+++ b/app/views/audits/reports/_progress_bar.html.erb
@@ -1,6 +1,7 @@
 <% formatted = format_percentage(percentage, precision: 5) %>
 
-<div class="progress">
+<div class="progress"
+     data-test="<%= data_test %>">
   <div class="progress-bar"
         role="progressbar"
         aria-valuenow="<%= percentage %>"

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -16,7 +16,7 @@
     <div id="progress">
       <h3>Audit progress</h3>
 
-      <%= render "progress_bar", percentage: @monitor.audited_percentage %>
+      <%= render "progress_bar", percentage: @monitor.audited_percentage, data_test: 'audit_progress_bar' %>
 
       <table class="table">
         <tr>
@@ -35,7 +35,7 @@
     <div id="items-needing-improvement">
       <h3>Items needing improvement</h3>
 
-      <%= render "progress_bar", percentage: @monitor.passing_percentage %>
+      <%= render "progress_bar", percentage: @monitor.passing_percentage, data_test: 'improvement_progress_bar' %>
 
       <table class="table">
         <tr>

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -1,12 +1,12 @@
 RSpec.feature "Content Allocation", type: :feature do
   scenario "Filter allocated content" do
-    given_I_am_auditing_a_content_item
-    then_I_see_all_content_items
-    given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
-    then_I_see_no_content_items
+    given_i_am_auditing_a_content_item
+    then_i_see_all_content_items
+    given_that_i_filter_by_attributes_that_do_not_apply_to_any_content_items
+    then_i_see_no_content_items
   end
 
-  def given_I_am_auditing_a_content_item
+  def given_i_am_auditing_a_content_item
     organisation = create(:organisation)
     user = create(:user, organisation: organisation)
     content_item = create(
@@ -19,16 +19,16 @@ RSpec.feature "Content Allocation", type: :feature do
     @audit_report.load(content_id: content_item.content_id)
   end
 
-  def then_I_see_all_content_items
+  def then_i_see_all_content_items
     expect(@audit_report).to have_report_section(text: '1')
   end
 
-  def given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
+  def given_that_i_filter_by_attributes_that_do_not_apply_to_any_content_items
     @audit_report.allocated_to.select 'No one'
     @audit_report.apply_filters.click
   end
 
-  def then_I_see_no_content_items
+  def then_i_see_no_content_items
     expect(@audit_report).to have_report_section(text: '0')
   end
 end

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -24,9 +24,8 @@ RSpec.feature "Content Allocation", type: :feature do
   end
 
   def given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
-    # TODO think of a better method name
-    select "No one", from: "allocated_to"
-    click_on "Apply filters"
+    @audit_report_item.allocated_to.select 'No one'
+    @audit_report_item.apply_filters.click
   end
 
   def then_I_see_no_content_items

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -1,31 +1,35 @@
 RSpec.feature "Content Allocation", type: :feature do
-  let!(:my_organisation) do
-    create(
-      :organisation,
-    )
-  end
-
-  let!(:me) do
-    create(
-      :user,
-      organisation: my_organisation,
-    )
-  end
-
   scenario "Filter allocated content" do
-    create(
+    given_i_am_auditing_a_content_item
+    then_I_see_all_content_items
+    given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
+    then_I_see_no_content_items
+  end
+
+  def given_i_am_auditing_a_content_item
+    organisation = create(:organisation)
+    user = create(:user, organisation: organisation)
+    content_item = create(
       :content_item,
       title: "Do Androids Dream of Electric Sheep",
-      allocated_to: me,
-      primary_publishing_organisation: my_organisation,
+      allocated_to: user,
+      primary_publishing_organisation: organisation,
     )
+    @audit_report_item = ContentAuditTool.new.audit_report_item
+    @audit_report_item.load(content_id: content_item.content_id)
+  end
 
-    visit audits_report_path
+  def then_I_see_all_content_items
+    expect(@audit_report_item).to have_report_section(text: '1')
+  end
 
-    expect(page).to have_selector(".report-section", text: "1")
-
+  def given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
+    # TODO think of a better method name
     select "No one", from: "allocated_to"
     click_on "Apply filters"
-    expect(page).to have_selector(".report-section", text: "0")
+  end
+
+  def then_I_see_no_content_items
+    expect(@audit_report_item).to have_report_section(text: '0')
   end
 end

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -1,12 +1,12 @@
 RSpec.feature "Content Allocation", type: :feature do
   scenario "Filter allocated content" do
-    given_i_am_auditing_a_content_item
+    given_I_am_auditing_a_content_item
     then_I_see_all_content_items
     given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
     then_I_see_no_content_items
   end
 
-  def given_i_am_auditing_a_content_item
+  def given_I_am_auditing_a_content_item
     organisation = create(:organisation)
     user = create(:user, organisation: organisation)
     content_item = create(
@@ -15,20 +15,20 @@ RSpec.feature "Content Allocation", type: :feature do
       allocated_to: user,
       primary_publishing_organisation: organisation,
     )
-    @audit_report_item = ContentAuditTool.new.audit_report_item
-    @audit_report_item.load(content_id: content_item.content_id)
+    @audit_report = ContentAuditTool.new.audit_report
+    @audit_report.load(content_id: content_item.content_id)
   end
 
   def then_I_see_all_content_items
-    expect(@audit_report_item).to have_report_section(text: '1')
+    expect(@audit_report).to have_report_section(text: '1')
   end
 
   def given_that_I_filter_by_attributes_that_do_not_apply_to_any_content_items
-    @audit_report_item.allocated_to.select 'No one'
-    @audit_report_item.apply_filters.click
+    @audit_report.allocated_to.select 'No one'
+    @audit_report.apply_filters.click
   end
 
   def then_I_see_no_content_items
-    expect(@audit_report_item).to have_report_section(text: '0')
+    expect(@audit_report).to have_report_section(text: '0')
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -9,17 +9,17 @@ RSpec.feature "Exporting a CSV from the report page" do
 
   scenario "Exporting a csv file as an attachment" do
     given_i_am_exporting_an_audit_report
-    then_i_receive_an_audit_progress_report_in_CSV_format
+    then_i_receive_an_audit_progress_report_in_csv_format
   end
 
   scenario "Applying the filters to the export" do
     given_i_have_applied_filters_and_exported_audits
-    then_i_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
+    then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
   end
 
   scenario "Multiple pagesincluding_details_of_audit_progress_ of content items are in the database" do
     given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
-    then_i_receive_an_audit_progress_report_for_all_audits_in_CSV_format
+    then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
   end
 
   scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -8,28 +8,28 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   scenario "Exporting a csv file as an attachment" do
-    given_I_am_exporting_an_audit_report
-    then_I_receive_an_audit_progress_report_in_CSV_format
+    given_i_am_exporting_an_audit_report
+    then_i_receive_an_audit_progress_report_in_CSV_format
   end
 
   scenario "Applying the filters to the export" do
-    given_I_have_applied_filters_and_exported_audits
-    then_I_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
+    given_i_have_applied_filters_and_exported_audits
+    then_i_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
   end
 
   scenario "Multiple pagesincluding_details_of_audit_progress_ of content items are in the database" do
-    given_I_have_multiple_pages_of_content_items_and_do_not_filter_them
-    then_I_receive_an_audit_progress_report_for_all_audits_in_CSV_format
+    given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+    then_i_receive_an_audit_progress_report_for_all_audits_in_CSV_format
   end
 
   scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-    given_I_apply_filters_to_the_audit_content_page
-    then_I_see_filtered_audits
-    given_that_I_navigate_to_audits_report_page
-    then_I_see_an_unfiltered_audit_progress_report
+    given_i_apply_filters_to_the_audit_content_page
+    then_i_see_filtered_audits
+    given_that_i_navigate_to_audits_report_page
+    then_i_see_an_unfiltered_audit_progress_report
   end
 
-  def given_I_am_exporting_an_audit_report
+  def given_i_am_exporting_an_audit_report
     user = create(:user)
     hmrc = create(
       :content_item,
@@ -53,7 +53,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     @audit_report.export_to_csv.click
   end
 
-  def then_I_receive_an_audit_progress_report_in_CSV_format
+  def then_i_receive_an_audit_progress_report_in_CSV_format
     expect(content_type).to eq("text/csv")
     expect(content_disposition).to start_with("attachment")
     expect(content_disposition).to include(
@@ -63,7 +63,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
   end
 
-  def given_I_have_applied_filters_and_exported_audits
+  def given_i_have_applied_filters_and_exported_audits
     user = create(:user)
     hmrc = create(
       :content_item,
@@ -90,28 +90,28 @@ RSpec.feature "Exporting a CSV from the report page" do
     @audit_report.export_to_csv.click
   end
 
-  def then_I_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
+  def then_i_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
     expect(@audit_report).to have_content("Title,URL")
     expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
     expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
   end
 
-  def given_I_have_multiple_pages_of_content_items_and_do_not_filter_them
-    user = create(:user)
+  def given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+    create(:user)
     create_list(:content_item, 110)
     visit audits_report_path
     select "Anyone", from: "allocated_to"
     click_on "Apply filters"
   end
 
-  def then_I_receive_an_audit_progress_report_for_all_audits_in_CSV_format
+  def then_i_receive_an_audit_progress_report_for_all_audits_in_CSV_format
     click_link "Export filtered audit to CSV"
     csv = CSV.parse(page.body, headers: true)
     number_of_metadata_rows = 1
     expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
   end
 
-  def given_I_apply_filters_to_the_audit_content_page
+  def given_i_apply_filters_to_the_audit_content_page
     user = create(:user)
     hmrc = create(:content_item,
                   title: "HMRC",
@@ -124,28 +124,27 @@ RSpec.feature "Exporting a CSV from the report page" do
            source_content_id: example1.content_id,
            target_content_id: hmrc.content_id,
            link_type: "primary_publishing_organisation")
-    example2 = create(:content_item,
-           title: "Example 2",
-           base_path: "/example2",
-           allocated_to: user)
+  create(:content_item,
+         title: "Example 2",
+         base_path: "/example2",
+         allocated_to: user)
     @audit_content_page = ContentAuditTool.new.audit_content_page
     @audit_report_page = ContentAuditTool.new.audit_report
     @audit_content_page.load
     @audit_content_page.allocated_to.select 'No one'
     @audit_content_page.apply_filters.click
-
   end
 
-  def then_I_see_filtered_audits
+  def then_i_see_filtered_audits
     expect(@audit_content_page).to have_content("Example 1")
     expect(@audit_content_page).to have_no_content("Example 2")
   end
 
-  def given_that_I_navigate_to_audits_report_page
+  def given_that_i_navigate_to_audits_report_page
     @audit_content_page.audits_progress_tab.click
   end
 
-  def then_I_see_an_unfiltered_audit_progress_report
+  def then_i_see_an_unfiltered_audit_progress_report
     expect(@audit_report_page).to be_displayed
     expect(@audit_report_page).to have_no_content('Example 1')
   end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -13,99 +13,101 @@ RSpec.feature "Exporting a CSV from the report page" do
     page.response_headers.fetch("Content-Disposition")
   end
 
-  context "Two content items are in the database" do
-    let!(:hmrc) {
-      create(
-        :content_item,
-        title: "HMRC",
-        document_type: "organisation"
-      )
-    }
-
-    before do
-      example1 = create(
-        :content_item,
-        title: "Example 1",
-        base_path: "/example1",
-        allocated_to: me,
-      )
-
-      create(
-        :link,
-        source_content_id: example1.content_id,
-        target_content_id: hmrc.content_id,
-        link_type: "primary_publishing_organisation",
-      )
-
-      create(
-        :content_item,
-        title: "Example 2",
-        base_path: "/example2",
-      )
-
-      create(:audit, content_item: example1)
-    end
-
-    scenario "Exporting a csv file as an attachment" do
-      visit audits_report_path
-      click_link "Export filtered audit to CSV"
-
-      expect(content_type).to eq("text/csv")
-      expect(content_disposition).to start_with("attachment")
-      expect(content_disposition).to include(
-        'filename="Transformation_audit_report_CSV_download.csv"',
-      )
-
-      expect(page).to have_content("Title,URL")
-      expect(page).to have_content("Example 1,https://gov.uk/example1")
-    end
-
-    scenario "Applying the filters to the export" do
-      visit audits_report_path
-      select "Anyone", from: "allocated_to"
-
-      select "HMRC", from: "Organisations"
-      click_on "Apply filters"
-
-      click_link "Export filtered audit to CSV"
-      expect(page).to have_content("Example 1,https://gov.uk/example1")
-      expect(page).to have_no_content("Example 2,https://gov.uk/example2")
-    end
-
-    scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-      visit audits_path
-      select "Anyone", from: "allocated_to"
-
-      choose "Audited"
-
-      click_on "Apply filters"
-      expect(page).to have_content("Example 1")
-      expect(page).to have_no_content("Example 2")
-
-      click_link "Audit progress"
-
-      click_link "Export filtered audit to CSV"
-      expect(content_disposition).to include(
-        'filename="Transformation_audit_report_CSV_download.csv"',
-      )
-      expect(page).to have_content("Example 1")
-      expect(page).to have_no_content("Example 2")
-    end
+  scenario "Exporting a csv file as an attachment" do
+    given_i_am_exporting_an_audit_report
+    then_i_download_a_csv_file
   end
 
-  context "Multiple pages of content items are in the database" do
-    let!(:content_items) { create_list(:content_item, 110) }
+  scenario "Applying the filters to the export" do
+    given_i_have_applied_filters_and_exported_audit
+    then_i_download_a_csv_file_for_the_filtered_audits
+  end
 
-    scenario "Exporting an unfiltered audit to CSV with all the content items" do
-      visit audits_report_path
-      select "Anyone", from: "allocated_to"
-      click_on "Apply filters"
-      click_link "Export filtered audit to CSV"
+  scenario "Multiple pages of content items are in the database" do
+    given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+    then_i_download_a_csv_file_for_all_content_items
+  end
 
-      csv = CSV.parse(page.body, headers: true)
+  def given_i_am_exporting_an_audit_report
+    user = create(:user)
+    hmrc = create(
+      :content_item,
+      title: "HMRC",
+      document_type: "organisation"
+    )
+    example1 = create(:content_item,
+                      title: "Example 1",
+                      base_path: "/example1",
+                      allocated_to: me)
+    create(:link,
+           source_content_id: example1.content_id,
+           target_content_id: hmrc.content_id,
+           link_type: "primary_publishing_organisation")
+    example2 = create(:content_item,
+           title: "Example 2",
+           base_path: "/example2")
+    create(:audit, content_item: example1)
+    @audit_report_item = ContentAuditTool.new.audit_report_item
+    @audit_report_item.load(content_id: example2.content_id)
+    @audit_report_item.export_to_csv.click
+  end
 
-      number_of_metadata_rows = 1
-      expect(csv.count).to eq(content_items.count + number_of_metadata_rows)
-    end
+  def then_i_download_a_csv_file
+    expect(content_type).to eq("text/csv")
+    expect(content_disposition).to start_with("attachment")
+    expect(content_disposition).to include(
+      'filename="Transformation_audit_report_CSV_download.csv"',
+    )
+    expect(@audit_report_item).to have_content("Title,URL")
+    expect(@audit_report_item).to have_content("Example 1,https://gov.uk/example1")
+    expect(@audit_report_item).to have_content("Example 1,https://gov.uk/example1")
+  end
+
+  def given_i_have_applied_filters_and_exported_audit
+    user = create(:user)
+    hmrc = create(
+      :content_item,
+      title: "HMRC",
+      document_type: "organisation"
+    )
+    example1 = create(:content_item,
+                      title: "Example 1",
+                      base_path: "/example1",
+                      allocated_to: me)
+    create(:link,
+           source_content_id: example1.content_id,
+           target_content_id: hmrc.content_id,
+           link_type: "primary_publishing_organisation")
+    example2 = create(:content_item,
+           title: "Example 2",
+           base_path: "/example2")
+    create(:audit, content_item: example1)
+    @audit_report_item = ContentAuditTool.new.audit_report_item
+    @audit_report_item.load(content_id: example2.content_id)
+    @audit_report_item.allocated_to.select 'Anyone'
+    @audit_report_item.organisations.select 'HMRC'
+    @audit_report_item.apply_filters.click
+    @audit_report_item.export_to_csv.click
+  end
+
+  def then_i_download_a_csv_file_for_the_filtered_audits
+    expect(@audit_report_item).to have_content("Title,URL")
+    expect(@audit_report_item).to have_content("Example 1,https://gov.uk/example1")
+    expect(@audit_report_item).to have_no_content("Example 2,https://gov.uk/example2")
+  end
+
+  def given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+    user = create(:user)
+    create_list(:content_item, 110)
+    visit audits_report_path
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
+  end
+
+  def then_i_download_a_csv_file_for_all_content_items
+    click_link "Export filtered audit to CSV"
+    csv = CSV.parse(page.body, headers: true)
+    number_of_metadata_rows = 1
+    expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -1,10 +1,4 @@
 RSpec.feature "Exporting a CSV from the report page" do
-  let!(:me) do
-    create(
-      :user,
-    )
-  end
-
   def content_type
     page.response_headers.fetch("Content-Type")
   end
@@ -14,21 +8,28 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   scenario "Exporting a csv file as an attachment" do
-    given_i_am_exporting_an_audit_report
-    then_i_download_a_csv_file
+    given_I_am_exporting_an_audit_report
+    then_I_receive_an_audit_progress_report_in_CSV_format
   end
 
   scenario "Applying the filters to the export" do
-    given_i_have_applied_filters_and_exported_audit
-    then_i_download_a_csv_file_for_the_filtered_audits
+    given_I_have_applied_filters_and_exported_audits
+    then_I_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
   end
 
-  scenario "Multiple pages of content items are in the database" do
-    given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
-    then_i_download_a_csv_file_for_all_content_items
+  scenario "Multiple pagesincluding_details_of_audit_progress_ of content items are in the database" do
+    given_I_have_multiple_pages_of_content_items_and_do_not_filter_them
+    then_I_receive_an_audit_progress_report_for_all_audits_in_CSV_format
   end
 
-  def given_i_am_exporting_an_audit_report
+  scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
+    given_I_apply_filters_to_the_audit_content_page
+    then_I_see_filtered_audits
+    given_that_I_navigate_to_audits_report_page
+    then_I_see_an_unfiltered_audit_progress_report
+  end
+
+  def given_I_am_exporting_an_audit_report
     user = create(:user)
     hmrc = create(
       :content_item,
@@ -38,7 +39,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     example1 = create(:content_item,
                       title: "Example 1",
                       base_path: "/example1",
-                      allocated_to: me)
+                      allocated_to: user)
     create(:link,
            source_content_id: example1.content_id,
            target_content_id: hmrc.content_id,
@@ -47,23 +48,22 @@ RSpec.feature "Exporting a CSV from the report page" do
            title: "Example 2",
            base_path: "/example2")
     create(:audit, content_item: example1)
-    @audit_report_item = ContentAuditTool.new.audit_report_item
-    @audit_report_item.load(content_id: example2.content_id)
-    @audit_report_item.export_to_csv.click
+    @audit_report = ContentAuditTool.new.audit_report
+    @audit_report.load(content_id: example2.content_id)
+    @audit_report.export_to_csv.click
   end
 
-  def then_i_download_a_csv_file
+  def then_I_receive_an_audit_progress_report_in_CSV_format
     expect(content_type).to eq("text/csv")
     expect(content_disposition).to start_with("attachment")
     expect(content_disposition).to include(
       'filename="Transformation_audit_report_CSV_download.csv"',
     )
-    expect(@audit_report_item).to have_content("Title,URL")
-    expect(@audit_report_item).to have_content("Example 1,https://gov.uk/example1")
-    expect(@audit_report_item).to have_content("Example 1,https://gov.uk/example1")
+    expect(@audit_report).to have_content("Title,URL")
+    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
   end
 
-  def given_i_have_applied_filters_and_exported_audit
+  def given_I_have_applied_filters_and_exported_audits
     user = create(:user)
     hmrc = create(
       :content_item,
@@ -73,7 +73,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     example1 = create(:content_item,
                       title: "Example 1",
                       base_path: "/example1",
-                      allocated_to: me)
+                      allocated_to: user)
     create(:link,
            source_content_id: example1.content_id,
            target_content_id: hmrc.content_id,
@@ -82,21 +82,21 @@ RSpec.feature "Exporting a CSV from the report page" do
            title: "Example 2",
            base_path: "/example2")
     create(:audit, content_item: example1)
-    @audit_report_item = ContentAuditTool.new.audit_report_item
-    @audit_report_item.load(content_id: example2.content_id)
-    @audit_report_item.allocated_to.select 'Anyone'
-    @audit_report_item.organisations.select 'HMRC'
-    @audit_report_item.apply_filters.click
-    @audit_report_item.export_to_csv.click
+    @audit_report = ContentAuditTool.new.audit_report
+    @audit_report.load(content_id: example2.content_id)
+    @audit_report.allocated_to.select 'Anyone'
+    @audit_report.organisations.select 'HMRC'
+    @audit_report.apply_filters.click
+    @audit_report.export_to_csv.click
   end
 
-  def then_i_download_a_csv_file_for_the_filtered_audits
-    expect(@audit_report_item).to have_content("Title,URL")
-    expect(@audit_report_item).to have_content("Example 1,https://gov.uk/example1")
-    expect(@audit_report_item).to have_no_content("Example 2,https://gov.uk/example2")
+  def then_I_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
+    expect(@audit_report).to have_content("Title,URL")
+    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
+    expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
   end
 
-  def given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+  def given_I_have_multiple_pages_of_content_items_and_do_not_filter_them
     user = create(:user)
     create_list(:content_item, 110)
     visit audits_report_path
@@ -104,10 +104,49 @@ RSpec.feature "Exporting a CSV from the report page" do
     click_on "Apply filters"
   end
 
-  def then_i_download_a_csv_file_for_all_content_items
+  def then_I_receive_an_audit_progress_report_for_all_audits_in_CSV_format
     click_link "Export filtered audit to CSV"
     csv = CSV.parse(page.body, headers: true)
     number_of_metadata_rows = 1
     expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
+  end
+
+  def given_I_apply_filters_to_the_audit_content_page
+    user = create(:user)
+    hmrc = create(:content_item,
+                  title: "HMRC",
+                  document_type: "organisation",
+                  allocated_to: user)
+    example1 = create(:content_item,
+                      title: "Example 1",
+                      base_path: "/example1")
+    create(:link,
+           source_content_id: example1.content_id,
+           target_content_id: hmrc.content_id,
+           link_type: "primary_publishing_organisation")
+    example2 = create(:content_item,
+           title: "Example 2",
+           base_path: "/example2",
+           allocated_to: user)
+    @audit_content_page = ContentAuditTool.new.audit_content_page
+    @audit_report_page = ContentAuditTool.new.audit_report
+    @audit_content_page.load
+    @audit_content_page.allocated_to.select 'No one'
+    @audit_content_page.apply_filters.click
+
+  end
+
+  def then_I_see_filtered_audits
+    expect(@audit_content_page).to have_content("Example 1")
+    expect(@audit_content_page).to have_no_content("Example 2")
+  end
+
+  def given_that_I_navigate_to_audits_report_page
+    @audit_content_page.audits_progress_tab.click
+  end
+
+  def then_I_see_an_unfiltered_audit_progress_report
+    expect(@audit_report_page).to be_displayed
+    expect(@audit_report_page).to have_no_content('Example 1')
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     @audit_report.export_to_csv.click
   end
 
-  def then_i_receive_an_audit_progress_report_in_CSV_format
+  def then_i_receive_an_audit_progress_report_in_csv_format
     expect(content_type).to eq("text/csv")
     expect(content_disposition).to start_with("attachment")
     expect(content_disposition).to include(
@@ -90,7 +90,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     @audit_report.export_to_csv.click
   end
 
-  def then_i_receive_an_audit_progress_report_for_filtered_audits_in_CSV_format
+  def then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
     expect(@audit_report).to have_content("Title,URL")
     expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
     expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
@@ -104,7 +104,7 @@ RSpec.feature "Exporting a CSV from the report page" do
     click_on "Apply filters"
   end
 
-  def then_i_receive_an_audit_progress_report_for_all_audits_in_CSV_format
+  def then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
     click_link "Export filtered audit to CSV"
     csv = CSV.parse(page.body, headers: true)
     number_of_metadata_rows = 1
@@ -124,7 +124,7 @@ RSpec.feature "Exporting a CSV from the report page" do
            source_content_id: example1.content_id,
            target_content_id: hmrc.content_id,
            link_type: "primary_publishing_organisation")
-  create(:content_item,
+    create(:content_item,
          title: "Example 2",
          base_path: "/example2",
          allocated_to: user)

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,30 +1,29 @@
 RSpec.feature "Reporting on audit progress" do
-
   scenario "Displaying the number of items included in the audit" do
-    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_I_see_all_content_items
-    given_that_I_select_a_document_type_that_does_not_apply_to_any_content_item
-    then_I_see_no_content_items
-    given_that_I_select_a_document_type_that_applies_to_all_content_items
-    then_I_see_all_content_items
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_all_content_items
+    given_that_i_select_a_document_type_that_does_not_apply_to_any_content_item
+    then_i_see_no_content_items
+    given_that_i_select_a_document_type_that_applies_to_all_content_items
+    then_i_see_all_content_items
   end
 
   scenario "Displaying the number of items audited/not audited" do
-    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_I_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
   end
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
-    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_I_see_a_percentage_breakdown_of_how_many_items_need_improvement
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
   end
 
   scenario "Audit status filter is not present" do
-    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_I_do_not_see_audit_status_filter
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_do_not_see_audit_status_filter
   end
 
-  def given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+  def given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
     organisation = create(:organisation)
     user = create(:user, organisation: organisation)
     content_items = create_list(
@@ -41,38 +40,38 @@ RSpec.feature "Reporting on audit progress" do
     @audit_report.load(content_id: content_items.last.content_id)
   end
 
-  def then_I_see_all_content_items
+  def then_i_see_all_content_items
     expect(@audit_report).to have_report_section(text: '3 Content items')
   end
 
-  def given_that_I_select_a_document_type_that_does_not_apply_to_any_content_item
+  def given_that_i_select_a_document_type_that_does_not_apply_to_any_content_item
     @audit_report.allocated_to.select 'Anyone'
     @audit_report.content_type.select 'Guide'
     @audit_report.apply_filters.click
   end
 
-  def then_I_see_no_content_items
+  def then_i_see_no_content_items
     expect(@audit_report).to have_report_section(text: '0 Content items')
   end
 
-  def given_that_I_select_a_document_type_that_applies_to_all_content_items
+  def given_that_i_select_a_document_type_that_applies_to_all_content_items
     @audit_report.content_type.select 'Transaction'
     @audit_report.apply_filters.click
   end
 
-  def then_I_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+  def then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
     expect(@audit_report).to have_report_section(text: 'Audited 2 67%')
     expect(@audit_report).to have_report_section(text: 'Still to audit 1 33%')
     expect(@audit_report).to have_audit_progress_bar(text: '66.66667% Complete')
   end
 
-  def then_I_see_a_percentage_breakdown_of_how_many_items_need_improvement
+  def then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
     expect(@audit_report).to have_report_section(text: 'Need improvement 1 50%')
     expect(@audit_report).to have_report_section(text: "Don't need improvement 1 50%")
-    expect(@audit_report).to have_improvement_progress_bar(text: '50% Complete' )
+    expect(@audit_report).to have_improvement_progress_bar(text: '50% Complete')
   end
 
-  def then_I_do_not_see_audit_status_filter
+  def then_i_do_not_see_audit_status_filter
     expect(@audit_report).to have_no_report_section(text: 'Audit Status')
   end
 end

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,72 +1,78 @@
 RSpec.feature "Reporting on audit progress" do
-  let!(:my_organisation) do
-    create(
-      :organisation
-    )
+
+  scenario "Displaying the number of items included in the audit" do
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_I_see_all_content_items
+    given_that_select_a_document_type_that_does_not_apply_to_any_content_item
+    then_I_see_no_content_items
+    given_that_select_a_document_type_that_applies_to_all_content_items
+    then_I_see_all_content_items
   end
 
-  let!(:me) do
-    create(
-      :user,
-      organisation: my_organisation,
-    )
+  scenario "Displaying the number of items audited/not audited" do
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
   end
 
-  context "I have been allocated some audited and unaudited content items belonging to my organisation" do
-    before(:each) do
-      content_items = create_list(
-        :content_item,
-        3,
-        document_type: "transaction",
-        allocated_to: me,
-        primary_publishing_organisation: my_organisation,
-      )
-
-      create(:passing_audit, content_item: content_items[0])
-      create(:failing_audit, content_item: content_items[1])
-    end
-
-    scenario "Displaying the number of items included in the audit" do
-      visit audits_report_path
-
-      expect(page).to have_content("3 Content items")
-
-      select "Anyone", from: "allocated_to"
-      select "Guide", from: "document_type"
-      click_on "Apply filters"
-
-      expect(page).to have_content("0 Content items")
-
-      select "Transaction", from: "document_type"
-      click_on "Apply filters"
-
-      expect(page).to have_content("3 Content items")
-    end
-
-    scenario "Displaying the number of items audited/not audited" do
-      visit audits_report_path
-
-      expect(page).to have_content("Audited 2 67%")
-      expect(page).to have_content("Still to audit 1 33%")
-      expect(width("#progress")).to eq("width: 66.66667%;")
-    end
-
-    scenario "Displaying the number of items needing improvement/not needing improvement" do
-      visit audits_report_path
-
-      expect(page).to have_content("Need improvement 1 50%")
-      expect(page).to have_content("Don't need improvement 1 50%")
-      expect(width("#items-needing-improvement")).to eq("width: 50%;")
-    end
+  scenario "Displaying the number of items needing improvement/not needing improvement" do
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
   end
 
   scenario "Audit status filter is not present" do
-    visit audits_report_path
-
-    expect(page).to have_no_content("Audit status")
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_do_not_see_audit_status_filter
   end
 
-  def width(id)
-    page.find("#{id} .progress .progress-bar")[:style]
+  def given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    organisation = create(:organisation)
+    user = create(:user, organisation: organisation)
+    content_items = create_list(
+      :content_item,
+      3,
+      document_type: "transaction",
+      allocated_to: user,
+      primary_publishing_organisation: organisation,
+    )
+    create(:passing_audit, content_item: content_items[0])
+    create(:failing_audit, content_item: content_items[1])
+
+    @audit_report_item = ContentAuditTool.new.audit_report_item
+    @audit_report_item.load(content_id: content_items.last.content_id)
+  end
+
+  def then_I_see_all_content_items
+    expect(@audit_report_item).to have_report_section(text: '3 Content items')
+  end
+
+  def given_that_select_a_document_type_that_does_not_apply_to_any_content_item
+    @audit_report_item.allocated_to.select 'Anyone'
+    @audit_report_item.content_type.select 'Guide'
+    @audit_report_item.apply_filters.click
+  end
+
+  def then_I_see_no_content_items
+    expect(@audit_report_item).to have_report_section(text: '0 Content items')
+  end
+
+  def given_that_select_a_document_type_that_applies_to_all_content_items
+    @audit_report_item.content_type.select 'Transaction'
+    @audit_report_item.apply_filters.click
+  end
+
+  def then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+    expect(@audit_report_item).to have_report_section(text: 'Audited 2 67%')
+    expect(@audit_report_item).to have_report_section(text: 'Still to audit 1 33%')
+    expect(@audit_report_item).to have_audit_progress_bar(text: '66.66667% Complete')
+  end
+
+  def then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
+    expect(@audit_report_item).to have_report_section(text: 'Need improvement 1 50%')
+    expect(@audit_report_item).to have_report_section(text: "Don't need improvement 1 50%")
+    expect(@audit_report_item).to have_improvement_progress_bar(text: '50% Complete' )
+  end
+
+  def then_i_do_not_see_audit_status_filter
+    expect(@audit_report_item).to_not have_report_section(text: 'Audit Status')
   end
 end

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,30 +1,30 @@
 RSpec.feature "Reporting on audit progress" do
 
   scenario "Displaying the number of items included in the audit" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
     then_I_see_all_content_items
-    given_that_select_a_document_type_that_does_not_apply_to_any_content_item
+    given_that_I_select_a_document_type_that_does_not_apply_to_any_content_item
     then_I_see_no_content_items
-    given_that_select_a_document_type_that_applies_to_all_content_items
+    given_that_I_select_a_document_type_that_applies_to_all_content_items
     then_I_see_all_content_items
   end
 
   scenario "Displaying the number of items audited/not audited" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_I_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
   end
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
+    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_I_see_a_percentage_breakdown_of_how_many_items_need_improvement
   end
 
   scenario "Audit status filter is not present" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_i_do_not_see_audit_status_filter
+    given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_I_do_not_see_audit_status_filter
   end
 
-  def given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+  def given_I_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
     organisation = create(:organisation)
     user = create(:user, organisation: organisation)
     content_items = create_list(
@@ -37,42 +37,42 @@ RSpec.feature "Reporting on audit progress" do
     create(:passing_audit, content_item: content_items[0])
     create(:failing_audit, content_item: content_items[1])
 
-    @audit_report_item = ContentAuditTool.new.audit_report_item
-    @audit_report_item.load(content_id: content_items.last.content_id)
+    @audit_report = ContentAuditTool.new.audit_report
+    @audit_report.load(content_id: content_items.last.content_id)
   end
 
   def then_I_see_all_content_items
-    expect(@audit_report_item).to have_report_section(text: '3 Content items')
+    expect(@audit_report).to have_report_section(text: '3 Content items')
   end
 
-  def given_that_select_a_document_type_that_does_not_apply_to_any_content_item
-    @audit_report_item.allocated_to.select 'Anyone'
-    @audit_report_item.content_type.select 'Guide'
-    @audit_report_item.apply_filters.click
+  def given_that_I_select_a_document_type_that_does_not_apply_to_any_content_item
+    @audit_report.allocated_to.select 'Anyone'
+    @audit_report.content_type.select 'Guide'
+    @audit_report.apply_filters.click
   end
 
   def then_I_see_no_content_items
-    expect(@audit_report_item).to have_report_section(text: '0 Content items')
+    expect(@audit_report).to have_report_section(text: '0 Content items')
   end
 
-  def given_that_select_a_document_type_that_applies_to_all_content_items
-    @audit_report_item.content_type.select 'Transaction'
-    @audit_report_item.apply_filters.click
+  def given_that_I_select_a_document_type_that_applies_to_all_content_items
+    @audit_report.content_type.select 'Transaction'
+    @audit_report.apply_filters.click
   end
 
-  def then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
-    expect(@audit_report_item).to have_report_section(text: 'Audited 2 67%')
-    expect(@audit_report_item).to have_report_section(text: 'Still to audit 1 33%')
-    expect(@audit_report_item).to have_audit_progress_bar(text: '66.66667% Complete')
+  def then_I_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+    expect(@audit_report).to have_report_section(text: 'Audited 2 67%')
+    expect(@audit_report).to have_report_section(text: 'Still to audit 1 33%')
+    expect(@audit_report).to have_audit_progress_bar(text: '66.66667% Complete')
   end
 
-  def then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
-    expect(@audit_report_item).to have_report_section(text: 'Need improvement 1 50%')
-    expect(@audit_report_item).to have_report_section(text: "Don't need improvement 1 50%")
-    expect(@audit_report_item).to have_improvement_progress_bar(text: '50% Complete' )
+  def then_I_see_a_percentage_breakdown_of_how_many_items_need_improvement
+    expect(@audit_report).to have_report_section(text: 'Need improvement 1 50%')
+    expect(@audit_report).to have_report_section(text: "Don't need improvement 1 50%")
+    expect(@audit_report).to have_improvement_progress_bar(text: '50% Complete' )
   end
 
-  def then_i_do_not_see_audit_status_filter
-    expect(@audit_report_item).to_not have_report_section(text: 'Audit Status')
+  def then_I_do_not_see_audit_status_filter
+    expect(@audit_report).to have_no_report_section(text: 'Audit Status')
   end
 end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -5,11 +5,11 @@ class ContentAuditTool
     AuditContentItemPage.new
   end
 
-  def audit_report_item
+  def audit_report
     AuditReportPage.new
   end
 
-  def audit_content
+  def audit_content_page
     AuditContentPage.new
   end
 end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -4,4 +4,8 @@ class ContentAuditTool
   def audit_content_item
     AuditContentItemPage.new
   end
+
+  def audit_report_item
+    AuditReportPage.new
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -8,4 +8,8 @@ class ContentAuditTool
   def audit_report_item
     AuditReportPage.new
   end
+
+  def audit_content
+    AuditContentPage.new
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -1,0 +1,10 @@
+require 'site_prism/page'
+
+class AuditContentPage < SitePrism::Page
+  set_url '/audits'
+
+  element :allocated_to, '#allocated_to'
+  element :audit_status, '[data-test=audit-status]'
+  element :apply_filters, 'input[type=submit]'
+  element :audits_progress_tab, '[data-test=audit_progress_tab]'
+end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -9,4 +9,6 @@ class AuditReportPage < SitePrism::Page
   element :content_type, '#document_type'
   element :audit_progress_bar, '[data-test=audit_progress_bar]'
   element :improvement_progress_bar, '[data-test=improvement_progress_bar]'
+  element :export_to_csv, '.report-export'
+  element :organisations, '#organisations'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -4,4 +4,9 @@ class AuditReportPage < SitePrism::Page
   set_url '/audits/report'
 
   element :report_section, '.report-section'
+  element :allocated_to, '#allocated_to'
+  element :apply_filters, 'input[type=submit]'
+  element :content_type, '#document_type'
+  element :audit_progress_bar, '[data-test=audit_progress_bar]'
+  element :improvement_progress_bar, '[data-test=improvement_progress_bar]'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -1,0 +1,7 @@
+require 'site_prism/page'
+
+class AuditReportPage < SitePrism::Page
+  set_url '/audits/report'
+
+  element :report_section, '.report-section'
+end


### PR DESCRIPTION
* Refactor allocation_spec.rb, csv_export_spec.rb and progress_spec.rb to use the page object model and a declarative style.
* Add data-test attributes to allow for easy identification of elements in tests
* Add page objects using the site-prism gem for AuditContentPage and AuditReportPage