### PR TITLE
Number of word files

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -14,8 +14,9 @@ class Importers::ContentDetails
   def run
     response = items_service.fetch_raw_json(base_path)
     number_of_pdfs = Performance::Metrics::NumberOfPdfs.parse(response.to_h['details'])
+    number_of_word_files = Performance::Metrics::NumberOfWordFiles.parse(response.to_h['details'])
     metadata = format_metadata(response.to_h)
-    attributes =  metadata.merge(raw_json: response, number_of_pdfs: number_of_pdfs)
+    attributes =  metadata.merge(raw_json: response, number_of_pdfs: number_of_pdfs, number_of_word_files: number_of_word_files)
     item = Dimensions::Item.find_by(content_id: content_id, latest: true)
     item.update_attributes(attributes)
   end

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -13,10 +13,7 @@ class Importers::ContentDetails
 
   def run
     response = items_service.fetch_raw_json(base_path)
-    number_of_pdfs = Performance::Metrics::NumberOfPdfs.parse(response.to_h['details'])
-    number_of_word_files = Performance::Metrics::NumberOfWordFiles.parse(response.to_h['details'])
-    metadata = format_metadata(response.to_h)
-    attributes =  metadata.merge(raw_json: response, number_of_pdfs: number_of_pdfs, number_of_word_files: number_of_word_files)
+    attributes = format_response(response)
     item = Dimensions::Item.find_by(content_id: content_id, latest: true)
     item.update_attributes(attributes)
   end
@@ -34,7 +31,20 @@ private
     )
   end
 
-  def number_of_pdfs(formatted_response)
-    Performance::Metrics::NumberOfPdfs.parse(formatted_response['details'])
+  def format_response(response)
+    metadata = format_metadata(response.to_h)
+    metadata.merge(
+      raw_json: response,
+      number_of_pdfs: number_of_pdfs(response.to_h['details']),
+      number_of_word_files: number_of_word_files(response.to_h['details'])
+    )
+  end
+
+  def number_of_pdfs(response_details)
+    Performance::Metrics::NumberOfPdfs.parse(response_details)
+  end
+
+  def number_of_word_files(response_details)
+    Performance::Metrics::NumberOfWordFiles.parse(response_details)
   end
 end

--- a/app/domain/performance/metrics/number_of_word_files.rb
+++ b/app/domain/performance/metrics/number_of_word_files.rb
@@ -13,5 +13,11 @@ module Performance::Metrics
       documents = NumberOfFiles.parse documents_string
       { number_of_word_files: NumberOfFiles.number_of_files(documents, DOC_XPATH) }
     end
+
+    def self.parse(details)
+      documents_string = NumberOfFiles.extract_documents(details)
+      documents = NumberOfFiles.parse documents_string
+      NumberOfFiles.number_of_files(documents, DOC_XPATH)
+    end
   end
 end

--- a/db/migrate/20180220163110_add_number_of_word_files_to_dimensions_item.rb
+++ b/db/migrate/20180220163110_add_number_of_word_files_to_dimensions_item.rb
@@ -1,0 +1,5 @@
+class AddNumberOfWordFilesToDimensionsItem < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :number_of_word_files, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180219151742) do
+ActiveRecord::Schema.define(version: 20180220163110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20180219151742) do
     t.string "content_purpose_supertype"
     t.datetime "first_published_at"
     t.datetime "public_updated_at"
+    t.integer "number_of_word_files"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest"
     t.index ["latest", "base_path"], name: "index_dimensions_items_on_latest_and_base_path"
   end

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Importers::ContentDetails do
       expect(latest_dimension_item.reload.number_of_pdfs).to eq 99
     end
 
+    it 'stores the number of Word file attachments' do
+      allow(Performance::Metrics::NumberOfWordFiles).to receive(:parse).with('the-json').and_return(94)
+
+      subject.run
+      expect(latest_dimension_item.reload.number_of_word_files).to eq 94
+    end
+
     it 'populates the metadata' do
       allow(subject.items_service).to receive(:fetch_raw_json).and_return(
         'content_id' => '09hjasdfoj234',

--- a/spec/domain/performance/metrics/number_of_word_files_spec.rb
+++ b/spec/domain/performance/metrics/number_of_word_files_spec.rb
@@ -25,20 +25,48 @@ module Performance
     let(:content_without_document_keys) { build(:content_item, details: {}) }
     let(:content_without_details_key) { build(:content_item) }
 
-    it "returns the number of word files present" do
-      expect(subject.new(content_with_word_files).run).to eq(number_of_word_files: 3)
+    context "#run" do
+      it "returns the number of word files present" do
+        expect(subject.new(content_with_word_files).run).to eq(number_of_word_files: 3)
+      end
+
+      it "returns 0 if no pdfs are present" do
+        expect(subject.new(content_without_word_files).run).to eq(number_of_word_files: 0)
+      end
+
+      it "returns 0 if no document keys are present" do
+        expect(subject.new(content_without_document_keys).run).to eq(number_of_word_files: 0)
+      end
+
+      it "returns 0 if the 'details' key is not present" do
+        expect(subject.new(content_without_details_key).run).to eq(number_of_word_files: 0)
+      end
     end
 
-    it "returns 0 if no pdfs are present" do
-      expect(subject.new(content_without_word_files).run).to eq(number_of_word_files: 0)
-    end
+    context "#parse" do
+      it "returns the number of word files present" do
+        details = {
+          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.doc\">1</a>\n\n\n\n</div>'
+        }
 
-    it "returns 0 if no document keys are present" do
-      expect(subject.new(content_without_document_keys).run).to eq(number_of_word_files: 0)
-    end
+        expect(subject.parse(details)).to eq(1)
+      end
 
-    it "returns 0 if the 'details' key is not present" do
-      expect(subject.new(content_without_details_key).run).to eq(number_of_word_files: 0)
+      it "returns 0 if no word files are present" do
+        details = {
+          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>'
+        }
+
+        expect(subject.parse(details)).to eq(0)
+      end
+
+      it "returns 0 if no document keys are present" do
+        expect(subject.parse({})).to eq(0)
+      end
+
+      it "returns 0 if the details is nil" do
+        expect(subject.parse({})).to eq(0)
+      end
     end
   end
 end

--- a/spec/domain/performance/metrics/number_of_word_files_spec.rb
+++ b/spec/domain/performance/metrics/number_of_word_files_spec.rb
@@ -25,7 +25,7 @@ module Performance
     let(:content_without_document_keys) { build(:content_item, details: {}) }
     let(:content_without_details_key) { build(:content_item) }
 
-    context "#run" do
+    describe "#run" do
       it "returns the number of word files present" do
         expect(subject.new(content_with_word_files).run).to eq(number_of_word_files: 3)
       end
@@ -43,7 +43,7 @@ module Performance
       end
     end
 
-    context "#parse" do
+    describe "#parse" do
       it "returns the number of word files present" do
         details = {
           'documents' => '<div class=\"attachment-details\">\n<a href=\"link.doc\">1</a>\n\n\n\n</div>'


### PR DESCRIPTION
Populate number_of_word_files from the content_store api response at the same stage
at which we populate the raw json field for dimensions_items.

Very similar to this PR: https://github.com/alphagov/content-performance-manager/pull/503