### PR TITLE
Drop unused indexes / tables

### DIFF
--- a/db/migrate/20180305111459_drop_unused_indexes_to_reduce_space.rb
+++ b/db/migrate/20180305111459_drop_unused_indexes_to_reduce_space.rb
@@ -1,0 +1,16 @@
+class DropUnusedIndexesToReduceSpace < ActiveRecord::Migration[5.1]
+  def change
+    # duplicated of [:dimensions_date_id, dimensions_item_id]
+    remove_index :facts_metrics, :dimensions_date_id
+
+    # This is no longer in used
+    remove_index :content_items, :title
+
+    # This index is no longer in use
+    remove_index :dimensions_dates, :date_name_abbreviated
+
+    # We don't need an index on both fields, only on `latest`
+    remove_index :dimensions_items, [:latest, :base_path]
+    add_index :dimensions_items, :latest
+  end
+end

--- a/db/migrate/20180305112605_remove_table_dimensions_items_temp.rb
+++ b/db/migrate/20180305112605_remove_table_dimensions_items_temp.rb
@@ -1,0 +1,11 @@
+class RemoveTableDimensionsItemsTemp < ActiveRecord::Migration[5.1]
+  def change
+     drop_table :dimensions_items_temps do |t|
+       t.string :content_id
+       t.string :title
+       t.string :link
+       t.string :description
+       t.string :organisation_id
+     end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226111742) do
+ActiveRecord::Schema.define(version: 20180305111459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 20180226111742) do
     t.string "locale", null: false
     t.integer "number_of_word_files", default: 0
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true
-    t.index ["title"], name: "index_content_items_on_title"
   end
 
   create_table "dimensions_dates", primary_key: "date", id: :date, force: :cascade do |t|
@@ -53,7 +52,6 @@ ActiveRecord::Schema.define(version: 20180226111742) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["date_name"], name: "index_dimensions_dates_on_date_name"
-    t.index ["date_name_abbreviated"], name: "index_dimensions_dates_on_date_name_abbreviated"
   end
 
   create_table "dimensions_items", force: :cascade do |t|
@@ -74,8 +72,7 @@ ActiveRecord::Schema.define(version: 20180226111742) do
     t.integer "number_of_word_files"
     t.boolean "dirty", default: false
     t.string "status", default: "live"
-    t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest"
-    t.index ["latest", "base_path"], name: "index_dimensions_items_on_latest_and_base_path"
+    t.index ["latest"], name: "index_dimensions_items_on_latest"
   end
 
   create_table "dimensions_items_temps", id: false, force: :cascade do |t|
@@ -111,7 +108,6 @@ ActiveRecord::Schema.define(version: 20180226111742) do
     t.integer "unique_pageviews", default: 0
     t.integer "number_of_issues", default: 0
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "index_facts_metrics_unique", unique: true
-    t.index ["dimensions_date_id"], name: "index_facts_metrics_on_dimensions_date_id"
     t.index ["dimensions_item_id"], name: "index_facts_metrics_on_dimensions_item_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305111459) do
+ActiveRecord::Schema.define(version: 20180305112605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,13 +73,6 @@ ActiveRecord::Schema.define(version: 20180305111459) do
     t.boolean "dirty", default: false
     t.string "status", default: "live"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
-  end
-
-  create_table "dimensions_items_temps", id: false, force: :cascade do |t|
-    t.string "content_id"
-    t.string "description"
-    t.string "title"
-    t.string "base_path"
   end
 
   create_table "events_feedexes", force: :cascade do |t|


### PR DESCRIPTION
Removes indexes and tables that are not longer needed.
[It will hopefully help to reduce the size of the database](https://graphite.publishing.service.gov.uk/render?from=-2weeks&until=now&width=400&height=250&target=postgresql-primary-1_backend.postgresql-content_performance_manager_production.pg_db_size&_uniq=0.3446563042075015&title=postgresql-primary-1_backend.postgresql-content_performance_manager_production.pg_db_size).

