### PR TITLE
Change name, order and paths of audits navigation tabs

### DIFF
--- a/app/views/audits/audits/_sidebar.html.erb
+++ b/app/views/audits/audits/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag audits_path, method: :get do %>
+<%= form_tag audits_my_content_path, method: :get do %>
   <%= render 'audits/common/title' %>
   <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/organisations' %>

--- a/app/views/audits/common/_navigation.html.erb
+++ b/app/views/audits/common/_navigation.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs">
-  <%= navigation_link "My content (#{@my_content_items_count})", audits_url, 'audits'%>
-  <%= navigation_link "Assign content", audits_allocations_url, 'allocations' %>
+  <%= navigation_link "All content", audits_path, 'allocations' %>
+  <%= navigation_link "My content (#{@my_content_items_count})", audits_my_content_path, 'audits'%>
   <%= navigation_link "Audit progress", audits_report_url, 'reports' %>
 </ul>

--- a/app/views/audits/reports/show.html.erb
+++ b/app/views/audits/reports/show.html.erb
@@ -6,7 +6,7 @@
     <%= render 'audits/common/navigation' %>
 <% end %>
 
-<%= link_to "Export filtered audit to CSV", audits_path(params: filter_params, format: :csv), class: "report-export", data: { test_id: "report-export" } %>
+<%= link_to "Export filtered audit to CSV", audits_my_content_path(params: filter_params, format: :csv), class: "report-export", data: { test_id: "report-export" } %>
 
 <div class="report-section"
      data-test-id="report-section">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,10 @@ Rails.application.routes.draw do
     end
   end
 
+
   namespace :audits do
-    get '/', to: "audits#index"
+    get '/', to: "allocations#index"
+    get '/my-content', to: "audits#index", as: 'my_content'
     resource :report, only: :show
     resource :guidance, only: :show
 

--- a/spec/features/audit/audit/navigation_spec.rb
+++ b/spec/features/audit/audit/navigation_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature "Navigation", type: :feature do
     end
 
     scenario "navigating between audits and the index page" do
-      visit audits_path
+      visit audits_my_content_path
       click_link "Peter Rabbit"
 
       expected = content_item_audit_path(peter_rabbit, **filter_params)
@@ -80,7 +80,7 @@ RSpec.feature "Navigation", type: :feature do
     end
 
     scenario "returning to the first page of the index" do
-      visit audits_path
+      visit audits_my_content_path
       click_link "Peter Rabbit"
       click_link "< All items"
 
@@ -89,7 +89,7 @@ RSpec.feature "Navigation", type: :feature do
     end
 
     scenario "continuing to next item on save" do
-      visit audits_path
+      visit audits_my_content_path
       click_link "Peter Rabbit"
       perform_audit
 
@@ -100,7 +100,7 @@ RSpec.feature "Navigation", type: :feature do
     end
 
     scenario "not continuing to next item if fails to save" do
-      visit audits_path
+      visit audits_my_content_path
       click_link "Peter Rabbit"
       click_on "Save and continue"
 
@@ -108,6 +108,36 @@ RSpec.feature "Navigation", type: :feature do
       expect(current_url).to end_with(expected)
 
       expect(page).to have_content("Please answer all the questions.")
+    end
+
+    scenario "continuing to the next unaudited item on save" do
+      visit audits_my_content_path
+      click_link "Squirrel Nutkin"
+      perform_audit
+
+      visit audits_path
+      select "Anyone", from: "allocated_to"
+
+      choose "Not audited"
+      click_on "Apply filters"
+
+      expect(page).to have_content("Peter Rabbit")
+      expect(page).to have_content("Jemima Puddle-Duck")
+      expect(page).to have_content("Benjamin Bunny")
+      expect(page).to_not have_content("Squirrel Nutkin")
+      expect(page).to have_content("Timmy Tiptoes")
+      expect(page).to have_content("Miss Moppet")
+
+      click_link "Peter Rabbit"
+      perform_audit
+
+      expected = content_item_audit_path(jemima_puddle_duck,
+                                         allocated_to: 'anyone',
+                                         audit_status: 'non_audited',
+                                         primary: true)
+      expect(current_url).to end_with(expected)
+
+      expect(page).to have_content("Audit saved — 4 items remaining.")
     end
   end
 

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
   end
 
   scenario "User does not see CPM feedback survey link in banner" do
-    visit audits_path
+    visit audits_my_content_path
 
     expect(page).to have_no_link("these quick questions")
   end
@@ -15,7 +15,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id", allocated_to: me)
     create(:content_item, title: "item2", allocated_to: me)
 
-    visit audits_path
+    visit audits_my_content_path
 
     expect(page).to have_content("item1")
     expect(page).to have_content("10,000")
@@ -27,7 +27,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
   scenario "Displays the number of content items" do
     create_list(:content_item, 2, allocated_to: me)
 
-    visit audits_path
+    visit audits_my_content_path
 
     expect(page).to have_text("2 items")
   end
@@ -36,7 +36,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     create(:content_item, document_type: "guide", allocated_to: me)
     create(:content_item, document_type: "other-format", allocated_to: me)
 
-    visit audits_path
+    visit audits_my_content_path
 
     expect(page).to have_css("main tbody tr", count: 1)
   end
@@ -49,7 +49,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     }
 
     scenario "Showing 100 items on the first page" do
-      visit audits_path
+      visit audits_my_content_path
 
       content_items[0..99].each do |content_item|
         expect(page).to have_content(content_item.title)
@@ -61,7 +61,7 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     end
 
     scenario "Showing the second page of items" do
-      visit audits_path
+      visit audits_my_content_path
 
       click_link "Next →"
 

--- a/spec/features/audit/lists/no_content_spec.rb
+++ b/spec/features/audit/lists/no_content_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Notifying of no content to audit", type: :feature do
 
   context "there is no content for my organisation to audit" do
     before(:each) do
-      visit audits_path
+      visit audits_my_content_path
     end
 
     context "viewing content assigned to me" do

--- a/spec/features/audit/lists/sorting_spec.rb
+++ b/spec/features/audit/lists/sorting_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, six_months_page_views: 0, title: "item1", allocated_to: me)
     create(:content_item, six_months_page_views: 1234, title: "item2", allocated_to: me)
 
-    visit audits_path
+    visit audits_my_content_path
 
     rows = page.all('main tbody tr')
     expect(rows[0].text).to match("item2")
@@ -22,6 +22,8 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, title: "CCC", allocated_to: me)
 
     visit audits_path
+    select "Anyone", from: "allocated_to"
+
     select "Title A-Z", from: "sort_by"
     click_on "Apply filters"
 
@@ -37,6 +39,8 @@ RSpec.feature "Sort content items to audit", type: :feature do
     create(:content_item, title: "CCC", allocated_to: me)
 
     visit audits_path
+    select "Anyone", from: "allocated_to"
+
     select "Title Z-A", from: "sort_by"
     click_on "Apply filters"
 

--- a/spec/support/pages/audit/content_audit_tool/audit_assignment_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_assignment_page.rb
@@ -1,7 +1,7 @@
 require "site_prism/page"
 
 class AuditAssignmentPage < SitePrism::Page
-  set_url "/audits/allocations"
+  set_url "/audits"
 
   section :filter_form, "[data-test-id=allocations-sidebar]" do
     element :search, "[data-test-id=search]"

--- a/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_page.rb
@@ -1,7 +1,7 @@
 require "site_prism/page"
 
 class AuditContentPage < SitePrism::Page
-  set_url "/audits"
+  set_url "/audits/my-content"
 
   section :filter_form, "form" do
     element :search, "[data-test-id=search]"


### PR DESCRIPTION
- Rename `Assign content` tab to `All content` to more accurately reflect the
the contents of the page and re-order the tabs, so that the `All content` tab
is first, to improve user’s navigation and understanding of the appplication (as
validated by user research anaylsis).
- Change paths to reflect the new naming of the navigation tabs.
- Alter set up of tests and make changes to the urls of page object models to
ensure that tests navigate to the intended page after the changes that have
been made.