### PR TITLE
Add `assigned to` column to content items table

### DIFF
--- a/app/decorators/content/item_decorator.rb
+++ b/app/decorators/content/item_decorator.rb
@@ -17,6 +17,10 @@ class Content::ItemDecorator < Draper::Decorator
     names.join(', ').html_safe
   end
 
+  def assigned_to_name
+    object.allocation ? object.allocation.user.name : 'No one'
+  end
+
   def taxons_as_string
     object.linked_taxons.map(&:title).join(', ')
   end

--- a/app/views/audits/allocations/_content_item.html.erb
+++ b/app/views/audits/allocations/_content_item.html.erb
@@ -1,5 +1,6 @@
 <tr>
   <td><%= check_box_tag "content_ids[]", content_item.content_id, false, class: 'select-content-item' %></td>
   <td><%= link_to content_item.title, content_item_audit_path(content_item, filter_params) %></td>
+  <td data-test-id='item-assigned-to'><%= content_item.assigned_to_name %></td>
   <td><%= content_item.six_months_page_views %></td>
 </tr>

--- a/app/views/audits/allocations/_sidebar.html.erb
+++ b/app/views/audits/allocations/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag audits_allocations_path, method: :get do %>
+<%= form_tag audits_allocations_path, data: { test_id: 'allocations-sidebar' }, method: :get do %>
   <%= render 'audits/common/title' %>
   <%= render 'audits/common/allocated_to' %>
   <%= render 'audits/common/audit_status' %>

--- a/app/views/audits/allocations/index.html.erb
+++ b/app/views/audits/allocations/index.html.erb
@@ -31,6 +31,7 @@
             </span>
           </td>
           <td>Title</td>
+          <td>Assigned to</td>
           <td>Page views (6 months)</td>
         </tr>
         </thead>

--- a/spec/features/audit/allocation/allocated_to_spec.rb
+++ b/spec/features/audit/allocation/allocated_to_spec.rb
@@ -1,0 +1,49 @@
+RSpec.feature "Display the users whom content items are allocated to", type: :feature do
+  scenario "allocated user's name is displayed in assigned to column for content items with allocated users" do
+    given_i_am_a_user_belonging_to_an_organisation
+    and_i_have_been_assigned_a_content_item
+    when_i_visit_the_assignment_page
+    i_see_my_name_in_the_allocated_to_column_for_the_content_item
+  end
+
+  scenario "`No one` is displayed in assigned to column for content items without allocated users" do
+    given_i_am_a_user_belonging_to_an_organisation
+    and_a_content_item_has_not_been_assigned_to_anyone
+    when_i_visit_the_assignment_page
+    i_see_no_one_in_the_allocated_to_column_for_the_content_item
+  end
+
+  def given_i_am_a_user_belonging_to_an_organisation
+    @organisation = create(:organisation, title: 'YA Authors')
+    @user = create(:user, name: 'Garth Nix', organisation: @organisation)
+  end
+
+  def and_i_have_been_assigned_a_content_item
+    create(:content_item, allocated_to: @user,
+                          title: 'Assigned content item',
+                          primary_publishing_organisation: @organisation)
+  end
+
+  def when_i_visit_the_assignment_page
+    @audit_assignment_page = ContentAuditTool.new.audit_assignment_page
+    @audit_assignment_page.load
+  end
+
+  def i_see_my_name_in_the_allocated_to_column_for_the_content_item
+    @audit_assignment_page.filter_form do |form|
+      form.allocated_to.select 'Me'
+      form.apply_filters.click
+    end
+    expect(@audit_assignment_page.assigned_to_columns.first.text). to eq @user.name
+  end
+
+  def and_a_content_item_has_not_been_assigned_to_anyone
+    create(:content_item, allocated_to: nil,
+                          title: 'Unassigned content item',
+                          primary_publishing_organisation: @organisation)
+  end
+
+  def i_see_no_one_in_the_allocated_to_column_for_the_content_item
+    expect(@audit_assignment_page.assigned_to_columns.first.text).to eq 'No one'
+  end
+end

--- a/spec/support/pages/audit/content_audit_tool/audit_assignment_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_assignment_page.rb
@@ -3,7 +3,7 @@ require "site_prism/page"
 class AuditAssignmentPage < SitePrism::Page
   set_url "/audits/allocations"
 
-  section :filter_form, "form" do
+  section :filter_form, "[data-test-id=allocations-sidebar]" do
     element :search, "[data-test-id=search]"
     element :allocated_to, "[data-test-id=allocated-to]"
     element :audit_status, "[data-test-id=audit-status]"
@@ -25,4 +25,5 @@ class AuditAssignmentPage < SitePrism::Page
   element :my_content_tab, '[data-test-id=audits]'
   element :assign_content_tab, '[data-test-id=allocations]'
   element :checkbox, '.select-content-item'
+  elements :assigned_to_columns, "[data-test-id=item-assigned-to]"
 end


### PR DESCRIPTION
- Add `assigned to` column to content items table on the `all content` page to
help user easily identify which team member, if any, each task is assigned to
as validated by user research findings.
- Add tests to assert that the column is populated with either the correct user's
name or `No one` and add data-test attributes to easily and explicitly query
the necessary elements