### PR TITLE
Import content item by version number

### DIFF
--- a/app/domain/content/importers/all_content_items.rb
+++ b/app/domain/content/importers/all_content_items.rb
@@ -10,7 +10,7 @@ module Content
       content_items = content_items_service.fetch_all_with_default_locale_only
 
       content_items.each do |content_item|
-        ImportItemJob.perform_async(content_item[:content_id], content_item[:locale])
+        ImportItemJob.perform_async(content_item[:content_id], content_item[:locale], content_item[:user_facing_version])
       end
     end
   end

--- a/app/domain/content/importers/single_content_item.rb
+++ b/app/domain/content/importers/single_content_item.rb
@@ -11,8 +11,8 @@ module Content
       self.metric_builder = Performance::MetricBuilder.new
     end
 
-    def run(content_id, locale)
-      content_item = content_items_service.fetch(content_id, locale)
+    def run(content_id, locale, version)
+      content_item = content_items_service.fetch(content_id, locale, version)
       links = content_items_service.links(content_id)
 
       set_metrics(content_item)

--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -26,8 +26,8 @@ module Clients
         .flatten
     end
 
-    def fetch(content_id, locale)
-      normalise(publishing_api.get_content(content_id, locale: locale))
+    def fetch(content_id, options = {})
+      normalise(publishing_api.get_content(content_id, options))
     end
 
     def links(content_id)

--- a/app/services/content/items_service.rb
+++ b/app/services/content/items_service.rb
@@ -7,7 +7,7 @@ class Content::ItemsService
 
   def fetch_all_with_default_locale_only
     client
-      .fetch_all(%w[content_id locale])
+      .fetch_all(%w[content_id locale user_facing_version])
       .group_by { |content_item| content_item[:content_id] }
       .values
       .map do |content_items_with_the_same_id|
@@ -15,7 +15,7 @@ class Content::ItemsService
       end
   end
 
-  def fetch(content_id, locale)
+  def fetch(content_id, locale, version)
     attribute_names = %i[
       public_updated_at
       base_path
@@ -27,7 +27,7 @@ class Content::ItemsService
       publishing_app
       locale
     ]
-    all_attributes = client.fetch(content_id, locale)
+    all_attributes = client.fetch(content_id, locale: locale, version: version)
 
     Content::Item.new(all_attributes.slice(*attribute_names))
   end

--- a/spec/domain/content/importers/all_content_items_spec.rb
+++ b/spec/domain/content/importers/all_content_items_spec.rb
@@ -4,15 +4,15 @@ module Content
       allow(subject.content_items_service)
         .to receive(:fetch_all_with_default_locale_only)
           .and_return([
-            { content_id: "id-123", locale: "en" },
-            { content_id: "id-456", locale: "cy" },
+            { content_id: "id-123", locale: "en", user_facing_version: "2" },
+            { content_id: "id-456", locale: "cy", user_facing_version: "3" },
           ])
     end
 
     describe '#run' do
       it 'creates a job for each content item to import' do
-        expect(ImportItemJob).to receive(:perform_async).with("id-123", "en")
-        expect(ImportItemJob).to receive(:perform_async).with("id-456", "cy")
+        expect(ImportItemJob).to receive(:perform_async).with("id-123", "en", "2")
+        expect(ImportItemJob).to receive(:perform_async).with("id-456", "cy", "3")
 
         subject.run
       end

--- a/spec/features/import_spec.rb
+++ b/spec/features/import_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Import a single content item", type: :feature do
     publishing_api_has_links(content_id: "id-123", links: { organisation: ["org-123"] })
     publishing_api_has_item(build(:content_item, content_id: "id-123", title: "title"))
 
-    expect { Content::ImportItemJob.new.perform("id-123", "en") }
+    expect { Content::ImportItemJob.new.perform("id-123", "en", "10") }
       .to change(Content::Item, :count).by(1)
       .and change(Content::Link, :count).by(1)
   end

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Clients::PublishingAPI do
     end
 
     it "fetches a content item by content id" do
-      result = subject.fetch("id-123", "en")
+      result = subject.fetch("id-123", locale: "en")
       expect(result).to eq(content_item)
     end
   end

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Content::ItemsService do
 
     before do
       allow(client).to receive(:fetch_all)
-        .with(%w[content_id locale])
+        .with(%w[content_id locale user_facing_version])
         .and_return(editions)
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Content::ItemsService do
 
   describe "#fetch" do
     it "returns a new content item object" do
-      allow(subject.client).to receive(:fetch).with("id-123", "en").and_return(
+      allow(subject.client).to receive(:fetch).with("id-123", locale: "en", version: "9").and_return(
         content_id: "id-123",
         title: "title",
         description: "description",
@@ -57,7 +57,7 @@ RSpec.describe Content::ItemsService do
         locale: "en",
       )
 
-      content_item = subject.fetch("id-123", "en")
+      content_item = subject.fetch("id-123", "en", "9")
       expect(content_item).to be_a(Content::Item)
 
       expect(content_item.content_id).to eq("id-123")


### PR DESCRIPTION
We currently import content from the Publishing API by requesting a list
of content IDs of published content, and then requesting each item one
by one by its ID and its locale.

The problem with this approach is that if a published content item also
has a draft in progress, we will be returned the draft version instead
of the published version.

This change reads the `user_facing_version` also returned in the
original request for all published content, and then requests individual
items by ID, locale and version in order to retrieve the published
edition rather than the draft.

## Before

![before](https://user-images.githubusercontent.com/12036746/33933314-3edead1a-dfed-11e7-9c0f-627f6c07643c.png)

## After

![after](https://user-images.githubusercontent.com/12036746/33933323-4397a97e-dfed-11e7-8879-e7ca7befc376.png)
