### PR TITLE
Update the Content Items Dimension On Publishing-api Events.

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -24,6 +24,10 @@ class Dimensions::Item < ApplicationRecord
     update_attributes!(dirty: true)
   end
 
+  def gone!
+    update_attributes(status: 'gone')
+  end
+
   def self.create_empty(content_id, base_path)
     create(
       content_id: content_id,

--- a/bin/yarn
+++ b/bin/yarn
@@ -4,8 +4,8 @@ Dir.chdir(VENDOR_PATH) do
   begin
     exec "yarnpkg #{ARGV.join(' ')}"
   rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn "Yarn executable was not detected in the system."
+    warn "Download Yarn at https://yarnpkg.com/en/docs/install"
     exit 1
   end
 end

--- a/db/migrate/20180216114348_add_dirty_to_dimension_items.rb
+++ b/db/migrate/20180216114348_add_dirty_to_dimension_items.rb
@@ -1,0 +1,5 @@
+class AddDirtyToDimensionItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :dirty, :boolean, default: false
+  end
+end

--- a/db/migrate/20180221151608_add_status_to_dimensions_items.rb
+++ b/db/migrate/20180221151608_add_status_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :status, :string, default: 'live'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,14 +58,15 @@ ActiveRecord::Schema.define(version: 20180220163110) do
 
   create_table "dimensions_items", force: :cascade do |t|
     t.string "content_id"
+    t.string "title"
+    t.string "base_path"
+    t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "latest"
-    t.string "description"
-    t.string "title"
-    t.string "base_path"
     t.json "raw_json"
     t.integer "number_of_pdfs"
+    t.boolean "dirty", default: false
     t.string "document_type"
     t.string "content_purpose_supertype"
     t.datetime "first_published_at"
@@ -77,9 +78,9 @@ ActiveRecord::Schema.define(version: 20180220163110) do
 
   create_table "dimensions_items_temps", id: false, force: :cascade do |t|
     t.string "content_id"
-    t.string "description"
     t.string "title"
     t.string "base_path"
+    t.string "description"
   end
 
   create_table "events_gas", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220163110) do
+ActiveRecord::Schema.define(version: 20180221151608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20180220163110) do
     t.datetime "public_updated_at"
     t.integer "number_of_word_files"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest"
+    t.string "status", default: "live"
     t.index ["latest", "base_path"], name: "index_dimensions_items_on_latest_and_base_path"
   end
 

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -5,11 +5,18 @@ class PublishingApiConsumer
 
     item = Dimensions::Item.find_by(content_id: content_id, latest: true)
     if item
-      item.dirty!
+      handle_existing(item, message.delivery_info.routing_key)
     else
       Dimensions::Item.create_empty(content_id, base_path)
     end
 
     message.ack
+  end
+
+private
+
+  def handle_existing(item, routing_key)
+    item.dirty!
+    item.gone! if routing_key.include? 'unpublished'
   end
 end

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -1,4 +1,4 @@
-class PublisingApiConsumer
+class PublishingApiConsumer
   def process(message)
     message.ack
     p "message received : #{message.payload}"

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -1,6 +1,15 @@
 class PublishingApiConsumer
   def process(message)
+    content_id = message.payload['content_id']
+    base_path = message.payload['base_path']
+
+    item = Dimensions::Item.find_by(content_id: content_id, latest: true)
+    if item
+      item.dirty!
+    else
+      Dimensions::Item.create_empty(content_id, base_path)
+    end
+
     message.ack
-    p "message received : #{message.payload}"
   end
 end

--- a/lib/tasks/publishing_api_consumer.rake
+++ b/lib/tasks/publishing_api_consumer.rake
@@ -4,7 +4,7 @@ namespace :publishing_api do
   task consumer: :environment do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "content_performance_manager",
-      processor: PublisingApiConsumer.new,
+      processor: PublishingApiConsumer.new,
       ).run
   end
 end

--- a/spec/lib/publishing_api_consumer_spec.rb
+++ b/spec/lib/publishing_api_consumer_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require 'publishing_api_consumer'
+require 'govuk_message_queue_consumer/test_helpers'
+
+RSpec.describe PublishingApiConsumer do
+  let(:subject) { described_class.new }
+
+  it_behaves_like 'a message queue processor'
+
+  context 'when the Dimensions::Item already exists' do
+    let(:latest_item) { create(:dimensions_item, latest: true, dirty: false) }
+
+    let(:older_item) do
+      create(:dimensions_item,
+        content_id: latest_item.content_id,
+        base_path: latest_item.base_path,
+        latest: false,
+        dirty: false)
+    end
+    let(:different_item) { create(:dimensions_item, latest: true, dirty: false) }
+    let(:base_path) { '/some/path/to' }
+    let(:payload) do
+      {
+        'base_path' => latest_item.base_path,
+        'content_id' => latest_item.content_id
+      }
+    end
+    let(:message) { double('message', payload: payload) }
+
+    before :each do
+      allow(message).to receive(:ack)
+      subject.process(message)
+    end
+
+    it 'updates the latest content item with a dirty flag' do
+      expect(latest_item.reload.dirty?).to be true
+      expect(older_item.reload.dirty?).to be false
+      expect(different_item.reload.dirty?).to be false
+    end
+
+    it "ack's the message" do
+      expect(message).to have_received(:ack)
+    end
+  end
+
+  context 'when the Dimensions::Item does not exist yet' do
+    let(:payload) do
+      {
+        'base_path' => '/path/to/new/content',
+        'content_id' => 'does-not-exist-yet',
+      }
+    end
+    let(:message) { double('message', payload: payload) }
+
+    before :each do
+      allow(message).to receive(:ack)
+      subject.process(message)
+    end
+
+    it 'creates a new item with the correct base path' do
+      item = Dimensions::Item.where(content_id: payload['content_id']).first
+
+      expect(item).to have_attributes(
+        base_path: payload['base_path'],
+        latest: true,
+        dirty: true,
+      )
+    end
+
+    it "ack's the message" do
+      expect(message).to have_received(:ack)
+    end
+  end
+end

--- a/spec/lib/publishing_api_consumer_spec.rb
+++ b/spec/lib/publishing_api_consumer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PublishingApiConsumer do
 
   it_behaves_like 'a message queue processor'
 
-  context 'when the Dimensions::Item already exists' do
+  context 'when the Dimensions::Item already exists - all events but unpublish' do
     let(:latest_item) { create(:dimensions_item, latest: true, dirty: false) }
 
     let(:older_item) do
@@ -25,7 +25,11 @@ RSpec.describe PublishingApiConsumer do
         'content_id' => latest_item.content_id
       }
     end
-    let(:message) { double('message', payload: payload) }
+    let(:message) do
+      double('message',
+        payload: payload,
+        delivery_info: double('del_info', routing_key: 'news_story.major'))
+    end
 
     before :each do
       allow(message).to receive(:ack)
@@ -36,6 +40,42 @@ RSpec.describe PublishingApiConsumer do
       expect(latest_item.reload.dirty?).to be true
       expect(older_item.reload.dirty?).to be false
       expect(different_item.reload.dirty?).to be false
+    end
+
+    it 'leaves the status as "live"' do
+      expect(latest_item.reload.status).to eq('live')
+    end
+
+    it "ack's the message" do
+      expect(message).to have_received(:ack)
+    end
+  end
+
+  context 'on an unpublish event' do
+    let(:latest_item) { create(:dimensions_item, latest: true, dirty: false) }
+    let(:payload) do
+      {
+        'base_path' => latest_item.base_path,
+        'content_id' => latest_item.content_id
+      }
+    end
+    let(:message) do
+      double('message',
+        payload: payload,
+        delivery_info: double('del_info', routing_key: 'gone.unpublished'))
+    end
+
+    before :each do
+      allow(message).to receive(:ack)
+      subject.process(message)
+    end
+
+    it 'updates the latest content item with a dirty flag' do
+      expect(latest_item.reload.dirty?).to be true
+    end
+
+    it 'sets the status to "gone"' do
+      expect(latest_item.reload.status).to eq('gone')
     end
 
     it "ack's the message" do

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -73,10 +73,6 @@ RSpec.describe Dimensions::Item, type: :model do
     end
   end
 
-  describe '#dirty' do
-     # todo
-  end
-
   describe '#new_version!' do
     let(:dirty_item) { create(:dimensions_item, dirty: true, latest: true) }
 
@@ -104,6 +100,14 @@ RSpec.describe Dimensions::Item, type: :model do
       item = create(:dimensions_item, dirty: false)
       item.dirty!
       expect(item.reload.dirty?).to be true
+    end
+  end
+
+  describe '#gone!' do
+    it 'sets the status to "gone"' do
+      item = create(:dimensions_item, dirty: false)
+      item.gone!
+      expect(item.reload.status).to eq 'gone'
     end
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -63,4 +63,61 @@ RSpec.describe Dimensions::Item, type: :model do
       end
     end
   end
+
+  describe '.dirty' do
+    it 'only returns the dirty items' do
+      dirty_item = create(:dimensions_item, dirty: true)
+      create(:dimensions_item, dirty: false)
+
+      expect(Dimensions::Item.dirty).to match_array(dirty_item)
+    end
+  end
+
+  describe '#dirty' do
+     # todo
+  end
+
+  describe '#new_version!' do
+    let(:dirty_item) { create(:dimensions_item, dirty: true, latest: true) }
+
+    it 'duplicates the item with latest?: true, dirty?: false' do
+      new_item = dirty_item.new_version!
+
+      expect(new_item).to have_attributes(
+        latest: true,
+        dirty: false
+      )
+    end
+
+    it 'sets latest? and dirty? to false on the old item' do
+      dirty_item.new_version!
+
+      expect(dirty_item.reload).to have_attributes(
+        latest: false,
+        dirty: false
+      )
+    end
+  end
+
+  describe '#dirty!' do
+    it 'sets the dirty? flag to true' do
+      item = create(:dimensions_item, dirty: false)
+      item.dirty!
+      expect(item.reload.dirty?).to be true
+    end
+  end
+
+  describe '##create_empty' do
+    let(:content_id) { 'new-item' }
+    let(:base_path) { '/path/to/new-item' }
+    it 'creates a new item with the correct attributes' do
+      item = Dimensions::Item.create_empty content_id, base_path
+      expect(item.reload).to have_attributes(
+        content_id: content_id,
+        base_path: base_path,
+        dirty: true,
+        latest: true
+      )
+    end
+  end
 end

--- a/spec/models/etl/master_spec.rb
+++ b/spec/models/etl/master_spec.rb
@@ -51,4 +51,32 @@ RSpec.describe ETL::Master do
       dimensions_item: item,
     )
   end
+
+  context 'when dirty items are present' do
+    let(:content_id) { 'dirty1' }
+    let(:base_path) { '/the/base/path' }
+
+    before :each do
+      allow(ImportContentDetailsJob).to receive(:perform_async)
+      create(:dimensions_item,
+             latest:     true,
+             dirty:      true,
+             content_id: content_id,
+             base_path: base_path)
+      subject.process
+    end
+
+    it 'resets the dirty flag on the item' do
+      expect(Dimensions::Item.where(content_id: content_id, dirty: true).count).to eq(0)
+    end
+
+    it 'resets the latest flag on the old item' do
+      expect(Dimensions::Item.where(content_id: content_id, latest: true).count).to eq(1)
+      expect(Dimensions::Item.where(content_id: content_id, latest: false).count).to eq(1)
+    end
+
+    it 'fires a Sidekiq job for the new item' do
+      expect(ImportContentDetailsJob).to have_received(:perform_async).with(content_id, base_path)
+    end
+  end
 end


### PR DESCRIPTION
This is needed for the [Update the Content Items dimension on publishing-api events](https://trello.com/c/sxiYIvsf/72-3-update-the-content-items-dimension-on-publishing-api-events-depends-on-94) card.
Set dirty flag in Dimensions::Item on publishing api event when the item exists.
Create a new Dimensions::Item with dirty and latest flags set to true if it does not exist.

Duplicate content items dimension and fire Sidekiq job for items marked as dirty when
ETL::Master#process is run.

Does not handle unpublish events.