### PR TITLE
Force the API to always return JSON

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
 
   get '/audits', to: redirect(Plek.find('content-audit-tool', status: 302))
 
-  get '/api/v1/metrics/:content_id', to: "metrics#show"
+  scope '/api', defaults: { format: :json } do
+    get '/v1/metrics/:content_id', to: "metrics#show"
+  end
+
   get '/sandbox', to: 'sandbox#index'
 end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
         from: Date.new(2018, 1, 13),
         to: Date.new(2018, 1, 15),
       }
-      get '/api/v1/metrics/id1.json', params: query_params
+      get '/api/v1/metrics/id1', params: query_params
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(pageviews_response)


### PR DESCRIPTION
At the moment the API errors if you go to it in the browser,
because it tries to render an HTML template that doesn't exist.

Not sure if there's a cleaner way to do this in rails, but this
forces it to always use the JSON template and content type.