### PR TITLE
Decrease pagesize when querying Content Items in Publishing-API

### DIFF
--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -2,7 +2,7 @@ require 'gds_api/publishing_api_v2'
 
 module Clients
   class PublishingAPI
-    PER_PAGE = 700
+    PER_PAGE = 350
 
     attr_accessor :publishing_api, :per_page
 
@@ -12,7 +12,7 @@ module Clients
         disable_cache: true,
         bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
       )
-      @per_page = 700
+      @per_page = 350
     end
 
     def fetch_all(fields)

--- a/spec/models/etl/items_spec.rb
+++ b/spec/models/etl/items_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ETL::Items do
   end
 
   before :each do
-    publishing_api_get_editions(content_items, fields: fields, per_page: 700, states: ['published'])
+    publishing_api_get_editions(content_items, fields: fields, per_page: 350, states: ['published'])
     allow(ImportContentDetailsJob).to receive(:perform_async)
     subject.process
   end

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Clients::PublishingAPI do
 
   describe "#all_content_items" do
     describe "multiple pages of 'en' content items" do
-      let(:page_size) { 700 }
+      let(:page_size) { 350 }
 
       let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/OjqLlwoS/107-2-fix-timeout-issue-with-publishing-api)

We are getting Timeout errors when we iterate through the
Publishing-API to retrieve the list of Content Items[1]

I am decreasing the page_size as we don't have performance
restrictions and seems to fix the problem.

[1]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_all_content_items/184/