### PR TITLE
Add ADR to ignore translations to other languages

### DIFF
--- a/doc/arch/adr-008-focus-on-english-content.md
+++ b/doc/arch/adr-008-focus-on-english-content.md
@@ -1,0 +1,24 @@
+# ADR 008: Focus on english content in the first iterations.
+
+28-01-2018
+
+## Context
+
+Some Content Items are written in different languages, so [Publishing-api][1] will return the `content_id` along with all locales assigned to the Content Item.  
+
+## Decision
+
+Focus on content written in English.
+
+The main reason is that we would need different algorithms and libraries to make our application consistent among all the languages / locales. 
+If this is a real need, we will support it in future iterations of the Data Warehouse.
+
+### Benefits:
+
+This makes the codebase simpler.   
+
+## Status
+
+Accepted.
+
+[1]: http://github.com/alphagov/publishing-api


### PR DESCRIPTION
Some Content Items have multiple translation of the content, so the
[Publishing-api][1] will return the `content_id` along with all locales
assigned to the Content Item.

We have decided to ignore content metrics and Analytics metrics for
non-english content for the first iterations.

The main reason is that we would need different algorithms and libraries
to make our application consistent among all the languages/ locales.
If this is a real need, then we will support it in future iterations of
the Data Warehouse.

The bigger benefit is that it makes the codebase much simpler as the
grain in the Fact Table for metrics linked to the Content Item's
dimension.

[1]: http://github.com/alphagov/publishing-api