### PR TITLE
Single-column audit page layout

### DIFF
--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -60,12 +60,13 @@ $all-items-link-colour: #000000;
 }
 
 .audit-metadata {
-  h4 {
-    margin-top: 2em;
+  p {
+    font-size: 14px;
+    margin: 0;
   }
 
-  p {
-    margin: 0;
+  .row {
+    padding-bottom: 12px;
   }
 }
 

--- a/app/helpers/content/items_helper.rb
+++ b/app/helpers/content/items_helper.rb
@@ -2,4 +2,81 @@ module Content::ItemsHelper
   def advanced_filter_enabled?
     params[:taxons].present?
   end
+
+  def content_metadata
+    [
+      {
+        title: "Assigned to",
+        content: assigned_to_metadata,
+        test_id: "allocated",
+      },
+      {
+        title: "Audited",
+        content: audited_metadata,
+        test_id: "audited",
+      },
+      {
+        title: "Organisations",
+        content: content_item.organisations,
+        test_id: "organisations",
+      },
+      {
+        title: "Last major update",
+        content: content_item.last_updated,
+        test_id: "last-updated",
+      },
+      {
+        title: "Content type",
+        content: content_item.document_type,
+        test_id: "content-type",
+      },
+      {
+        title: "Guidance",
+        content: content_item.guidance,
+        test_id: "guidance",
+      },
+      {
+        title: "Topics",
+        content: content_item.topics,
+        test_id: "topics",
+      },
+      {
+        title: "Policy areas",
+        content: content_item.policy_areas,
+        test_id: "policy-areas",
+      },
+      {
+        title: "Withdrawn",
+        content: content_item.withdrawn,
+        test_id: "withdrawn",
+      },
+      {
+        title: "Unique pageviews",
+        content: [
+          "#{content_item.one_month_page_views} in the  last month",
+          "#{content_item.six_months_page_views} in the last six months",
+        ],
+        test_id: "pageviews",
+      },
+    ]
+  end
+
+  def assigned_to_metadata
+    return "No one" unless content_item.allocation
+
+    [
+      content_item.auditor,
+      content_item.auditor_org,
+    ]
+  end
+
+  def audited_metadata
+    return "Not audited yet" if audit.incomplete?
+
+    [
+      audit.last_updated,
+      "by #{audit.user.name}",
+      audit.user.organisation&.title,
+    ]
+  end
 end

--- a/app/views/audits/audits/_metadata.html.erb
+++ b/app/views/audits/audits/_metadata.html.erb
@@ -1,0 +1,21 @@
+<div id="metadata" class="audit-metadata">
+  <h4>Item details</h4>
+
+  <% content_metadata.each_slice(3) do |row| %>
+    <div class="row">
+
+      <% row.each do |column| %>
+
+        <div class="col-sm-4" data-test-id="<%= column[:test_id] %>">
+          <h5><%= column[:title] %></h5>
+
+          <% [column[:content]].flatten.each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
+        </div>
+
+      <% end %>
+
+    </div>
+  <% end %>
+</div>

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -1,4 +1,4 @@
-<div class="audit-content-item col-sm-7">
+<div class="audit-content-item">
   <% if flash.notice %>
     <div class="alert alert-success" role="alert" data-test-id="audit-success-message">
       <p>
@@ -25,6 +25,10 @@
   <p class="description" data-test-id="content-item-description">
     <%= content_item.description %>
   </p>
+
+  <hr/>
+
+  <%= render "metadata" %>
 
   <hr/>
 
@@ -92,72 +96,4 @@
 
     <%= form.submit "Save and continue", class: "btn btn-success", data: { test_id: 'save-audit-form'} %>
   <% end %>
-</div>
-
-<div class="col-sm-1"></div>
-
-<div class="col-sm-4">
-  <div id="metadata" class="audit-metadata">
-    <div id="allocated" data-test-id="allocated" >
-      <h4>Assigned to</h4>
-      <% if content_item.allocation %>
-        <p><%= content_item.auditor %></p>
-        <p><%= content_item.auditor_org %></p>
-     <% else %>
-        <p>No one</p>
-      <% end %>
-    </div>
-    <div id="audited" data-test-id="audited">
-      <h4>Audited</h4>
-
-      <% if audit.incomplete? %>
-        <p>Not audited yet</p>
-      <% else %>
-        <p><%= audit.last_updated %></p>
-        <p>by <%= audit.user.name %></p>
-        <p><%= audit.user.organisation&.title %></p>
-      <% end %>
-    </div>
-
-    <div id="organisations" data-test-id="organisations">
-      <h4>Organisations</h4>
-      <p><%= content_item.organisations %></p>
-    </div>
-
-    <div id="last-updated" data-test-id="last-updated">
-      <h4>Last major update</h4>
-      <p><%= content_item.last_updated %></p>
-    </div>
-
-    <div id="content-type" data-test-id="content-type">
-      <h4>Content type</h4>
-      <p><%= content_item.document_type %></p>
-    </div>
-
-    <div id="guidance" data-test-id="guidance">
-      <h4>Guidance</h4>
-      <p><%= content_item.guidance %></p>
-    </div>
-
-    <div id="topics" data-test-id="topics">
-      <h4>Topics</h4>
-      <p><%= content_item.topics %></p>
-    </div>
-
-    <div id="policy-areas" data-test-id="policy-areas">
-      <h4>Policy areas</h4>
-      <p><%= content_item.policy_areas %></p>
-    </div>
-
-    <div id="withdrawn" data-test-id="withdrawn">
-      <h4>Withdrawn</h4>
-      <p><%= content_item.withdrawn %></p>
-    </div>
-
-    <div id="pageviews" data-test-id="pageviews">
-      <h4>Unique pageviews</h4>
-      <p><%= content_item.one_month_page_views %> in the last month</p>
-      <p><%= content_item.six_months_page_views %> in the last six months</p>
-    </div>
-  </div>
 </div>


### PR DESCRIPTION
We wish to add a preview of the content item being audited to the side
of the audit page. In order to prepare for this, this change collapses
the audit page into a single-column layout.

To achieve this single-column layout, the metadata is to be moved from
its own column to a grid underneath the description.

The grid layout is achieved by separating the concern of the grid
content from the mechanic of creating the Boostrap grid.

## Before

![before](https://user-images.githubusercontent.com/12036746/33435289-ae7c364c-d5d9-11e7-8c8b-7afba7277eff.png)

## After

![after](https://user-images.githubusercontent.com/12036746/33435572-66a91dac-d5da-11e7-9c1b-8059472217bc.png)
