### PR TITLE
Decrease default range to 5 days.

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -9,7 +9,7 @@ class SandboxController < ApplicationController
 private
 
   def from
-    params[:from] ||= 1.month.ago.to_date
+    params[:from] ||= 5.days.ago.to_date
   end
 
   def to


### PR DESCRIPTION
The first query, as we are not filtering by organisations, takes too much
time. This will do the trick fro the time being as we have not pulled yet
the organisation from the JSON.