### PR TITLE
Move audit metadata to the top of the audit page

### DIFF
--- a/app/assets/stylesheets/_audit.scss
+++ b/app/assets/stylesheets/_audit.scss
@@ -71,6 +71,15 @@ $all-items-link-colour: #000000;
   }
 }
 
+.allocation-metadata {
+  text-align: right;
+  font-size: 15px;
+
+  p {
+    margin-bottom: 6px;
+  }
+}
+
 .alert-heading {
   font-size: 18px;
   margin-top: 0;

--- a/app/assets/stylesheets/_full_width_audit.scss
+++ b/app/assets/stylesheets/_full_width_audit.scss
@@ -20,6 +20,7 @@
 
     .phase-banner {
       margin-top: 0;
+      margin-bottom: 12px;
     }
   }
 

--- a/app/decorators/content/item_decorator.rb
+++ b/app/decorators/content/item_decorator.rb
@@ -54,7 +54,7 @@ class Content::ItemDecorator < Draper::Decorator
   end
 
   def auditor
-    allocation.user.name
+    allocation&.user&.name
   end
 
   def auditor_org

--- a/app/helpers/content/items_helper.rb
+++ b/app/helpers/content/items_helper.rb
@@ -6,16 +6,6 @@ module Content::ItemsHelper
   def content_metadata
     [
       {
-        title: "Assigned to",
-        content: assigned_to_metadata,
-        test_id: "allocated",
-      },
-      {
-        title: "Audited",
-        content: audited_metadata,
-        test_id: "audited",
-      },
-      {
         title: "Topics",
         content: content_item.topics,
         test_id: "topics",
@@ -63,25 +53,6 @@ module Content::ItemsHelper
         content: content_item.withdrawn,
         test_id: "withdrawn",
       },
-    ]
-  end
-
-  def assigned_to_metadata
-    return "No one" unless content_item.allocation
-
-    [
-      content_item.auditor,
-      content_item.auditor_org,
-    ]
-  end
-
-  def audited_metadata
-    return "Not audited yet" if audit.incomplete?
-
-    [
-      audit.last_updated,
-      "by #{audit.user.name}",
-      audit.user.organisation&.title,
     ]
   end
 end

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -14,9 +14,24 @@
     </div>
   <% end %>
 
-  <nav class="all-items-nav">
-    <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
-  </nav>
+  <div class="row">
+    <nav class="all-items-nav col-sm-6">
+      <%= link_to "< All items", audits_path(filter_params.without(:page)), class: "all-items" %>
+    </nav>
+
+    <div class="allocation-metadata col-sm-6">
+      <p data-test-id="allocated">
+        Assigned to: <%= content_item.auditor || "No one" %>
+      </p>
+      <p data-test-id="audited">
+        <% if audit.incomplete? %>
+          Not audited yet
+        <% else %>
+          Audited by <%= audit.user.name %> on <%= audit.last_updated %>
+        <% end %>
+      </p>
+    </div>
+  </div>
 
   <h2 data-test-id='content-item-title'>
     <%= link_to content_item.title, content_item.url, target: :_blank %>

--- a/spec/features/audit/audit/audit_spec.rb
+++ b/spec/features/audit/audit/audit_spec.rb
@@ -63,8 +63,8 @@ private
   end
 
   def then_the_name_of_the_assignee_is_shown
-    expect(@audit_content_item.metadata)
-      .to have_assigned_to(text: 'Garth Nix YA Authors')
+    expect(@audit_content_item)
+      .to have_assigned_to(text: 'Garth Nix')
   end
 
   def when_i_answer_some_of_the_questions

--- a/spec/features/audit/audit/metadata_spec.rb
+++ b/spec/features/audit/audit/metadata_spec.rb
@@ -102,23 +102,23 @@ RSpec.feature 'Audit metadata', type: :feature do
   end
 
   def then_i_am_shown_that_the_content_item_is_assigned_to_no_one
-    expect(@audit_content_item.metadata).to have_assigned_to(text: 'No one')
+    expect(@audit_content_item).to have_assigned_to(text: 'No one')
   end
 
   def then_i_am_shown_that_the_content_item_has_been_assigned
-    expect(@audit_content_item.metadata)
-      .to have_assigned_to(text: 'Edd The Duck CBBC')
+    expect(@audit_content_item)
+      .to have_assigned_to(text: 'Edd The Duck')
   end
 
   def and_i_am_shown_that_the_content_item_is_not_audited_yet
-    expect(@audit_content_item.metadata)
+    expect(@audit_content_item)
       .to have_audited(text: 'Not audited yet')
   end
 
   def and_i_am_shown_that_the_content_item_has_been_audited
-    expect(@audit_content_item.metadata)
-      .to have_audited(text: '01/01/17 (less than a minute ago) ' \
-                             'by Harper Lee Authors')
+    expect(@audit_content_item)
+      .to have_audited(text: 'by Harper Lee ' \
+                             'on 01/01/17 (less than a minute ago)')
   end
 
   def and_i_am_shown_the_content_type

--- a/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
@@ -6,6 +6,9 @@ class AuditContentItemPage < SitePrism::Page
   element :error_message, '[data-test-id=audit-error-message]'
   element :success_message, '[data-test-id=audit-success-message]'
 
+  element :assigned_to, '[data-test-id=allocated]'
+  element :audited, '[data-test-id=audited]'
+
   element :content_item_description, '[data-test-id=content-item-description]'
   element :content_item_title, '[data-test-id=content-item-title]'
   element :questions_title, '[data-test-id=questions-title]'
@@ -28,8 +31,6 @@ class AuditContentItemPage < SitePrism::Page
   end
 
   section :metadata, '#metadata' do
-    element :assigned_to, '[data-test-id=allocated]'
-    element :audited, '[data-test-id=audited]'
     element :content_type, '[data-test-id=content-type]'
     element :guidance, '[data-test-id=guidance]'
     element :last_major_update, '[data-test-id=last-updated]'


### PR DESCRIPTION
This change moves the audit metadata out of the "Item details" section,
to the top of the page, where it will be more prominent, and is
visually separate from metadata about the content item.

## Dependencies

- [x] https://github.com/alphagov/content-performance-manager/pull/422

## Before

![before](https://user-images.githubusercontent.com/12036746/33720355-9c08622e-db5b-11e7-9d5a-93d4e7d5f8ed.png)

## After

![after](https://user-images.githubusercontent.com/12036746/33720364-a1438796-db5b-11e7-940e-1657458e50bd.png)
