### PR TITLE
Add ADR to Split CPM and Content Audit Tool

### DIFF
--- a/doc/arch/adr-005-split-audit-tool-cpm.md
+++ b/doc/arch/adr-005-split-audit-tool-cpm.md
@@ -1,0 +1,28 @@
+# ADR 005: Split Audit Tool and Content Performance Manager
+
+18-01-2018
+
+## Context
+
+Content Performance Manager and Content Audit Tool have lived on the same repo for 10 months as we didn't have a very clear picture of the process that was driving both tools, and the underlying user needs.
+
+We decided to keep them together because:
+1. As per user research, both tools were addressing similar needs the content publishing workflow
+2. It is easier to split both apps once you know that they are different, than to join them later on.
+
+In the last quarter, we noticed that both tools are addressing very different user needs, hence we need to split them.
+
+## Decision
+
+[Split Content Audit Tool and Content Performance Manager][1]
+
+## Status
+
+Accepted.
+
+
+[1]: https://trello.com/c/l7fn1C1P/20-2-split-term-generation-tool
+
+
+
+


### PR DESCRIPTION
Content Performance Manager and Content Audit Tool have lived on the same repo for 10 months as we didn't have a very clear picture of the process that was driving both tools, and the underlying user needs.

We decided to keep them together because:

1. As per user research, both tools were addressing similar needs the content publishing workflow
1. It is easier to split both apps once you know that they are different, than to join them later on.

In the last quarter, we noticed that both tools are addressing very different user needs, hence we need to split them.

