### PR TITLE
Restrict iframe proxy endpoint to SAMEORIGIN frames

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,16 +37,10 @@ Rails.application.routes.draw do
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end
 
-  class ProxyAccessContraint
-    def matches?(request)
-      !request.env['warden'].try(:user).nil?
-    end
-  end
-
   # rack-proxy does not work with webmock, so disable it for tests: https://github.com/ncr/rack-proxy#warning
   if Rails.env.test?
     get "#{Proxies::IframeAllowingProxy::PROXY_BASE_PATH}*base_path", to: proc { [200, {}, ['Proxy disabled in Test environment']] }
   else
-    mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH, constraints: ProxyAccessContraint.new
+    mount Proxies::IframeAllowingProxy.new => Proxies::IframeAllowingProxy::PROXY_BASE_PATH
   end
 end

--- a/lib/proxies/iframe_allowing_proxy.rb
+++ b/lib/proxies/iframe_allowing_proxy.rb
@@ -34,7 +34,7 @@ module Proxies
         result = body
       end
 
-      [status, headers.tap { |h| h['x-frame-options'] = 'ALLOWALL' }, result]
+      [status, headers.tap { |h| h['x-frame-options'] = 'SAMEORIGIN' }, result]
     end
 
     def rewrite_relative_link!(link)


### PR DESCRIPTION
We currently have a constraint on our iframe proxy endpoint that means
a user must be logged in to access it. However, when we deploy our app
to Heroku, we don't have Signon, and this constraint fails.

We can't just enable the endpoint on Heroku, because this would allow
arbitrary people to use our proxy in their own iframes.

This change allows us to make this endpoint work on Heroku, whilst also
preventing people from using our proxy on their own sites. We achieve
this by:

- removing the logged-in constraint
- making our own proxy return an `X-FRAME-OPTIONS SAMEORIGIN` header,
  which is exactly the thing we were trying to circumvent on GOV.UK in
  the first place, and therefore should be adequate security when
  applied here, too