### PR TITLE
Return accurate counts when allocating and unallocating

### DIFF
--- a/app/domain/audits/allocate_content.rb
+++ b/app/domain/audits/allocate_content.rb
@@ -12,9 +12,9 @@ module Audits
     end
 
     def call
-      Allocation.transaction { create_or_update_allocation! }
+      result = Allocation.transaction { create_or_update_allocation! }
 
-      AllocationResult.new(user.name, content_ids.count)
+      AllocationResult.new(user.name, result.ids.size)
     end
 
   private

--- a/app/domain/audits/unallocate_content.rb
+++ b/app/domain/audits/unallocate_content.rb
@@ -11,9 +11,9 @@ module Audits
     end
 
     def call
-      Allocation.where(content_id: content_ids).delete_all
+      deleted_items = Allocation.where(content_id: content_ids).delete_all
 
-      AllocationResult.new("no one", content_ids.count)
+      AllocationResult.new("no one", deleted_items)
     end
   end
 end


### PR DESCRIPTION
This updates `Audits::AllocateContent` and `Audits::UnallocateContent` to return
return accurate counts of the number of items effected by during the transaction.