### PR TITLE
Add endpoint to retrieve a metric between 2 days

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,0 +1,32 @@
+class MetricsController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def show
+    @metrics = Facts::Metric
+      .joins(:dimensions_date)
+      .joins(:dimensions_item)
+      .where(dimensions_items: { content_id: content_id })
+      .where('dimensions_dates.date in (?)', from..to)
+      .order('dimensions_dates.date asc')
+      .group('dimensions_dates.date')
+      .sum("facts_metrics.#{metric}")
+  end
+
+private
+
+  def content_id
+    @content_id ||= params[:content_id]
+  end
+
+  def from
+    @from ||= params[:from]
+  end
+
+  def to
+    @to ||= params[:to]
+  end
+
+  def metric
+    @metric ||= params[:metric]
+  end
+end

--- a/app/views/metrics/show.json.jbuilder
+++ b/app/views/metrics/show.json.jbuilder
@@ -1,0 +1,12 @@
+json.metadata do
+  json.metric @metric
+  json.total @metrics.values.sum
+  json.from @from
+  json.to @to
+  json.content_id @content_id
+end
+json.results @metrics.each do |date, value|
+  json.content_id @content_id
+  json.date date
+  json.value value
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
     resources :allocations, only: %w(index create)
   end
 
+  get '/api/v1/metrics/:content_id', to: "metrics#show"
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+RSpec.describe "/api/v1/metrics/:content_id", type: :request do
+  it "List a metric for a content item between two dates" do
+    day1 = Dimensions::Date.build(Date.new(2018, 1, 13))
+    day2 = Dimensions::Date.build(Date.new(2018, 1, 14))
+    day3 = Dimensions::Date.build(Date.new(2018, 1, 15))
+    day4 = Dimensions::Date.build(Date.new(2018, 1, 16))
+    item1 = create(:dimensions_item, content_id: 'id1')
+
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day1, pageviews: 20, unique_pageviews: 0)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day2, pageviews: 10, unique_pageviews: 0)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day3, pageviews: 20, unique_pageviews: 0)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day4, pageviews: 20, unique_pageviews: 0)
+
+    query_params = {
+      metric: 'pageviews',
+      from: Date.new(2018, 1, 13),
+      to: Date.new(2018, 1, 15),
+    }
+    get "/api/v1/metrics/id1.json", params: query_params
+
+    json = JSON.parse(response.body)
+    expect(json.deep_symbolize_keys).to eq(pageviews_response)
+  end
+
+  def pageviews_response
+    {
+      metadata: {
+        metric: 'pageviews',
+        total: 50,
+        from: '2018-01-13',
+        to: '2018-01-15',
+        content_id: 'id1',
+      },
+      results: [
+        {
+          content_id: 'id1',
+          date: '2018-01-13',
+          value: 20,
+        },
+        {
+          content_id: 'id1',
+          date: '2018-01-14',
+          value: 10,
+        },
+        {
+          content_id: 'id1',
+          date: '2018-01-15',
+          value: 20,
+        }
+      ]
+    }
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/HixeuLnU/30-2-ga-endpoint-to-return-the-ga-metrics-between-two-dates)

Endpoint: `/api/v1/metrics/:content_id`, and it accepts the following
parameters:

1. `metric`: possible values: `pageviews` and `unique_pageviews`
2. `from`: date
3. `to`: date

```
{
  metadata: {
    metric: 'pageviews',
    total: 50,
    from: '2018-01-13',
    to: '2018-01-15',
    content_id: 'id1',
  },
  results: [
    {
      content_id: 'id1',
      date: '2018-01-13',
      value: 20,
    },
    {
      content_id: 'id1',
      date: '2018-01-14',
      value: 10,
    },
    {
      content_id: 'id1',
      date: '2018-01-15',
      value: 20,
    }
  ]
}
```