### PR TITLE
Filter by audit status report

### DIFF
--- a/app/helpers/radio_button_helper.rb
+++ b/app/helpers/radio_button_helper.rb
@@ -1,15 +1,15 @@
 module RadioButtonHelper
   def audit_status_radio_button_options(selected)
     options = [
-      { value: Audits::Audit::NON_AUDITED.to_s, label: 'Not audited' },
-      { value: Audits::Audit::AUDITED.to_s, label: 'Audited' },
-      { value: Audits::Audit::ALL.to_s, label: 'All' },
+      { value: Audits::Audit::NON_AUDITED, label: 'Not audited' },
+      { value: Audits::Audit::AUDITED, label: 'Audited' },
+      { value: Audits::Audit::ALL, label: 'All' },
     ]
 
     options.map.with_index do |option, index|
       option.merge(
         id: "audit_status_#{option[:value]}",
-        selected: selected == option[:value] || index.zero?,
+        selected: selected.to_s == option[:value].to_s || index.zero?,
       )
     end
   end

--- a/app/views/audits/reports/_sidebar.html.erb
+++ b/app/views/audits/reports/_sidebar.html.erb
@@ -1,5 +1,6 @@
 <%= form_tag audits_report_path, method: :get do %>
   <%= render 'audits/common/allocated_to' %>
+  <%= render 'audits/common/audit_status' %>
   <%= render 'audits/common/organisations' %>
   <%= render 'audits/common/primary' %>
   <%= render 'audits/common/document_type' %>

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -1,12 +1,4 @@
 RSpec.feature "Exporting a CSV from the report page" do
-  def content_type
-    page.response_headers.fetch("Content-Type")
-  end
-
-  def content_disposition
-    page.response_headers.fetch("Content-Disposition")
-  end
-
   scenario "Exporting a csv file as an attachment" do
     given_i_am_an_auditor_belonging_to_an_organisation
     and_there_are_three_content_items
@@ -80,6 +72,9 @@ RSpec.feature "Exporting a CSV from the report page" do
   end
 
   def then_i_receive_the_report_in_csv_format
+    content_type = page.response_headers.fetch("Content-Type")
+    content_disposition = page.response_headers.fetch("Content-Disposition")
+
     expect(content_type).to eq("text/csv")
     expect(content_disposition).to start_with("attachment")
     expect(content_disposition).to include(

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -95,9 +95,9 @@ RSpec.feature "Exporting a CSV from the report page" do
     @audit_report.export_to_csv.click
   end
 
-  def and_there_are_multiple_pages_of_unfiltered_content_items
-    content_items_per_page = 100
-    create_list(:content_item, content_items_per_page * 2)
+  def and_there_are_multiple_pages_of_content_items
+    content_items_per_page = 101
+    create_list(:content_item, content_items_per_page)
   end
 
   def when_i_export_all_the_reports

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Export to CSV" do
   scenario "Apply filters" do
     given_i_am_an_auditor_belonging_to_an_organisation
     and_there_are_three_content_items
-    and_a_filter_is_applied_to_show_only_hmrc_content_items
+    and_a_filter_is_applied_to_show_only_audited_hmrc_content_items
     when_i_export_the_reports
     then_i_receive_only_hmrc_related_content_items_in_the_report
   end
@@ -84,10 +84,11 @@ RSpec.feature "Export to CSV" do
     expect(@audit_report).to have_content("Assigned HMRC content,https://gov.uk/example1")
   end
 
-  def and_a_filter_is_applied_to_show_only_hmrc_content_items
+  def and_a_filter_is_applied_to_show_only_audited_hmrc_content_items
     @audit_report = ContentAuditTool.new.audit_report_page
     @audit_report.load
     @audit_report.organisations.select 'HMRC'
+    @audit_report.audit_status.choose 'Audited'
     @audit_report.apply_filters.click
   end
 
@@ -134,6 +135,7 @@ RSpec.feature "Export to CSV" do
            base_path: "/example2")
     create(:content_item,
            title: "Unassigned content 3",
-           base_path: "/example3")
+           base_path: "/example3",
+           primary_publishing_organisation: @hmrc)
   end
 end

--- a/spec/features/audit/report/csv_export_spec.rb
+++ b/spec/features/audit/report/csv_export_spec.rb
@@ -1,12 +1,12 @@
-RSpec.feature "Exporting a CSV from the report page" do
-  scenario "Exporting a csv file as an attachment" do
+RSpec.feature "Export to CSV" do
+  scenario "Export a csv file as an attachment" do
     given_i_am_an_auditor_belonging_to_an_organisation
     and_there_are_three_content_items
     when_i_export_an_audit_report
     then_i_receive_the_report_in_csv_format
   end
 
-  scenario "Applying the filters to the export" do
+  scenario "Apply filters" do
     given_i_am_an_auditor_belonging_to_an_organisation
     and_there_are_three_content_items
     and_a_filter_is_applied_to_show_only_hmrc_content_items
@@ -14,11 +14,11 @@ RSpec.feature "Exporting a CSV from the report page" do
     then_i_receive_only_hmrc_related_content_items_in_the_report
   end
 
-  scenario "Multiple pages including_details_of_audit_progress_ of content items are in the database" do
+  scenario "Export multiple pages" do
     given_i_am_an_auditor_belonging_to_an_organisation
-    and_there_are_multiple_pages_of_unfiltered_content_items
-    when_i_export_all_the_reports
-    then_i_receive_an_audit_progress_report_for_all_content_items_in_csv_format
+    and_there_are_multiple_pages_of_content_items
+    when_i_export_to_csv
+    then_all_content_items_are_included_in_the_csv
   end
 
   scenario "Discard audit status filter when clicking from content view to report, and then exporting CSV" do
@@ -100,14 +100,14 @@ RSpec.feature "Exporting a CSV from the report page" do
     create_list(:content_item, content_items_per_page)
   end
 
-  def when_i_export_all_the_reports
+  def when_i_export_to_csv
     visit audits_report_path
     select "Anyone", from: "allocated_to"
     click_on "Apply filters"
     click_link "Export filtered audit to CSV"
   end
 
-  def then_i_receive_an_audit_progress_report_for_all_content_items_in_csv_format
+  def then_all_content_items_are_included_in_the_csv
     csv = CSV.parse(page.body)
     number_of_metadata_rows = 1
     expect(csv.count).to eq(Content::Item.count + number_of_metadata_rows)

--- a/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_report_page.rb
@@ -4,6 +4,7 @@ class AuditReportPage < SitePrism::Page
   set_url '/audits/report'
 
   element :report_section, '[data-test-id=report-section]'
+  element :audit_status, '[data-test-id=audit-status]'
   element :allocated_to, '[data-test-id=allocated-to]'
   element :apply_filters, '[data-test-id=apply-filters]'
   element :content_type, '[data-test-id=document-type]'


### PR DESCRIPTION
[Trello card](https://trello.com/c/E2I3wbPe/639-3-filter-the-export-by-audit-status)

### User need

As a **content auditor**..
I **need** filter the audit progress tab and csv export by audit status
**So that** I can efficiently prioritise audited items for improvement

### Background

This has been requested by HMRC. At present they can filter the audit progress report (and therefore the csv export) by `Assigned to`, `Organisation(s)` and `Content type`

This allows them to download a csv but currently the file contains all audited and unaudited items, which is an unmanageably long list to review. Viewing audited items and unaudited items separately would be much more useful 

### Before

![image](https://user-images.githubusercontent.com/227328/33713631-f0ef74fc-db43-11e7-965b-8ce17fe4eaeb.png)

### After

![image](https://user-images.githubusercontent.com/227328/33713606-d6463384-db43-11e7-8a23-eff173250e40.png)
