### PR TITLE
Add date dimension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
+  gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'site_prism'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,8 @@ GEM
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -531,6 +533,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   selectize-rails
+  shoulda-matchers
   simplecov
   site_prism
   spring
@@ -548,4 +551,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/models/dimensions.rb
+++ b/app/models/dimensions.rb
@@ -1,0 +1,5 @@
+module Dimensions
+  def self.table_name_prefix
+    'dimensions_'
+  end
+end

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -1,0 +1,88 @@
+class Dimensions::Date < ApplicationRecord
+  self.primary_key = 'date'
+
+  def self.build(date)
+    new(
+      date: date,
+      date_name: date.to_s(:govuk_date),
+      date_name_abbreviated: date.to_s(:govuk_date_short),
+      year: date.year,
+      quarter: ((date.month - 1) / 3) + 1,
+      month: date.month,
+      month_name: date.strftime('%B'),
+      month_name_abbreviated: date.strftime('%b'),
+      week: date.cweek,
+      day_of_year: date.yday,
+      day_of_quarter: (date - date.beginning_of_quarter).to_i + 1,
+      day_of_month: date.mday,
+      day_of_week: date.strftime('%u').to_i,
+      day_name: date.strftime('%A'),
+      day_name_abbreviated: date.strftime('%a'),
+      weekday_weekend: date.saturday? || date.sunday? ? 'Weekend' : 'Weekday',
+      )
+  end
+
+  validates :date, presence: true
+
+  validates :date_name, presence: true
+  validates :date_name_abbreviated, presence: true
+
+  validates :year,
+            presence: true,
+            numericality: { only_integer: true }
+
+  validates :quarter,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..4) }
+
+  validates :month,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..12) }
+
+  validates :month_name,
+            presence: true,
+            inclusion: { in: ::Date::MONTHNAMES }
+
+  validates :month_name_abbreviated,
+            presence: true,
+            inclusion: { in: ::Date::ABBR_MONTHNAMES }
+
+  validates :week,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..53) }
+
+  validates :day_of_year,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..365) }
+
+  validates :day_of_quarter,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..124) }
+
+  validates :day_of_month,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..31) }
+
+  validates :day_of_week,
+            presence: true,
+            numericality: { only_integer: true },
+            inclusion: { in: (1..7) }
+
+  validates :day_name,
+            presence: true,
+            inclusion: { in: ::Date::DAYNAMES }
+
+  validates :day_name_abbreviated,
+            presence: true,
+            inclusion: { in: ::Date::ABBR_DAYNAMES }
+
+  validates :weekday_weekend,
+            presence: true,
+            inclusion: { in: %w(Weekday Weekend) }
+end

--- a/db/migrate/20171220091851_create_dimensions_dates.rb
+++ b/db/migrate/20171220091851_create_dimensions_dates.rb
@@ -1,0 +1,23 @@
+class CreateDimensionsDates < ActiveRecord::Migration[5.1]
+  def change
+    create_table :dimensions_dates, id: :date, primary_key: :date do |t|
+      t.string :date_name, index: true, null: false
+      t.string :date_name_abbreviated, index: true, null: false
+      t.integer :year, null: false
+      t.integer :quarter, null: false
+      t.integer :month, null: false
+      t.string :month_name, null: false
+      t.string :month_name_abbreviated, null: false
+      t.integer :week, null: false
+      t.integer :day_of_year, null: false
+      t.integer :day_of_quarter, null: false
+      t.integer :day_of_month, null: false
+      t.integer :day_of_week, null: false
+      t.string :day_name, null: false
+      t.string :day_name_abbreviated, null: false
+      t.string :weekday_weekend, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171207164824) do
+ActiveRecord::Schema.define(version: 20171220091851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,28 @@ ActiveRecord::Schema.define(version: 20171207164824) do
     t.string "locale", null: false
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true
     t.index ["title"], name: "index_content_items_on_title"
+  end
+
+  create_table "dimensions_dates", primary_key: "date", id: :date, force: :cascade do |t|
+    t.string "date_name", null: false
+    t.string "date_name_abbreviated", null: false
+    t.integer "year", null: false
+    t.integer "quarter", null: false
+    t.integer "month", null: false
+    t.string "month_name", null: false
+    t.string "month_name_abbreviated", null: false
+    t.integer "week", null: false
+    t.integer "day_of_year", null: false
+    t.integer "day_of_quarter", null: false
+    t.integer "day_of_month", null: false
+    t.integer "day_of_week", null: false
+    t.string "day_name", null: false
+    t.string "day_name_abbreviated", null: false
+    t.string "weekday_weekend", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date_name"], name: "index_dimensions_dates_on_date_name"
+    t.index ["date_name_abbreviated"], name: "index_dimensions_dates_on_date_name_abbreviated"
   end
 
   create_table "links", id: :serial, force: :cascade do |t|

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Dimensions::Date, type: :model do
+  it { is_expected.to validate_presence_of(:date) }
+
+  it { is_expected.to validate_presence_of(:date_name) }
+  it { is_expected.to validate_presence_of(:date_name_abbreviated) }
+
+  it { is_expected.to validate_presence_of(:year) }
+  it { is_expected.to validate_numericality_of(:year).only_integer }
+
+  it { is_expected.to validate_presence_of(:quarter) }
+  it { is_expected.to validate_numericality_of(:quarter).only_integer }
+  it { is_expected.to validate_inclusion_of(:quarter).in_range(1..4) }
+
+  it { is_expected.to validate_presence_of(:month) }
+  it { is_expected.to validate_numericality_of(:month).only_integer }
+  it { is_expected.to validate_inclusion_of(:month).in_range(1..12) }
+
+  it { is_expected.to validate_presence_of(:month_name) }
+  it do
+    is_expected.to validate_inclusion_of(:month_name)
+                     .in_array(
+                       %w(
+                        January February March April May June July August
+                        September October November December
+                       )
+                     )
+  end
+
+  it { is_expected.to validate_presence_of(:month_name_abbreviated) }
+  it do
+    is_expected.to validate_inclusion_of(:month_name_abbreviated)
+                     .in_array(
+                       %w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)
+                     )
+  end
+
+  it { is_expected.to validate_presence_of(:week) }
+  it { is_expected.to validate_numericality_of(:week).only_integer }
+  it { is_expected.to validate_inclusion_of(:week).in_range(1..53) }
+
+  it { is_expected.to validate_presence_of(:day_of_year) }
+  it { is_expected.to validate_numericality_of(:day_of_year).only_integer }
+  it { is_expected.to validate_inclusion_of(:day_of_year).in_range(1..365) }
+
+  it { is_expected.to validate_presence_of(:day_of_quarter) }
+  it { is_expected.to validate_numericality_of(:day_of_quarter).only_integer }
+  it { is_expected.to validate_inclusion_of(:day_of_quarter).in_range(1..124) }
+
+  it { is_expected.to validate_presence_of(:day_of_month) }
+  it { is_expected.to validate_numericality_of(:day_of_month).only_integer }
+  it { is_expected.to validate_inclusion_of(:day_of_month).in_range(1..31) }
+
+  it { is_expected.to validate_presence_of(:day_of_week) }
+  it { is_expected.to validate_numericality_of(:day_of_week).only_integer }
+  it { is_expected.to validate_inclusion_of(:day_of_week).in_range(1..7) }
+
+  it { is_expected.to validate_presence_of(:day_name) }
+  it do
+    is_expected.to validate_inclusion_of(:day_name)
+                     .in_array(
+                       %w(
+                        Monday Tuesday Wednesday Thursday Friday
+                        Saturday Sunday
+                       )
+                     )
+  end
+
+  it { is_expected.to validate_presence_of(:day_name_abbreviated) }
+  it do
+    is_expected.to validate_inclusion_of(:day_name_abbreviated)
+                     .in_array(%w(Mon Tue Wed Thu Fri Sat Sun))
+  end
+
+  it { is_expected.to validate_presence_of(:weekday_weekend) }
+  it do
+    is_expected.to validate_inclusion_of(:weekday_weekend)
+                     .in_array(%w(Weekday Weekend))
+  end
+
+  describe '.build' do
+    subject { described_class.build(date) }
+
+    let(:date) { ::Date.new(2017, 12, 21) }
+
+    it "builds a date dimension from the date" do
+      is_expected.to have_attributes(
+        date: ::Date.new(2017, 12, 21),
+        date_name: '21 December 2017',
+        date_name_abbreviated: '21 Dec 2017',
+        day_name: 'Thursday',
+        day_name_abbreviated: 'Thu',
+        day_of_month: 21,
+        day_of_quarter: 82,
+        day_of_week: 4,
+        day_of_year: 355,
+        month: 12,
+        month_name: 'December',
+        month_name_abbreviated: 'Dec',
+        quarter: 4,
+        week: 51,
+        weekday_weekend: 'Weekday',
+        year: 2017,
+      )
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,13 @@ RSpec.configure do |config|
   end
 end
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.library :rails
+    with.test_framework :rspec
+  end
+end
+
 SitePrism.configure do |config|
   config.use_implicit_waits = true
 end


### PR DESCRIPTION
Adds a dimension table for calendar dates to allow us to easily partition future fact tables based on aspects of date. Includes a factory method to allow us to populate the dimension table given a date object from the Ruby standard library.

Once we have an ETL framework in place we can put in place the logic needed to seed the dimension table daily.