### PR TITLE
Fix Heroku deploy

### DIFF
--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -8,7 +8,7 @@ namespace :heroku do
     )
 
     ## Find the organisation
-    (organisation = Content::Item.find_by(title: options.organisation_name)) || raise("Error -> Organisation not found: #{options.organisation_name}")
+    organisation = Content::Item.find_by!(title: options.organisation_name, document_type: "organisation")
 
     ## Application name
     app_name = "cpm-prototype-#{options.identifier}"

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,7 +2,7 @@ namespace :heroku do
   task :deploy, %i[identifier organisation_name number_of_content_items link_types] => :environment do |_task, options|
     raise 'Invalid parameters' unless options.identifier
     options.with_defaults(
-      link_types: %w(organisations primary_publishing_organisation topics),
+      link_types: %w(organisations primary_publishing_organisation topics parent),
       number_of_content_items: 1000,
       organisation_name: 'HM Revenue & Customs',
     )


### PR DESCRIPTION
This change fixes some problems with our `heroku:deploy` task:
- fixes the "Topics" filter, which requires the "parent" links to be included
- makes sure it selects an `organisation` document when fetching organisations whose titles might be duplicated in other documents