### PR TITLE
Content preview iframe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby File.read('.ruby-version').chomp
 gem 'gds-api-adapters'
 gem 'gds-sso'
 gem 'govspeak'
-gem 'govuk_admin_template', '~> 6.3'
+gem 'govuk_admin_template', '~> 6.4'
 gem 'govuk_app_config'
 gem 'govuk_sidekiq'
 gem 'plek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     govuk-lint (3.2.0)
       rubocop (~> 0.49.0)
       scss_lint
-    govuk_admin_template (6.3.0)
+    govuk_admin_template (6.4.0)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
@@ -498,7 +498,7 @@ DEPENDENCIES
   google-api-client (~> 0.9)
   govspeak
   govuk-lint (~> 3.2)
-  govuk_admin_template (~> 6.3)
+  govuk_admin_template (~> 6.4)
   govuk_app_config
   govuk_sidekiq
   guard-rspec

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require organisation-autocomplete
 //= require batch-selection
 //= require expandable-filters
+//= require content-preview
 
 // --- Analytics ---
 //= require analytics/google-tag-manager

--- a/app/assets/javascripts/content-preview.js
+++ b/app/assets/javascripts/content-preview.js
@@ -1,0 +1,31 @@
+(function (Modules) {
+  "use strict";
+
+  Modules.ContentPreview = function () {
+    this.start = function ($element) {
+      var $iframe = $element.find('iframe');
+
+      initialise();
+
+      function initialise() {
+        addSpinner();
+        $iframe.load(onIframeLoaded);
+      }
+
+      function addSpinner() {
+        $element.append(
+          '<div class="spinner"></div>'
+        );
+      }
+
+      function onIframeLoaded() {
+        hideSpinner();
+        $iframe.removeClass('if-js-hide');
+      }
+
+      function hideSpinner() {
+        $element.children('.spinner').remove();
+      }
+    };
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -47,6 +47,7 @@ $all-items-link-colour: #000000;
 
 .audit-content-item {
   font-size: 19px;
+  padding-bottom: 20px;
 
   h4 {
     margin-top: 1em;

--- a/app/assets/stylesheets/_content_preview.scss
+++ b/app/assets/stylesheets/_content_preview.scss
@@ -1,0 +1,29 @@
+.preview-pane {
+  $preview-url-border: #bfc1c3;
+
+  padding-left: 0;
+  padding-right: 0;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+
+  .preview-url {
+    flex: 0 0 auto;
+    padding: 10px;
+    margin: 0;
+    border-bottom: 1px solid $preview-url-border;
+  }
+
+  iframe {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .lte-ie7 &,
+  .ie8 &,
+  .ie9 & {
+    iframe {
+      height: 450px;
+    }
+  }
+}

--- a/app/assets/stylesheets/_full_width_audit.scss
+++ b/app/assets/stylesheets/_full_width_audit.scss
@@ -3,17 +3,24 @@
 
   .audit-pane,
   .preview-pane {
-    overflow-y: auto;
     height: calc(100vh - 57px);
     margin-top: -20px;
   }
 
-  .audit-pane {
-    padding-bottom: 20px;
+  &.lte-ie7,
+  &.ie8 {
+    .audit-pane,
+    .preview-pane {
+      height: 500px;
+    }
   }
 
-  .phase-banner {
-    margin-top: 0;
+  .audit-pane {
+    overflow-y: auto;
+
+    .phase-banner {
+      margin-top: 0;
+    }
   }
 
   .page-footer {

--- a/app/assets/stylesheets/_spinner.scss
+++ b/app/assets/stylesheets/_spinner.scss
@@ -1,0 +1,29 @@
+.spinner {
+  $spinner-background: #eeeeee;
+  $spinner-foreground: #000000;
+
+  border: 4px solid $spinner-background;
+  border-top: 4px solid $spinner-foreground;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  margin: auto;
+  animation: spinner 2s linear infinite;
+
+  .lte-ie7 &,
+  .ie8 &,
+  .ie9 & {
+    height: 0;
+    width: 0;
+    border: none;
+
+    &:after {
+      content: 'Loading...';
+    }
+  }
+}
+
+@keyframes spinner {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,4 @@
 @import 'expandable_filters';
 @import 'full_width_audit';
 @import 'content_preview';
+@import 'spinner';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,3 +31,4 @@
 @import 'guidance';
 @import 'expandable_filters';
 @import 'full_width_audit';
+@import 'content_preview';

--- a/app/decorators/content/item_decorator.rb
+++ b/app/decorators/content/item_decorator.rb
@@ -61,6 +61,10 @@ class Content::ItemDecorator < Draper::Decorator
     allocation.user.organisation&.title
   end
 
+  def proxy_url
+    File.join(Proxies::IframeAllowingProxy::PROXY_BASE_PATH, base_path)
+  end
+
 private
 
   def titles(content_items)

--- a/app/views/audits/audits/_content_preview.html.erb
+++ b/app/views/audits/audits/_content_preview.html.erb
@@ -1,0 +1,15 @@
+<p class="preview-url">
+  <%= link_to("https://www.gov.uk#{content_item.base_path}",
+    "https://www.gov.uk#{content_item.base_path}",
+    target: "_blank",
+    rel: "noopener noreferrer",
+  ) %>
+</p>
+
+<%= tag(:iframe,
+  id: "content-preview",
+  title: "Content as shown on GOV.UK",
+  src: content_item.proxy_url,
+  scrolling: "yes",
+  frameborder: "no",
+) %>

--- a/app/views/audits/audits/_content_preview.html.erb
+++ b/app/views/audits/audits/_content_preview.html.erb
@@ -12,4 +12,5 @@
   src: content_item.proxy_url,
   scrolling: "yes",
   frameborder: "no",
+  class: "if-js-hide",
 ) %>

--- a/app/views/layouts/audit.html.erb
+++ b/app/views/layouts/audit.html.erb
@@ -8,7 +8,7 @@
     <%= render 'application/beta_banner' %>
     <%= yield %>
   </div>
-  <div class="preview-pane col-md-6 hidden-xs hidden-sm">
+  <div class="preview-pane col-md-6 hidden-xs hidden-sm" data-module="content-preview">
     <%= render "content_preview" %>
   </div>
 </div>

--- a/app/views/layouts/audit.html.erb
+++ b/app/views/layouts/audit.html.erb
@@ -9,6 +9,7 @@
     <%= yield %>
   </div>
   <div class="preview-pane col-md-6 hidden-xs hidden-sm">
+    <%= render "content_preview" %>
   </div>
 </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,5 +41,10 @@ Rails.application.routes.draw do
     end
   end
 
-  mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH, constraints: ProxyAccessContraint.new
+  # rack-proxy does not work with webmock, so disable it for tests: https://github.com/ncr/rack-proxy#warning
+  if Rails.env.test?
+    get "#{Proxies::IframeAllowingProxy::PROXY_BASE_PATH}*base_path", to: proc { [200, {}, ['Proxy disabled in Test environment']] }
+  else
+    mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH, constraints: ProxyAccessContraint.new
+  end
 end


### PR DESCRIPTION
This change:

- adds a preview of the content being audited to the right of the audit page
- uses JavaScript to add a CSS spinner while the iframe is loading
- changes the iframe proxy to open all links in a new tab, removing confusion about how to navigate around in an iframe

## Screenshots

### Side-by-side preview

![preview](https://user-images.githubusercontent.com/12036746/33606920-0da1bcce-d9b7-11e7-8c92-51e21cadfb7e.png)

### Loading spinner

![preview-spinner](https://user-images.githubusercontent.com/12036746/33608443-6d30862a-d9bc-11e7-83d7-e92740b4b189.gif)

## Compatibility

This solution has been tested on:

- Chrome v62.0.3202.94 on Mac
- Firefox v57.0.1 on Mac
- Safari v11.0.1 on Mac
- Internet Explorer 8 on PC
- Internet Explorer 9 on PC
- Internet Explorer 11 on PC
- Edge 16 on PC

Some compatibility issues exist in versions of IE9 and below.

### Flexbox

The panels' height is set using flexbox. Setting height through flexbox means that we can make the iframe take up as much screen real estate as possible (without resorting to JavaScript). A similar effect could have been achieved by using `position: fixed` and anchoring the two panes to the viewport. However, this would have removed the responsiveness of the page (see below). In order to address this, the height of the page is set to a fixed height of 500px on older browsers.

![preview-ie8](https://user-images.githubusercontent.com/12036746/33607660-c410d9ac-d9b9-11e7-81d5-c5569fd5839e.jpg)

### CSS animations

IE9 and below also don't support CSS animations. In these cases, the CSS spinner is simply replaced with text: "Loading..."

![preview-ie8-loading](https://user-images.githubusercontent.com/12036746/33607678-c81b6314-d9b9-11e7-9de9-b855df2d741a.jpg)

## Accessibility

The iframe is inserted at the end of the page so to not be obstructive when using a screenreader, or navigating using the keyboard. It has a title that announces its purpose to screen readers, and can be navigated using the keyboard if the user prefers to stay on the same page, rather than open the content in a new tab.

### No script

The only difference users will see with JavaScript disabled is that they will not get the loading spinner.

### Responsiveness

The side-by-side view makes no sense on a narrower viewport, so the preview is hidden completely on mobile and tablet using Bootstrap's built-in classes.

![preview-tablet](https://user-images.githubusercontent.com/12036746/33607582-90154a5c-d9b9-11e7-9979-52e192e0b0f7.png)
