### PR TITLE
Allocate from an audit page

### DIFF
--- a/app/controllers/audits/allocations_controller.rb
+++ b/app/controllers/audits/allocations_controller.rb
@@ -75,7 +75,11 @@ module Audits
     end
 
     def redirect_url
-      audits_allocations_url(redirect_params)
+      if params[:redirect_to_content_item] && content_ids.count == 1
+        content_item_audit_path(content_ids.first)
+      else
+        audits_allocations_url(redirect_params)
+      end
     end
   end
 end

--- a/app/helpers/content/items_helper.rb
+++ b/app/helpers/content/items_helper.rb
@@ -55,4 +55,8 @@ module Content::ItemsHelper
       },
     ]
   end
+
+  def assigned_to_current_user
+    content_item.allocation&.user == current_user
+  end
 end

--- a/app/views/audits/allocations/_select.html.erb
+++ b/app/views/audits/allocations/_select.html.erb
@@ -1,0 +1,8 @@
+<%= select_tag "allocate_to",
+  allocation_options_for_select(params[:allocate_to], include_anyone: false),
+  class: "form-control",
+  id: "allocate_to",
+  data: {
+    tracking_id: "allocate-to",
+    test_id: "allocate-to",
+  } %>

--- a/app/views/audits/allocations/_toolbar.html.erb
+++ b/app/views/audits/allocations/_toolbar.html.erb
@@ -11,14 +11,7 @@
             test_id: "allocation-batch-size",
           } %>
       <%= label_tag :allocate_to, "items to", class: "items"  %>
-      <%= select_tag "allocate_to",
-        allocation_options_for_select(params[:allocate_to], include_anyone: false),
-        class: "form-control",
-        id: "allocate_to",
-        data: {
-          tracking_id: "allocate-to",
-          test_id: "allocate-to",
-        } %>
+      <%= render "audits/allocations/select" %>
       <%= filter_to_hidden_fields %>
       <%= submit_tag "Assign", class: "btn btn-default", data: { test_id: 'allocate-button'} %>
     </div>

--- a/app/views/audits/audits/_allocation.html.erb
+++ b/app/views/audits/audits/_allocation.html.erb
@@ -1,0 +1,20 @@
+<div class="alert alert-info">
+  <p>
+    This item is assigned to <%= content_item.auditor || "no one" %>
+  </p>
+  <%= form_tag audits_allocations_path,
+    class: "form-inline",
+    data: {
+      test_id: "allocation-form"
+    } do %>
+    <input type="hidden" name="content_ids[]" value="<%= content_item.content_id %>" />
+    <input type="hidden" name="redirect_to_content_item" value="true" />
+    <div class="form-group">
+      <label for="allocate_to">Assign to</label>
+      <%= render "audits/allocations/select" %>
+    </div>
+    <button type="submit" class="btn btn-default" data-test-id="allocate">
+      Assign
+    </button>
+  <% end %>
+</div>

--- a/app/views/audits/audits/_questions.html.erb
+++ b/app/views/audits/audits/_questions.html.erb
@@ -1,0 +1,65 @@
+
+<%= link_to "Audit guidance", audits_guidance_path, target: "_blank", rel: "noopener noreferrer" %>
+
+<% if audit.errors.any? %>
+  <div class="alert alert-danger" role="alert" data-test-id="audit-error-message">
+    <p>Please answer all the questions.</p>
+  </div>
+<% end %>
+
+<h4 data-test-id="questions-title">Do these things need to change?</h4>
+
+<%= form_for audit, url: content_item_audit_path(filter_params), html: { "data-test-id": "audit-form" } do |form| %>
+  <%= render 'boolean_question', form: form,
+              attribute: :change_title,
+              question: 'Title' %>
+
+  <%= render 'boolean_question', form: form,
+              attribute: :change_description,
+              question: 'Summary' %>
+
+  <%= render 'boolean_question', form: form,
+              attribute: :change_body,
+              question: 'Page detail' %>
+
+  <%= render 'boolean_question', form: form,
+              attribute: :change_attachments,
+              question: 'Attachments' %>
+
+  <%= render 'boolean_question', form: form,
+              attribute: :reformat,
+              question: 'Content type' %>
+
+  <%= render 'boolean_question', form: form,
+              attribute: :outdated,
+              question: 'Is the content out of date?' %>
+
+  <div data-module="show-free-text-question">
+    <%= render 'boolean_question', form: form,
+                attribute: :similar,
+                question: 'Is this content very similar to other pages?' %>
+
+    <%= render 'free_text_question', form: form,
+                attribute: :similar_urls,
+                question: 'URLs of similar pages',
+                related_question_answered: audit.similar %>
+  </div>
+
+  <div data-module="show-free-text-question">
+    <%= render 'boolean_question', form: form,
+                attribute: :redundant,
+                question: 'Should the content be removed?' %>
+
+    <%= render 'free_text_question', form: form,
+                attribute: :redirect_urls,
+                question: 'Where should users be redirected to? (optional)',
+                related_question_answered: audit.redundant %>
+  </div>
+
+  <%= render 'free_text_question', form: form,
+              attribute: :notes,
+              question: 'Notes',
+              related_question_answered: {} %>
+
+  <%= form.submit "Save and continue", class: "btn btn-success", data: { test_id: 'save-audit-form'} %>
+<% end %>

--- a/app/views/audits/audits/show.html.erb
+++ b/app/views/audits/audits/show.html.erb
@@ -47,68 +47,10 @@
 
   <hr/>
 
-  <%= link_to "Audit guidance", audits_guidance_path, target: "_blank", rel: "noopener noreferrer" %>
-
-  <% if audit.errors.any? %>
-    <div class="alert alert-danger" role="alert" data-test-id="audit-error-message">
-      <p>Please answer all the questions.</p>
-    </div>
+  <% if assigned_to_current_user %>
+    <%= render "audits/audits/questions" %>
+  <% else %>
+    <%= render "audits/audits/allocation" %>
   <% end %>
 
-  <h4 data-test-id="questions-title">Do these things need to change?</h4>
-
-  <%= form_for audit, url: content_item_audit_path(filter_params) do |form| %>
-    <%= render 'boolean_question', form: form,
-               attribute: :change_title,
-               question: 'Title' %>
-
-    <%= render 'boolean_question', form: form,
-               attribute: :change_description,
-               question: 'Summary' %>
-
-    <%= render 'boolean_question', form: form,
-               attribute: :change_body,
-               question: 'Page detail' %>
-
-    <%= render 'boolean_question', form: form,
-               attribute: :change_attachments,
-               question: 'Attachments' %>
-
-    <%= render 'boolean_question', form: form,
-               attribute: :reformat,
-               question: 'Content type' %>
-
-    <%= render 'boolean_question', form: form,
-               attribute: :outdated,
-               question: 'Is the content out of date?' %>
-
-    <div data-module="show-free-text-question">
-      <%= render 'boolean_question', form: form,
-                 attribute: :similar,
-                 question: 'Is this content very similar to other pages?' %>
-
-      <%= render 'free_text_question', form: form,
-                 attribute: :similar_urls,
-                 question: 'URLs of similar pages',
-                 related_question_answered: audit.similar %>
-    </div>
-
-    <div data-module="show-free-text-question">
-      <%= render 'boolean_question', form: form,
-                 attribute: :redundant,
-                 question: 'Should the content be removed?' %>
-
-      <%= render 'free_text_question', form: form,
-                 attribute: :redirect_urls,
-                 question: 'Where should users be redirected to? (optional)',
-                 related_question_answered: audit.redundant %>
-    </div>
-
-    <%= render 'free_text_question', form: form,
-               attribute: :notes,
-               question: 'Notes',
-               related_question_answered: {} %>
-
-    <%= form.submit "Save and continue", class: "btn btn-success", data: { test_id: 'save-audit-form'} %>
-  <% end %>
 </div>

--- a/spec/features/audit/guidance/guidance_spec.rb
+++ b/spec/features/audit/guidance/guidance_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Using guidance while auditing a content item", type: :feature do
       description: "All about flooding.",
       base_path: "/flooding",
       publishing_app: "whitehall",
+      allocated_to: me,
     )
   end
 

--- a/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
+++ b/spec/support/pages/audit/content_audit_tool/audit_content_item_page.rb
@@ -16,7 +16,7 @@ class AuditContentItemPage < SitePrism::Page
 
   element :content_preview, '[data-test-id=content-preview]'
 
-  section :audit_form, 'form' do
+  section :audit_form, '[data-test-id=audit-form]' do
     element :attachments, '[data-test-id=change-attachments]'
     element :content_out_of_date, '[data-test-id=outdated]'
     element :content_should_be_removed, '[data-test-id=redundant]'
@@ -54,5 +54,10 @@ class AuditContentItemPage < SitePrism::Page
       form.content_similar.choose 'No'
       form.save_and_continue.click
     end
+  end
+
+  section :allocation_form, '[data-test-id=allocation-form]' do
+    element :allocate_to, '[data-test-id=allocate-to]'
+    element :allocate, '[data-test-id=allocate]'
   end
 end


### PR DESCRIPTION
This change makes it possible to allocate content from the audit page.
Further, it actually prevents users from auditing content that is not
allocated to them.

![allocation](https://user-images.githubusercontent.com/12036746/33775278-c1db1eda-dc35-11e7-8085-df65d588a26f.gif)
