### PR TITLE
Reorder "My content" filters

### DIFF
--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -7,6 +7,7 @@ module Audits
         format.html do
           params[:allocated_to] ||= current_user.uid
           params[:audit_status] ||= Audits::Audit::NON_AUDITED
+          params[:organisations] ||= [current_user.organisation_content_id]
           params[:primary] = 'true' unless params.key?(:primary)
 
           @content_items = FindContent.paged(params_to_filter)

--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,10 +1,9 @@
 <%= form_tag audits_path, method: :get do %>
   <%= render 'audits/common/title' %>
-  <%= render 'audits/common/allocated_to' %>
   <%= render 'audits/common/audit_status' %>
-  <%= render 'audits/common/document_type' %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
+  <%= render 'audits/common/document_type' %>
   <%= render 'audits/common/sort' %>
   <%= render 'audits/common/submit' %>
 <% end %>

--- a/spec/features/audit/audit/navigation_spec.rb
+++ b/spec/features/audit/audit/navigation_spec.rb
@@ -109,36 +109,6 @@ RSpec.feature "Navigation", type: :feature do
 
       expect(page).to have_content("Please answer all the questions.")
     end
-
-    scenario "continuing to the next unaudited item on save" do
-      visit audits_path
-      click_link "Squirrel Nutkin"
-      perform_audit
-
-      visit audits_path
-      select "Anyone", from: "allocated_to"
-
-      choose "Not audited"
-      click_on "Apply filters"
-
-      expect(page).to have_content("Peter Rabbit")
-      expect(page).to have_content("Jemima Puddle-Duck")
-      expect(page).to have_content("Benjamin Bunny")
-      expect(page).to_not have_content("Squirrel Nutkin")
-      expect(page).to have_content("Timmy Tiptoes")
-      expect(page).to have_content("Miss Moppet")
-
-      click_link "Peter Rabbit"
-      perform_audit
-
-      expected = content_item_audit_path(jemima_puddle_duck,
-                                         allocated_to: 'anyone',
-                                         audit_status: 'non_audited',
-                                         primary: true)
-      expect(current_url).to end_with(expected)
-
-      expect(page).to have_content("Audit saved — 4 items remaining.")
-    end
   end
 
   def answer_question(question, answer)

--- a/spec/features/audit/lists/no_content_spec.rb
+++ b/spec/features/audit/lists/no_content_spec.rb
@@ -24,11 +24,6 @@ RSpec.feature "Notifying of no content to audit", type: :feature do
     end
 
     context "viewing content assigned to me" do
-      before(:each) do
-        select "Me", from: :allocated_to
-        click_on "Apply filters"
-      end
-
       scenario "not audited content should show a banner" do
         choose "Not audited"
         click_on "Apply filters"
@@ -48,56 +43,6 @@ RSpec.feature "Notifying of no content to audit", type: :feature do
         choose "All"
         click_on "Apply filters"
         expect(page).to have_content("You have no content to audit.")
-        expect(page).to have_css(".alert")
-      end
-    end
-
-    context "viewing content assigned to someone else" do
-      let!(:aslan) do
-        create(
-          :user,
-          name: "Aslan",
-          organisation: narnia,
-        )
-      end
-
-      before(:each) do
-        visit audits_path
-        select "Aslan", from: :allocated_to
-        click_on "Apply filters"
-      end
-
-      scenario "not audited content should show a banner" do
-        choose "Not audited"
-        click_on "Apply filters"
-        expect(page).to have_content("Aslan has no content to audit.")
-        expect(page).to have_css(".alert")
-        expect(page).to have_css(".alert a")
-      end
-    end
-
-    context "viewing content assigned to no one" do
-      before(:each) do
-        select "No one", from: :allocated_to
-        click_on "Apply filters"
-      end
-
-      scenario "not audited content should show a banner" do
-        choose "Not audited"
-        click_on "Apply filters"
-        expect(page).to have_css(".alert")
-      end
-    end
-
-    context "viewing content assigned to anyone" do
-      before(:each) do
-        select "Anyone", from: :allocated_to
-        click_on "Apply filters"
-      end
-
-      scenario "not audited content should show a banner" do
-        choose "Not audited"
-        click_on "Apply filters"
         expect(page).to have_css(".alert")
       end
     end

--- a/spec/features/audit/lists/sorting_spec.rb
+++ b/spec/features/audit/lists/sorting_spec.rb
@@ -22,8 +22,6 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, title: "CCC", allocated_to: me)
 
     visit audits_path
-    select "Anyone", from: "allocated_to"
-
     select "Title A-Z", from: "sort_by"
     click_on "Apply filters"
 
@@ -39,8 +37,6 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, title: "CCC", allocated_to: me)
 
     visit audits_path
-    select "Anyone", from: "allocated_to"
-
     select "Title Z-A", from: "sort_by"
     click_on "Apply filters"
 

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -21,16 +21,6 @@ RSpec.feature "Export to CSV" do
     then_all_content_items_are_included_in_the_csv
   end
 
-  scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
-    given_i_am_an_auditor_belonging_to_an_organisation
-    and_there_are_three_content_items
-    when_i_filter_the_content_page_for_content_items_with_no_one_assigned_to_them
-    then_i_see_the_two_unassigned_content_items
-    when_i_navigate_to_audits_report_page
-    then_i_do_not_see_the_two_unassigned_content_items
-    and_i_see_the_one_content_item_assigned_to_me
-  end
-
   def given_i_am_an_auditor_belonging_to_an_organisation
     @user = create(:user)
     @hmrc = create(:content_item,
@@ -43,26 +33,6 @@ RSpec.feature "Export to CSV" do
     expect(@audit_report).to have_content("Title,URL")
     expect(@audit_report).to have_content("Assigned HMRC content,https://gov.uk/example1")
     expect(@audit_report).to have_no_content("Unassigned content 2,https://gov.uk/example2")
-  end
-
-  def then_i_see_the_two_unassigned_content_items
-    expect(@audit_content_page).to have_no_content("Assigned HMRC content")
-    expect(@audit_content_page).to have_content("Unassigned content 2")
-    expect(@audit_content_page).to have_content("Unassigned content 3")
-  end
-
-  def when_i_navigate_to_audits_report_page
-    @audit_report_page = ContentAuditTool.new.audit_report_page
-    @audit_content_page.audits_progress_tab.click
-  end
-
-  def then_i_do_not_see_the_two_unassigned_content_items
-    expect(@audit_report_page).to be_displayed
-    expect(@audit_report_page.content_item_count.text).not_to eq('2')
-  end
-
-  def and_i_see_the_one_content_item_assigned_to_me
-    expect(@audit_report_page.content_item_count.text).to eq('1')
   end
 
   def when_i_export_an_audit_report
@@ -112,15 +82,6 @@ RSpec.feature "Export to CSV" do
     csv = CSV.parse(page.body)
     number_of_metadata_rows = 1
     expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)
-  end
-
-  def when_i_filter_the_content_page_for_content_items_with_no_one_assigned_to_them
-    @audit_content_page = ContentAuditTool.new.audit_content_page
-    @audit_content_page.load
-    @audit_content_page.filter_form do |form|
-      form.allocated_to.select "No one"
-      form.apply_filters.click
-    end
   end
 
   def and_there_are_three_content_items


### PR DESCRIPTION
This commit makes three changes to the "My content" view:

- remove the "Assigned to" filter
- reorder the remaining filters
- default the organisation filter to the user's organisation

## Dependencies

- [ ] https://github.com/alphagov/content-performance-manager/pull/420

## Before

![before](https://user-images.githubusercontent.com/12036746/33676781-9153392e-daae-11e7-8cfc-eb685255db3a.png)

## After

![after](https://user-images.githubusercontent.com/12036746/33676794-954442f8-daae-11e7-8711-5e7e24c660df.png)