### PR TITLE
Disallow allocation to "Anyone"

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -31,8 +31,15 @@ module DropdownHelper
     options_for_select(document_type_options, selected)
   end
 
-  def allocation_options_for_select(selected = nil)
+  def allocation_options_for_select(selected = nil, include_anyone: true)
     selected = current_user.uid if selected.nil?
+
+    additional_options = [
+      ['Me', current_user.uid],
+      ['No one', :no_one],
+    ]
+
+    additional_options << ['Anyone', :anyone] if include_anyone
 
     allocation_options = FindOrganisationUsers
                            .call(organisation_slug: current_user.organisation_slug)
@@ -40,11 +47,7 @@ module DropdownHelper
                            .map { |name, uid| [name.squish, uid] }
                            .reject { |_, uid| uid == current_user.uid }
                            .sort_by { |name, _| name }
-                           .unshift(
-                             ['Me', current_user.uid],
-                             ['No one', :no_one],
-                             ['Anyone', :anyone],
-                           )
+                           .unshift(*additional_options)
 
     options_for_select(allocation_options, selected)
   end

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -11,11 +11,12 @@
           } %>
       <%= label_tag :allocate_to, "items to", class: "items"  %>
       <%= select_tag "allocate_to",
-        allocation_options_for_select(params[:allocate_to]),
+        allocation_options_for_select(params[:allocate_to], include_anyone: false),
         class: "form-control",
         id: "allocate_to",
         data: {
-            tracking_id: "allocate-to",
+          tracking_id: "allocate-to",
+          test_id: "allocate-to",
         } %>
       <%= filter_to_hidden_fields %>
       <%= submit_tag "Assign", class: "btn btn-default" %>

--- a/db/migrate/20171207164824_add_foreign_keys_to_allocations.rb
+++ b/db/migrate/20171207164824_add_foreign_keys_to_allocations.rb
@@ -1,0 +1,8 @@
+class AddForeignKeysToAllocations < ActiveRecord::Migration[5.1]
+  def change
+    add_index "users", :uid, unique: true
+
+    add_foreign_key "allocations", "content_items", column: :content_id, primary_key: :content_id
+    add_foreign_key "allocations", "users", column: :uid, primary_key: :uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170912052927) do
+ActiveRecord::Schema.define(version: 20171207164824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,19 @@ ActiveRecord::Schema.define(version: 20170912052927) do
     t.index ["link_type"], name: "index_links_on_link_type"
     t.index ["source_content_id"], name: "index_links_on_source_content_id"
     t.index ["target_content_id"], name: "index_links_on_target_content_id"
+  end
+
+  create_table "metrics", force: :cascade do |t|
+    t.date "date", null: false
+    t.string "content_id", null: false
+    t.integer "title_length"
+    t.float "reading_grade"
+    t.integer "word_count"
+    t.datetime "last_updated_at"
+    t.string "phase"
+    t.string "publication_state"
+    t.integer "version_number"
+    t.index ["content_id", "date"], name: "metrics_unique_content_id_date", unique: true
   end
 
   create_table "questions", id: :serial, force: :cascade do |t|
@@ -142,8 +155,12 @@ ActiveRecord::Schema.define(version: 20170912052927) do
     t.boolean "disabled", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "allocations", "content_items", column: "content_id", primary_key: "content_id"
+  add_foreign_key "allocations", "users", column: "uid", primary_key: "uid"
+  add_foreign_key "metrics", "content_items", column: "content_id", primary_key: "content_id"
   add_foreign_key "taxonomy_todos", "content_items"
   add_foreign_key "taxonomy_todos", "taxonomy_projects"
 end

--- a/spec/features/audit/allocation/allocate_spec.rb
+++ b/spec/features/audit/allocation/allocate_spec.rb
@@ -158,4 +158,10 @@ RSpec.feature "Allocate multiple content items", type: :feature do
       expect(page).to have_content("19 items")
     end
   end
+
+  scenario "I cannot assign items to 'anyone'" do
+    visit audits_allocations_path
+    allocation_select = page.first("[data-tracking-id='allocate-to']")
+    expect(allocation_select).to_not have_content("Anyone")
+  end
 end


### PR DESCRIPTION
This change addresses [an error](https://sentry.io/govuk/app-content-performance-manager/issues/413345465/) we've been seeing, which arises from users assigning content to "Anyone". The fix:

- adds foreign keys to the Allocations table
- adds a uniqueness constraint to users' IDs (so that we can FK to it, apart from it also just being a Good Thing)
- removes "Anyone" from the choices for allocation