### PR TITLE
Live pages report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'plek'
 
 # Third party gems
 gem 'activerecord-import'
+gem 'chartkick'
 gem 'draper'
 gem 'feature'
 gem 'google-api-client', '~> 0.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chartkick (2.2.5)
     cliver (0.3.2)
     coderay (1.1.2)
     coffee-script (2.4.1)
@@ -500,6 +501,7 @@ DEPENDENCIES
   binding_of_caller
   byebug
   capybara
+  chartkick
   coffee-script
   database_cleaner
   draper
@@ -551,4 +553,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,3 +26,7 @@
 //= require analytics/google-tag-manager
 //= require analytics/track-select-change
 //= require analytics/track-allocation-batch-size
+
+// --- Reporting ---
+//= require Chart.bundle
+//= require chartkick

--- a/app/controllers/content/live_pages_reports_controller.rb
+++ b/app/controllers/content/live_pages_reports_controller.rb
@@ -2,6 +2,13 @@ class Content::LivePagesReportsController < ApplicationController
   def show
     @live_pages = Facts::Metric
                     .by_date_name
+                    .for_organisation(content_id: filter_params[:organisation])
                     .count
+  end
+
+private
+
+  def filter_params
+    params.permit(:organisation)
   end
 end

--- a/app/controllers/content/live_pages_reports_controller.rb
+++ b/app/controllers/content/live_pages_reports_controller.rb
@@ -1,0 +1,7 @@
+class Content::LivePagesReportsController < ApplicationController
+  def show
+    @live_pages = Facts::Metric
+                    .by_date_name
+                    .count
+  end
+end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,0 +1,10 @@
+module ReportHelper
+  def organisation_dimension_options_for_select(selected = nil)
+    options = Dimensions::Organisation
+                .pluck(:title, :content_id)
+                .map { |title, content_id| [title.squish, content_id] }
+                .sort_by { |title, _| title }
+
+    options_for_select(options, selected)
+  end
+end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -10,4 +10,15 @@ class Facts::Metric < ApplicationRecord
     joins(:dimensions_date)
       .group(:date_name)
   end
+
+  scope :for_organisation, ->(content_id:) do
+    return unless content_id.present?
+
+    joins(:dimensions_organisation)
+      .where(
+        dimensions_organisations: {
+          content_id: content_id
+        }
+      )
+  end
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -5,4 +5,9 @@ class Facts::Metric < ApplicationRecord
 
   validates :dimensions_date, presence: true
   validates :dimensions_item, presence: true
+
+  scope :by_date_name, -> do
+    joins(:dimensions_date)
+      .group(:date_name)
+  end
 end

--- a/app/views/content/live_pages_reports/show.html.erb
+++ b/app/views/content/live_pages_reports/show.html.erb
@@ -4,6 +4,26 @@
   </div>
 </div>
 
+<div class="row add-bottom-margin pull-right" data-test-id="filter-form">
+  <div class="col-md-12">
+    <%= form_tag content_live_pages_report_path, class: 'form-inline', method: :get do %>
+      <div class="form-group">
+        <%= label_tag :organisation %>
+        <%= select_tag :organisation,
+                       organisation_dimension_options_for_select(params[:organisation]),
+                       include_blank: 'All',
+                       class: 'form-control',
+                       data: {
+                           'test-id' => 'organisation-select',
+                       } %>
+      </div>
+      <button type="submit" class="btn btn-default" data-test-id="submit-button">
+        Filter
+      </button>
+    <% end %>
+  </div>
+</div>
+
 <div class="row add-bottom-margin">
   <div class="col-md-12" data-test-id="line-chart">
     <%= line_chart @live_pages %>

--- a/app/views/content/live_pages_reports/show.html.erb
+++ b/app/views/content/live_pages_reports/show.html.erb
@@ -1,0 +1,40 @@
+<div class="row add-bottom-margin">
+  <div class="col-md-12">
+    <h1>Live pages</h1>
+  </div>
+</div>
+
+<div class="row add-bottom-margin">
+  <div class="col-md-12" data-test-id="line-chart">
+    <%= line_chart @live_pages %>
+  </div>
+</div>
+
+<div class="row add-bottom-margin" data-test-id="summary-table">
+  <div class="col-md-12">
+    <table class="table table-condensed table-hover">
+      <thead>
+      <tr class="table-header">
+        <th>
+          Date
+        </th>
+        <th>
+          Live pages
+        </th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @live_pages.each do |date, count| %>
+        <tr>
+          <td data-test-class="date">
+            <%= date %>
+          </td>
+          <td data-test-class="live-pages">
+            <%= number_with_delimiter count %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,19 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
+<% content_for :navbar_items do %>
+  <li>
+    <%= link_to 'Home',
+                root_path,
+                data: { 'test-id' => 'home' } %>
+  </li>
+  <li>
+    <%= link_to 'Reports',
+                content_live_pages_report_path,
+                data: { 'test-id' => 'reports' } %>
+  </li>
+<% end %>
+
 <% content_for :content do %>
   <%= render 'application/heroku' if Heroku.enabled?%>
   <%= render 'application/alpha_banner' %>

--- a/app/views/layouts/audit_wrapper.html.erb
+++ b/app/views/layouts/audit_wrapper.html.erb
@@ -10,6 +10,10 @@
   <%= audits_path %>
 <% end %>
 
+<% content_for :navbar_items do %>
+
+<% end %>
+
 <% content_for :head do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
 
   namespace :content do
     resources :items, only: %w(index show), param: :content_id
+
+    scope 'reports' do
+      resource :live_pages_report, only: %w(show), path: 'live-pages'
+    end
   end
 
   resources :content_items, only: %w(index show), param: :content_id do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -119,6 +119,12 @@ FactoryBot.define do
     allocated_to :anyone
   end
 
+  factory :dimensions_date, class: Dimensions::Date do
+    sequence(:date) { |i| i.days.ago.to_date }
+
+    initialize_with { Dimensions::Date.build(date) }
+  end
+
   factory :dimensions_organisation, class: Dimensions::Organisation do
     sequence(:title) { |i| "title - #{i}" }
     sequence(:slug) { |i| "slug - #{i}" }
@@ -135,5 +141,11 @@ FactoryBot.define do
     sequence(:link) { |i| "link - #{i}" }
     sequence(:description) { |i| "description - #{i}" }
     sequence(:organisation_id) { |i| "organisation_id - #{i}" }
+  end
+
+  factory :facts_metric, class: Facts::Metric do
+    dimensions_date
+    dimensions_item
+    dimensions_organisation
   end
 end

--- a/spec/features/performance/live_pages_report_spec.rb
+++ b/spec/features/performance/live_pages_report_spec.rb
@@ -12,6 +12,13 @@ RSpec.feature 'Live pages report', type: :feature do
     then_i_can_see_the_total_live_pages_each_day
   end
 
+  scenario 'Filtering by organisation' do
+    given_i_am_logged_in
+    and_there_is_historical_page_data
+    when_i_navigate_to_the_live_pages_report
+    then_i_can_filter_the_report_by_organisation
+  end
+
   around(:example) do |example|
     Timecop.freeze(Time.local(2018, 1, 1)) do
       example.run
@@ -82,6 +89,27 @@ RSpec.feature 'Live pages report', type: :feature do
 
       expect(summary_table.live_pages.collect(&:text))
         .to contain_exactly('14', '12', '10', '8', '6', '4', '2')
+    end
+  end
+
+  def then_i_can_filter_the_report_by_organisation
+    @live_pages_report.filter do |filter|
+      filter.organisation.select 'Ministry of Peace'
+      filter.submit.click
+    end
+
+    @live_pages_report.summary_table do |summary_table|
+      expect(summary_table.dates.collect(&:text))
+        .to contain_exactly('31 December 2017',
+                            '30 December 2017',
+                            '29 December 2017',
+                            '28 December 2017',
+                            '27 December 2017',
+                            '26 December 2017',
+                            '25 December 2017')
+
+      expect(summary_table.live_pages.collect(&:text))
+        .to contain_exactly('7', '6', '5', '4', '3', '2', '1')
     end
   end
 end

--- a/spec/features/performance/live_pages_report_spec.rb
+++ b/spec/features/performance/live_pages_report_spec.rb
@@ -1,0 +1,87 @@
+RSpec.feature 'Live pages report', type: :feature do
+  scenario 'Navigate to a live pages report from the home page' do
+    given_i_am_logged_in
+    when_i_view_the_home_page
+    then_i_can_navigate_to_a_live_pages_report
+  end
+
+  scenario 'Live pages report shows the total live pages each day' do
+    given_i_am_logged_in
+    and_there_is_historical_page_data
+    when_i_navigate_to_the_live_pages_report
+    then_i_can_see_the_total_live_pages_each_day
+  end
+
+  around(:example) do |example|
+    Timecop.freeze(Time.local(2018, 1, 1)) do
+      example.run
+    end
+  end
+
+  def given_i_am_logged_in
+    create(:user)
+  end
+
+  def and_there_is_historical_page_data
+    # Create dimensions for the last 7 days
+    dates = (7.days.ago.to_date..Date.yesterday)
+              .map { |date| create(:dimensions_date, date: date) }
+
+    # We have two publishing organisations
+    ministry_of_love = create(:dimensions_organisation, title: 'Ministry of Love')
+    ministry_of_peace = create(:dimensions_organisation, title: 'Ministry of Peace')
+
+    # On Monday they publish once, twice on Tuesday, three times on Wednesday etc
+    dates.map do |date|
+      items = create_list(:dimensions_item, date.day_of_week)
+
+      metrics = items.map do |item|
+        [
+          Facts::Metric.new(dimensions_date: date,
+                            dimensions_item: item,
+                            dimensions_organisation: ministry_of_love),
+
+          Facts::Metric.new(dimensions_date: date,
+                            dimensions_item: item,
+                            dimensions_organisation: ministry_of_peace)
+        ]
+      end
+
+      Facts::Metric.import(metrics.flatten)
+    end
+  end
+
+  def when_i_view_the_home_page
+    @home_page = ContentPerformanceManager.home_page
+    @home_page.load
+  end
+
+  def when_i_navigate_to_the_live_pages_report
+    @live_pages_report = ContentPerformanceManager.live_pages_report
+    @live_pages_report.load
+  end
+
+  def then_i_can_navigate_to_a_live_pages_report
+    expect(@home_page.navigation.reports['href'])
+      .to eq('/content/reports/live-pages')
+  end
+
+  def then_i_can_see_the_total_live_pages_each_day
+    expect(@live_pages_report).to have_line_chart
+    expect(@live_pages_report).to have_summary_table
+
+    @live_pages_report.summary_table do |summary_table|
+      expect(summary_table.dates.collect(&:text))
+        .to contain_exactly('31 December 2017',
+                            '30 December 2017',
+                            '29 December 2017',
+                            '28 December 2017',
+                            '27 December 2017',
+                            '26 December 2017',
+                            '25 December 2017')
+
+      expect(summary_table.live_pages.collect(&:text))
+        .to contain_exactly('14', '12', '10', '8', '6', '4', '2')
+    end
+  end
+end

--- a/spec/support/pages/performance/content_performance_manager.rb
+++ b/spec/support/pages/performance/content_performance_manager.rb
@@ -1,0 +1,12 @@
+require_relative 'content_performance_manager/home_page'
+require_relative 'content_performance_manager/live_pages_report_page'
+
+module ContentPerformanceManager
+  def self.home_page
+    HomePage.new
+  end
+
+  def self.live_pages_report
+    LivePagesReportPage.new
+  end
+end

--- a/spec/support/pages/performance/content_performance_manager/base_page.rb
+++ b/spec/support/pages/performance/content_performance_manager/base_page.rb
@@ -1,0 +1,9 @@
+require 'site_prism/page'
+
+require_relative './navigation_section'
+
+module ContentPerformanceManager
+  class BasePage < SitePrism::Page
+    section :navigation, NavigationSection, 'nav[role=navigation]'
+  end
+end

--- a/spec/support/pages/performance/content_performance_manager/home_page.rb
+++ b/spec/support/pages/performance/content_performance_manager/home_page.rb
@@ -1,0 +1,7 @@
+require_relative './base_page'
+
+module ContentPerformanceManager
+  class HomePage < BasePage
+    set_url '/'
+  end
+end

--- a/spec/support/pages/performance/content_performance_manager/live_pages_report_page.rb
+++ b/spec/support/pages/performance/content_performance_manager/live_pages_report_page.rb
@@ -4,6 +4,11 @@ module ContentPerformanceManager
   class LivePagesReportPage < BasePage
     set_url '/content/reports/live-pages'
 
+    section :filter, '[data-test-id=filter-form]' do
+      element :organisation, '[data-test-id=organisation-select]'
+      element :submit, '[data-test-id=submit-button]'
+    end
+
     element :line_chart, '[data-test-id=line-chart]'
 
     section :summary_table, '[data-test-id=summary-table]' do

--- a/spec/support/pages/performance/content_performance_manager/live_pages_report_page.rb
+++ b/spec/support/pages/performance/content_performance_manager/live_pages_report_page.rb
@@ -1,0 +1,14 @@
+require_relative './base_page'
+
+module ContentPerformanceManager
+  class LivePagesReportPage < BasePage
+    set_url '/content/reports/live-pages'
+
+    element :line_chart, '[data-test-id=line-chart]'
+
+    section :summary_table, '[data-test-id=summary-table]' do
+      elements :dates, '[data-test-class=date]'
+      elements :live_pages, '[data-test-class=live-pages]'
+    end
+  end
+end

--- a/spec/support/pages/performance/content_performance_manager/navigation_section.rb
+++ b/spec/support/pages/performance/content_performance_manager/navigation_section.rb
@@ -1,0 +1,8 @@
+require 'site_prism/section'
+
+module ContentPerformanceManager
+  class NavigationSection < SitePrism::Section
+    element :home, '[data-test-id=home]'
+    element :reports, '[data-test-id=reports]'
+  end
+end


### PR DESCRIPTION
Adds a basic initial report showing the number of live pages per day, filterable by organisation. Initially this will be limited until we can mine for historical data.

<img width="1219" alt="screen shot 2018-01-04 at 14 36 42" src="https://user-images.githubusercontent.com/2715/34568457-c874e64e-f15d-11e7-84d9-973c637ed50a.png">

