### PR TITLE
Use SQL for date ranges

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -6,7 +6,7 @@ class MetricsController < ApplicationController
       .joins(:dimensions_date)
       .joins(:dimensions_item)
       .where(dimensions_items: { content_id: content_id })
-      .where('dimensions_dates.date in (?)', from..to)
+      .where('dimensions_dates.date between ? and ?', from, to)
       .order('dimensions_dates.date asc')
       .group('dimensions_dates.date')
       .sum("facts_metrics.#{metric}")


### PR DESCRIPTION
The previous version of this query constructed a range in ruby and passed it to an `IN` clause.

This generates a massive query if you feed it a date range more than a couple of days apart, which will probably break.

It breaks at the moment because (to..from) is a range of strings, not dates, so the range `'2018-02-28'..'2018-03-01'` has a size of 74.

I'll revisit this as part of https://trello.com/c/K80isIdI/100-3-add-error-handling-to-api-endpoint