### PR TITLE
Add page counter to Audit tabs 'All content' and 'My content'

### DIFF
--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -17,7 +17,7 @@
 <div class="allocations" data-module="batch-selection">
   <%= form_tag audits_allocations_path, data: { module: "track-allocation-batch-size" } do %>
       <%= render 'toolbar' %>
-      <%= render 'audits/common/counter', count: content_items.total_count  %>
+      <%= render 'audits/common/counter', count: content_items.total_count %>
 
       <table class="table table-bordered table-hover">
         <thead>
@@ -32,5 +32,6 @@
         </tbody>
       </table>
   <% end %>
+  <%= render 'audits/common/counter', count: content_items.total_count %>
   <%= paginate content_items, window: 2 %>
 </div>

--- a/app/views/audits/audits/_content_items.html.erb
+++ b/app/views/audits/audits/_content_items.html.erb
@@ -11,5 +11,5 @@
   <%= render collection: content_items, partial: "content_item" %>
   </tbody>
 </table>
-
+<%= render 'audits/common/counter', count: content_items.total_count  %>
 <%= paginate content_items, :window => 2 %>

--- a/app/views/audits/common/_counter.html.erb
+++ b/app/views/audits/common/_counter.html.erb
@@ -1,3 +1,3 @@
 <div class="content-items-counter">
-  <strong><%= format_number(count) %> <%="item".pluralize(count) %></strong>
+  <%= page_entries_info content_items %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
     page_entries_info:
       one_page:
         display_entries:
-          one: "1 - %{count} of %{count} %{entry_name}"
-          other: "1 - %{count} of %{count} %{entry_name}"
+          one: "1&nbsp;-&nbsp;%{count} of %{count} %{entry_name}"
+          other: "1&nbsp;-&nbsp;%{count} of %{count} %{entry_name}"
       more_pages:
         display_entries: "%{first}&nbsp;-&nbsp;%{last} of %{total} %{entry_name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,11 @@ en:
   term_generation_states:
     dont-know: "Don't know"
     not-relevant: "Not relevant to theme"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          one: "1 - %{count} of %{count} %{entry_name}"
+          other: "1 - %{count} of %{count} %{entry_name}"
+      more_pages:
+        display_entries: "%{first}&nbsp;-&nbsp;%{last} of %{total} %{entry_name}"


### PR DESCRIPTION
Amend the format of the page counter and make it appear at both the
top and bottom of the 'All content' and 'My content' pages.

We are use the gem Kaminari for pagination, to format the display
of the page counter we customise the Kaminari helpers on page-entries_info.

[Trello](https://trello.com/c/S4OPeGYb/676-2-add-an-page-counter-x-y-of-z)