### PR TITLE
Number of pdfs

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -13,7 +13,8 @@ class Importers::ContentDetails
 
   def run
     response = items_service.fetch_raw_json(base_path)
+    number_of_pdfs = Performance::Metrics::NumberOfPdfs.parse(response.to_h['details'])
     item = Dimensions::Item.find_by(content_id: content_id, latest: true)
-    item.update_attributes(raw_json: response)
+    item.update_attributes(raw_json: response, number_of_pdfs: number_of_pdfs)
   end
 end

--- a/app/domain/performance/metrics/number_of_pdfs.rb
+++ b/app/domain/performance/metrics/number_of_pdfs.rb
@@ -13,5 +13,11 @@ module Performance::Metrics
       documents = NumberOfFiles.parse documents_string
       { number_of_pdfs: NumberOfFiles.number_of_files(documents, PDF_XPATH) }
     end
+
+    def self.parse(details)
+      documents_string = NumberOfFiles.extract_documents(details)
+      documents = NumberOfFiles.parse documents_string
+      NumberOfFiles.number_of_files(documents, PDF_XPATH)
+    end
   end
 end

--- a/db/migrate/20180214145821_add_number_of_pdfs_to_dimensions_items.rb
+++ b/db/migrate/20180214145821_add_number_of_pdfs_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddNumberOfPdfsToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :number_of_pdfs, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180210231645) do
+ActiveRecord::Schema.define(version: 20180214145821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,22 +58,23 @@ ActiveRecord::Schema.define(version: 20180210231645) do
 
   create_table "dimensions_items", force: :cascade do |t|
     t.string "content_id"
-    t.string "title"
-    t.string "base_path"
-    t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "latest"
+    t.string "description"
+    t.string "title"
+    t.string "base_path"
     t.json "raw_json"
+    t.integer "number_of_pdfs"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest"
     t.index ["latest", "base_path"], name: "index_dimensions_items_on_latest_and_base_path"
   end
 
   create_table "dimensions_items_temps", id: false, force: :cascade do |t|
     t.string "content_id"
+    t.string "description"
     t.string "title"
     t.string "base_path"
-    t.string "description"
   end
 
   create_table "events_gas", force: :cascade do |t|

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -23,5 +23,13 @@ RSpec.describe Importers::ContentDetails do
       expect(latest_dimension_item.reload.raw_json).to eq content_store_response
       expect(older_dimension_item.reload.raw_json).to eq nil
     end
+
+    it 'stores the number of PDF attachments' do
+      allow(subject.items_service).to receive(:fetch_raw_json).and_return({'details' => :the_details})
+      allow(Performance::Metrics::NumberOfPdfs).to receive(:parse).with(:the_details).and_return(99)
+
+      subject.run
+      expect(latest_dimension_item.reload.number_of_pdfs).to eq 99
+    end
   end
 end

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -1,32 +1,26 @@
-require 'gds_api/test_helpers/content_store'
-
 RSpec.describe Importers::ContentDetails do
-  include GdsApi::TestHelpers::ContentStore
+  let(:base_path) { '/base_path' }
+  let(:content_id) { 'content_id' }
 
-  subject { Importers::ContentDetails.new(latest_dimension_item.content_id, latest_dimension_item.base_path) }
+  subject { Importers::ContentDetails.new(content_id, base_path) }
 
   context 'Import contents' do
-    let(:base_path) { '/base_path' }
-    let(:latest_dimension_item) { create(:dimensions_item, latest: true, raw_json: nil) }
-    let(:older_dimension_item) do
-      create(:dimensions_item, content_id: latest_dimension_item.content_id,
-                               base_path: latest_dimension_item.base_path,
-                               latest: false,
-                               raw_json: nil)
+    let!(:latest_dimension_item) { create(:dimensions_item, content_id: content_id, base_path: base_path, latest: true, raw_json: nil) }
+    let!(:older_dimension_item) { create(:dimensions_item, content_id: content_id, base_path: base_path, latest: false, raw_json: nil) }
+
+    before do
+      allow(subject.items_service).to receive(:fetch_raw_json).and_return('details' => 'the-json')
     end
-    let(:content_store_response) { content_item_for_base_path(base_path) }
 
     it 'populates raw_json field of latest version of dimensions_items' do
-      allow(subject.items_service).to receive(:fetch_raw_json)
-      .and_return(content_store_response)
       subject.run
-      expect(latest_dimension_item.reload.raw_json).to eq content_store_response
+
+      expect(latest_dimension_item.reload.raw_json).to eq 'details' => 'the-json'
       expect(older_dimension_item.reload.raw_json).to eq nil
     end
 
     it 'stores the number of PDF attachments' do
-      allow(subject.items_service).to receive(:fetch_raw_json).and_return({'details' => :the_details})
-      allow(Performance::Metrics::NumberOfPdfs).to receive(:parse).with(:the_details).and_return(99)
+      allow(Performance::Metrics::NumberOfPdfs).to receive(:parse).with('the-json').and_return(99)
 
       subject.run
       expect(latest_dimension_item.reload.number_of_pdfs).to eq 99

--- a/spec/domain/performance/metrics/number_of_pdfs_spec.rb
+++ b/spec/domain/performance/metrics/number_of_pdfs_spec.rb
@@ -1,5 +1,7 @@
+require 'gds_api/test_helpers/content_store'
 module Performance
   RSpec.describe Metrics::NumberOfPdfs do
+    include GdsApi::TestHelpers::ContentStore
     subject { Metrics::NumberOfPdfs }
 
     let(:content_with_pdfs) {
@@ -24,21 +26,67 @@ module Performance
     }
     let(:content_without_document_keys) { build(:content_item, details: {}) }
     let(:content_without_details_key) { build(:content_item) }
+    let(:response_without_document_keys) do
+      {
+        details: {}
+      }.to_json
+    end
+    let(:response_without_details_key) do
+      {}.to_json
+    end
+    let(:content_store_response) { content_item_for_base_path('/base_path') }
 
-    it "returns the number of pdfs present" do
-      expect(subject.new(content_with_pdfs).run).to eq(number_of_pdfs: 3)
+
+    def response_with_document_key(document = nil)
+      {
+        details: {
+          document: document
+        }
+      }.to_json
     end
 
-    it "returns 0 if no pdfs are present" do
-      expect(subject.new(content_without_pdfs).run).to eq(number_of_pdfs: 0)
+    context "#run" do
+      it "returns the number of pdfs present" do
+        expect(subject.new(content_with_pdfs).run).to eq(number_of_pdfs: 3)
+      end
+
+      it "returns 0 if no pdfs are present" do
+        expect(subject.new(content_without_pdfs).run).to eq(number_of_pdfs: 0)
+      end
+
+      it "returns 0 if no document keys are present" do
+        expect(subject.new(content_without_document_keys).run).to eq(number_of_pdfs: 0)
+      end
+
+      it "returns 0 if the 'details' key is not present" do
+        expect(subject.new(content_without_details_key).run).to eq(number_of_pdfs: 0)
+      end
     end
 
-    it "returns 0 if no document keys are present" do
-      expect(subject.new(content_without_document_keys).run).to eq(number_of_pdfs: 0)
-    end
+    context "#parse" do
+      it "returns the number of pdfs present" do
+        details = {
+          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>'
+        }
 
-    it "returns 0 if the 'details' key is not present" do
-      expect(subject.new(content_without_details_key).run).to eq(number_of_pdfs: 0)
+        expect(subject.parse(details)).to eq(1)
+      end
+
+      it "returns 0 if no pdfs are present" do
+        details = {
+          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>'
+        }
+
+        expect(subject.parse(details)).to eq(0)
+      end
+
+      it "returns 0 if no document keys are present" do
+        expect(subject.parse({})).to eq(0)
+      end
+
+      it "returns 0 if the details is nil" do
+        expect(subject.parse({})).to eq(0)
+      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -112,6 +112,7 @@ FactoryBot.define do
     sequence(:title) { |i| "title - #{i}" }
     sequence(:base_path) { |i| "link - #{i}" }
     sequence(:description) { |i| "description - #{i}" }
+    number_of_pdfs 0
   end
 
   factory :facts_metric, class: Facts::Metric do


### PR DESCRIPTION
Populate number_of_pdfs from the content_store api response at the same stage
at which we populate the raw json field for dimensions_items.

Add a `run_for_api_response` method as to metrics/number_of_pdfs.rb as we need
to keep the previous `run` method for legacy cpm.