### PR TITLE
Handle GdsApi::HTTPGone Exception

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -12,10 +12,12 @@ class Importers::ContentDetails
   end
 
   def run
+    item = Dimensions::Item.find_by(content_id: content_id, latest: true)
     response = items_service.fetch_raw_json(base_path)
     attributes = format_response(response)
-    item = Dimensions::Item.find_by(content_id: content_id, latest: true)
     item.update_attributes(attributes)
+  rescue GdsApi::HTTPGone
+    item.gone!
   end
 
 private

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -53,4 +53,18 @@ RSpec.describe Importers::ContentDetails do
       expect(latest_dimension_item.public_updated_at).to eq(Time.new.strftime('2015-06-03T11:13:44.000+00:00'))
     end
   end
+
+  context 'when items are gone' do
+    let!(:existing_content_item) { create :dimensions_item, content_id: content_id, status: 'something' }
+
+    before :each do
+      expect(subject.items_service).to receive(:fetch_raw_json).and_raise(GdsApi::HTTPGone.new(410))
+
+      subject.run
+    end
+
+    it 'should set the status to gone' do
+      expect(existing_content_item.reload.status).to eq('gone')
+    end
+  end
 end


### PR DESCRIPTION
We are seeing this exception in Sentry logs.
Set the status to 'gone' when we get this exception.