### PR TITLE
Add audit start button

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.2.2)
+    autoprefixer-rails (7.2.1)
       execjs
     better_errors (2.4.0)
       coderay (>= 1.0.0)
@@ -111,14 +111,14 @@ GEM
     feature (1.4.0)
     ffi (1.9.18)
     formatador (0.2.5)
-    gds-api-adapters (50.5.0)
+    gds-api-adapters (50.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gds-sso (13.3.0)
+    gds-sso (13.2.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -128,7 +128,7 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.18.0)
+    google-api-client (0.17.3)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -160,16 +160,15 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (1.1.0)
+    govuk_app_config (1.0.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.3.1)
-    govuk_sidekiq (3.0.0)
+    govuk_sidekiq (2.0.0)
       gds-api-adapters (>= 19.1.0)
-      govuk_app_config (>= 1.1)
-      redis-namespace (~> 1.6)
-      sidekiq (>= 5, < 6)
+      redis-namespace (~> 1.5.2)
+      sidekiq (~> 4.2.8)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
     guard (2.14.1)
@@ -303,7 +302,7 @@ GEM
       rack (>= 0.4)
     rack-protection (2.0.0)
       rack
-    rack-proxy (0.6.3)
+    rack-proxy (0.6.2)
       rack
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
@@ -341,9 +340,9 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    redis (4.0.1)
-    redis-namespace (1.6.0)
-      redis (>= 3.0.4)
+    redis (3.3.5)
+    redis-namespace (1.5.3)
+      redis (~> 3.0, >= 3.0.4)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -405,11 +404,11 @@ GEM
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
-    sidekiq (5.0.5)
+    sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.4, < 5)
+      redis (~> 3.2, >= 3.2.1)
     sidekiq-logging-json (0.0.18)
       sidekiq (>= 3)
     sidekiq-statsd (0.1.5)
@@ -458,7 +457,7 @@ GEM
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (4.0.2)
+    uglifier (4.0.1)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -546,4 +545,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.2.1)
+    autoprefixer-rails (7.2.2)
       execjs
     better_errors (2.4.0)
       coderay (>= 1.0.0)
@@ -111,14 +111,14 @@ GEM
     feature (1.4.0)
     ffi (1.9.18)
     formatador (0.2.5)
-    gds-api-adapters (50.1.0)
+    gds-api-adapters (50.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gds-sso (13.2.0)
+    gds-sso (13.3.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -128,7 +128,7 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.17.3)
+    google-api-client (0.18.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -160,15 +160,16 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (1.0.0)
+    govuk_app_config (1.1.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.3.1)
-    govuk_sidekiq (2.0.0)
+    govuk_sidekiq (3.0.0)
       gds-api-adapters (>= 19.1.0)
-      redis-namespace (~> 1.5.2)
-      sidekiq (~> 4.2.8)
+      govuk_app_config (>= 1.1)
+      redis-namespace (~> 1.6)
+      sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
     guard (2.14.1)
@@ -302,7 +303,7 @@ GEM
       rack (>= 0.4)
     rack-protection (2.0.0)
       rack
-    rack-proxy (0.6.2)
+    rack-proxy (0.6.3)
       rack
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
@@ -340,9 +341,9 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    redis (3.3.5)
-    redis-namespace (1.5.3)
-      redis (~> 3.0, >= 3.0.4)
+    redis (4.0.1)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -404,11 +405,11 @@ GEM
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
-    sidekiq (4.2.10)
+    sidekiq (5.0.5)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (~> 3.2, >= 3.2.1)
+      redis (>= 3.3.4, < 5)
     sidekiq-logging-json (0.0.18)
       sidekiq (>= 3)
     sidekiq-statsd (0.1.5)
@@ -457,7 +458,7 @@ GEM
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (4.0.1)
+    uglifier (4.0.2)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -545,4 +546,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -7,7 +7,9 @@
     <%= render 'audits/common/navigation' %>
 <% end %>
 
-<button type="button" class="btn btn-success">Start audit of first item</button>
+<% if !content_items.empty? %>
+	<button type="button" class="btn btn-success">Start audit of first item</button>
+<% end %>
 
 <%= render "no_content_to_audit" if content_items.empty? %>
 <%= render "content_items", locals: { content_items: content_items } if content_items.any? %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -9,7 +9,7 @@
 
 <% if !content_items.empty? %>
 	<a class="btn btn-success" href=<%=content_item_audit_path(content_items.first, filter_params) %>
-		role="button">Start audit of first item</a>
+		role="button">Start audit</a>
 <% end %>
 
 <%= render "no_content_to_audit" if content_items.empty? %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -7,5 +7,7 @@
     <%= render 'audits/common/navigation' %>
 <% end %>
 
+<button type="button" class="btn btn-success">Start audit of first item</button>
+
 <%= render "no_content_to_audit" if content_items.empty? %>
 <%= render "content_items", locals: { content_items: content_items } if content_items.any? %>

--- a/app/views/audits/audits/index.html.erb
+++ b/app/views/audits/audits/index.html.erb
@@ -8,7 +8,8 @@
 <% end %>
 
 <% if !content_items.empty? %>
-	<button type="button" class="btn btn-success">Start audit of first item</button>
+	<a class="btn btn-success" href=<%=content_item_audit_path(content_items.first, filter_params) %>
+		role="button">Start audit of first item</a>
 <% end %>
 
 <%= render "no_content_to_audit" if content_items.empty? %>

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -32,16 +32,29 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     expect(page).to have_text("2 items")
   end
 
+  scenario "start audit button is not displayed if user does not have any audit items" do
+    create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id")
+    visit audits_my_content_path
+    expect(page).to_not have_content("Start audit")
+  end
+
+  scenario "start audit button is displayed if user has any audit items" do
+    create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id", allocated_to: me)
+    visit audits_my_content_path
+    expect(page).to have_content("Start audit")
+  end
+
   scenario "start audit button goes to first audit item" do
     create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id", allocated_to: me)
     create(:content_item, title: "item2", allocated_to: me)
 
-    visit audits_path
+    visit audits_my_content_path
     click_link("Start audit")
 
     expect(page).to have_content("item1")
     expect(page).to have_content("Do these things need to change?")
   end
+
 
   scenario "List content items of auditable formats" do
     create(:content_item, document_type: "guide", allocated_to: me)

--- a/spec/features/audit/lists/list_content_items_spec.rb
+++ b/spec/features/audit/lists/list_content_items_spec.rb
@@ -32,6 +32,17 @@ RSpec.feature "List Content Items to Audit", type: :feature do
     expect(page).to have_text("2 items")
   end
 
+  scenario "start audit button goes to first audit item" do
+    create(:content_item, title: "item1", six_months_page_views: 10_000, content_id: "content-id", allocated_to: me)
+    create(:content_item, title: "item2", allocated_to: me)
+
+    visit audits_path
+    click_link("Start audit")
+
+    expect(page).to have_content("item1")
+    expect(page).to have_content("Do these things need to change?")
+  end
+
   scenario "List content items of auditable formats" do
     create(:content_item, document_type: "guide", allocated_to: me)
     create(:content_item, document_type: "other-format", allocated_to: me)


### PR DESCRIPTION
Added a 'Start audit' button that when clicked links to the first item in the items to audit list.

![](https://github.trello.services/images/mini-trello-icon.png) [(1) Add 'Start audit of first item' to the 'My content' page](https://trello.com/c/jGGyfvjd/680-1-add-start-audit-of-first-item-to-the-my-content-page)