### PR TITLE
ETL for Google Analytics report data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
+  gem 'rspec-sidekiq'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,6 +373,9 @@ GEM
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
+    rspec-sidekiq (3.0.3)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.7.0)
     rubocop (0.51.0)
       parallel (~> 1.10)
@@ -529,6 +532,7 @@ DEPENDENCIES
   rails (~> 5.1)
   rails-controller-testing
   rspec-rails
+  rspec-sidekiq
   sass-rails
   selectize-rails
   shoulda-matchers
@@ -549,4 +553,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/jobs/etl/google_analytics_report_data_job.rb
+++ b/app/jobs/etl/google_analytics_report_data_job.rb
@@ -1,0 +1,17 @@
+class ETL::GoogleAnalyticsReportDataJob < ApplicationJob
+  sidekiq_options queue: 'google_analytics'
+
+  def run(year, month, day, *_args)
+    date = Date.new(year, month, day)
+    date_dimension = Dimensions::Date.for(date)
+
+    source = GoogleAnalyticsReportDataSource.new(date: date)
+    transform = GoogleAnalyticsReportDataTransform.new(date_dimension: date_dimension)
+    destination = GoogleAnalyticsReportDataDestination.new
+
+    source
+      .map { |report_data| transform.process(report_data) }
+      .compact
+      .each { |attributes| destination.write(attributes) }
+  end
+end

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -22,6 +22,14 @@ class Dimensions::Date < ApplicationRecord
       )
   end
 
+  def self.for(date)
+    where(date: date).first || begin
+      date_dimension = build(date)
+      date_dimension.save
+      date_dimension
+    end
+  end
+
   validates :date, presence: true
 
   validates :date_name, presence: true

--- a/app/models/etl/dates.rb
+++ b/app/models/etl/dates.rb
@@ -4,6 +4,6 @@ class ETL::Dates
   end
 
   def process
-    Dimensions::Date.for(Date.today)
+    Dimensions::Date.for(Date.yesterday)
   end
 end

--- a/app/models/etl/dates.rb
+++ b/app/models/etl/dates.rb
@@ -4,10 +4,6 @@ class ETL::Dates
   end
 
   def process
-    Dimensions::Date.find(Date.today)
-  rescue ActiveRecord::RecordNotFound
-    date = Dimensions::Date.build(Date.today)
-    date.save!
-    date
+    Dimensions::Date.for(Date.today)
   end
 end

--- a/app/models/etl/google_analytics_report_data_destination.rb
+++ b/app/models/etl/google_analytics_report_data_destination.rb
@@ -1,0 +1,14 @@
+class ETL::GoogleAnalyticsReportDataDestination
+  def write(dimensions_date_id:, dimensions_item_id:, pageviews:, unique_pageviews:)
+    Facts::Metric
+      .where(
+        dimensions_date_id: dimensions_date_id,
+        dimensions_item_id: dimensions_item_id
+      )
+      .first_or_initialize
+      .update!(
+        pageviews: pageviews,
+        unique_pageviews: unique_pageviews
+      )
+  end
+end

--- a/app/models/etl/google_analytics_report_data_source.rb
+++ b/app/models/etl/google_analytics_report_data_source.rb
@@ -1,0 +1,81 @@
+require 'google/apis/analyticsreporting_v4'
+
+class ETL::GoogleAnalyticsReportDataSource
+  include Enumerable
+
+  def initialize(reporting_service: GoogleAnalyticsService.new.client, date:)
+    self.date = date
+    self.reporting_service = reporting_service
+  end
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    paged_report_data
+      .lazy
+      .map(&:to_h)
+      .flat_map(&method(:extract_rows))
+      .map(&method(:extract_dimensions_and_metrics))
+      .map(&method(:append_data_labels))
+      .each { |report_data| yield report_data }
+  end
+
+private
+
+  attr_accessor :date, :reporting_service
+
+  def append_data_labels(values)
+    page_path, pageviews, unique_pageviews = *values
+
+    {
+      'ga:pagePath' => page_path,
+      'ga:pageviews' => pageviews,
+      'ga:uniquePageviews' => unique_pageviews,
+    }
+  end
+
+  def extract_dimensions_and_metrics(row)
+    dimensions = row.fetch(:dimensions)
+    metrics = row.fetch(:metrics).flat_map do |metric|
+      metric.fetch(:values).map(&:to_i)
+    end
+
+    dimensions + metrics
+  end
+
+  def extract_rows(report)
+    report.fetch(:rows)
+  end
+
+  def paged_report_data
+    @data ||= reporting_service.fetch_all(items: :data) do |page_token, service|
+      service
+        .batch_get_reports(
+          Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
+            report_requests: [report_request.merge(page_token: page_token)]
+          )
+        )
+        .reports
+        .first
+    end
+  end
+
+  def report_request
+    {
+      date_ranges: [
+        { start_date: date.to_s("%Y-%m-%d"), end_date: date.to_s("%Y-%m-%d") },
+      ],
+      dimensions: [
+        { name: 'ga:pagePath' },
+      ],
+      hide_totals: true,
+      hide_value_ranges: true,
+      metrics: [
+        { expression: 'ga:pageviews' },
+        { expression: 'ga:uniquePageviews' },
+      ],
+      page_size: 10_000,
+      view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+    }
+  end
+end

--- a/app/models/etl/google_analytics_report_data_transform.rb
+++ b/app/models/etl/google_analytics_report_data_transform.rb
@@ -1,0 +1,28 @@
+class ETL::GoogleAnalyticsReportDataTransform
+  def initialize(date_dimension:, item_dimension_scope: Dimensions::Item)
+    self.date_dimension = date_dimension
+    self.item_dimension_scope = item_dimension_scope
+  end
+
+  def process(report_row)
+    return unless (item_dimension_id = first_id_for_link(report_row['ga:pagePath']))
+
+    {
+      dimensions_date_id: date_dimension.id,
+      dimensions_item_id: item_dimension_id,
+      pageviews: report_row['ga:pageviews'],
+      unique_pageviews: report_row['ga:uniquePageviews'],
+    }
+  end
+
+private
+
+  attr_accessor :date_dimension, :item_dimension_scope
+
+  def first_id_for_link(link)
+    item_dimension_scope
+      .where(latest: true, link: link)
+      .pluck(:id)
+      .first
+  end
+end

--- a/app/services/google_analytics/client.rb
+++ b/app/services/google_analytics/client.rb
@@ -6,7 +6,7 @@ module GoogleAnalytics
     include Google::Apis::AnalyticsreportingV4
     include Google::Auth
 
-    def build(scope: "https://www.googleapis.com/auth/analytics.readonly")
+    def build(scope: AUTH_ANALYTICS_READONLY)
       @client ||= AnalyticsReportingService.new
       @client.authorization ||= ServiceAccountCredentials.make_creds(scope: scope)
       @client

--- a/db/migrate/20180206105803_add_unique_index_to_facts_metrics.rb
+++ b/db/migrate/20180206105803_add_unique_index_to_facts_metrics.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexToFactsMetrics < ActiveRecord::Migration[5.1]
+  def change
+    add_index :facts_metrics,
+              %i(dimensions_date_id dimensions_item_id),
+              name: 'index_facts_metrics_unique',
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180128183042) do
+ActiveRecord::Schema.define(version: 20180206105803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 20180128183042) do
     t.datetime "updated_at", null: false
     t.integer "pageviews"
     t.integer "unique_pageviews"
+    t.index ["dimensions_date_id", "dimensions_item_id"], name: "index_facts_metrics_unique", unique: true
     t.index ["dimensions_date_id"], name: "index_facts_metrics_on_dimensions_date_id"
     t.index ["dimensions_item_id"], name: "index_facts_metrics_on_dimensions_item_id"
     t.index ["dimensions_organisation_id"], name: "index_facts_metrics_on_dimensions_organisation_id"

--- a/spec/jobs/etl/google_analytics_report_data_job_spec.rb
+++ b/spec/jobs/etl/google_analytics_report_data_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ETL::GoogleAnalyticsReportDataJob, type: :job do
+  let(:year) { 2018 }
+  let(:month) { 1 }
+  let(:day) { 1 }
+
+  it { is_expected.to be_processed_in(:google_analytics) }
+
+  it 'enqueues a job with additional metadata' do
+    described_class.perform_async(year, month, day)
+
+    expect(described_class).to have_enqueued_sidekiq_job(
+      year, month, day, authenticated_user: nil, request_id: nil
+    )
+  end
+end

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -105,4 +105,39 @@ RSpec.describe Dimensions::Date, type: :model do
       )
     end
   end
+
+  describe '.for' do
+    subject { described_class.for(date) }
+
+    let(:date) { ::Date.new(2017, 12, 21) }
+    let(:date_dimension) { instance_double('Dimensions::Date') }
+
+    context 'when a dimension exists for the given date' do
+      before do
+        expect(described_class)
+          .to receive_message_chain('where.first') { date_dimension }
+      end
+
+      it 'should return the existing dimension' do
+        is_expected.to eq(date_dimension)
+      end
+    end
+
+    context 'when a dimension does not exist for the given date' do
+      before do
+        expect(described_class)
+          .to receive_message_chain('where.first') { nil }
+
+        expect(described_class)
+          .to receive(:build) { date_dimension }
+
+        expect(date_dimension)
+          .to receive(:save) { true }
+      end
+
+      it 'should return the newly created dimension' do
+        is_expected.to eq(date_dimension)
+      end
+    end
+  end
 end

--- a/spec/models/etl/dates_spec.rb
+++ b/spec/models/etl/dates_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe ETL::Dates do
-  it 'creates current date when no date exist' do
+  it 'creates yesterdays date when no date exist' do
     ETL::Dates.process
 
     expect(Dimensions::Date.count).to eq(1)
-    expect(Dimensions::Date.first.date).to eq(Date.today)
+    expect(Dimensions::Date.first.date).to eq(Date.yesterday)
   end
 
   it 'does not create duplicates' do

--- a/spec/models/etl/google_analytics_report_data_destination_spec.rb
+++ b/spec/models/etl/google_analytics_report_data_destination_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe ETL::GoogleAnalyticsReportDataDestination do
+  subject(:destination) { described_class.new }
+
+  let(:date_dimension) { create(:dimensions_date) }
+  let(:item_dimensions) { create_list(:dimensions_item, 2) }
+
+  context 'writing new facts to the metric fact table' do
+    subject do
+      destination.write(dimensions_date_id: date_dimension.id,
+                        dimensions_item_id: item_dimensions.first.id,
+                        pageviews: 10,
+                        unique_pageviews: 5)
+
+      destination.write(dimensions_date_id: date_dimension.id,
+                        dimensions_item_id: item_dimensions.second.id,
+                        pageviews: 20,
+                        unique_pageviews: 5)
+    end
+
+    it 'imports the values into the metric fact table' do
+      expect { subject }.to change { Facts::Metric.count }.from(0).to(2)
+    end
+  end
+
+  context 'updating existing facts in the metric fact table' do
+    let!(:existing_fact) do
+      create(:facts_metric,
+             dimensions_date: date_dimension,
+             dimensions_item: item_dimensions.first,
+             pageviews: 1,
+             unique_pageviews: 1)
+    end
+
+    subject do
+      destination.write(dimensions_date_id: date_dimension.id,
+                        dimensions_item_id: item_dimensions.first.id,
+                        pageviews: 50,
+                        unique_pageviews: 20)
+
+      destination.write(dimensions_date_id: date_dimension.id,
+                        dimensions_item_id: item_dimensions.second.id,
+                        pageviews: 9,
+                        unique_pageviews: 3)
+    end
+
+    it 'imports the values into the metric fact table' do
+      expect { subject }
+        .to change { Facts::Metric.count }.from(1).to(2)
+
+      expect(existing_fact.reload)
+        .to have_attributes(pageviews: 50, unique_pageviews: 20)
+    end
+  end
+end

--- a/spec/models/etl/google_analytics_report_data_source_spec.rb
+++ b/spec/models/etl/google_analytics_report_data_source_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe ETL::GoogleAnalyticsReportDataSource do
+  subject(:source) do
+    described_class.new(
+      reporting_service: reporting_service,
+      date: Date.today,
+    )
+  end
+
+  let(:reporting_service) do
+    instance_double(
+      'Google::Apis::AnalyticsreportingV4::AnalyticsReportingService'
+    )
+  end
+
+  describe '#each' do
+    before do
+      allow(reporting_service).to receive(:fetch_all) do
+        [
+          build_report_data(
+            build_report_row(dimensions: %w(/foo), metrics: %w(1 1))
+          ),
+          build_report_data(
+            build_report_row(dimensions: %w(/bar), metrics: %w(2 2))
+          ),
+        ]
+      end
+    end
+
+    context 'when called without a block' do
+      subject { source.each }
+
+      it { is_expected.to be_a_kind_of(Enumerator) }
+    end
+
+    context 'when called with a block' do
+      it 'should yield successive report data' do
+        expected_report_data = [
+          a_hash_including(
+            'ga:pagePath' => '/foo',
+            'ga:pageviews' => 1,
+            'ga:uniquePageviews' => 1
+          ),
+          a_hash_including(
+            'ga:pagePath' => '/bar',
+            'ga:pageviews' => 2,
+            'ga:uniquePageviews' => 2
+          ),
+        ]
+
+        expect { |probe| source.each(&probe) }
+          .to yield_successive_args(*expected_report_data)
+      end
+    end
+  end
+
+private
+
+  def build_report_data(*report_rows)
+    Google::Apis::AnalyticsreportingV4::ReportData.new(rows: report_rows)
+  end
+
+  def build_report_row(dimensions:, metrics:)
+    Google::Apis::AnalyticsreportingV4::ReportRow.new(
+      dimensions: dimensions,
+      metrics: metrics.map do |metric|
+        Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
+          values: Array(metric)
+        )
+      end
+    )
+  end
+end

--- a/spec/models/etl/google_analytics_report_data_transform_spec.rb
+++ b/spec/models/etl/google_analytics_report_data_transform_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ETL::GoogleAnalyticsReportDataTransform do
+  subject(:transform) do
+    described_class.new(
+      date_dimension: date_dimension,
+      item_dimension_scope: item_dimension_scope
+    )
+  end
+
+  let(:date_dimension) { create(:dimensions_date) }
+  let(:item_dimension) { create(:dimensions_item) }
+  let(:item_dimension_scope) { class_double('Dimensions::Item') }
+
+  describe '#process' do
+    subject do
+      transform.process(
+        'ga:pagePath' => page_path,
+        'ga:pageviews' => pageviews,
+        'ga:uniquePageviews' => unique_pageviews
+      )
+    end
+
+    let(:page_path) { double }
+    let(:pageviews) { double }
+    let(:unique_pageviews) { double }
+
+    context 'when an item dimension exists matching the ga:pagePath' do
+      before do
+        expect(item_dimension_scope)
+          .to receive_message_chain('where.pluck.first') { item_dimension.id }
+      end
+
+      it 'transforms the report row into values that can be imported' do
+        is_expected.to include(dimensions_date_id: date_dimension.id,
+                               dimensions_item_id: item_dimension.id,
+                               pageviews: pageviews,
+                               unique_pageviews: unique_pageviews)
+      end
+    end
+
+    context 'when no item dimension exists matching the ga:pagePath' do
+      let(:item_dimension) { nil }
+
+      before do
+        expect(item_dimension_scope)
+          .to receive_message_chain('where.pluck.first') { nil }
+      end
+
+      it 'should discard the report row' do
+        is_expected.to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/etl/metrics_spec.rb
+++ b/spec/models/etl/metrics_spec.rb
@@ -4,7 +4,7 @@ require 'gds-api-adapters'
 RSpec.describe ETL::Metrics do
   subject { described_class }
 
-  let!(:date) { Dimensions::Date.build(Date.today) }
+  let!(:date) { Dimensions::Date.build(Date.yesterday) }
 
   let(:organisation) { create(:dimensions_organisation, content_id: 'id1') }
 

--- a/spec/models/etl/metrics_spec.rb
+++ b/spec/models/etl/metrics_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ETL::Metrics do
       create :dimensions_item, latest: true, organisation_id: 'id1'
       create :dimensions_item, latest: true, organisation_id: 'id1'
     end
+    allow(ETL::GoogleAnalyticsReportDataJob).to receive(:perform_async)
     allow(ETL::Organisations).to receive(:process).and_return([organisation])
 
     subject.process
@@ -21,6 +22,7 @@ RSpec.describe ETL::Metrics do
   end
 
   it 'does not duplicate facts' do
+    allow(ETL::GoogleAnalyticsReportDataJob).to receive(:perform_async)
     allow(ETL::Organisations).to receive(:process).and_return([organisation])
     expect(ETL::Items).to receive(:process).twice do
       Dimensions::Item.update(latest: false)
@@ -34,6 +36,7 @@ RSpec.describe ETL::Metrics do
   end
 
   it 'does not raise an exception if the content item has no organisation' do
+    allow(ETL::GoogleAnalyticsReportDataJob).to receive(:perform_async)
     allow(ETL::Organisations).to receive(:process).and_return([organisation])
     expect(ETL::Items).to receive(:process) do
       create :dimensions_item, latest: true, organisation_id: nil
@@ -45,6 +48,7 @@ RSpec.describe ETL::Metrics do
   end
 
   it 'creates a metrics fact with the associated dimensions' do
+    allow(ETL::GoogleAnalyticsReportDataJob).to receive(:perform_async)
     allow(ETL::Organisations).to receive(:process).and_return([organisation])
     expect(ETL::Items).to receive(:process) do
       create(:dimensions_item, organisation_id: 'id1', latest: true, content_id: 'cid1')
@@ -60,6 +64,8 @@ RSpec.describe ETL::Metrics do
   end
 
   it 'creates multiple items for multiple organisations' do
+    allow(ETL::GoogleAnalyticsReportDataJob).to receive(:perform_async)
+
     expect(ETL::Items).to receive(:process) do
       create(:dimensions_item, organisation_id: 'id1', latest: true, content_id: 'cid1')
       create(:dimensions_item, organisation_id: 'id2', latest: true, content_id: 'cid2')


### PR DESCRIPTION
This implements an ETL pipeline for Google Analytics report data. The pipeline will populate the metrics fact table with pageview and unique pageview metrics for a given day.

The Google Analytics Reporting API restricts us to 10,000 requests per day. Each request can return a maximum of 10,000 data points.

Only a subset of the GOV.UK content is actually viewed everyday by someone, so fetching all the metrics for a given day is more economical than making more computationally expensive queries to the API with constraints for know content item dimensions. At the time of writing we should be able to import a days worth of data by utilising ~15 requests.

A "source" class returns an enumerable collection that can be traversed, searched, filtered etc as part of a pipelines of steps.

A "transform" class filters out any rows where we don't have a latest content item dimension matching the page path and returns a set of attributes suitable for importing into the fact table.

A "destination" class updates the fact table.

Closes #476 