### PR TITLE
Tracking metrics through time: Items dimension

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -1,0 +1,3 @@
+class Dimensions::Item < ApplicationRecord
+  validates :content_id, presence: true
+end

--- a/app/models/etl/items.rb
+++ b/app/models/etl/items.rb
@@ -36,7 +36,7 @@ private
 
   def load(items)
     new_records = items.select(&:new_record?)
-    new_records.each { |record| record.save! }
+    Dimensions::Item.import(new_records, validate: false)
   end
 
   def rummager

--- a/app/models/etl/items.rb
+++ b/app/models/etl/items.rb
@@ -1,0 +1,45 @@
+require 'gds_api/rummager'
+
+class ETL::Items
+  def process
+    raw_data = extract
+    items = transform(raw_data)
+    load(items)
+  end
+
+private
+
+  def extract
+    rummager.search_enum(
+      {
+        fields: 'content_id,title,link,description,organisations,indexable_content',
+      },
+      page_size: 1000,
+      additional_headers: {},
+    )
+  end
+
+  def transform(items)
+    items = items.map do |item|
+      {
+        content_id: item['content_id'],
+        title: item['title'],
+        link: item['link'],
+        description: item['description'],
+        organisation_id: item.fetch('organisations', [{}]).first['content_id'],
+        content: item['indexable_content'],
+      }
+    end
+
+    items.map { |item| Dimensions::Item.find_or_initialize_by(item) }
+  end
+
+  def load(items)
+    new_records = items.select(&:new_record?)
+    new_records.each { |record| record.save! }
+  end
+
+  def rummager
+    @rummager = GdsApi::Rummager.new(Plek.new.find('rummager'))
+  end
+end

--- a/db/migrate/20171228132858_create_dimensions_items.rb
+++ b/db/migrate/20171228132858_create_dimensions_items.rb
@@ -1,0 +1,14 @@
+class CreateDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    create_table :dimensions_items do |t|
+      t.string :content_id
+      t.string :title
+      t.string :link
+      t.string :description
+      t.string :organisation_id
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171222101252) do
+ActiveRecord::Schema.define(version: 20171228132858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,17 @@ ActiveRecord::Schema.define(version: 20171222101252) do
     t.datetime "updated_at", null: false
     t.index ["date_name"], name: "index_dimensions_dates_on_date_name"
     t.index ["date_name_abbreviated"], name: "index_dimensions_dates_on_date_name_abbreviated"
+  end
+
+  create_table "dimensions_items", force: :cascade do |t|
+    t.string "content_id"
+    t.string "title"
+    t.string "link"
+    t.string "description"
+    t.string "organisation_id"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "dimensions_organisations", force: :cascade do |t|

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Dimensions::Item, type: :model do
+  it { is_expected.to validate_presence_of(:content_id) }
+end

--- a/spec/models/etl/items_spec.rb
+++ b/spec/models/etl/items_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+require 'gds-api-adapters'
+
+RSpec.describe ETL::Items do
+  let(:query) do
+    %r{search.json\?.*(fields=content_id,title,link,description,organisations,indexable_content)}
+  end
+
+  it 'saves an item per entry in Search API' do
+    stub_request(:get, query).to_return(body: rummager_response)
+    subject.process
+
+    expect(Dimensions::Item.count).to eq(2)
+  end
+
+  it 'transform an entry in SearchAPI into a Dimension::Item' do
+    stub_request(:get, query).to_return(body: rummager_response)
+    subject.process
+
+    organisation = Dimensions::Item.first
+    expect(organisation).to have_attributes(
+      content_id: 'fa748fae-3de4-4266-ae85-0797ada3f40c',
+      title: 'Tax your vehicle',
+      link: '/vehicle-tax',
+      description: "Renew or tax your vehicle for the first time using a reminder letter, your log book, the 'new keeper's details' section of a log book - and how to tax if you don't have any documents",
+      organisation_id: '70580624-93b5-4aed-823b-76042486c769',
+      content: 'Some content'
+    )
+  end
+
+  context 'when items already exist' do
+    before do
+      stub_request(:get, query).to_return(body: rummager_response)
+      subject.process
+    end
+
+    it 'does not store duplicated items' do
+      subject.process
+
+      expect(Dimensions::Item.count).to eq(2)
+    end
+
+    it 'adds a new item if an attribute changed' do
+      Dimensions::Item.first.update(title: 'old title')
+      subject.process
+
+      expect(Dimensions::Item.count).to eq(3)
+    end
+  end
+
+  def rummager_response
+    <<-JSON
+    {
+      "results": [
+        {
+          "content_id": "fa748fae-3de4-4266-ae85-0797ada3f40c",
+          "title": "Tax your vehicle",
+          "link": "/vehicle-tax",
+          "description": "Renew or tax your vehicle for the first time using a reminder letter, your log book, the 'new keeper's details' section of a log book - and how to tax if you don't have any documents",
+          "organisations": [
+            {
+              "content_id": "70580624-93b5-4aed-823b-76042486c769",
+              "acronym": "DVLA",
+              "link": "/government/organisations/driver-and-vehicle-licensing-agency",
+              "slug": "driver-and-vehicle-licensing-agency",
+              "organisation_type": "executive_agency",
+              "organisation_state": "live"
+            }
+          ],
+          "indexable_content": "Some content"
+        },
+        {
+          "content_id": "c36bd301-d0c5-4492-86ad-ee7843b8383b",
+          "title": "Companies House",
+          "link": "/government/organisations/companies-house",
+          "description": "The home of Companies House  on GOV.UK. We incorporate and dissolve limited companies. We register company information and make it available to the public.",
+          "organisations": [
+            {
+              "title": "Companies House ",
+              "content_id": "c36bd301-d0c5-4492-86ad-ee7843b8383b",
+              "acronym": "Companies House",
+              "link": "/government/organisations/companies-house",
+              "slug": "companies-house",
+              "organisation_type": "executive_agency",
+              "organisation_state": "live"
+            }
+          ],
+          "indexable_content": "another content"
+        }
+      ]
+    }
+    JSON
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/vBXeO3de/725-2-build-items-dimension)

The grain for our first facts table is the `content item` as all requests/queries from the business are related to retrieving information regarding the performance of content items filtered/grouped by different criteria.

For example:

- Number of content items published per organisation
- Number of content items in PDF format for an organisation
- Number of visits in the last six months for content items tagged to a particular taxon

I have decided to validate only the `content_id` because, as of today, there are content_items with no organisation returned by `rummager`; this is going to change in incoming PRs when we move to other sources of data.

#### Performance

The process takes around 45 minutes to finish; this is a very first step towards a more robust and performant solution, but it seems good enough for our first MVP.

#### ETL process

We first retrieve all the content items from SearchAPI, and then, one by one we check if there is a new version of the content item, and if so, we save it.

The natural key is all the attributes that belong to the item
dimension. We can't use the `content_id` as the primary key because we are denormalising the entity as per the `star schema` approach of the datawhare house.