### PR TITLE
Fix loading JSON from Content Store with Job

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -1,6 +1,10 @@
 class Importers::ContentDetails
   attr_reader :items_service, :content_id, :base_path
 
+  def self.run(*args)
+    new(*args).run
+  end
+
   def initialize(content_id, base_path)
     @content_id = content_id
     @base_path = base_path

--- a/app/jobs/import_content_details_job.rb
+++ b/app/jobs/import_content_details_job.rb
@@ -1,0 +1,7 @@
+class ImportContentDetailsJob < ApplicationJob
+  sidekiq_options queue: 'publishing_api'
+
+  def run(*args)
+    Importers::ContentDetails.run(*args)
+  end
+end

--- a/app/models/etl/items.rb
+++ b/app/models/etl/items.rb
@@ -35,7 +35,7 @@ private
 
   def create_import_detail_job(items)
     items.each do |item|
-      ImportItemJob.perform_async(item[:content_id], item[:base_path])
+      ImportContentDetailsJob.perform_async(item[:content_id], item[:base_path])
     end
   end
 end

--- a/spec/models/etl/items_spec.rb
+++ b/spec/models/etl/items_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ETL::Items do
 
   before :each do
     publishing_api_get_editions(content_items, fields: fields, per_page: 700, states: ['published'])
-    allow(ImportItemJob).to receive(:perform_async)
+    allow(ImportContentDetailsJob).to receive(:perform_async)
     subject.process
   end
 
@@ -42,7 +42,7 @@ RSpec.describe ETL::Items do
   end
 
   it 'creates a ImportItemJob for each item' do
-    expect(ImportItemJob).to have_received(:perform_async).with('abc123', '/abc')
-    expect(ImportItemJob).to have_received(:perform_async).with('xyz789', '/xyz')
+    expect(ImportContentDetailsJob).to have_received(:perform_async).with('abc123', '/abc')
+    expect(ImportContentDetailsJob).to have_received(:perform_async).with('xyz789', '/xyz')
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/oQhjeCza/40-3-content-items-store-json-in-the-content-item)

It seems that in #482 the jobs that are created to retrieve the JSON
are not the right ones. ETL::Items was calling `ImportItemJob` when it 
should be invoking `ImportContentDetailsJob`