### PR TITLE
Fix content preview after saving an audit

### DIFF
--- a/app/controllers/audits/audits_controller.rb
+++ b/app/controllers/audits/audits_controller.rb
@@ -47,10 +47,10 @@ module Audits
           redirect_to content_item_audit_path(next_content_item, filter_params)
         else
           flash.now.notice = "Audit saved — no items remaining."
-          render :show
+          render :show, layout: "audit"
         end
       else
-        render :show
+        render :show, layout: "audit"
       end
     end
 

--- a/app/views/audits/audits/_content_preview.html.erb
+++ b/app/views/audits/audits/_content_preview.html.erb
@@ -13,4 +13,7 @@
   scrolling: "yes",
   frameborder: "no",
   class: "if-js-hide",
+  data: {
+    test_id: "content-preview"
+  }
 ) %>

--- a/spec/features/audit/audit/audit_spec.rb
+++ b/spec/features/audit/audit/audit_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Auditing a content item', type: :feature do
     when_i_answer_all_of_the_questions
     then_a_success_message_is_shown
     and_my_answers_to_the_questions_are_remembered
+    and_i_can_still_see_the_content_preview
   end
 
   scenario 'clicking on yes and no buttons for redundant/similar content questions', js: true do
@@ -156,6 +157,10 @@ private
       expect(form).to have_similar_urls(text: 'https://example.com/similar')
       expect(form).to have_notes(text: 'something')
     end
+  end
+
+  def and_i_can_still_see_the_content_preview
+    expect(@audit_content_item).to have_content_preview
   end
 
   def then_i_am_prompted_to_specify_redirect_urls_if_the_content_should_be_removed

--- a/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
@@ -10,6 +10,8 @@ class AuditContentItemPage < SitePrism::Page
   element :content_item_title, '[data-test-id=content-item-title]'
   element :questions_title, '[data-test-id=questions-title]'
 
+  element :content_preview, '[data-test-id=content-preview]'
+
   section :audit_form, 'form' do
     element :attachments, '[data-test-id=change-attachments]'
     element :content_out_of_date, '[data-test-id=outdated]'


### PR DESCRIPTION
After saving an audit, if there is no content item to audit next, the
audit page collapses into a single-column layout.

This is because in the `save` action we manually render the `show`
view, bypassing the layout that gets set in the `show` action.

This change fixes this by correctly setting the layout in this case.