### PR TITLE
Ignore drafts when fetching content items

### DIFF
--- a/app/domain/content/importers/single_content_item.rb
+++ b/app/domain/content/importers/single_content_item.rb
@@ -13,6 +13,7 @@ module Content
 
     def run(content_id, locale)
       content_item = content_items_service.fetch(content_id, locale)
+      return unless content_item.present?
       links = content_items_service.links(content_id)
 
       set_metrics(content_item)

--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -26,8 +26,18 @@ module Clients
         .flatten
     end
 
-    def fetch(content_id, locale)
-      normalise(publishing_api.get_content(content_id, locale: locale))
+    def fetch(content_id, options = {})
+      normalise(publishing_api.get_content(content_id, options))
+    end
+
+    def fetch_latest_published(content_id, locale)
+      content_item = fetch(content_id, locale: locale)
+      return content_item if content_item[:publication_state] == "published"
+
+      preceding_version = content_item[:user_facing_version] - 1
+      return nil if preceding_version < 1
+
+      fetch(content_id, locale: locale, version: preceding_version)
     end
 
     def links(content_id)

--- a/app/services/content/items_service.rb
+++ b/app/services/content/items_service.rb
@@ -27,7 +27,8 @@ class Content::ItemsService
       publishing_app
       locale
     ]
-    all_attributes = client.fetch(content_id, locale)
+    all_attributes = client.fetch_latest_published(content_id, locale)
+    return nil unless all_attributes.present?
 
     Content::Item.new(all_attributes.slice(*attribute_names))
   end

--- a/spec/features/import_spec.rb
+++ b/spec/features/import_spec.rb
@@ -4,11 +4,43 @@ RSpec.feature "Import a single content item", type: :feature do
   include GdsApi::TestHelpers::PublishingApiV2
 
   it "creates jobs to import a single content items" do
-    publishing_api_has_links(content_id: "id-123", links: { organisation: ["org-123"] })
-    publishing_api_has_item(build(:content_item, content_id: "id-123", title: "title"))
+    content_item = build(
+      :content_item,
+      content_id: "id-123",
+      title: "title",
+    ).as_json.merge(
+      publication_state: "published",
+    ).deep_symbolize_keys
+
+    publishing_api_has_links(content_id: content_item[:content_id], links: { organisation: ["org-123"] })
+    publishing_api_has_item(content_item)
 
     expect { Content::ImportItemJob.new.perform("id-123", "en") }
       .to change(Content::Item, :count).by(1)
       .and change(Content::Link, :count).by(1)
+  end
+
+  describe "a content item that exists as only a draft" do
+    before do
+      content_item = build(
+        :content_item,
+        content_id: "id-123",
+        title: "title",
+      ).as_json.merge(
+        publication_state: "draft",
+        user_facing_version: 1,
+      ).deep_symbolize_keys
+
+      publishing_api_has_links(content_id: content_item[:content_id], links: {})
+      publishing_api_has_item(content_item)
+    end
+
+    it "does not import anything" do
+      expect { Content::ImportItemJob.new.perform("id-123", "en") }
+        .to change(Content::Item, :count).by(0)
+        .and change(Content::Link, :count).by(0)
+
+      expect(Content::Item.find_by(content_id: "id-123")).to be_nil
+    end
   end
 end

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -43,8 +43,37 @@ RSpec.describe Clients::PublishingAPI do
     end
 
     it "fetches a content item by content id" do
-      result = subject.fetch("id-123", "en")
+      result = subject.fetch("id-123", locale: "en")
       expect(result).to eq(content_item)
+    end
+  end
+
+  describe "#fetch_latest_published" do
+    let(:published) do
+      {
+        content_id: "id-123",
+        title: "Published title",
+        user_facing_version: 1,
+        publication_state: "published",
+      }
+    end
+
+    let(:draft) do
+      published.merge(
+        title: "Draft title",
+        user_facing_version: 2,
+        publication_state: "draft",
+      )
+    end
+
+    before do
+      publishing_api_has_item(draft)
+      publishing_api_has_item(published, "version" => "1")
+    end
+
+    it "fetches the latest published edition" do
+      result = subject.fetch_latest_published("id-123", "en")
+      expect(result).to eq(published)
     end
   end
 

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Content::ItemsService do
 
   describe "#fetch" do
     it "returns a new content item object" do
-      allow(subject.client).to receive(:fetch).with("id-123", "en").and_return(
+      allow(subject.client).to receive(:fetch_latest_published).with("id-123", "en").and_return(
         content_id: "id-123",
         title: "title",
         description: "description",


### PR DESCRIPTION
We currently have a mismatch between the Audit Tool and the live GOV.UK
site when a draft of a content item exists.

If a draft exists, the Audit Tool will import the draft, and display
that, rather than the latest published edition (which is shown on
GOV.UK).

This change adds a method to our Publishing API client to fetch the
latest published edition, or to return `nil`, so that the content we
display in the Audit Tool will match that on GOV.UK.

## Screenshots

### GOV.UK

![govuk-summary](https://user-images.githubusercontent.com/12036746/33167079-53f5319c-d034-11e7-9d99-ecd5ac9d0a88.png)

### Audit tool - before

![cpm-summary-before](https://user-images.githubusercontent.com/12036746/33167093-5cb48404-d034-11e7-8f4a-9dc0f4b0e2fa.png)

### Audit tool - after

![cpm-summary-after](https://user-images.githubusercontent.com/12036746/33167106-67311a00-d034-11e7-8b1b-9f34dcc1d889.png)
