### PR TITLE
Removes automatic definition of associations

### DIFF
--- a/app/domain/content/query.rb
+++ b/app/domain/content/query.rb
@@ -106,10 +106,9 @@ module Content
 
   private
 
-    def apply_link_filter(link_type:, source_ids: nil, target_ids: nil)
+    def apply_link_filter(link_type:, target_ids: nil)
       filter = LinkFilter.new(
         link_type: link_type,
-        source_ids: source_ids,
         target_ids: target_ids,
       )
 

--- a/app/models/audits/report_row.rb
+++ b/app/models/audits/report_row.rb
@@ -53,7 +53,7 @@ module Audits
     end
 
     def primary_organisation
-      primary = content_item.linked_primary_publishing_organisation.first
+      primary = content_item.linked_primary_org.first
       primary.title if primary
     end
 

--- a/app/models/content/item.rb
+++ b/app/models/content/item.rb
@@ -8,13 +8,15 @@ class Content::Item < ApplicationRecord
 
   after_save { Audits::ReportRow.precompute(self) }
 
-  has_many :linked_policy_areas, -> { where(links: { link_type: Content::Link::POLICY_AREAS }) }, through: :links, source: :target
-  has_many :linked_policies, -> { where(links: { link_type: Content::Link::POLICIES }) }, through: :links, source: :target
-  has_many :linked_primary_publishing_organisation, -> { where(links: { link_type: Content::Link::PRIMARY_ORG }) }, through: :links, source: :target
-  has_many :linked_organisations, -> { where(links: { link_type: Content::Link::ALL_ORGS }) }, through: :links, source: :target
-  has_many :linked_mainstream_browse_pages, -> { where(links: { link_type: Content::Link::MAINSTREAM }) }, through: :links, source: :target
-  has_many :linked_topics, -> { where(links: { link_type: Content::Link::TOPICS }) }, through: :links, source: :target
-  has_many :linked_taxons, -> { where(links: { link_type: Content::Link::TAXONOMIES }) }, through: :links, source: :target
+  with_options through: :links, source: :target do |assoc|
+    assoc.has_many :linked_policy_areas, -> { where(links: { link_type: Content::Link::POLICY_AREAS }) }
+    assoc.has_many :linked_policies, -> { where(links: { link_type: Content::Link::POLICIES }) }
+    assoc.has_many :linked_primary_publishing_organisation, -> { where(links: { link_type: Content::Link::PRIMARY_ORG }) }
+    assoc.has_many :linked_organisations, -> { where(links: { link_type: Content::Link::ALL_ORGS }) }
+    assoc.has_many :linked_mainstream_browse_pages, -> { where(links: { link_type: Content::Link::MAINSTREAM }) }
+    assoc.has_many :linked_topics, -> { where(links: { link_type: Content::Link::TOPICS }) }
+    assoc.has_many :linked_taxons, -> { where(links: { link_type: Content::Link::TAXONOMIES }) }
+  end
 
   attr_accessor :details
 

--- a/app/models/content/item.rb
+++ b/app/models/content/item.rb
@@ -8,14 +8,13 @@ class Content::Item < ApplicationRecord
 
   after_save { Audits::ReportRow.precompute(self) }
 
-  Content::Link.all_link_types.each do |link_type|
-    has_many(
-      :"linked_#{link_type}",
-      -> { where(links: { link_type: link_type }) },
-      through: :links,
-      source: :target,
-    )
-  end
+  has_many :linked_policy_areas, -> { where(links: { link_type: Content::Link::POLICY_AREAS }) }, through: :links, source: :target
+  has_many :linked_policies, -> { where(links: { link_type: Content::Link::POLICIES }) }, through: :links, source: :target
+  has_many :linked_primary_publishing_organisation, -> { where(links: { link_type: Content::Link::PRIMARY_ORG }) }, through: :links, source: :target
+  has_many :linked_organisations, -> { where(links: { link_type: Content::Link::ALL_ORGS }) }, through: :links, source: :target
+  has_many :linked_mainstream_browse_pages, -> { where(links: { link_type: Content::Link::MAINSTREAM }) }, through: :links, source: :target
+  has_many :linked_topics, -> { where(links: { link_type: Content::Link::TOPICS }) }, through: :links, source: :target
+  has_many :linked_taxons, -> { where(links: { link_type: Content::Link::TAXONOMIES }) }, through: :links, source: :target
 
   attr_accessor :details
 

--- a/app/models/content/item.rb
+++ b/app/models/content/item.rb
@@ -13,7 +13,7 @@ class Content::Item < ApplicationRecord
   with_options through: :links, source: :target do |assoc|
     assoc.has_many :linked_policy_areas, -> { linked_by Content::Link::POLICY_AREAS }
     assoc.has_many :linked_policies, -> { linked_by Content::Link::POLICIES }
-    assoc.has_many :linked_primary_publishing_organisation, -> { linked_by Content::Link::PRIMARY_ORG }
+    assoc.has_many :linked_primary_org, -> { linked_by Content::Link::PRIMARY_ORG }
     assoc.has_many :linked_organisations, -> { linked_by Content::Link::ALL_ORGS }
     assoc.has_many :linked_mainstream_browse_pages, -> { linked_by Content::Link::MAINSTREAM }
     assoc.has_many :linked_topics, -> { linked_by Content::Link::TOPICS }

--- a/app/models/content/item.rb
+++ b/app/models/content/item.rb
@@ -8,14 +8,16 @@ class Content::Item < ApplicationRecord
 
   after_save { Audits::ReportRow.precompute(self) }
 
+  scope :linked_by, ->(link_type) { where(links: { link_type: link_type }) }
+
   with_options through: :links, source: :target do |assoc|
-    assoc.has_many :linked_policy_areas, -> { where(links: { link_type: Content::Link::POLICY_AREAS }) }
-    assoc.has_many :linked_policies, -> { where(links: { link_type: Content::Link::POLICIES }) }
-    assoc.has_many :linked_primary_publishing_organisation, -> { where(links: { link_type: Content::Link::PRIMARY_ORG }) }
-    assoc.has_many :linked_organisations, -> { where(links: { link_type: Content::Link::ALL_ORGS }) }
-    assoc.has_many :linked_mainstream_browse_pages, -> { where(links: { link_type: Content::Link::MAINSTREAM }) }
-    assoc.has_many :linked_topics, -> { where(links: { link_type: Content::Link::TOPICS }) }
-    assoc.has_many :linked_taxons, -> { where(links: { link_type: Content::Link::TAXONOMIES }) }
+    assoc.has_many :linked_policy_areas, -> { linked_by Content::Link::POLICY_AREAS }
+    assoc.has_many :linked_policies, -> { linked_by Content::Link::POLICIES }
+    assoc.has_many :linked_primary_publishing_organisation, -> { linked_by Content::Link::PRIMARY_ORG }
+    assoc.has_many :linked_organisations, -> { linked_by Content::Link::ALL_ORGS }
+    assoc.has_many :linked_mainstream_browse_pages, -> { linked_by Content::Link::MAINSTREAM }
+    assoc.has_many :linked_topics, -> { linked_by Content::Link::TOPICS }
+    assoc.has_many :linked_taxons, -> { linked_by Content::Link::TAXONOMIES }
   end
 
   attr_accessor :details

--- a/app/models/content/item.rb
+++ b/app/models/content/item.rb
@@ -15,7 +15,6 @@ class Content::Item < ApplicationRecord
     assoc.has_many :linked_policies, -> { linked_by Content::Link::POLICIES }
     assoc.has_many :linked_primary_org, -> { linked_by Content::Link::PRIMARY_ORG }
     assoc.has_many :linked_organisations, -> { linked_by Content::Link::ALL_ORGS }
-    assoc.has_many :linked_mainstream_browse_pages, -> { linked_by Content::Link::MAINSTREAM }
     assoc.has_many :linked_topics, -> { linked_by Content::Link::TOPICS }
     assoc.has_many :linked_taxons, -> { linked_by Content::Link::TAXONOMIES }
   end

--- a/app/models/content/link.rb
+++ b/app/models/content/link.rb
@@ -7,21 +7,6 @@ class Content::Link < ApplicationRecord
   TOPICS = "topics".freeze
   TAXONOMIES = "taxons".freeze
 
-  FILTERABLE_LINK_TYPES = [
-    Content::Link::PRIMARY_ORG,
-    Content::Link::ALL_ORGS,
-    Content::Link::TAXONOMIES,
-  ].freeze
-
-  GROUPABLE_LINK_TYPES = [
-    Content::Link::POLICY_AREAS,
-    Content::Link::POLICIES,
-    Content::Link::PRIMARY_ORG,
-    Content::Link::ALL_ORGS,
-    Content::Link::MAINSTREAM,
-    Content::Link::TOPICS,
-  ].freeze
-
   after_save { Audits::ReportRow.precompute(source) }
 
   belongs_to :source,
@@ -35,8 +20,4 @@ class Content::Link < ApplicationRecord
     foreign_key: :target_content_id,
     primary_key: :content_id,
     optional: true
-
-  def self.all_link_types
-    (FILTERABLE_LINK_TYPES + GROUPABLE_LINK_TYPES).uniq
-  end
 end

--- a/app/models/content/link.rb
+++ b/app/models/content/link.rb
@@ -3,7 +3,6 @@ class Content::Link < ApplicationRecord
   POLICIES = "policies".freeze
   PRIMARY_ORG = "primary_publishing_organisation".freeze
   ALL_ORGS = "organisations".freeze
-  MAINSTREAM = "mainstream_browse_pages".freeze
   TOPICS = "topics".freeze
   TAXONOMIES = "taxons".freeze
 


### PR DESCRIPTION
There is too much automation in `Content::Item` in creating the associations
This is making our code less readable, and more difficult to maintain.

```ruby
Content::Link.all_link_types.each do |link_type|
  has_many(
    :"linked_#{link_type}"
    -> { where(links: { link_type: link_type }) },
    through: :links,
    source: :target,
)
```

I am refactoring how links are being set in the Audit tool because:

1. We have a fixed number of associations in our application. They are not being added/removed frequently, and if they are, we just need to be explicit and add it.

2. There were some constants defined in the `Link` whose only purpose was to support this magic.



