### PR TITLE
Content item count tab

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -6,6 +6,7 @@ module Audits
     decorates_assigned :content_items
 
     def index
+      @my_content_items_count = FindContent.my_content(current_user.uid).count
       @content_items = FindContent.paged(params_to_filter)
     end
 

--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -6,7 +6,7 @@ module Audits
     decorates_assigned :content_items
 
     def index
-      @my_content_items_count = FindContent.my_content(current_user.uid).count
+      @my_content_items_count = FindContent.users_unaudited_content(current_user.uid).count
       @content_items = FindContent.paged(params_to_filter)
     end
 

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -10,7 +10,7 @@ module Audits
           params[:organisations] ||= [current_user.organisation_content_id]
           params[:primary] = 'true' unless params.key?(:primary)
 
-          @my_content_items_count = FindContent.my_content(current_user.uid).count
+          @my_content_items_count = FindContent.users_unaudited_content(current_user.uid).count
           @content_items = FindContent.paged(params_to_filter)
           render layout: "audits"
         end

--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -10,6 +10,7 @@ module Audits
           params[:organisations] ||= [current_user.organisation_content_id]
           params[:primary] = 'true' unless params.key?(:primary)
 
+          @my_content_items_count = FindContent.my_content(current_user.uid).count
           @content_items = FindContent.paged(params_to_filter)
           render layout: "audits"
         end

--- a/app/controllers/audits/reports_controller.rb
+++ b/app/controllers/audits/reports_controller.rb
@@ -4,6 +4,7 @@ module Audits
 
     def show
       @monitor = ::Audits::Monitor.new(params_to_filter)
+      @my_content_items_count = FindContent.users_unaudited_content(current_user.uid).count
     end
 
   private

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -22,6 +22,15 @@ module Audits
       end
     end
 
+    def self.my_content(current_user_uid)
+      filter = Filter.new(
+        allocated_to: current_user_uid,
+        audit_status: Audits::Audit::NON_AUDITED
+      )
+      scope = query(filter).all_content_items
+      do_filter!(filter, scope)
+    end
+
     def self.do_filter!(filter, scope)
       scope = filter.audited_policy.call(scope)
       filter.allocated_policy.call(scope, allocated_to: filter.allocated_to)

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -27,8 +27,7 @@ module Audits
         allocated_to: current_user_uid,
         audit_status: Audits::Audit::NON_AUDITED
       )
-      scope = query(filter).all_content_items
-      do_filter!(filter, scope)
+      self.all(filter)
     end
 
     def self.do_filter!(filter, scope)

--- a/app/domain/audits/find_content.rb
+++ b/app/domain/audits/find_content.rb
@@ -22,7 +22,7 @@ module Audits
       end
     end
 
-    def self.my_content(current_user_uid)
+    def self.users_unaudited_content(current_user_uid)
       filter = Filter.new(
         allocated_to: current_user_uid,
         audit_status: Audits::Audit::NON_AUDITED

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -4,7 +4,7 @@ module MenuHelper
 
     content_tag :li, role: "presentation", class: status do
       link_to_unless_current text, url, aria_controls: "home", role: "tab", data: { test_id: scope } do
-        link_to text, "#", aria_controls: "home", role: "tab"
+        link_to text, "#", aria_controls: "home", role: "tab", data: { test_id: scope }
       end
     end
   end

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -8,6 +8,7 @@
           value: 0,
           data: {
             tracking_id: "allocation-batch-size",
+            test_id: "allocation-batch-size"
           } %>
       <%= label_tag :allocate_to, "items to", class: "items"  %>
       <%= select_tag "allocate_to",
@@ -19,7 +20,7 @@
           test_id: "allocate-to",
         } %>
       <%= filter_to_hidden_fields %>
-      <%= submit_tag "Assign", class: "btn btn-default" %>
+      <%= submit_tag "Assign", class: "btn btn-default", data: { test_id: 'allocate-button'} %>
     </div>
   </div>
 </div>

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -8,7 +8,7 @@
           value: 0,
           data: {
             tracking_id: "allocation-batch-size",
-            test_id: "allocation-batch-size"
+            test_id: "allocation-batch-size",
           } %>
       <%= label_tag :allocate_to, "items to", class: "items"  %>
       <%= select_tag "allocate_to",

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -16,7 +16,7 @@
 
   <div class="row">
     <nav class="all-items-nav col-sm-6">
-      <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
+      <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items", data: { test_id: 'all-items-link' }  %>
     </nav>
 
     <div class="allocation-metadata col-sm-6">

--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs">
-  <%= navigation_link "Audit content", audits_url, 'audits'%>
+  <%= navigation_link "My content (#{@my_content_items_count})", audits_url, 'audits'%>
   <%= navigation_link "Assign content", audits_allocations_url, 'allocations' %>
   <%= navigation_link "Audit progress", audits_report_url, 'reports' %>
 </ul>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,19 +73,6 @@ ActiveRecord::Schema.define(version: 20171207164824) do
     t.index ["target_content_id"], name: "index_links_on_target_content_id"
   end
 
-  create_table "metrics", force: :cascade do |t|
-    t.date "date", null: false
-    t.string "content_id", null: false
-    t.integer "title_length"
-    t.float "reading_grade"
-    t.integer "word_count"
-    t.datetime "last_updated_at"
-    t.string "phase"
-    t.string "publication_state"
-    t.integer "version_number"
-    t.index ["content_id", "date"], name: "metrics_unique_content_id_date", unique: true
-  end
-
   create_table "questions", id: :serial, force: :cascade do |t|
     t.string "type", null: false
     t.text "text", null: false
@@ -160,7 +147,6 @@ ActiveRecord::Schema.define(version: 20171207164824) do
 
   add_foreign_key "allocations", "content_items", column: "content_id", primary_key: "content_id"
   add_foreign_key "allocations", "users", column: "uid", primary_key: "uid"
-  add_foreign_key "metrics", "content_items", column: "content_id", primary_key: "content_id"
   add_foreign_key "taxonomy_todos", "content_items"
   add_foreign_key "taxonomy_todos", "taxonomy_projects"
 end

--- a/spec/domain/audits/find_content_spec.rb
+++ b/spec/domain/audits/find_content_spec.rb
@@ -47,16 +47,16 @@ module Audits
     end
 
     describe '#my_content' do
-      subject(:relation) { described_class.my_content(user.uid) }
+      subject(:relation) { described_class.users_unaudited_content(user.uid) }
 
       before do
-        Audits::Allocation.create(uid: user.uid, content_id: Content::Item.first.content_id)
-        Audits::Allocation.create(uid: user.uid, content_id: Content::Item.second.content_id)
-        Audits::Allocation.create(uid: user.uid, content_id: Content::Item.third.content_id)
+        create(:allocation, user: user, content_item: Content::Item.first)
+        create(:allocation, user: user, content_item: Content::Item.second)
+        create(:allocation, user: user, content_item: Content::Item.third)
       end
 
       it 'returns my content' do
-        expect(relation).to match_array(content_items.sort_by(&:id)[0...3])
+        expect(relation).to match_array(content_items.first(3))
       end
     end
 

--- a/spec/domain/audits/find_content_spec.rb
+++ b/spec/domain/audits/find_content_spec.rb
@@ -1,6 +1,7 @@
 module Audits
   RSpec.describe FindContent do
     let!(:content_items) { create_list(:content_item, 210) }
+    let!(:user) { create(:user) }
 
     describe '#all' do
       subject(:relation) { described_class.all(filter) }
@@ -42,6 +43,20 @@ module Audits
       it 'returns the next page of filtered content items' do
         expect(relation)
           .to match_array(content_items.sort_by(&:id)[20...30])
+      end
+    end
+
+    describe '#my_content' do
+      subject(:relation) { described_class.my_content(user.uid) }
+
+      before do
+        Audits::Allocation.create(uid: user.uid, content_id: Content::Item.first.content_id)
+        Audits::Allocation.create(uid: user.uid, content_id: Content::Item.second.content_id)
+        Audits::Allocation.create(uid: user.uid, content_id: Content::Item.third.content_id)
+      end
+
+      it 'returns my content' do
+        expect(relation).to match_array(content_items.sort_by(&:id)[0...3])
       end
     end
 

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -68,6 +68,29 @@ RSpec.feature "Allocate multiple content items", type: :feature do
       expect(page).to_not have_content("Sense and Sensibility")
     end
 
+    scenario "Allocate content within current page and apply filters" do
+      visit audits_allocations_path
+      expect(page).to have_content("My content (0)")
+
+      check option: "emma"
+      check option: "sense-and-sensibility"
+
+      select "Me", from: "allocate_to"
+      click_on "Assign"
+
+      expect(page).to have_content("My content (2)")
+
+      select "Me", from: "allocated_to"
+      click_on "Apply filters"
+
+      expect(page).to have_content("My content (2)")
+
+      select "No one", from: "allocated_to"
+      click_on "Apply filters"
+
+      expect(page).to have_content("My content (2)")
+    end
+
     scenario "Allocate using the batch input" do
       visit audits_allocations_path
 

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Allocate multiple content items", type: :feature do
       expect(page).to_not have_content("Sense and Sensibility")
     end
 
-    scenario "Allocate content within current page and apply filters" do
+    scenario "My content tab shows number of items allocated to me regardless of page filters" do
       visit audits_allocations_path
       expect(page).to have_content("My content (0)")
 

--- a/spec/features/audit/tabs/my_content_spec.rb
+++ b/spec/features/audit/tabs/my_content_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "`My content` tab", type: :feature do
   scenario 'assigning content items to user to audit' do
     given_i_am_an_auditor_belonging_to_an_organisation
     and_i_have_no_content_items_assigned_to_me
-    when_i_visit_the_assign_content_page
+    when_i_visit_the_my_content_page
     then_i_can_see_that_i_have_0_content_items_to_audit
     when_i_navigate_to_assign_content_page
     and_i_assign_2_content_items_to_myself
@@ -14,10 +14,31 @@ RSpec.feature "`My content` tab", type: :feature do
   scenario 'auditing content items' do
     given_i_am_an_auditor_belonging_to_an_organisation
     and_i_have_5_content_items_assigned_to_me
-    when_i_visit_the_assign_content_page
+    when_i_visit_the_my_content_page
     then_i_can_see_that_i_have_5_content_items_to_audit
     when_i_audit_one_of_my_content_items
     then_i_can_see_that_i_have_4_content_items_left_to_audit
+  end
+
+  scenario 'on the my content page' do
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_i_have_5_content_items_assigned_to_me
+    when_i_visit_the_my_content_page
+    then_i_can_see_that_i_have_5_content_items_left_to_audit_from_the_my_content_page
+  end
+
+  scenario 'on the assign content page' do
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_i_have_5_content_items_assigned_to_me
+    when_i_visit_the_assign_content_page
+    then_i_can_see_that_i_have_5_content_items_left_to_audit_from_the_assignment_page
+  end
+
+  scenario 'on the audit progress page' do
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_i_have_5_content_items_assigned_to_me
+    when_i_visit_the_audit_progress_page
+    then_i_can_see_that_i_have_5_content_items_left_to_audit_from_the_progress_page
   end
 
   def given_i_am_an_auditor_belonging_to_an_organisation
@@ -34,7 +55,7 @@ RSpec.feature "`My content` tab", type: :feature do
            primary_publishing_organisation: @organisation)
   end
 
-  def when_i_visit_the_assign_content_page
+  def when_i_visit_the_my_content_page
     @audit_content_page = ContentAuditTool.new.audit_content_page
     @audit_content_page.load
   end
@@ -96,5 +117,27 @@ RSpec.feature "`My content` tab", type: :feature do
 
   def then_i_can_see_that_i_have_4_content_items_left_to_audit
     expect(@audit_content_page).to have_my_content_tab(text: 'My content (4)')
+  end
+
+  def when_i_visit_the_audit_progress_page
+    @audit_report_page = ContentAuditTool.new.audit_report_page
+    @audit_report_page.load
+  end
+
+  def when_i_visit_the_assign_content_page
+    @audit_assignment_page = ContentAuditTool.new.audit_assignment_page
+    @audit_assignment_page.load
+  end
+
+  def then_i_can_see_that_i_have_5_content_items_left_to_audit_from_the_progress_page
+    expect(@audit_report_page).to have_my_content_tab(text: 'My content (5)')
+  end
+
+  def then_i_can_see_that_i_have_5_content_items_left_to_audit_from_the_assignment_page
+    expect(@audit_assignment_page).to have_my_content_tab(text: 'My content (5)')
+  end
+
+  def then_i_can_see_that_i_have_5_content_items_left_to_audit_from_the_my_content_page
+    expect(@audit_content_page).to have_my_content_tab(text: 'My content (5)')
   end
 end

--- a/spec/features/audit/tabs/my_content_spec.rb
+++ b/spec/features/audit/tabs/my_content_spec.rb
@@ -70,26 +70,10 @@ RSpec.feature "`My content` tab", type: :feature do
   end
 
   def and_i_have_5_content_items_assigned_to_me
-    create(:content_item,
-           allocated_to: @user,
-           title: "content item",
-           primary_publishing_organisation: @organisation)
-    create(:content_item,
-           allocated_to: @user,
-           title: "content item2",
-           primary_publishing_organisation: @organisation)
-    create(:content_item,
-           allocated_to: @user,
-           title: "content item3",
-           primary_publishing_organisation: @organisation)
-    create(:content_item,
-           allocated_to: @user,
-           title: "content item4",
-           primary_publishing_organisation: @organisation)
-    create(:content_item,
-           allocated_to: @user,
-           title: "content item5",
-           primary_publishing_organisation: @organisation)
+    create_list(:content_item,
+                5,
+                allocated_to: @user,
+                primary_publishing_organisation: @organisation)
   end
 
   def then_i_can_see_that_i_have_5_content_items_to_audit
@@ -97,7 +81,7 @@ RSpec.feature "`My content` tab", type: :feature do
   end
 
   def when_i_audit_one_of_my_content_items
-    content_item = Content::Item.find_by(title: 'content item5')
+    content_item = Content::Item.last
     @audit_content_item = ContentAuditTool.new.audit_content_item
     @audit_content_item.load(
       content_id: content_item.content_id,
@@ -106,17 +90,7 @@ RSpec.feature "`My content` tab", type: :feature do
         audit_status: 'non_audited'
       }
     )
-    @audit_content_item.audit_form do |form|
-      form.title.choose 'No'
-      form.summary.choose 'No'
-      form.page_detail.choose 'No'
-      form.attachments.choose 'No'
-      form.content_type.choose 'No'
-      form.content_out_of_date.choose 'No'
-      form.content_should_be_removed.choose 'No'
-      form.content_similar.choose 'No'
-      form.save_and_continue.click
-    end
+    @audit_content_item.fill_in_audit_form
     @audit_content_item.all_items_link.click
   end
 

--- a/spec/features/audit/tabs/my_content_spec.rb
+++ b/spec/features/audit/tabs/my_content_spec.rb
@@ -1,0 +1,126 @@
+RSpec.feature "`My content` tab", type: :feature do
+  scenario 'assigning content items to user to audit' do
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_i_have_no_content_items_assigned_to_me
+    when_i_visit_the_assign_content_page
+    then_i_can_see_that_i_have_0_content_items_to_audit
+    when_i_navigate_to_assign_content_page
+    and_i_assign_2_content_items_to_myself
+    then_i_can_see_that_i_have_2_content_items_to_audit
+    when_i_unassign_1_of_my_content_items
+    then_i_can_see_that_i_have_1_content_items_to_audit
+  end
+
+  scenario 'auditing content items' do
+    given_i_am_an_auditor_belonging_to_an_organisation
+    and_i_have_5_content_items_assigned_to_me
+    when_i_visit_the_assign_content_page
+    then_i_can_see_that_i_have_5_content_items_to_audit
+    when_i_audit_one_of_my_content_items
+    then_i_can_see_that_i_have_4_content_items_left_to_audit
+  end
+
+  def given_i_am_an_auditor_belonging_to_an_organisation
+    @organisation = create(:organisation)
+    @user = create(:user, organisation: @organisation)
+  end
+
+  def and_i_have_no_content_items_assigned_to_me
+    create(:content_item,
+           title: "Unassigned content item",
+           primary_publishing_organisation: @organisation)
+    create(:content_item,
+           title: "Unassigned content item2",
+           primary_publishing_organisation: @organisation)
+  end
+
+  def when_i_visit_the_assign_content_page
+    @audit_content_page = ContentAuditTool.new.audit_content_page
+    @audit_content_page.load
+  end
+
+  def then_i_can_see_that_i_have_0_content_items_to_audit
+    expect(@audit_content_page).to have_my_content_tab(text: 'My content (0)')
+  end
+
+  def when_i_navigate_to_assign_content_page
+    @audit_assignment_page = ContentAuditTool.new.audit_assignment_page
+    @audit_content_page.assign_content_tab.click
+    @audit_assignment_page.load
+  end
+
+  def and_i_assign_2_content_items_to_myself
+    @audit_assignment_page.allocation_size.set '2'
+    @audit_assignment_page.allocate_to.select 'Me'
+    @audit_assignment_page.allocate_button.click
+  end
+
+  def then_i_can_see_that_i_have_2_content_items_to_audit
+    expect(@audit_assignment_page).to have_my_content_tab(text: 'My content (2)')
+  end
+
+  def when_i_unassign_1_of_my_content_items
+    @audit_assignment_page.allocation_size.set '1'
+    @audit_assignment_page.allocate_to.select 'No one'
+    @audit_assignment_page.allocate_button.click
+  end
+
+  def then_i_can_see_that_i_have_1_content_items_to_audit
+    expect(@audit_assignment_page).to have_my_content_tab(text: 'My content (1)')
+  end
+
+  def and_i_have_5_content_items_assigned_to_me
+    create(:content_item,
+           allocated_to: @user,
+           title: "content item",
+           primary_publishing_organisation: @organisation)
+    create(:content_item,
+           allocated_to: @user,
+           title: "content item2",
+           primary_publishing_organisation: @organisation)
+    create(:content_item,
+           allocated_to: @user,
+           title: "content item3",
+           primary_publishing_organisation: @organisation)
+    create(:content_item,
+           allocated_to: @user,
+           title: "content item4",
+           primary_publishing_organisation: @organisation)
+    create(:content_item,
+           allocated_to: @user,
+           title: "content item5",
+           primary_publishing_organisation: @organisation)
+  end
+
+  def then_i_can_see_that_i_have_5_content_items_to_audit
+    expect(@audit_content_page).to have_my_content_tab(text: 'My content (5)')
+  end
+
+  def when_i_audit_one_of_my_content_items
+    content_item = Content::Item.find_by(title: 'content item5')
+    @audit_content_item = ContentAuditTool.new.audit_content_item
+    @audit_content_item.load(
+      content_id: content_item.content_id,
+      query: {
+        allocated_to: @user.id.to_s,
+        audit_status: 'non_audited'
+      }
+    )
+    @audit_content_item.audit_form do |form|
+      form.title.choose 'No'
+      form.summary.choose 'No'
+      form.page_detail.choose 'No'
+      form.attachments.choose 'No'
+      form.content_type.choose 'No'
+      form.content_out_of_date.choose 'No'
+      form.content_should_be_removed.choose 'No'
+      form.content_similar.choose 'No'
+      form.save_and_continue.click
+    end
+    @audit_content_item.all_items_link.click
+  end
+
+  def then_i_can_see_that_i_have_4_content_items_left_to_audit
+    expect(@audit_content_page).to have_my_content_tab(text: 'My content (4)')
+  end
+end

--- a/spec/support/pages/audit/content_audit_tool.rb
+++ b/spec/support/pages/audit/content_audit_tool.rb
@@ -16,4 +16,8 @@ class ContentAuditTool
   def audit_report_page
     AuditReportPage.new
   end
+
+  def audit_assignment_page
+    AuditAssignmentPage.new
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_assignment_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_assignment_page.rb
@@ -1,7 +1,7 @@
 require "site_prism/page"
 
-class AuditContentPage < SitePrism::Page
-  set_url "/audits"
+class AuditAssignmentPage < SitePrism::Page
+  set_url "/audits/allocations"
 
   section :filter_form, "form" do
     element :search, "[data-test-id=search]"
@@ -18,8 +18,11 @@ class AuditContentPage < SitePrism::Page
     element :audits_progress_tab, '[data-test-id=reports]'
   end
 
-  element :pagination, ".pagination"
-  element :audits_progress_tab, '[data-test-id=reports]'
+
+  element :allocation_size, '[data-tracking-id=allocation-batch-size]'
+  element :allocate_to, '[data-test-id=allocate-to]'
+  element :allocate_button, '[data-test-id=allocate-button]'
   element :my_content_tab, '[data-test-id=audits]'
   element :assign_content_tab, '[data-test-id=allocations]'
+  element :checkbox, '.select-content-item'
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
@@ -5,6 +5,7 @@ class AuditContentItemPage < SitePrism::Page
 
   element :error_message, '[data-test-id=audit-error-message]'
   element :success_message, '[data-test-id=audit-success-message]'
+  element :all_items_link, '[data-test-id=all-items-link]'
 
   element :assigned_to, '[data-test-id=allocated]'
   element :audited, '[data-test-id=audited]'

--- a/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
@@ -41,4 +41,18 @@ class AuditContentItemPage < SitePrism::Page
     element :unique_page_views, '[data-test-id=pageviews]'
     element :withdrawn, '[data-test-id=withdrawn]'
   end
+
+  def fill_in_audit_form
+    audit_form do |form|
+      form.title.choose 'No'
+      form.summary.choose 'No'
+      form.page_detail.choose 'No'
+      form.attachments.choose 'No'
+      form.content_type.choose 'No'
+      form.content_out_of_date.choose 'No'
+      form.content_should_be_removed.choose 'No'
+      form.content_similar.choose 'No'
+      form.save_and_continue.click
+    end
+  end
 end

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -13,4 +13,5 @@ class AuditReportPage < SitePrism::Page
   element :export_to_csv, '[data-test-id=report-export]'
   element :organisations, '[data-test-id=organisations]'
   element :content_item_count, '[data-test-id=content-item-count]'
+  element :my_content_tab, '[data-test-id=audits]'
 end


### PR DESCRIPTION
 - Change `Audit Content` tab to `My content (x)`, where x is the number of unaudited content items that are assigned to the current user, due to the positive feedback that was received on the prototype feature during user research sessions.
- Add my_content_spec.rb to test that the `My content` tab reflects the correct number of content items as the user assigns, unassigns and audits content items.
- Add audit_assignment_page object model, and assign new elements in other page object models, to allow testing using the page object model pattern currently employed in similar feature tests in the application.