### PR TITLE
Refactor audit report feature tests

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -3,7 +3,7 @@ module MenuHelper
     status = controller.controller_name == scope ? 'active' : ''
 
     content_tag :li, role: "presentation", class: status do
-      link_to_unless_current text, url, aria_controls: "home", role: "tab" do
+      link_to_unless_current text, url, aria_controls: "home", role: "tab", data: { test_id: scope } do
         link_to text, "#", aria_controls: "home", role: "tab"
       end
     end

--- a/app/views/audits/reports/_progress_bar.html.erb
+++ b/app/views/audits/reports/_progress_bar.html.erb
@@ -1,6 +1,7 @@
 <% formatted = format_percentage(percentage, precision: 5) %>
 
-<div class="progress">
+<div class="progress"
+     data-test-id="<%= data_test_id %>">
   <div class="progress-bar"
         role="progressbar"
         aria-valuenow="<%= percentage %>"

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="report-section"
      data-test-id="report-section">
-  <h3><%= format_number(@monitor.total_count) %></h3>
+  <h3 data-test-id="content-item-count">><%= format_number(@monitor.total_count) %></h3>
   <p>Content items</p>
   <div>
 

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -17,7 +17,7 @@
     <div id="progress">
       <h3>Audit progress</h3>
 
-      <%= render "progress_bar", percentage: @monitor.audited_percentage, data_test_id: 'audit_progress_bar' %>
+      <%= render "progress_bar", percentage: @monitor.audited_percentage, data_test_id: 'audit-progress-bar' %>
 
       <table class="table">
         <tr>
@@ -36,7 +36,7 @@
     <div id="items-needing-improvement">
       <h3>Items needing improvement</h3>
 
-      <%= render "progress_bar", percentage: @monitor.passing_percentage, data_test_id: 'improvement_progress_bar' %>
+      <%= render "progress_bar", percentage: @monitor.passing_percentage, data_test_id: 'improvement-progress-bar' %>
 
       <table class="table">
         <tr>

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="report-section"
      data-test-id="report-section">
-  <h3 data-test-id="content-item-count">><%= format_number(@monitor.total_count) %></h3>
+  <h3 data-test-id="content-item-count"><%= format_number(@monitor.total_count) %></h3>
   <p>Content items</p>
   <div>
 

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -16,7 +16,7 @@
     <div id="progress">
       <h3>Audit progress</h3>
 
-      <%= render "progress_bar", percentage: @monitor.audited_percentage %>
+      <%= render "progress_bar", percentage: @monitor.audited_percentage, data_test_id: 'audit_progress_bar' %>
 
       <table class="table">
         <tr>
@@ -35,7 +35,7 @@
     <div id="items-needing-improvement">
       <h3>Items needing improvement</h3>
 
-      <%= render "progress_bar", percentage: @monitor.passing_percentage %>
+      <%= render "progress_bar", percentage: @monitor.passing_percentage, data_test_id: 'improvement_progress_bar' %>
 
       <table class="table">
         <tr>

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -6,9 +6,10 @@
     <%= render 'audits/common/navigation' %>
 <% end %>
 
-<%= link_to "Export filtered audit to CSV", audits_path(params: filter_params, format: :csv), class: "report-export" %>
+<%= link_to "Export filtered audit to CSV", audits_path(params: filter_params, format: :csv), class: "report-export", data: { test_id: "report-export" } %>
 
-<div class="report-section">
+<div class="report-section"
+     data-test-id="report-section">
   <h3><%= format_number(@monitor.total_count) %></h3>
   <p>Content items</p>
   <div>

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -1,34 +1,38 @@
 RSpec.feature "Content Allocation", type: :feature do
   scenario "Filter allocated content" do
-    given_i_am_auditing_a_content_item
-    then_i_see_all_content_items
-    given_that_i_filter_by_attributes_that_do_not_apply_to_any_content_items
-    then_i_see_no_content_items
+    given_i_am_an_auditor_belonging_to_an_organisation
+    when_i_visit_the_report_page
+    then_i_can_see_the_content_item_i_have_been_allocated
+    when_i_select_no_one_in_the_allocated_to_filter
+    then_i_cannot_see_the_content_item_i_have_been_allocated
   end
 
-  def given_i_am_auditing_a_content_item
+  def given_i_am_an_auditor_belonging_to_an_organisation
     organisation = create(:organisation)
     user = create(:user, organisation: organisation)
-    content_item = create(
+    @content_item = create(
       :content_item,
       title: "Do Androids Dream of Electric Sheep",
       allocated_to: user,
       primary_publishing_organisation: organisation,
     )
-    @audit_report_page = ContentAuditTool.new.audit_report_page
-    @audit_report_page.load(content_id: content_item.content_id)
   end
 
-  def then_i_see_all_content_items
+  def when_i_visit_the_report_page
+    @audit_report_page = ContentAuditTool.new.audit_report_page
+    @audit_report_page.load(content_id: @content_item.content_id)
+  end
+
+  def then_i_can_see_the_content_item_i_have_been_allocated
     expect(@audit_report_page).to have_report_section(text: '1')
   end
 
-  def given_that_i_filter_by_attributes_that_do_not_apply_to_any_content_items
+  def when_i_select_no_one_in_the_allocated_to_filter
     @audit_report_page.allocated_to.select 'No one'
     @audit_report_page.apply_filters.click
   end
 
-  def then_i_see_no_content_items
+  def then_i_cannot_see_the_content_item_i_have_been_allocated
     expect(@audit_report_page).to have_report_section(text: '0')
   end
 end

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Content Allocation", type: :feature do
   end
 
   def then_i_can_see_the_content_item_i_have_been_allocated
-    expect(@audit_report_page).to have_report_section(text: '1')
+    expect(@audit_report_page).to have_content_item_count(1)
   end
 
   def when_i_select_no_one_in_the_allocated_to_filter

--- a/spec/features/audit/report/allocation_spec.rb
+++ b/spec/features/audit/report/allocation_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Content Allocation", type: :feature do
   end
 
   def then_i_can_see_the_content_item_i_have_been_allocated
-    expect(@audit_report_page).to have_content_item_count(1)
+    expect(@audit_report_page.content_item_count.text).to eq('1')
   end
 
   def when_i_select_no_one_in_the_allocated_to_filter
@@ -33,6 +33,6 @@ RSpec.feature "Content Allocation", type: :feature do
   end
 
   def then_i_cannot_see_the_content_item_i_have_been_allocated
-    expect(@audit_report_page).to have_report_section(text: '0')
+    expect(@audit_report_page.content_item_count.text).to eq('0')
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -8,63 +8,36 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   scenario "Exporting a csv file as an attachment" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+    given_i_am_an_auditor_belonging_to_an_organisation
     when_i_export_an_audit_report
     then_i_receive_the_report_in_csv_format
   end
 
   scenario "Applying the filters to the export" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
-    and_they_are_filtered
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_filter_is_applied_to_show_only_hmrc_content_items
     when_i_export_the_reports
-    then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
+    then_i_receive_only_hmrc_related_content_items_in_the_report
   end
 
   scenario "Multiple pages including_details_of_audit_progress_ of content items are in the database" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+    given_i_am_an_auditor_belonging_to_an_organisation
     and_there_are_multiple_pages_of_unfiltered_content_items
     when_i_export_all_the_reports
-    then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
+    then_i_receive_an_audit_progress_report_for_all_content_items_in_csv_format
   end
 
   scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
-    when_i_apply_filters
-    then_i_see_the_two_content_items_which_match_the_filters
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_there_are_two_unassigned_content_items
+    when_i_filter_the_content_page_for_content_items_with_no_one_assigned_to_them
+    then_i_see_the_two_unassigned_content_items
     when_i_navigate_to_audits_report_page
-    then_i_see_one_content_item_which_matches_default_filters
+    then_i_do_not_see_the_two_unassigned_content_items
+    and_i_see_the_one_content_item_assigned_to_me
   end
 
-  def given_i_am_exporting_an_audit_report
-    user = create(:user)
-    hmrc = create(
-      :content_item,
-      title: "HMRC",
-      document_type: "organisation"
-    )
-    example1 = create(:content_item,
-                      title: "Example 1",
-                      base_path: "/example1",
-                      allocated_to: user)
-    create(:link,
-           source_content_id: example1.content_id,
-           target_content_id: hmrc.content_id,
-           link_type: "primary_publishing_organisation")
-    create(:content_item,
-           title: "Example 2",
-           base_path: "/example2",
-           allocated_to: nil)
-    create(:content_item,
-           title: "Example 3",
-           base_path: "/example3",
-           allocated_to: nil)
-    create(:audit, content_item: example1)
-    @audit_report = ContentAuditTool.new.audit_report_page
-    @audit_report.load(content_id: Content::Item.last.content_id)
-    @audit_report.export_to_csv.click
-  end
-
-  def given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+  def given_i_am_an_auditor_belonging_to_an_organisation
     user = create(:user)
     hmrc = create(
       :content_item,
@@ -80,24 +53,16 @@ RSpec.feature "Exporting a CSV from the report page" do
            source_content_id: example1.content_id,
            target_content_id: hmrc.content_id,
            link_type: "primary_publishing_organisation")
-    create(:content_item,
-           title: "Example 2",
-           base_path: "/example2",
-           allocated_to: nil)
-    create(:content_item,
-           title: "Example 3",
-           base_path: "/example3",
-           allocated_to: nil)
     create(:audit, content_item: example1)
   end
 
-  def then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
+  def then_i_receive_only_hmrc_related_content_items_in_the_report
     expect(@audit_report).to have_content("Title,URL")
     expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
     expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
   end
 
-  def then_i_see_the_two_content_items_which_match_the_filters
+  def then_i_see_the_two_unassigned_content_items
     expect(@audit_content_page).to have_no_content("Example 1")
     expect(@audit_content_page).to have_content("Example 2")
     expect(@audit_content_page).to have_content("Example 3")
@@ -107,10 +72,13 @@ RSpec.feature "Exporting a CSV from the report page" do
     @audit_content_page.audits_progress_tab.click
   end
 
-  def then_i_see_one_content_item_which_matches_default_filters
+  def then_i_do_not_see_the_two_unassigned_content_items
     expect(@audit_report_page).to be_displayed
-    expect(@audit_report_page).to have_content('1 Content items')
     expect(@audit_report_page).to have_no_content('2 Content items')
+  end
+
+  def and_i_see_the_one_content_item_assigned_to_me
+    expect(@audit_report_page).to have_content('1 Content items')
   end
 
   def when_i_export_an_audit_report
@@ -129,10 +97,9 @@ RSpec.feature "Exporting a CSV from the report page" do
     expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
   end
 
-  def and_they_are_filtered
+  def and_filter_is_applied_to_show_only_hmrc_content_items
     @audit_report = ContentAuditTool.new.audit_report_page
     @audit_report.load(content_id: Content::Item.last.content_id)
-    @audit_report.allocated_to.select 'Anyone'
     @audit_report.organisations.select 'HMRC'
     @audit_report.apply_filters.click
   end
@@ -152,13 +119,13 @@ RSpec.feature "Exporting a CSV from the report page" do
     click_link "Export filtered audit to CSV"
   end
 
-  def then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
+  def then_i_receive_an_audit_progress_report_for_all_content_items_in_csv_format
     csv = CSV.parse(page.body)
     number_of_metadata_rows = 1
     expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
   end
 
-  def when_i_apply_filters
+  def when_i_filter_the_content_page_for_content_items_with_no_one_assigned_to_them
     @audit_content_page = ContentAuditTool.new.audit_content_page
     @audit_report_page = ContentAuditTool.new.audit_report_page
     @audit_content_page.load
@@ -166,5 +133,14 @@ RSpec.feature "Exporting a CSV from the report page" do
       form.allocated_to.select "No one"
       form.apply_filters.click
     end
+  end
+
+  def and_there_are_two_unassigned_content_items
+    create(:content_item,
+           title: "Example 2",
+           base_path: "/example2")
+    create(:content_item,
+           title: "Example 3",
+           base_path: "/example3")
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -8,25 +8,31 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   scenario "Exporting a csv file as an attachment" do
-    given_i_am_exporting_an_audit_report
-    then_i_receive_an_audit_progress_report_in_csv_format
+    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+    when_i_export_an_audit_report
+    then_i_receive_the_report_in_csv_format
   end
 
   scenario "Applying the filters to the export" do
-    given_i_have_applied_filters_and_exported_audits
+    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+    and_they_are_filtered
+    when_i_export_the_reports
     then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
   end
 
-  scenario "Multiple pagesincluding_details_of_audit_progress_ of content items are in the database" do
-    given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+  scenario "Multiple pages including_details_of_audit_progress_ of content items are in the database" do
+    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+    and_there_are_multiple_pages_of_unfiltered_content_items
+    when_i_export_all_the_reports
     then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
   end
 
   scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-    given_i_apply_filters_to_the_audit_content_page
-    then_i_see_filtered_audits
-    given_that_i_navigate_to_audits_report_page
-    then_i_see_an_unfiltered_audit_progress_report
+    given_i_am_an_auditor_belonging_to_an_organisation_with_audits
+    when_i_apply_filters
+    then_i_see_the_two_content_items_which_match_the_filters
+    when_i_navigate_to_audits_report_page
+    then_i_see_one_content_item_which_matches_default_filters
   end
 
   def given_i_am_exporting_an_audit_report
@@ -46,29 +52,25 @@ RSpec.feature "Exporting a CSV from the report page" do
            link_type: "primary_publishing_organisation")
     create(:content_item,
            title: "Example 2",
-           base_path: "/example2")
+           base_path: "/example2",
+           allocated_to: nil)
+    create(:content_item,
+           title: "Example 3",
+           base_path: "/example3",
+           allocated_to: nil)
     create(:audit, content_item: example1)
     @audit_report = ContentAuditTool.new.audit_report_page
     @audit_report.load(content_id: Content::Item.last.content_id)
     @audit_report.export_to_csv.click
   end
 
-  def then_i_receive_an_audit_progress_report_in_csv_format
-    expect(content_type).to eq("text/csv")
-    expect(content_disposition).to start_with("attachment")
-    expect(content_disposition).to include(
-      'filename="Transformation_audit_report_CSV_download.csv"',
-    )
-    expect(@audit_report).to have_content("Title,URL")
-    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
-  end
-
-  def given_i_have_applied_filters_and_exported_audits
+  def given_i_am_an_auditor_belonging_to_an_organisation_with_audits
     user = create(:user)
     hmrc = create(
       :content_item,
       title: "HMRC",
-      document_type: "organisation"
+      document_type: "organisation",
+      allocated_to: user
     )
     example1 = create(:content_item,
                       title: "Example 1",
@@ -80,14 +82,13 @@ RSpec.feature "Exporting a CSV from the report page" do
            link_type: "primary_publishing_organisation")
     create(:content_item,
            title: "Example 2",
-           base_path: "/example2")
+           base_path: "/example2",
+           allocated_to: nil)
+    create(:content_item,
+           title: "Example 3",
+           base_path: "/example3",
+           allocated_to: nil)
     create(:audit, content_item: example1)
-    @audit_report = ContentAuditTool.new.audit_report_page
-    @audit_report.load(content_id: Content::Item.last.content_id)
-    @audit_report.allocated_to.select 'Anyone'
-    @audit_report.organisations.select 'HMRC'
-    @audit_report.apply_filters.click
-    @audit_report.export_to_csv.click
   end
 
   def then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
@@ -96,38 +97,68 @@ RSpec.feature "Exporting a CSV from the report page" do
     expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
   end
 
-  def given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
-    create(:user)
-    create_list(:content_item, 110)
+  def then_i_see_the_two_content_items_which_match_the_filters
+    expect(@audit_content_page).to have_no_content("Example 1")
+    expect(@audit_content_page).to have_content("Example 2")
+    expect(@audit_content_page).to have_content("Example 3")
+  end
+
+  def when_i_navigate_to_audits_report_page
+    @audit_content_page.audits_progress_tab.click
+  end
+
+  def then_i_see_one_content_item_which_matches_default_filters
+    expect(@audit_report_page).to be_displayed
+    expect(@audit_report_page).to have_content('1 Content items')
+    expect(@audit_report_page).to have_no_content('2 Content items')
+  end
+
+  def when_i_export_an_audit_report
+    @audit_report = ContentAuditTool.new.audit_report_page
+    @audit_report.load(content_id: Content::Item.last.content_id)
+    @audit_report.export_to_csv.click
+  end
+
+  def then_i_receive_the_report_in_csv_format
+    expect(content_type).to eq("text/csv")
+    expect(content_disposition).to start_with("attachment")
+    expect(content_disposition).to include(
+      'filename="Transformation_audit_report_CSV_download.csv"',
+    )
+    expect(@audit_report).to have_content("Title,URL")
+    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
+  end
+
+  def and_they_are_filtered
+    @audit_report = ContentAuditTool.new.audit_report_page
+    @audit_report.load(content_id: Content::Item.last.content_id)
+    @audit_report.allocated_to.select 'Anyone'
+    @audit_report.organisations.select 'HMRC'
+    @audit_report.apply_filters.click
+  end
+
+  def when_i_export_the_reports
+    @audit_report.export_to_csv.click
+  end
+
+  def and_there_are_multiple_pages_of_unfiltered_content_items
+    create_list(:content_item, 100)
+  end
+
+  def when_i_export_all_the_reports
     visit audits_report_path
     select "Anyone", from: "allocated_to"
     click_on "Apply filters"
+    click_link "Export filtered audit to CSV"
   end
 
   def then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
-    click_link "Export filtered audit to CSV"
-    csv = CSV.parse(page.body, headers: true)
+    csv = CSV.parse(page.body)
     number_of_metadata_rows = 1
     expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
   end
 
-  def given_i_apply_filters_to_the_audit_content_page
-    user = create(:user)
-    hmrc = create(:content_item,
-                  title: "HMRC",
-                  document_type: "organisation",
-                  allocated_to: user)
-    example1 = create(:content_item,
-                      title: "Example 1",
-                      base_path: "/example1")
-    create(:link,
-           source_content_id: example1.content_id,
-           target_content_id: hmrc.content_id,
-           link_type: "primary_publishing_organisation")
-    create(:content_item,
-           title: "Example 2",
-           base_path: "/example2",
-           allocated_to: user)
+  def when_i_apply_filters
     @audit_content_page = ContentAuditTool.new.audit_content_page
     @audit_report_page = ContentAuditTool.new.audit_report_page
     @audit_content_page.load
@@ -135,19 +166,5 @@ RSpec.feature "Exporting a CSV from the report page" do
       form.allocated_to.select "No one"
       form.apply_filters.click
     end
-  end
-
-  def then_i_see_filtered_audits
-    expect(@audit_content_page).to have_content("Example 1")
-    expect(@audit_content_page).to have_no_content("Example 2")
-  end
-
-  def given_that_i_navigate_to_audits_report_page
-    @audit_content_page.audits_progress_tab.click
-  end
-
-  def then_i_see_an_unfiltered_audit_progress_report
-    expect(@audit_report_page).to be_displayed
-    expect(@audit_report_page).to have_no_content('Example 1')
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -1,10 +1,4 @@
 RSpec.feature "Exporting a CSV from the report page" do
-  let!(:me) do
-    create(
-      :user,
-    )
-  end
-
   def content_type
     page.response_headers.fetch("Content-Type")
   end
@@ -13,99 +7,147 @@ RSpec.feature "Exporting a CSV from the report page" do
     page.response_headers.fetch("Content-Disposition")
   end
 
-  context "Two content items are in the database" do
-    let!(:hmrc) {
-      create(
-        :content_item,
-        title: "HMRC",
-        document_type: "organisation"
-      )
-    }
+  scenario "Exporting a csv file as an attachment" do
+    given_i_am_exporting_an_audit_report
+    then_i_receive_an_audit_progress_report_in_csv_format
+  end
 
-    before do
-      example1 = create(
-        :content_item,
-        title: "Example 1",
-        base_path: "/example1",
-        allocated_to: me,
-      )
+  scenario "Applying the filters to the export" do
+    given_i_have_applied_filters_and_exported_audits
+    then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
+  end
 
-      create(
-        :link,
-        source_content_id: example1.content_id,
-        target_content_id: hmrc.content_id,
-        link_type: "primary_publishing_organisation",
-      )
+  scenario "Multiple pagesincluding_details_of_audit_progress_ of content items are in the database" do
+    given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+    then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
+  end
 
-      create(
-        :content_item,
-        title: "Example 2",
-        base_path: "/example2",
-      )
+  scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
+    given_i_apply_filters_to_the_audit_content_page
+    then_i_see_filtered_audits
+    given_that_i_navigate_to_audits_report_page
+    then_i_see_an_unfiltered_audit_progress_report
+  end
 
-      create(:audit, content_item: example1)
-    end
+  def given_i_am_exporting_an_audit_report
+    user = create(:user)
+    hmrc = create(
+      :content_item,
+      title: "HMRC",
+      document_type: "organisation"
+    )
+    example1 = create(:content_item,
+                      title: "Example 1",
+                      base_path: "/example1",
+                      allocated_to: user)
+    create(:link,
+           source_content_id: example1.content_id,
+           target_content_id: hmrc.content_id,
+           link_type: "primary_publishing_organisation")
+    create(:content_item,
+           title: "Example 2",
+           base_path: "/example2")
+    create(:audit, content_item: example1)
+    @audit_report = ContentAuditTool.new.audit_report_page
+    @audit_report.load(content_id: Content::Item.last.content_id)
+    @audit_report.export_to_csv.click
+  end
 
-    scenario "Exporting a csv file as an attachment" do
-      visit audits_report_path
-      click_link "Export filtered audit to CSV"
+  def then_i_receive_an_audit_progress_report_in_csv_format
+    expect(content_type).to eq("text/csv")
+    expect(content_disposition).to start_with("attachment")
+    expect(content_disposition).to include(
+      'filename="Transformation_audit_report_CSV_download.csv"',
+    )
+    expect(@audit_report).to have_content("Title,URL")
+    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
+  end
 
-      expect(content_type).to eq("text/csv")
-      expect(content_disposition).to start_with("attachment")
-      expect(content_disposition).to include(
-        'filename="Transformation_audit_report_CSV_download.csv"',
-      )
+  def given_i_have_applied_filters_and_exported_audits
+    user = create(:user)
+    hmrc = create(
+      :content_item,
+      title: "HMRC",
+      document_type: "organisation"
+    )
+    example1 = create(:content_item,
+                      title: "Example 1",
+                      base_path: "/example1",
+                      allocated_to: user)
+    create(:link,
+           source_content_id: example1.content_id,
+           target_content_id: hmrc.content_id,
+           link_type: "primary_publishing_organisation")
+    create(:content_item,
+           title: "Example 2",
+           base_path: "/example2")
+    create(:audit, content_item: example1)
+    @audit_report = ContentAuditTool.new.audit_report_page
+    @audit_report.load(content_id: Content::Item.last.content_id)
+    @audit_report.allocated_to.select 'Anyone'
+    @audit_report.organisations.select 'HMRC'
+    @audit_report.apply_filters.click
+    @audit_report.export_to_csv.click
+  end
 
-      expect(page).to have_content("Title,URL")
-      expect(page).to have_content("Example 1,https://gov.uk/example1")
-    end
+  def then_i_receive_an_audit_progress_report_for_filtered_audits_in_csv_format
+    expect(@audit_report).to have_content("Title,URL")
+    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
+    expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
+  end
 
-    scenario "Applying the filters to the export" do
-      visit audits_report_path
-      select "Anyone", from: "allocated_to"
+  def given_i_have_multiple_pages_of_content_items_and_do_not_filter_them
+    create(:user)
+    create_list(:content_item, 110)
+    visit audits_report_path
+    select "Anyone", from: "allocated_to"
+    click_on "Apply filters"
+  end
 
-      select "HMRC", from: "Organisations"
-      click_on "Apply filters"
+  def then_i_receive_an_audit_progress_report_for_all_audits_in_csv_format
+    click_link "Export filtered audit to CSV"
+    csv = CSV.parse(page.body, headers: true)
+    number_of_metadata_rows = 1
+    expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
+  end
 
-      click_link "Export filtered audit to CSV"
-      expect(page).to have_content("Example 1,https://gov.uk/example1")
-      expect(page).to have_no_content("Example 2,https://gov.uk/example2")
-    end
-
-    scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-      visit audits_path
-      select "Anyone", from: "allocated_to"
-
-      choose "Audited"
-
-      click_on "Apply filters"
-      expect(page).to have_content("Example 1")
-      expect(page).to have_no_content("Example 2")
-
-      click_link "Audit progress"
-
-      click_link "Export filtered audit to CSV"
-      expect(content_disposition).to include(
-        'filename="Transformation_audit_report_CSV_download.csv"',
-      )
-      expect(page).to have_content("Example 1")
-      expect(page).to have_no_content("Example 2")
+  def given_i_apply_filters_to_the_audit_content_page
+    user = create(:user)
+    hmrc = create(:content_item,
+                  title: "HMRC",
+                  document_type: "organisation",
+                  allocated_to: user)
+    example1 = create(:content_item,
+                      title: "Example 1",
+                      base_path: "/example1")
+    create(:link,
+           source_content_id: example1.content_id,
+           target_content_id: hmrc.content_id,
+           link_type: "primary_publishing_organisation")
+    create(:content_item,
+           title: "Example 2",
+           base_path: "/example2",
+           allocated_to: user)
+    @audit_content_page = ContentAuditTool.new.audit_content_page
+    @audit_report_page = ContentAuditTool.new.audit_report_page
+    @audit_content_page.load
+    @audit_content_page.filter_form do |form|
+      form.allocated_to.select "No one"
+      form.apply_filters.click
     end
   end
 
-  context "Multiple pages of content items are in the database" do
-    let!(:content_items) { create_list(:content_item, 110) }
+  def then_i_see_filtered_audits
+    expect(@audit_content_page).to have_content("Example 1")
+    expect(@audit_content_page).to have_no_content("Example 2")
+  end
 
-    scenario "Exporting an unfiltered audit to CSV with all the content items" do
-      visit audits_report_path
-      select "Anyone", from: "allocated_to"
-      click_on "Apply filters"
-      click_link "Export filtered audit to CSV"
+  def given_that_i_navigate_to_audits_report_page
+    @audit_content_page.audits_progress_tab.click
+  end
 
-      csv = CSV.parse(page.body, headers: true)
-
-      number_of_metadata_rows = 1
-      expect(csv.count).to eq(content_items.count + number_of_metadata_rows)
-    end
+  def then_i_see_an_unfiltered_audit_progress_report
+    expect(@audit_report_page).to be_displayed
+    expect(@audit_report_page).to have_no_content('Example 1')
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -9,13 +9,15 @@ RSpec.feature "Exporting a CSV from the report page" do
 
   scenario "Exporting a csv file as an attachment" do
     given_i_am_an_auditor_belonging_to_an_organisation
+    and_there_are_three_content_items
     when_i_export_an_audit_report
     then_i_receive_the_report_in_csv_format
   end
 
   scenario "Applying the filters to the export" do
     given_i_am_an_auditor_belonging_to_an_organisation
-    and_filter_is_applied_to_show_only_hmrc_content_items
+    and_there_are_three_content_items
+    and_a_filter_is_applied_to_show_only_hmrc_content_items
     when_i_export_the_reports
     then_i_receive_only_hmrc_related_content_items_in_the_report
   end
@@ -29,7 +31,7 @@ RSpec.feature "Exporting a CSV from the report page" do
 
   scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
     given_i_am_an_auditor_belonging_to_an_organisation
-    and_there_are_two_unassigned_content_items
+    and_there_are_three_content_items
     when_i_filter_the_content_page_for_content_items_with_no_one_assigned_to_them
     then_i_see_the_two_unassigned_content_items
     when_i_navigate_to_audits_report_page
@@ -38,52 +40,42 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   def given_i_am_an_auditor_belonging_to_an_organisation
-    user = create(:user)
-    hmrc = create(
-      :content_item,
-      title: "HMRC",
-      document_type: "organisation",
-      allocated_to: user
-    )
-    example1 = create(:content_item,
-                      title: "Example 1",
-                      base_path: "/example1",
-                      allocated_to: user)
-    create(:link,
-           source_content_id: example1.content_id,
-           target_content_id: hmrc.content_id,
-           link_type: "primary_publishing_organisation")
-    create(:audit, content_item: example1)
+    @user = create(:user)
+    @hmrc = create(:content_item,
+                  title: "HMRC",
+                  document_type: "organisation",
+                  allocated_to: @user)
   end
 
   def then_i_receive_only_hmrc_related_content_items_in_the_report
     expect(@audit_report).to have_content("Title,URL")
-    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
-    expect(@audit_report).to have_no_content("Example 2,https://gov.uk/example2")
+    expect(@audit_report).to have_content("Assigned HMRC content,https://gov.uk/example1")
+    expect(@audit_report).to have_no_content("Unassigned content 2,https://gov.uk/example2")
   end
 
   def then_i_see_the_two_unassigned_content_items
-    expect(@audit_content_page).to have_no_content("Example 1")
-    expect(@audit_content_page).to have_content("Example 2")
-    expect(@audit_content_page).to have_content("Example 3")
+    expect(@audit_content_page).to have_no_content("Assigned HMRC content")
+    expect(@audit_content_page).to have_content("Unassigned content 2")
+    expect(@audit_content_page).to have_content("Unassigned content 3")
   end
 
   def when_i_navigate_to_audits_report_page
+    @audit_report_page = ContentAuditTool.new.audit_report_page
     @audit_content_page.audits_progress_tab.click
   end
 
   def then_i_do_not_see_the_two_unassigned_content_items
     expect(@audit_report_page).to be_displayed
-    expect(@audit_report_page).to have_no_content('2 Content items')
+    expect(@audit_report_page.content_item_count.text).not_to eq('2')
   end
 
   def and_i_see_the_one_content_item_assigned_to_me
-    expect(@audit_report_page).to have_content('1 Content items')
+    expect(@audit_report_page.content_item_count.text).to eq('1')
   end
 
   def when_i_export_an_audit_report
     @audit_report = ContentAuditTool.new.audit_report_page
-    @audit_report.load(content_id: Content::Item.last.content_id)
+    @audit_report.load
     @audit_report.export_to_csv.click
   end
 
@@ -94,12 +86,12 @@ RSpec.feature "Exporting a CSV from the report page" do
       'filename="Transformation_audit_report_CSV_download.csv"',
     )
     expect(@audit_report).to have_content("Title,URL")
-    expect(@audit_report).to have_content("Example 1,https://gov.uk/example1")
+    expect(@audit_report).to have_content("Assigned HMRC content,https://gov.uk/example1")
   end
 
-  def and_filter_is_applied_to_show_only_hmrc_content_items
+  def and_a_filter_is_applied_to_show_only_hmrc_content_items
     @audit_report = ContentAuditTool.new.audit_report_page
-    @audit_report.load(content_id: Content::Item.last.content_id)
+    @audit_report.load
     @audit_report.organisations.select 'HMRC'
     @audit_report.apply_filters.click
   end
@@ -109,7 +101,8 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   def and_there_are_multiple_pages_of_unfiltered_content_items
-    create_list(:content_item, 100)
+    content_items_per_page = 100
+    create_list(:content_item, content_items_per_page * 2)
   end
 
   def when_i_export_all_the_reports
@@ -127,7 +120,6 @@ RSpec.feature "Exporting a CSV from the report page" do
 
   def when_i_filter_the_content_page_for_content_items_with_no_one_assigned_to_them
     @audit_content_page = ContentAuditTool.new.audit_content_page
-    @audit_report_page = ContentAuditTool.new.audit_report_page
     @audit_content_page.load
     @audit_content_page.filter_form do |form|
       form.allocated_to.select "No one"
@@ -135,12 +127,18 @@ RSpec.feature "Exporting a CSV from the report page" do
     end
   end
 
-  def and_there_are_two_unassigned_content_items
+  def and_there_are_three_content_items
+    example1 = create(:content_item,
+                      title: "Assigned HMRC content",
+                      base_path: "/example1",
+                      allocated_to: @user,
+                      primary_publishing_organisation: @hmrc)
+    create(:audit, content_item: example1)
     create(:content_item,
-           title: "Example 2",
+           title: "Unassigned content 2",
            base_path: "/example2")
     create(:content_item,
-           title: "Example 3",
+           title: "Unassigned content 3",
            base_path: "/example3")
   end
 end

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,43 +1,34 @@
 RSpec.feature "Reporting on audit progress" do
   scenario "Displaying the number of items included in the audit" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    when_i_visit_the_report_page
     then_i_see_all_content_items
-    given_that_select_a_document_type_that_does_not_apply_to_any_content_item
+    when_i_select_a_document_type_that_does_not_apply_to_any_content_item
     then_i_see_no_content_items
-    given_that_select_a_document_type_that_applies_to_all_content_items
-    then_i_see_all_content_items
+    when_i_select_a_document_type_that_does_apply_to_content_items
+    then_i_see_how_many_content_items_it_applies_to
   end
 
   scenario "Displaying the number of items audited/not audited" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    when_i_visit_the_report_page
+    then_i_see_a_percentage_breakdown_of_audited_tasks
   end
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    when_i_visit_the_report_page
     then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
   end
 
   scenario "Audit status filter is not present" do
-    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    when_i_visit_the_report_page
     then_i_do_not_see_audit_status_filter
   end
 
-  def given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
-    organisation = create(:organisation)
-    user = create(:user, organisation: organisation)
-    content_items = create_list(
-      :content_item,
-      3,
-      document_type: "transaction",
-      allocated_to: user,
-      primary_publishing_organisation: organisation,
-    )
-    create(:passing_audit, content_item: content_items[0])
-    create(:failing_audit, content_item: content_items[1])
-
-    @audit_report_page = ContentAuditTool.new.audit_report_page
-    @audit_report_page.load(content_id: content_items.last.content_id)
+  def then_i_see_how_many_content_items_it_applies_to
+    expect(@audit_report_page).to have_report_section(text: '3 Content items')
   end
 
   def then_i_see_all_content_items
@@ -59,7 +50,7 @@ RSpec.feature "Reporting on audit progress" do
     @audit_report_page.apply_filters.click
   end
 
-  def then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+  def then_i_see_a_percentage_breakdown_of_audited_tasks
     expect(@audit_report_page).to have_report_section(text: 'Audited 2 67%')
     expect(@audit_report_page).to have_report_section(text: 'Still to audit 1 33%')
     expect(@audit_report_page).to have_audit_progress_bar(text: '66.66667% Complete')
@@ -73,5 +64,35 @@ RSpec.feature "Reporting on audit progress" do
 
   def then_i_do_not_see_audit_status_filter
     expect(@audit_report_page).to_not have_report_section(text: 'Audit Status')
+  end
+
+  def given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    organisation = create(:organisation)
+    user = create(:user, organisation: organisation)
+    content_items = create_list(
+      :content_item,
+      3,
+      document_type: "transaction",
+      allocated_to: user,
+      primary_publishing_organisation: organisation,
+    )
+    create(:passing_audit, content_item: content_items[0])
+    create(:failing_audit, content_item: content_items[1])
+  end
+
+  def when_i_visit_the_report_page
+    @audit_report_page = ContentAuditTool.new.audit_report_page
+    @audit_report_page.load(content_id: Content::Item.last.content_id)
+  end
+
+  def when_i_select_a_document_type_that_does_not_apply_to_any_content_item
+    @audit_report_page.allocated_to.select 'Anyone'
+    @audit_report_page.content_type.select 'Guide'
+    @audit_report_page.apply_filters.click
+  end
+
+  def when_i_select_a_document_type_that_does_apply_to_content_items
+    @audit_report_page.content_type.select 'Transaction'
+    @audit_report_page.apply_filters.click
   end
 end

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,72 +1,77 @@
 RSpec.feature "Reporting on audit progress" do
-  let!(:my_organisation) do
-    create(
-      :organisation
-    )
+  scenario "Displaying the number of items included in the audit" do
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_all_content_items
+    given_that_select_a_document_type_that_does_not_apply_to_any_content_item
+    then_i_see_no_content_items
+    given_that_select_a_document_type_that_applies_to_all_content_items
+    then_i_see_all_content_items
   end
 
-  let!(:me) do
-    create(
-      :user,
-      organisation: my_organisation,
-    )
+  scenario "Displaying the number of items audited/not audited" do
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
   end
 
-  context "I have been allocated some audited and unaudited content items belonging to my organisation" do
-    before(:each) do
-      content_items = create_list(
-        :content_item,
-        3,
-        document_type: "transaction",
-        allocated_to: me,
-        primary_publishing_organisation: my_organisation,
-      )
-
-      create(:passing_audit, content_item: content_items[0])
-      create(:failing_audit, content_item: content_items[1])
-    end
-
-    scenario "Displaying the number of items included in the audit" do
-      visit audits_report_path
-
-      expect(page).to have_content("3 Content items")
-
-      select "Anyone", from: "allocated_to"
-      select "Guide", from: "document_type"
-      click_on "Apply filters"
-
-      expect(page).to have_content("0 Content items")
-
-      select "Transaction", from: "document_type"
-      click_on "Apply filters"
-
-      expect(page).to have_content("3 Content items")
-    end
-
-    scenario "Displaying the number of items audited/not audited" do
-      visit audits_report_path
-
-      expect(page).to have_content("Audited 2 67%")
-      expect(page).to have_content("Still to audit 1 33%")
-      expect(width("#progress")).to eq("width: 66.66667%;")
-    end
-
-    scenario "Displaying the number of items needing improvement/not needing improvement" do
-      visit audits_report_path
-
-      expect(page).to have_content("Need improvement 1 50%")
-      expect(page).to have_content("Don't need improvement 1 50%")
-      expect(width("#items-needing-improvement")).to eq("width: 50%;")
-    end
+  scenario "Displaying the number of items needing improvement/not needing improvement" do
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
   end
 
   scenario "Audit status filter is not present" do
-    visit audits_report_path
-
-    expect(page).to have_no_content("Audit status")
+    given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    then_i_do_not_see_audit_status_filter
   end
 
-  def width(id)
-    page.find("#{id} .progress .progress-bar")[:style]
+  def given_i_have_been_allocated_audited_and_unaudited_content_items_belonging_to_my_organisation
+    organisation = create(:organisation)
+    user = create(:user, organisation: organisation)
+    content_items = create_list(
+      :content_item,
+      3,
+      document_type: "transaction",
+      allocated_to: user,
+      primary_publishing_organisation: organisation,
+    )
+    create(:passing_audit, content_item: content_items[0])
+    create(:failing_audit, content_item: content_items[1])
+
+    @audit_report_page = ContentAuditTool.new.audit_report_page
+    @audit_report_page.load(content_id: content_items.last.content_id)
+  end
+
+  def then_i_see_all_content_items
+    expect(@audit_report_page).to have_report_section(text: '3 Content items')
+  end
+
+  def given_that_select_a_document_type_that_does_not_apply_to_any_content_item
+    @audit_report_page.allocated_to.select 'Anyone'
+    @audit_report_page.content_type.select 'Guide'
+    @audit_report_page.apply_filters.click
+  end
+
+  def then_i_see_no_content_items
+    expect(@audit_report_page).to have_report_section(text: '0 Content items')
+  end
+
+  def given_that_select_a_document_type_that_applies_to_all_content_items
+    @audit_report_page.content_type.select 'Transaction'
+    @audit_report_page.apply_filters.click
+  end
+
+  def then_i_see_a_percentage_breakdown_of_audited_tasks_and_a_progress_bar
+    expect(@audit_report_page).to have_report_section(text: 'Audited 2 67%')
+    expect(@audit_report_page).to have_report_section(text: 'Still to audit 1 33%')
+    expect(@audit_report_page).to have_audit_progress_bar(text: '66.66667% Complete')
+  end
+
+  def then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
+    expect(@audit_report_page).to have_report_section(text: 'Need improvement 1 50%')
+    expect(@audit_report_page).to have_report_section(text: "Don't need improvement 1 50%")
+    expect(@audit_report_page).to have_improvement_progress_bar(text: '50% Complete')
+  end
+
+  def then_i_do_not_see_audit_status_filter
+    expect(@audit_report_page).to_not have_report_section(text: 'Audit Status')
   end
 end

--- a/spec/features/audit/report/progress_spec.rb
+++ b/spec/features/audit/report/progress_spec.rb
@@ -1,83 +1,69 @@
 RSpec.feature "Reporting on audit progress" do
   scenario "Displaying the number of items included in the audit" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    given_i_am_an_auditor_belonging_to_an_organisation_with_three_content_items
+    and_one_content_item_needs_improvement_and_one_does_not
     when_i_visit_the_report_page
-    then_i_see_all_content_items
+    then_i_see_the_report_includes_all_three_content_items
     when_i_select_a_document_type_that_does_not_apply_to_any_content_item
-    then_i_see_no_content_items
-    when_i_select_a_document_type_that_does_apply_to_content_items
-    then_i_see_how_many_content_items_it_applies_to
+    then_i_see_the_report_includes_no_content_items
+    when_i_select_a_document_type_that_applies_to_all_three_content_items
+    then_i_see_the_report_includes_all_three_content_items
   end
 
   scenario "Displaying the number of items audited/not audited" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    given_i_am_an_auditor_belonging_to_an_organisation_with_three_content_items
+    and_two_items_have_been_audited
     when_i_visit_the_report_page
-    then_i_see_a_percentage_breakdown_of_audited_tasks
+    then_i_see_that_67_percent_of_my_audit_is_completed
+    and_i_see_that_33_percent_of_my_audit_is_not_completed
   end
 
   scenario "Displaying the number of items needing improvement/not needing improvement" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    given_i_am_an_auditor_belonging_to_an_organisation_with_three_content_items
+    and_one_content_item_needs_improvement_and_one_does_not
     when_i_visit_the_report_page
-    then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
+    then_i_see_that_50_percent_of_content_needs_improvement
+    and_i_see_that_50_percent_of_content_does_not_need_improvement
   end
 
   scenario "Audit status filter is not present" do
-    given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+    given_i_am_an_auditor_belonging_to_an_organisation_with_three_content_items
     when_i_visit_the_report_page
     then_i_do_not_see_audit_status_filter
   end
 
-  def then_i_see_how_many_content_items_it_applies_to
+  def then_i_see_the_report_includes_all_three_content_items
     expect(@audit_report_page).to have_report_section(text: '3 Content items')
   end
 
-  def then_i_see_all_content_items
-    expect(@audit_report_page).to have_report_section(text: '3 Content items')
-  end
-
-  def given_that_select_a_document_type_that_does_not_apply_to_any_content_item
-    @audit_report_page.allocated_to.select 'Anyone'
-    @audit_report_page.content_type.select 'Guide'
-    @audit_report_page.apply_filters.click
-  end
-
-  def then_i_see_no_content_items
+  def then_i_see_the_report_includes_no_content_items
     expect(@audit_report_page).to have_report_section(text: '0 Content items')
-  end
-
-  def given_that_select_a_document_type_that_applies_to_all_content_items
-    @audit_report_page.content_type.select 'Transaction'
-    @audit_report_page.apply_filters.click
-  end
-
-  def then_i_see_a_percentage_breakdown_of_audited_tasks
-    expect(@audit_report_page).to have_report_section(text: 'Audited 2 67%')
-    expect(@audit_report_page).to have_report_section(text: 'Still to audit 1 33%')
-    expect(@audit_report_page).to have_audit_progress_bar(text: '66.66667% Complete')
-  end
-
-  def then_i_see_a_percentage_breakdown_of_how_many_items_need_improvement
-    expect(@audit_report_page).to have_report_section(text: 'Need improvement 1 50%')
-    expect(@audit_report_page).to have_report_section(text: "Don't need improvement 1 50%")
-    expect(@audit_report_page).to have_improvement_progress_bar(text: '50% Complete')
   end
 
   def then_i_do_not_see_audit_status_filter
     expect(@audit_report_page).to_not have_report_section(text: 'Audit Status')
   end
 
-  def given_i_am_an_auditor_belonging_to_an_organisation_with_content_items
+  def given_i_am_an_auditor_belonging_to_an_organisation_with_three_content_items
     organisation = create(:organisation)
     user = create(:user, organisation: organisation)
-    content_items = create_list(
+    @content_items = create_list(
       :content_item,
       3,
       document_type: "transaction",
       allocated_to: user,
       primary_publishing_organisation: organisation,
     )
-    create(:passing_audit, content_item: content_items[0])
-    create(:failing_audit, content_item: content_items[1])
+  end
+
+  def and_one_content_item_needs_improvement_and_one_does_not
+    create(:passing_audit, content_item: @content_items[0])
+    create(:failing_audit, content_item: @content_items[1])
+  end
+
+  def and_two_items_have_been_audited
+    create(:passing_audit, content_item: @content_items[0])
+    create(:failing_audit, content_item: @content_items[1])
   end
 
   def when_i_visit_the_report_page
@@ -91,8 +77,26 @@ RSpec.feature "Reporting on audit progress" do
     @audit_report_page.apply_filters.click
   end
 
-  def when_i_select_a_document_type_that_does_apply_to_content_items
+  def when_i_select_a_document_type_that_applies_to_all_three_content_items
     @audit_report_page.content_type.select 'Transaction'
     @audit_report_page.apply_filters.click
+  end
+
+  def then_i_see_that_67_percent_of_my_audit_is_completed
+    expect(@audit_report_page).to have_report_section(text: 'Audited 2 67%')
+    expect(@audit_report_page).to have_audit_progress_bar(text: '66.66667% Complete')
+  end
+
+  def and_i_see_that_33_percent_of_my_audit_is_not_completed
+    expect(@audit_report_page).to have_report_section(text: 'Still to audit 1 33%')
+  end
+
+  def then_i_see_that_50_percent_of_content_needs_improvement
+    expect(@audit_report_page).to have_report_section(text: 'Need improvement 1 50%')
+    expect(@audit_report_page).to have_improvement_progress_bar(text: '50% Complete')
+  end
+
+  def and_i_see_that_50_percent_of_content_does_not_need_improvement
+    expect(@audit_report_page).to have_report_section(text: "Don't need improvement 1 50%")
   end
 end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -12,4 +12,8 @@ class ContentAuditTool
   def audits_filter_list
     AuditsFilterList.new
   end
+
+  def audit_report_page
+    AuditReportPage.new
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -15,6 +15,7 @@ class AuditContentPage < SitePrism::Page
     element :primary_orgs, "[data-test-id=primary-orgs]"
     element :document_type, "[data-test-id=document-type]"
     element :apply_filters, "[data-test-id=apply-filters]"
+    element :audits_progress_tab, '[data-test-id=reports]'
   end
 
   element :pagination, ".pagination"

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -18,4 +18,5 @@ class AuditContentPage < SitePrism::Page
   end
 
   element :pagination, ".pagination"
+  element :audits_progress_tab, '[data-test-id=reports]'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -1,0 +1,9 @@
+require 'site_prism/page'
+
+class AuditReportPage < SitePrism::Page
+  set_url '/audits/report'
+
+  element :report_section, '.report-section'
+  element :allocated_to, '#allocated_to'
+  element :apply_filters, 'input[type=submit]'
+end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -11,4 +11,5 @@ class AuditReportPage < SitePrism::Page
   element :improvement_progress_bar, '[data-test-id=improvement-progress-bar]'
   element :export_to_csv, '[data-test-id=report-export]'
   element :organisations, '[data-test-id=organisations]'
+  element :content_item_count, '[data-test-id=content-item-count]'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -6,4 +6,7 @@ class AuditReportPage < SitePrism::Page
   element :report_section, '.report-section'
   element :allocated_to, '#allocated_to'
   element :apply_filters, 'input[type=submit]'
+  element :content_type, '#document_type'
+  element :audit_progress_bar, '[data-test-id=audit_progress_bar]'
+  element :improvement_progress_bar, '[data-test-id=improvement_progress_bar]'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -7,8 +7,8 @@ class AuditReportPage < SitePrism::Page
   element :allocated_to, '[data-test-id=allocated-to]'
   element :apply_filters, '[data-test-id=apply-filters]'
   element :content_type, '[data-test-id=document-type]'
-  element :audit_progress_bar, '[data-test-id=audit_progress_bar]'
-  element :improvement_progress_bar, '[data-test-id=improvement_progress_bar]'
+  element :audit_progress_bar, '[data-test-id=audit-progress-bar]'
+  element :improvement_progress_bar, '[data-test-id=improvement-progress-bar]'
   element :export_to_csv, '[data-test-id=report-export]'
   element :organisations, '[data-test-id=organisations]'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -9,4 +9,6 @@ class AuditReportPage < SitePrism::Page
   element :content_type, '#document_type'
   element :audit_progress_bar, '[data-test-id=audit_progress_bar]'
   element :improvement_progress_bar, '[data-test-id=improvement_progress_bar]'
+  element :export_to_csv, '.report-export'
+  element :organisations, '#organisations'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -3,12 +3,12 @@ require 'site_prism/page'
 class AuditReportPage < SitePrism::Page
   set_url '/audits/report'
 
-  element :report_section, '.report-section'
-  element :allocated_to, '#allocated_to'
-  element :apply_filters, 'input[type=submit]'
-  element :content_type, '#document_type'
+  element :report_section, '[data-test-id=report-section]'
+  element :allocated_to, '[data-test-id=allocated-to]'
+  element :apply_filters, '[data-test-id=apply-filters]'
+  element :content_type, '[data-test-id=document-type]'
   element :audit_progress_bar, '[data-test-id=audit_progress_bar]'
   element :improvement_progress_bar, '[data-test-id=improvement_progress_bar]'
-  element :export_to_csv, '.report-export'
-  element :organisations, '#organisations'
+  element :export_to_csv, '[data-test-id=report-export]'
+  element :organisations, '[data-test-id=organisations]'
 end


### PR DESCRIPTION
* Refactors the audit report feature specs by introducing a semantic DSL for describing the report page elements using the Page Object Model pattern.
* Changes the style the feature specs are written in to add clear separation between the Arrange, Act, Assert parts of the test.

See:

https://docs.publishing.service.gov.uk/manual/testing.html
https://martinfowler.com/bliki/PageObject.html
https://robots.thoughtbot.com/better-acceptance-tests-with-page-objects
https://github.com/natritmeyer/site_prism
https://about.futurelearn.com/blog/how-we-write-readable-feature-tests-with-rspec

Following on from these previous PRs which refactor other specs to follow a similar pattern:
https://github.com/alphagov/content-performance-manager/pull/374
https://github.com/alphagov/content-performance-manager/pull/398