### PR TITLE
Pad factory-generated content titles

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     sequence(:content_id) { |index| "content-id-%04i" % index }
-    sequence(:title) { |index| "content-item-title-#{index}" }
+    sequence(:title) { |index| "content-item-title-%04i" % index }
     document_type { Audits::Plan.document_type_ids.sample }
     sequence(:base_path) { |index| "api/content/item/path-%04i" % index }
     public_updated_at { Time.now }


### PR DESCRIPTION
Our Content Item factory currently generates titles like:

```
content-item-title-1
content-item-title-2
content-item-title-3
...
content-item-title-10
```

This can cause problems in tests which assert that the page does not
contain `content-item-title-1` when the page contains
`content-item-title-10` (of which `content-item-title-1` is a substring).

This change fixes this by zero-padding the numbers to generate titles
like:

```
content-item-title-0001
content-item-title-0002
content-item-title-0003
...
content-item-title-0010
```

This is in keeping with the other indices in this factory, and
guarantees that none of the IDs are substrings of each other.