### PR TITLE
Add rake task to import daily metrics

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -22,4 +22,9 @@ namespace :import do
     importer.run
     puts "Imported #{importer.completed.size} with #{importer.errors.size} errors"
   end
+
+  desc 'Load all metric facts'
+  task daily_metrics: :environment do
+    ETL::Metrics.process
+  end
 end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/R2mwzTKv/730-add-rake-task-to-populate-metrics-for-a-given-day)

It receives no parameters as by default it will populate the Facts::Metric
table with data for the current date (Date.today)

See:

- Dimensions::Date
- ETL::Dates