### PR TITLE
Store content v2

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -1,3 +1,55 @@
+require 'json'
+
 class Dimensions::Item < ApplicationRecord
   validates :content_id, presence: true
+
+  def get_content
+    json_object = JSON.parse(self.raw_json)
+    return if json_object.blank?
+    extract_by_schema_type(json_object)
+  end
+
+private
+
+  VALID_SCHEMA_TYPES = %w[
+    answer
+    case_study
+    consultation
+    corporate_information_page
+    detailed_guide
+    document_collection
+    fatality_notice
+    help
+    hmrc_manual_section
+    html_publication
+    manual
+    manual_section
+    news_article
+    publication
+    service_manual_guide
+    simple_smart_answer
+    specialist_document
+    speech
+    statistical_data_set
+    take_part
+    topical_event_about_page
+    working_group
+    world_location_news_article
+  ].freeze
+
+  def extract_by_schema_type(json)
+    schema = json.dig("schema_name")
+
+    if schema.nil? || !VALID_SCHEMA_TYPES.include?(schema)
+      raise InvalidSchemaError, "Schema does not exist"
+    end
+
+    html = json.dig("details", "body")
+    return if html.nil?
+    html.delete!("\n")
+    Nokogiri::HTML.parse(html).text
+  end
+end
+
+class InvalidSchemaError < StandardError;
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -112,6 +112,7 @@ FactoryBot.define do
     sequence(:title) { |i| "title - #{i}" }
     sequence(:base_path) { |i| "link - #{i}" }
     sequence(:description) { |i| "description - #{i}" }
+    sequence(:raw_json) { |i| "json - #{i}" }
     number_of_pdfs 0
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -1,5 +1,66 @@
 require 'rails_helper'
 
 RSpec.describe Dimensions::Item, type: :model do
+  let(:test_json) do
+    {
+      schema_name: "answer",
+      details: {
+        body: "This is a test"
+      }
+    }.to_json
+  end
+
   it { is_expected.to validate_presence_of(:content_id) }
+
+  describe "#get_content" do
+    it "returns nil if json is empty" do
+      item = create(:dimensions_item, raw_json: {}.to_json)
+      expect(item.get_content).to eq(nil)
+    end
+
+    context "when valid schema" do
+      it "returns content json if details.body exists" do
+        json = build_raw_json(body: 'the-body')
+
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq('the-body')
+      end
+
+      it "returns nil if details.body does NOT exist" do
+        valid_schema_json = { schema_name: "answer", details: {} }.to_json
+        item = create(:dimensions_item, raw_json: valid_schema_json)
+        expect(item.get_content).to eq(nil)
+      end
+
+      it "does not fail with unicode characters" do
+        json = build_raw_json(body: %{\u003cdiv class="govspeak"\u003e\u003cp\u003eLorem ipsum dolor sit amet.})
+
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Lorem ipsum dolor sit amet.")
+      end
+
+      def build_raw_json(body:)
+        {
+          schema_name: :detailed_guide,
+          details: {
+            body: body
+          }
+        }.to_json
+      end
+    end
+
+    context "when invalid schema" do
+      it "raise InvalidSchemaError if json schema_name is not known" do
+        no_schema_json = { schema_name: "blah" }.to_json
+        item = create(:dimensions_item, raw_json: no_schema_json)
+        expect { item.get_content }.to raise_error(InvalidSchemaError)
+      end
+
+      it "raises InvalidSchemaError if non-empty json does not have a schema_name" do
+        invalid_schema = { document_type: "answer" }.to_json
+        item = create(:dimensions_item, raw_json: invalid_schema)
+        expect { item.get_content }.to raise_error(InvalidSchemaError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello card: Storing the content in the data warehouse over time](https://trello.com/c/qfMM7eeb/73-3-storing-the-content-in-the-data-warehouse-over-time)

The are a number of different Content Schema Types and the page content for each of these types are stored in different ways. Around a third of these Content Schema Types store the page contents in the JSON details.body element. The is the focus of this pull request. 

Based on the work done on [Trello card:  Spike: Extract content from Content Item's JSON](https://trello.com/c/CkT8R7Mg/31-3-spike-extract-content-from-content-items-json) a list of the content schema types that store the page contents in details.body was generated. This is represented as a constant array (VALID_SCHEMA_TYPES) in app/models/dimensions/item.rb

The page contents are extracted from the Content Item’s JSON if the schema_name is in the VALID_SCHEMA_TYPES array.