### PR TITLE
Improve performance of etl::items

### DIFF
--- a/app/models/etl/items.rb
+++ b/app/models/etl/items.rb
@@ -47,8 +47,6 @@ private
     import_new_items
 
     load_cleanup
-
-    return_latest_items
   end
 
   def rummager
@@ -75,10 +73,6 @@ private
 
   def import_new_items
     Dimensions::Item.import(new_items, batch_size: 5000)
-  end
-
-  def return_latest_items
-    Dimensions::Item.where(latest: true)
   end
 
   def load_cleanup

--- a/app/models/etl/items.rb
+++ b/app/models/etl/items.rb
@@ -5,10 +5,14 @@ class ETL::Items
     new(*args).process
   end
 
+  attr_reader :new_items
+
   def process
-    raw_data = extract
-    items = transform(raw_data)
-    load(items)
+    ActiveRecord::Base.transaction do
+      raw_data = extract
+      items = transform(raw_data)
+      load(items)
+    end
   end
 
 private
@@ -23,8 +27,8 @@ private
     )
   end
 
-  def transform(items)
-    items = items.map do |item|
+  def transform(raw_data)
+    raw_data.map do |item|
       {
         content_id: item['content_id'],
         title: item['title'],
@@ -33,20 +37,65 @@ private
         organisation_id: item.fetch('organisations', [{}]).first['content_id'],
       }
     end
-
-    items.map { |item| Dimensions::Item.find_or_initialize_by(item) }
   end
 
   def load(items)
-    new_records = items.select(&:new_record?)
-    result = Dimensions::Item.import(new_records, validate: false, batch_size: 5000)
-    existing_records = items - new_records
-    all_ids = result.ids + existing_records.pluck(:id)
+    load_setup(items)
 
-    Dimensions::Item.where(id: all_ids)
+    find_new_items
+    update_latest_flag
+    import_new_items
+
+    load_cleanup
+
+    return_latest_items
   end
 
   def rummager
     @rummager = GdsApi::Rummager.new(Plek.new.find('rummager'))
+  end
+
+  def load_setup(items)
+    TemporaryItemStore.import(items, batch_size: 5000)
+  end
+
+  def find_new_items
+    result = ActiveRecord::Base.connection.execute(new_items_sql)
+    @new_items = result.map do |row|
+      item = Dimensions::Item.new(row)
+      item.latest = true
+      item
+    end
+  end
+
+  def update_latest_flag
+    new_items_ids = new_items.pluck(:content_id)
+    Dimensions::Item.where('content_id IN (?)', new_items_ids).update_all(latest: false)
+  end
+
+  def import_new_items
+    Dimensions::Item.import(new_items, batch_size: 5000)
+  end
+
+  def return_latest_items
+    Dimensions::Item.where(latest: true)
+  end
+
+  def load_cleanup
+    TemporaryItemStore.delete_all
+  end
+
+  def new_items_sql
+    <<~SQL
+      SELECT content_id, title, link, description, organisation_id
+      FROM dimensions_items_temps
+       EXCEPT
+      SELECT content_id, title, link, description, organisation_id
+      FROM dimensions_items
+    SQL
+  end
+
+  class TemporaryItemStore < ApplicationRecord
+    self.table_name = 'dimensions_items_temps'
   end
 end

--- a/db/migrate/20180103141736_create_dimensions_items_temps.rb
+++ b/db/migrate/20180103141736_create_dimensions_items_temps.rb
@@ -1,0 +1,11 @@
+class CreateDimensionsItemsTemps < ActiveRecord::Migration[5.1]
+  def change
+    create_table :dimensions_items_temps, id: false do |t|
+      t.string :content_id
+      t.string :title
+      t.string :link
+      t.string :description
+      t.string :organisation_id
+    end
+  end
+end

--- a/db/migrate/20180103161730_add_latest_to_dimensions_items.rb
+++ b/db/migrate/20180103161730_add_latest_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddLatestToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :latest, :boolean
+  end
+end

--- a/db/migrate/20180105112615_add_index_to_items_dimension.rb
+++ b/db/migrate/20180105112615_add_index_to_items_dimension.rb
@@ -1,0 +1,8 @@
+class AddIndexToItemsDimension < ActiveRecord::Migration[5.1]
+  def change
+    add_index :dimensions_items, [:content_id, :link, :organisation_id], name: :dimensions_items_natural_key
+    add_index :dimensions_items_temps, [:content_id, :link, :organisation_id], name: :dimensions_items_temps_natual_key
+  end
+end
+
+

--- a/db/migrate/20180105112615_add_index_to_items_dimension.rb
+++ b/db/migrate/20180105112615_add_index_to_items_dimension.rb
@@ -1,8 +1,6 @@
 class AddIndexToItemsDimension < ActiveRecord::Migration[5.1]
   def change
-    add_index :dimensions_items, [:content_id, :link, :organisation_id], name: :dimensions_items_natural_key
-    add_index :dimensions_items_temps, [:content_id, :link, :organisation_id], name: :dimensions_items_temps_natual_key
+    add_index :dimensions_items, %i[content_id link organisation_id], name: :dimensions_items_natural_key
+    add_index :dimensions_items_temps, %i[content_id link organisation_id], name: :dimensions_items_temps_natual_key
   end
 end
-
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180103115527) do
+ActiveRecord::Schema.define(version: 20180103161730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,15 @@ ActiveRecord::Schema.define(version: 20180103115527) do
     t.string "organisation_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "latest"
+  end
+
+  create_table "dimensions_items_temps", id: false, force: :cascade do |t|
+    t.string "content_id"
+    t.string "title"
+    t.string "link"
+    t.string "description"
+    t.string "organisation_id"
   end
 
   create_table "dimensions_organisations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180103161730) do
+ActiveRecord::Schema.define(version: 20180105112615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 20180103161730) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "latest"
+    t.index ["content_id", "link", "organisation_id"], name: "dimensions_items_natural_key"
   end
 
   create_table "dimensions_items_temps", id: false, force: :cascade do |t|
@@ -101,6 +102,7 @@ ActiveRecord::Schema.define(version: 20180103161730) do
     t.string "link"
     t.string "description"
     t.string "organisation_id"
+    t.index ["content_id", "link", "organisation_id"], name: "dimensions_items_temps_natual_key"
   end
 
   create_table "dimensions_organisations", force: :cascade do |t|

--- a/spec/models/etl/items_spec.rb
+++ b/spec/models/etl/items_spec.rb
@@ -49,18 +49,20 @@ RSpec.describe ETL::Items do
     end
 
     it 'returns the latest version of each item' do
-      Dimensions::Item.first.update(title: 'old title')
-      result = subject.process
+      Dimensions::Item.first.update(title: 'old title', latest: true)
+      subject.process
 
-      expect(result.pluck(:title)).to include('Tax your vehicle', 'Companies House')
+      latest_items = Dimensions::Item.where(latest: true)
+      expect(latest_items.pluck(:title)).to include('Tax your vehicle', 'Companies House')
     end
   end
 
-  it 'returns the list of persisted items' do
+  it 'Update the latest version of the content items' do
     stub_request(:get, query).to_return(body: rummager_response)
-    result = subject.process
+    subject.process
 
-    expect(Dimensions::Item.all).to match_array(result)
+    latest_items = Dimensions::Item.where(latest: true).pluck(:title)
+    expect(latest_items).to match_array(['Tax your vehicle', 'Companies House'])
   end
 
   def rummager_response

--- a/spec/models/etl/items_spec.rb
+++ b/spec/models/etl/items_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ETL::Items do
     stub_request(:get, query).to_return(body: rummager_response)
     subject.process
 
-    organisation = Dimensions::Item.first
-    expect(organisation).to have_attributes(
+    item = Dimensions::Item.find_by(title: 'Tax your vehicle')
+    expect(item).to have_attributes(
       content_id: 'fa748fae-3de4-4266-ae85-0797ada3f40c',
       title: 'Tax your vehicle',
       link: '/vehicle-tax',


### PR DESCRIPTION
We set up a 'dimensions_items_temps' table to act as a temporary
item store so that we could find the items that needed to be added to
the 'dimensions_items' table quickly and easily by comparing the two
tables. This reduced the time, and the number of database queries,
needed to ETL the items.

We also added a `latest` field to Dimensions::Items so that we can
easily identify, and return, the latest version of each item.