### PR TITLE
Tracking metrics through time: Organisation dimension

### DIFF
--- a/app/models/dimensions/organisation.rb
+++ b/app/models/dimensions/organisation.rb
@@ -1,0 +1,8 @@
+class Dimensions::Organisation < ApplicationRecord
+  validates :title, presence: true
+  validates :slug, presence: true
+  validates :link, presence: true
+  validates :content_id, presence: true
+  validates :organisation_state, presence: true
+  validates :content_id, presence: true
+end

--- a/app/models/etl/organisations.rb
+++ b/app/models/etl/organisations.rb
@@ -1,0 +1,45 @@
+require 'gds_api/rummager'
+
+class ETL::Organisations
+  def process
+    raw_data = extract
+    organisations = transform(raw_data)
+    load(organisations)
+  end
+
+private
+
+  def extract
+    rummager.search_enum(
+      {
+        filter_format: 'organisation',
+        fields: 'title,slug,description,link,organisation_state,content_id',
+      },
+      page_size: 1000,
+      additional_headers: {},
+    )
+  end
+
+  def transform(organisations)
+    organisations.map do |result|
+      attributes = %w(title slug description link organisation_state content_id)
+
+      Dimensions::Organisation.new(result.slice(*attributes))
+    end
+  end
+
+  def load(transformed_orgs)
+    validate!(transformed_orgs)
+
+    result = Dimensions::Organisation.import(transformed_orgs, validate: false)
+    Dimensions::Organisation.where(id: result.ids)
+  end
+
+  def validate!(transformed_orgs)
+    transformed_orgs.each(&:validate!)
+  end
+
+  def rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find('rummager'))
+  end
+end

--- a/db/migrate/20171222101252_create_dimensions_organisations.rb
+++ b/db/migrate/20171222101252_create_dimensions_organisations.rb
@@ -1,0 +1,15 @@
+class CreateDimensionsOrganisations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :dimensions_organisations do |t|
+      t.string :title
+      t.string :slug
+      t.string :description
+      t.string :link
+      t.string :organisation_id
+      t.string :organisation_state
+      t.string :content_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171220091851) do
+ActiveRecord::Schema.define(version: 20171222101252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,18 @@ ActiveRecord::Schema.define(version: 20171220091851) do
     t.datetime "updated_at", null: false
     t.index ["date_name"], name: "index_dimensions_dates_on_date_name"
     t.index ["date_name_abbreviated"], name: "index_dimensions_dates_on_date_name_abbreviated"
+  end
+
+  create_table "dimensions_organisations", force: :cascade do |t|
+    t.string "title"
+    t.string "slug"
+    t.string "description"
+    t.string "link"
+    t.string "organisation_id"
+    t.string "organisation_state"
+    t.string "content_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "links", id: :serial, force: :cascade do |t|

--- a/spec/models/dimensions/organisation_spec.rb
+++ b/spec/models/dimensions/organisation_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Dimensions::Organisation, type: :model do
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:slug) }
+  it { is_expected.to validate_presence_of(:link) }
+  it { is_expected.to validate_presence_of(:content_id) }
+  it { is_expected.to validate_presence_of(:organisation_state) }
+  it { is_expected.to validate_presence_of(:content_id) }
+end

--- a/spec/models/etl/organisations_spec.rb
+++ b/spec/models/etl/organisations_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ETL::Organisations do
     organisation = Dimensions::Organisation.first
     expect(organisation).to have_attributes(
       content_id: 'c36bd301-d0c5-4492-86ad-ee7843b8383b',
-      title: 'Companies House ',
+      title: 'Companies House',
       slug: 'companies-house',
       description: 'The home of Companies House  on GOV.UK. We incorporate and dissolve limited companies. We register company information and make it available to the public.',
       link: '/government/organisations/companies-house',
@@ -76,7 +76,7 @@ RSpec.describe ETL::Organisations do
          "results":[
             {
                "content_id":"c36bd301-d0c5-4492-86ad-ee7843b8383b",
-               "title":"Companies House ",
+               "title":"Companies House",
                "slug":"companies-house",
                "description":"The home of Companies House  on GOV.UK. We incorporate and dissolve limited companies. We register company information and make it available to the public.",
                "link":"/government/organisations/companies-house",

--- a/spec/models/etl/organisations_spec.rb
+++ b/spec/models/etl/organisations_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ETL::Organisations do
   end
 
   it 'extracts organisations dimension from Search API' do
-    stub_request(:get, query).to_return(body: new_policies_results)
+    stub_request(:get, query).to_return(body: rummager_response)
     result = subject.process
 
     expect(Dimensions::Organisation.count).to eq(2)
@@ -15,7 +15,7 @@ RSpec.describe ETL::Organisations do
   end
 
   it 'transforms and load an Organisation in the Dimensions table' do
-    stub_request(:get, query).to_return(body: new_policies_results)
+    stub_request(:get, query).to_return(body: rummager_response)
     subject.process
 
     organisation = Dimensions::Organisation.first
@@ -38,7 +38,7 @@ RSpec.describe ETL::Organisations do
 
   context 'when organisations already exist' do
     before do
-      stub_request(:get, query).to_return(body: new_policies_results)
+      stub_request(:get, query).to_return(body: rummager_response)
       subject.process
     end
 
@@ -64,13 +64,13 @@ RSpec.describe ETL::Organisations do
   end
 
   it 'returns the list of persisted items' do
-    stub_request(:get, query).to_return(body: new_policies_results)
+    stub_request(:get, query).to_return(body: rummager_response)
     result = subject.process
 
     expect(Dimensions::Organisation.all).to match_array(result)
   end
 
-  def new_policies_results
+  def rummager_response
     <<-JSON
       {
          "results":[

--- a/spec/models/etl/organisations_spec.rb
+++ b/spec/models/etl/organisations_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+require 'gds-api-adapters'
+
+RSpec.describe ETL::Organisations do
+  let(:query) do
+    %r{search.json\?.*(fields=title,slug,description,link,organisation_state,content_id).*(filter_format=organisation)}
+  end
+
+  it 'extracts organisations dimension from Search API' do
+    stub_request(:get, query).to_return(body: new_policies_results)
+    result = subject.process
+
+    expect(Dimensions::Organisation.count).to eq(2)
+    expect(Dimensions::Organisation.all).to match_array(result)
+  end
+
+  it 'transforms and load an Organisation in the Dimensions table' do
+    stub_request(:get, query).to_return(body: new_policies_results)
+    subject.process
+
+    organisation = Dimensions::Organisation.first
+    expect(organisation).to have_attributes(
+      content_id: 'c36bd301-d0c5-4492-86ad-ee7843b8383b',
+      title: 'Companies House ',
+      slug: 'companies-house',
+      description: 'The home of Companies House  on GOV.UK. We incorporate and dissolve limited companies. We register company information and make it available to the public.',
+      link: '/government/organisations/companies-house',
+      organisation_state: 'live',
+    )
+  end
+
+  it 'raises a validation error an organisation is not valid' do
+    invalid_response = %[{ "results": [{ "invalid": "response" }] }]
+    stub_request(:get, query).to_return(body: invalid_response)
+
+    expect(-> { subject.process }).to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  def new_policies_results
+    <<-JSON
+      {
+         "results":[
+            {
+               "content_id":"c36bd301-d0c5-4492-86ad-ee7843b8383b",
+               "title":"Companies House ",
+               "slug":"companies-house",
+               "description":"The home of Companies House  on GOV.UK. We incorporate and dissolve limited companies. We register company information and make it available to the public.",
+               "link":"/government/organisations/companies-house",
+               "organisation_state":"live",
+               "index":"government",
+               "es_score":null,
+               "_id":"/government/organisations/companies-house",
+               "elasticsearch_type":"edition",
+               "document_type":"edition"
+            },
+            {
+               "content_id":"6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+               "title":"HM Revenue & Customs",
+               "slug":"hm-revenue-customs",
+               "description":"The home of HM Revenue & Customs on GOV.UK. We are the UK’s tax, payments and customs authority, and we have a vital purpose: we collect the money that pays for the UK’s public services and help families and individuals with targeted financial support. We do this by being impartial and increasingly effective and efficient in our administration. We help the honest majority to get their tax right and make it hard for the dishonest minority to cheat the system.",
+               "link":"/government/organisations/hm-revenue-customs",
+               "organisation_state":"live",
+               "index":"government",
+               "es_score":null,
+               "_id":"/government/organisations/hm-revenue-customs",
+               "elasticsearch_type":"edition",
+               "document_type":"edition"
+            }
+         ],
+         "total":1035,
+         "start":0,
+         "aggregates":{
+         },
+         "suggested_queries":[
+         ]
+      }
+    JSON
+  end
+end


### PR DESCRIPTION
[Epic - Tracking metrics through time](https://trello.com/c/XAfsYd60/718-13-track-number-of-published-documents-on-a-daily-basis)

[Trello card](https://trello.com/c/wRuqvKOx/724-2-build-organisations-dimension)

The organisations will be used to filter metrics through time, so we
need to create a dimension that allows filtering by any of their
fields.

I have used some core attributes from the organisation, and in future
iterations other attributes could be removed / added.

All the organisations are retrieved from the [SearchAPI][rummager]; 
this mechanism has proved reliable and fast. This is the reason why 
I have chosen it. There are other options, like PublishingAPI, but it is 
not that fast and provides the same information.

[rummager]: https://github.com/alphagov/rummager