### PR TITLE
Revert Launching Publishing Api Consumer

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 publishing-api-worker: bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
 google-analytics-worker: bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
-publishing-api-consumer: bundle exec rake publishing_api:consumer
+# publishing-api-consumer: bundle exec rake publishing_api:consumer
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}


### PR DESCRIPTION
We need to avoid launching the publishing Api consumer in content performance manager.

This is because we can't work out how to set up the credentials for RabbitMQ beyond integration.

This was required for [Subscribe to content Changes in Publishing-API](https://trello.com/c/D1ht9Mb5/94-3-subscribe-to-content-changes-in-publishing-api)