### PR TITLE
Add audits redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   get '/api/v1/metrics/:content_id', to: "metrics#show"
 
+  get '/audits', to: redirect(Plek.find('content-audit-tool', status: 302))
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end

--- a/spec/requests/routing/redirect_audits_route_spec.rb
+++ b/spec/requests/routing/redirect_audits_route_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe "/audits", type: :request do
+  describe "audits" do
+    it "redirects to the Content Audit Tool" do
+      get "/audits"
+      expect(response).to redirect_to(Plek.find("content-audit-tool"))
+    end
+  end
+end


### PR DESCRIPTION
The route `/audits` was where the Audit Tool used to live in the Content Performance Manager. This now lives as its own service, so we need to redirect users to the correct location.

Have added a request spec as [redirects do not work with routing specs](https://stackoverflow.com/questions/10842448/do-routing-specs-support-redirect-routes-rspec/10844398#10844398).