### PR TITLE
Full-width, two-column layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby File.read('.ruby-version').chomp
 gem 'gds-api-adapters'
 gem 'gds-sso'
 gem 'govspeak'
-gem 'govuk_admin_template'
+gem 'govuk_admin_template', '~> 6.3'
 gem 'govuk_app_config'
 gem 'govuk_sidekiq'
 gem 'plek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.1.4)
+    autoprefixer-rails (7.2.1)
       execjs
     better_errors (2.3.0)
       coderay (>= 1.0.0)
@@ -155,7 +155,7 @@ GEM
     govuk-lint (3.2.0)
       rubocop (~> 0.49.0)
       scss_lint
-    govuk_admin_template (6.2.0)
+    govuk_admin_template (6.3.0)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
@@ -498,7 +498,7 @@ DEPENDENCIES
   google-api-client (~> 0.9)
   govspeak
   govuk-lint (~> 3.2)
-  govuk_admin_template
+  govuk_admin_template (~> 6.3)
   govuk_app_config
   govuk_sidekiq
   guard-rspec

--- a/app/assets/stylesheets/_container_fluid.scss
+++ b/app/assets/stylesheets/_container_fluid.scss
@@ -1,6 +1,0 @@
-.container-fluid {
-  .row {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}

--- a/app/assets/stylesheets/_container_fluid.scss
+++ b/app/assets/stylesheets/_container_fluid.scss
@@ -1,0 +1,6 @@
+.container-fluid {
+  .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}

--- a/app/assets/stylesheets/_full_width_audit.scss
+++ b/app/assets/stylesheets/_full_width_audit.scss
@@ -1,0 +1,22 @@
+.full-width-audit {
+  overflow-y: hidden;
+
+  .audit-pane,
+  .preview-pane {
+    overflow-y: auto;
+    height: calc(100vh - 57px);
+    margin-top: -20px;
+  }
+
+  .audit-pane {
+    padding-bottom: 20px;
+  }
+
+  .phase-banner {
+    margin-top: 0;
+  }
+
+  .page-footer {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,4 @@
 @import 'allocation';
 @import 'guidance';
 @import 'expandable_filters';
+@import 'container_fluid';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,4 +30,4 @@
 @import 'allocation';
 @import 'guidance';
 @import 'expandable_filters';
-@import 'container_fluid';
+@import 'full_width_audit';

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -10,6 +10,7 @@ module Audits
           params[:primary] = 'true' unless params.key?(:primary)
 
           @content_items = FindContent.paged(params_to_filter)
+          render layout: "audits"
         end
 
         format.csv do
@@ -24,6 +25,7 @@ module Audits
     def show
       @content_item = Content::Item.find_by!(content_id: params.fetch(:content_item_content_id))
       @audit = Audit.find_or_initialize_by(content_item: @content_item)
+      render layout: "audit"
     end
 
     def save

--- a/app/views/layouts/audit.html.erb
+++ b/app/views/layouts/audit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :full_width, true %>
+
+<%= render file: 'layouts/audits' %>

--- a/app/views/layouts/audit.html.erb
+++ b/app/views/layouts/audit.html.erb
@@ -1,3 +1,16 @@
 <% content_for :full_width, true %>
 
-<%= render file: 'layouts/audits' %>
+<% content_for :html_class, 'full-width-audit' %>
+
+<% content_for :content do %>
+  <div class="row">
+  <div class="audit-pane col-md-6">
+    <%= render 'application/beta_banner' %>
+    <%= yield %>
+  </div>
+  <div class="preview-pane col-md-6 hidden-xs hidden-sm">
+  </div>
+</div>
+<% end %>
+
+<%= render file: 'layouts/audit_wrapper' %>

--- a/app/views/layouts/audit_wrapper.html.erb
+++ b/app/views/layouts/audit_wrapper.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>
+  Content Audit Tool
+<% end %>
+
+<% content_for :app_title do %>
+  Content Audit Tool
+<% end %>
+
+<% content_for :app_home_path do %>
+  <%= audits_path %>
+<% end %>
+
+<% content_for :head do %>
+  <%= csrf_meta_tags %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= render "google_tag_manager" %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+<% end %>
+
+<%= render file: 'layouts/govuk_admin_template' %>

--- a/app/views/layouts/audits.html.erb
+++ b/app/views/layouts/audits.html.erb
@@ -1,22 +1,3 @@
-<% content_for :page_title do %>
-  Content Audit Tool
-<% end %>
-
-<% content_for :app_title do %>
-  Content Audit Tool
-<% end %>
-
-<% content_for :app_home_path do %>
-  <%= audits_path %>
-<% end %>
-
-<% content_for :head do %>
-  <%= csrf_meta_tags %>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-  <%= render "google_tag_manager" %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-<% end %>
-
 <% content_for :content do %>
   <%= render 'application/beta_banner' %>
   <%= render 'application/heroku' if Heroku.enabled?%>
@@ -35,4 +16,4 @@
   </div>
 <% end %>
 
-<%= render file: 'layouts/govuk_admin_template' %>
+<%= render file: 'layouts/audit_wrapper' %>


### PR DESCRIPTION
In preparation for displaying a content preview to the right-hand side of the audit page, this change rearranges the page into a full-width, two-column layout.

The two panes are independently scrollable. The right-hand pane will be hidden on mobile and tablet devices.

## Dependencies

- [x] https://github.com/alphagov/govuk_admin_template/pull/157
- [x] https://github.com/alphagov/govuk_admin_template/pull/158

## Before

![before](https://user-images.githubusercontent.com/12036746/33444450-423125b0-d5f2-11e7-8ae8-2dd32fa8f19d.png)

## After

![after](https://user-images.githubusercontent.com/12036746/33444457-461197aa-d5f2-11e7-88b2-b9dc95b0d7dc.png)
