### PR TITLE
Ensure the integrity of pageview and unique pageview data

### DIFF
--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -10,4 +10,30 @@ class Facts::Metric < ApplicationRecord
     validates :pageviews
     validates :unique_pageviews
   end
+
+  validate :pageviews_and_unique_pageviews_are_dependent
+
+private
+
+  def pageviews_and_unique_pageviews_are_dependent
+    if pageviews.present?
+      if unique_pageviews.blank?
+        errors.add(:unique_pageviews, :blank)
+      elsif unique_pageviews.zero? && pageviews.nonzero?
+        errors.add(:pageviews, "must be zero")
+      end
+    end
+
+    if unique_pageviews.present?
+      if pageviews.blank?
+        errors.add(:pageviews, :blank)
+      elsif pageviews.zero? && unique_pageviews.nonzero?
+        errors.add(:unique_pageviews, "must be zero")
+      end
+    end
+
+    if unique_pageviews.is_a?(Numeric) && pageviews.is_a?(Numeric) && unique_pageviews > pageviews
+      errors.add(:unique_pageviews, :less_than_or_equal_to, count: pageviews)
+    end
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -119,6 +119,12 @@ FactoryBot.define do
     allocated_to :anyone
   end
 
+  factory :dimensions_date, class: Dimensions::Date do
+    sequence(:date) { |i| i.days.ago.to_date }
+
+    initialize_with { Dimensions::Date.build(date) }
+  end
+
   factory :dimensions_organisation, class: Dimensions::Organisation do
     sequence(:title) { |i| "title - #{i}" }
     sequence(:slug) { |i| "slug - #{i}" }
@@ -135,5 +141,11 @@ FactoryBot.define do
     sequence(:link) { |i| "link - #{i}" }
     sequence(:description) { |i| "description - #{i}" }
     sequence(:organisation_id) { |i| "organisation_id - #{i}" }
+  end
+
+  factory :facts_metric, class: Facts::Metric do
+    dimensions_date
+    dimensions_item
+    dimensions_organisation
   end
 end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -15,4 +15,46 @@ RSpec.describe Facts::Metric, type: :model do
                      .only_integer
                      .allow_nil
   end
+
+  describe 'with zero pageviews and zero unique pageviews' do
+    subject { build(:facts_metric, pageviews: 0, unique_pageviews: 0) }
+
+    it { is_expected.to be_valid }
+  end
+
+  describe 'with zero pageviews but unique pageviews' do
+    subject { build(:facts_metric, pageviews: 0, unique_pageviews: 1) }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe 'with pageviews but zero unique pageviews' do
+    subject { build(:facts_metric, pageviews: 1, unique_pageviews: 0) }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe 'with more pageviews than unique pageviews' do
+    subject { build(:facts_metric, pageviews: 2, unique_pageviews: 1) }
+
+    it { is_expected.to be_valid }
+  end
+
+  describe 'with more unique pageviews than pageviews' do
+    subject { build(:facts_metric, pageviews: 1, unique_pageviews: 2) }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe 'with pageviews but non-existent unique pageviews' do
+    subject { build(:facts_metric, pageviews: 1, unique_pageviews: nil) }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe 'with non-existent pageviews but unique pageviews' do
+    subject { build(:facts_metric, pageviews: nil, unique_pageviews: 1) }
+
+    it { is_expected.not_to be_valid }
+  end
 end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "/api/v1/metrics/:content_id", type: :request do
     day4 = Dimensions::Date.build(Date.new(2018, 1, 16))
     item1 = create(:dimensions_item, content_id: 'id1')
 
-    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day1, pageviews: 20, unique_pageviews: 0)
-    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day2, pageviews: 10, unique_pageviews: 0)
-    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day3, pageviews: 20, unique_pageviews: 0)
-    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day4, pageviews: 20, unique_pageviews: 0)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day1, pageviews: 20, unique_pageviews: 10)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day2, pageviews: 10, unique_pageviews: 5)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day3, pageviews: 20, unique_pageviews: 10)
+    Facts::Metric.create!(dimensions_item: item1, dimensions_date: day4, pageviews: 20, unique_pageviews: 10)
 
     query_params = {
       metric: 'pageviews',


### PR DESCRIPTION
- There can't be more unique pageviews than pageviews
- If there are zero pageviews there must also be zero unique pageviews
- If there are zero unique pageviews there must also be zero pageviews
- If pageviews are unknown unique pageviews must also be unknown
- If unique pageviews are unknown pageviews must also be unknown