### PR TITLE
Delete allocations to `anyone`

### DIFF
--- a/db/migrate/20171207160000_delete_invalid_allocations.rb
+++ b/db/migrate/20171207160000_delete_invalid_allocations.rb
@@ -1,0 +1,5 @@
+class DeleteInvalidAllocations < ActiveRecord::Migration[5.1]
+  def up
+    Audits::Allocation.where(uid: 'anyone').delete_all
+  end
+end


### PR DESCRIPTION
As a result of a bug that is already fixed, we have invalid
allocations in our database. These allocations have the uid
of `anyone`.

The issue was [fixed in this PR][1], and there is [a constraint
in place][2] so it won't happen again.

[1]: https://github.com/alphagov/content-performance-manager/pull/430
[2]: https://github.com/alphagov/content-performance-manager/pull/430/commits/26495acbaff05d2209f2b680dcba63a813df4377