### PR TITLE
Update ETL for GA: remove constraint for an specific day

### DIFF
--- a/app/models/etl/ga.rb
+++ b/app/models/etl/ga.rb
@@ -38,7 +38,8 @@ private
                unique_pageviews,
                dimensions_items.id
         FROM events_gas, dimensions_items
-        WHERE page_path = base_path 
+        WHERE page_path = base_path
+              AND events_gas.date = '#{date_to_s}'
       ) AS s
       WHERE dimensions_item_id = s.id AND dimensions_date_id = '#{date_to_s}'
     SQL

--- a/app/models/etl/ga.rb
+++ b/app/models/etl/ga.rb
@@ -38,7 +38,7 @@ private
                unique_pageviews,
                dimensions_items.id
         FROM events_gas, dimensions_items
-        WHERE page_path = base_path AND latest = 'true'
+        WHERE page_path = base_path 
       ) AS s
       WHERE dimensions_item_id = s.id AND dimensions_date_id = '#{date_to_s}'
     SQL
@@ -52,7 +52,6 @@ private
         page_path in (
            SELECT base_path
            FROM dimensions_items
-           WHERE latest = 'true'
         )
     SQL
   end

--- a/app/models/etl/ga.rb
+++ b/app/models/etl/ga.rb
@@ -52,7 +52,9 @@ private
       WHERE date = '#{date_to_s}' AND
         page_path in (
            SELECT base_path
-           FROM dimensions_items
+           FROM dimensions_items, facts_metrics
+           WHERE dimensions_items.id = facts_metrics.dimensions_item_id
+           AND facts_metrics.dimensions_date_id = '#{date_to_s}'
         )
     SQL
   end

--- a/spec/models/etl/ga_spec.rb
+++ b/spec/models/etl/ga_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe ETL::GA do
 
       expect(Events::GA.count).to eq(1)
     end
+
+    context 'when there are events from other days' do
+      before do
+        Events::GA.create(date: date - 1, page_path: '/path1', pageviews: 10, unique_pageviews: 20)
+        Events::GA.create(date: date - 2, page_path: '/path1', pageviews: 10, unique_pageviews: 20)
+      end
+
+      it 'only updates metrics for the current day' do
+        fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+        described_class.process(date: date)
+
+        expect(fact1.reload).to have_attributes(pageviews: 1, unique_pageviews: 1)
+      end
+    end
   end
 
 private

--- a/spec/models/etl/ga_spec.rb
+++ b/spec/models/etl/ga_spec.rb
@@ -4,8 +4,8 @@ require 'gds-api-adapters'
 RSpec.describe ETL::GA do
   subject { described_class }
 
-  let(:item1) { create :dimensions_item, base_path: '/path1', latest: true }
-  let(:item2) { create :dimensions_item, base_path: '/path2', latest: true }
+  let!(:item1) { create :dimensions_item, base_path: '/path1', latest: true }
+  let!(:item2) { create :dimensions_item, base_path: '/path2', latest: true }
 
   let(:date) { Date.new(2018, 2, 20) }
   let(:dimensions_date) { Dimensions::Date.for(date) }
@@ -62,6 +62,14 @@ RSpec.describe ETL::GA do
         described_class.process(date: date)
 
         expect(fact1.reload).to have_attributes(pageviews: 1, unique_pageviews: 1)
+      end
+
+      it 'only deletes the events for the current day that matches' do
+        create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+        described_class.process(date: date)
+
+        expect(Events::GA.count).to eq(3)
       end
     end
   end


### PR DESCRIPTION

We should have the flexibility to apply ETL for a given day.
This PR enables this functionality by removing the `latest=true`
constraint, and by adding filters to match the existing metric.