### PR TITLE
Add SSO to API endpoints

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,6 +1,4 @@
 class MetricsController < ApplicationController
-  skip_before_action :authenticate_user!
-
   before_action :validate_metric!
 
   def show

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 RSpec.describe '/api/v1/metrics/:content_id', type: :request do
+  before { create(:user) }
+
   context 'with valid parmeters' do
     it 'List a metric for a content item between two dates' do
       day1 = Dimensions::Date.build(Date.new(2018, 1, 13))


### PR DESCRIPTION
Only authorized users can test the API until a decision is finally made
about how we share the metrics collected by the Content Performance
Manager.