### PR TITLE
Import quality metrics through time

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -17,6 +17,7 @@ class Importers::ContentDetails
   def run
     item = Dimensions::Item.find_by(content_id: content_id, latest: true)
     item_raw_json = items_service.fetch_raw_json(base_path)
+    item.update_attributes(raw_json: item_raw_json)
     metadata = format_response(item_raw_json)
     item.update_attributes(metadata)
       # quality_metrics = content_quality_service.run(item.get_content)

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -16,12 +16,13 @@ class Importers::ContentDetails
 
   def run
     item = Dimensions::Item.find_by(content_id: content_id, latest: true)
+
     item_raw_json = items_service.fetch_raw_json(base_path)
-    item.update_attributes(raw_json: item_raw_json)
     metadata = format_response(item_raw_json)
-    item.update_attributes(metadata)
-      # quality_metrics = content_quality_service.run(item.get_content)
-      # item.update_attributes(metadata.merge(quality_metrics))
+    item.update_attributes(metadata.merge! raw_json: item_raw_json)
+
+    quality_metrics = content_quality_service.run(item.get_content)
+    item.update_attributes(quality_metrics)
   rescue GdsApi::HTTPGone
     item.gone!
   rescue GdsApi::HTTPNotFound

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -26,6 +26,8 @@ class Importers::ContentDetails
     item.gone!
   rescue GdsApi::HTTPNotFound
     do_nothing
+  rescue InvalidSchemaError
+    do_nothing
   end
 
 private

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -19,15 +19,12 @@ class Importers::ContentDetails
 
     item_raw_json = items_service.fetch_raw_json(base_path)
     metadata = format_response(item_raw_json)
-    item.update_attributes(metadata.merge! raw_json: item_raw_json)
+    item.update_attributes(metadata.merge!(raw_json: item_raw_json))
 
-    quality_metrics = content_quality_service.run(item.get_content)
-    item.update_attributes(quality_metrics)
+    ImportQualityMetricsJob.perform_async(item.id)
   rescue GdsApi::HTTPGone
     item.gone!
   rescue GdsApi::HTTPNotFound
-    do_nothing
-  rescue InvalidSchemaError
     do_nothing
   end
 

--- a/app/domain/importers/quality_metrics.rb
+++ b/app/domain/importers/quality_metrics.rb
@@ -1,0 +1,27 @@
+require 'odyssey'
+
+class Importers::QualityMetrics
+  attr_reader :content_quality_service, :item_id
+
+  def self.run(*args)
+    new(*args).run
+  end
+
+  def initialize(item_id)
+    @item_id = item_id
+    @content_quality_service = ContentQualityService.new
+  end
+
+  def run
+    item = Dimensions::Item.find(@item_id)
+
+    quality_metrics = content_quality_service.run(item.get_content)
+    item.update_attributes(quality_metrics)
+  rescue InvalidSchemaError
+    do_nothing
+  end
+
+private
+
+  def do_nothing; end
+end

--- a/app/jobs/import_quality_metrics_job.rb
+++ b/app/jobs/import_quality_metrics_job.rb
@@ -1,5 +1,5 @@
 class ImportQualityMetricsJob < ApplicationJob
-  sidekiq_options queue: 'publishing_api'
+  sidekiq_options queue: 'quality_metrics'
 
   def run(*args)
     Importers::QualityMetrics.run(*args)

--- a/app/jobs/import_quality_metrics_job.rb
+++ b/app/jobs/import_quality_metrics_job.rb
@@ -1,0 +1,7 @@
+class ImportQualityMetricsJob < ApplicationJob
+  sidekiq_options queue: 'publishing_api'
+
+  def run(*args)
+    Importers::QualityMetrics.run(*args)
+  end
+end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -9,7 +9,7 @@ class Dimensions::Item < ApplicationRecord
   end
 
   def get_content
-    json_object = JSON.parse(self.raw_json)
+    json_object = raw_json.to_h
     return if json_object.blank?
     extract_by_schema_type(json_object)
   end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -9,9 +9,8 @@ class Dimensions::Item < ApplicationRecord
   end
 
   def get_content
-    json_object = raw_json
-    return if json_object.blank?
-    extract_by_schema_type(json_object)
+    return if raw_json.blank?
+    extract_by_schema_type(raw_json)
   end
 
   def new_version

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -71,7 +71,7 @@ private
   def extract_by_schema_type(json)
     schema = json.dig("schema_name")
     if schema.nil? || !VALID_SCHEMA_TYPES.include?(schema)
-      raise InvalidSchemaError, "Schema does not exist"
+      raise InvalidSchemaError, "Schema does not exist: #{schema}"
     end
 
     case schema

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -9,7 +9,7 @@ class Dimensions::Item < ApplicationRecord
   end
 
   def get_content
-    json_object = raw_json.to_h
+    json_object = raw_json
     return if json_object.blank?
     extract_by_schema_type(json_object)
   end

--- a/app/services/items_service.rb
+++ b/app/services/items_service.rb
@@ -18,7 +18,7 @@ class ItemsService
   end
 
   def fetch_raw_json(base_path)
-    content_store_client.content_item(base_path)
+    content_store_client.content_item(base_path).to_hash
   end
 
   def fetch(content_id, locale, version)

--- a/config/sidekiq/publishing_api.yml
+++ b/config/sidekiq/publishing_api.yml
@@ -2,3 +2,4 @@
 :concurrency:  3
 :queues:
   - publishing_api
+  - quality_metrics

--- a/spec/domain/importers/quality_metrics_spec.rb
+++ b/spec/domain/importers/quality_metrics_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Importers::QualityMetrics do
+  let(:dimensions_item) { create :dimensions_item }
+  subject { Importers::QualityMetrics.new(dimensions_item.id) }
+
+  context 'import quality metrics' do
+    before do
+      allow_any_instance_of(Dimensions::Item).to receive(:get_content).and_return('the-entire-body')
+      allow(subject.content_quality_service).to receive(:run).with('the-entire-body').and_return(
+        readability_score: 1,
+        contractions_count: 2,
+        equality_count: 3,
+        indefinite_article_count: 4,
+        passive_count: 5,
+        profanities_count: 6,
+        redundant_acronyms_count: 7,
+        repeated_words_count: 8,
+        simplify_count: 9,
+        spell_count: 10
+      )
+    end
+
+    it 'updates the metadata fields for dimensions item' do
+      subject.run
+      expect(dimensions_item.reload).to have_attributes(
+        spell_count: 10,
+        readability_score: 1,
+        contractions_count: 2,
+        equality_count: 3,
+        passive_count: 5,
+        indefinite_article_count: 4,
+        profanities_count: 6,
+        redundant_acronyms_count: 7,
+        repeated_words_count: 8,
+        simplify_count: 9,
+      )
+    end
+
+    it 'does not update fields if InvalidSchemaError is raised' do
+      allow_any_instance_of(Dimensions::Item).to receive(:get_content).and_raise(InvalidSchemaError)
+      subject.run
+      expect(dimensions_item.reload).to have_attributes(
+        spell_count: nil,
+        readability_score: nil,
+        contractions_count: nil,
+        equality_count: nil,
+        passive_count: nil,
+        indefinite_article_count: nil,
+        profanities_count: nil,
+        redundant_acronyms_count: nil,
+        repeated_words_count: nil,
+        simplify_count: nil
+      )
+    end
+  end
+end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -1,20 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Dimensions::Item, type: :model do
-  let(:test_json) do
-    {
-      schema_name: "answer",
-      details: {
-        body: "This is a test"
-      }
-    }.to_a
-  end
-
   it { is_expected.to validate_presence_of(:content_id) }
 
   describe "#get_content" do
     it "returns nil if json is empty" do
-      item = create(:dimensions_item, raw_json: {}.to_a)
+      item = create(:dimensions_item, raw_json: {})
       expect(item.get_content).to eq(nil)
     end
 
@@ -27,7 +18,7 @@ RSpec.describe Dimensions::Item, type: :model do
       end
 
       it "returns nil if details.body does NOT exist" do
-        valid_schema_json = { schema_name: "answer", details: {} }.to_a
+        valid_schema_json = { schema_name: "answer", details: {} }
         item = create(:dimensions_item, raw_json: valid_schema_json)
         expect(item.get_content).to eq(nil)
       end
@@ -41,7 +32,7 @@ RSpec.describe Dimensions::Item, type: :model do
 
       it "returns content json if schema is 'licence'" do
         json = { schema_name: "licence",
-                 details: { licence_overview: "licence expired" } }.to_a
+                 details: { licence_overview: "licence expired" } }
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq('licence expired')
       end
@@ -49,7 +40,7 @@ RSpec.describe Dimensions::Item, type: :model do
       it "returns content json if schema is 'place'" do
         json = { schema_name: "place",
                  details: { introduction: "Introduction",
-                 more_information: "Enter your postcode" } }.to_a
+                 more_information: "Enter your postcode" } }
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq('Introduction Enter your postcode')
       end
@@ -60,7 +51,7 @@ RSpec.describe Dimensions::Item, type: :model do
                    [{ title: "Schools",
                       body: "Local council" },
                     { title: "Appeal",
-                      body: "No placement" }] } }.to_a
+                      body: "No placement" }] } }
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq("Schools Local council Appeal No placement")
       end
@@ -71,19 +62,19 @@ RSpec.describe Dimensions::Item, type: :model do
           details: {
             body: body
           }
-        }.to_a
+        }
       end
     end
 
     context "when invalid schema" do
       it "raise InvalidSchemaError if json schema_name is not known" do
-        no_schema_json = { schema_name: "blah" }.to_a
+        no_schema_json = { schema_name: "blah" }
         item = create(:dimensions_item, raw_json: no_schema_json)
         expect { item.get_content }.to raise_error(InvalidSchemaError)
       end
 
       it "raises InvalidSchemaError if non-empty json does not have a schema_name" do
-        invalid_schema = { document_type: "answer" }.to_a
+        invalid_schema = { document_type: "answer" }
         item = create(:dimensions_item, raw_json: invalid_schema)
         expect { item.get_content }.to raise_error(InvalidSchemaError)
       end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Dimensions::Item, type: :model do
       details: {
         body: "This is a test"
       }
-    }.to_json
+    }.to_a
   end
 
   it { is_expected.to validate_presence_of(:content_id) }
 
   describe "#get_content" do
     it "returns nil if json is empty" do
-      item = create(:dimensions_item, raw_json: {}.to_json)
+      item = create(:dimensions_item, raw_json: {}.to_a)
       expect(item.get_content).to eq(nil)
     end
 
@@ -27,7 +27,7 @@ RSpec.describe Dimensions::Item, type: :model do
       end
 
       it "returns nil if details.body does NOT exist" do
-        valid_schema_json = { schema_name: "answer", details: {} }.to_json
+        valid_schema_json = { schema_name: "answer", details: {} }.to_a
         item = create(:dimensions_item, raw_json: valid_schema_json)
         expect(item.get_content).to eq(nil)
       end
@@ -41,26 +41,26 @@ RSpec.describe Dimensions::Item, type: :model do
 
       it "returns content json if schema is 'licence'" do
         json = { schema_name: "licence",
-          details: { licence_overview: "licence expired" } }.to_json
+                 details: { licence_overview: "licence expired" } }.to_a
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq('licence expired')
       end
 
       it "returns content json if schema is 'place'" do
         json = { schema_name: "place",
-          details: { introduction: "Introduction",
-            more_information: "Enter your postcode" } }.to_json
+                 details: { introduction: "Introduction",
+                 more_information: "Enter your postcode" } }.to_a
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq('Introduction Enter your postcode')
       end
 
       it "returns content json if schema_name is 'guide'" do
         json = { schema_name: "guide",
-          details: { parts:
-            [
-              { title: "Schools", body: "Local council" },
-              { title: "Appeal", body: "No placement" }
-            ] } }.to_json
+                 details: { parts:
+                   [{ title: "Schools",
+                      body: "Local council" },
+                    { title: "Appeal",
+                      body: "No placement" }] } }.to_a
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq("Schools Local council Appeal No placement")
       end
@@ -71,19 +71,19 @@ RSpec.describe Dimensions::Item, type: :model do
           details: {
             body: body
           }
-        }.to_json
+        }.to_a
       end
     end
 
     context "when invalid schema" do
       it "raise InvalidSchemaError if json schema_name is not known" do
-        no_schema_json = { schema_name: "blah" }.to_json
+        no_schema_json = { schema_name: "blah" }.to_a
         item = create(:dimensions_item, raw_json: no_schema_json)
         expect { item.get_content }.to raise_error(InvalidSchemaError)
       end
 
       it "raises InvalidSchemaError if non-empty json does not have a schema_name" do
-        invalid_schema = { document_type: "answer" }.to_json
+        invalid_schema = { document_type: "answer" }.to_a
         item = create(:dimensions_item, raw_json: invalid_schema)
         expect { item.get_content }.to raise_error(InvalidSchemaError)
       end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -17,43 +17,43 @@ RSpec.describe Dimensions::Item, type: :model do
         expect(item.get_content).to eq('the-body')
       end
 
-      it "returns nil if details.body does NOT exist" do
-        valid_schema_json = { schema_name: "answer", details: {} }
+      it 'returns nil if details.body does NOT exist' do
+        valid_schema_json = { schema_name: 'answer', details: {} }
         item = create(:dimensions_item, raw_json: valid_schema_json)
         expect(item.get_content).to eq(nil)
       end
 
-      it "does not fail with unicode characters" do
+      it 'does not fail with unicode characters' do
         json = build_raw_json(body: %{\u003cdiv class="govspeak"\u003e\u003cp\u003eLorem ipsum dolor sit amet.})
 
         item = create(:dimensions_item, raw_json: json)
-        expect(item.get_content).to eq("Lorem ipsum dolor sit amet.")
+        expect(item.get_content).to eq('Lorem ipsum dolor sit amet.')
       end
 
       it "returns content json if schema is 'licence'" do
-        json = { schema_name: "licence",
-                 details: { licence_overview: "licence expired" } }
+        json = { schema_name: 'licence',
+          details: { licence_overview: 'licence expired' } }
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq('licence expired')
       end
 
       it "returns content json if schema is 'place'" do
-        json = { schema_name: "place",
-                 details: { introduction: "Introduction",
-                 more_information: "Enter your postcode" } }
+        json = { schema_name: 'place',
+          details: { introduction: 'Introduction',
+            more_information: 'Enter your postcode' } }
         item = create(:dimensions_item, raw_json: json)
         expect(item.get_content).to eq('Introduction Enter your postcode')
       end
 
       it "returns content json if schema_name is 'guide'" do
-        json = { schema_name: "guide",
-                 details: { parts:
-                   [{ title: "Schools",
-                      body: "Local council" },
-                    { title: "Appeal",
-                      body: "No placement" }] } }
+        json = { schema_name: 'guide',
+          details: { parts:
+            [{ title: 'Schools',
+              body: 'Local council' },
+             { title: 'Appeal',
+               body: 'No placement' }] } }
         item = create(:dimensions_item, raw_json: json)
-        expect(item.get_content).to eq("Schools Local council Appeal No placement")
+        expect(item.get_content).to eq('Schools Local council Appeal No placement')
       end
 
       def build_raw_json(body:)
@@ -66,15 +66,15 @@ RSpec.describe Dimensions::Item, type: :model do
       end
     end
 
-    context "when invalid schema" do
-      it "raise InvalidSchemaError if json schema_name is not known" do
-        no_schema_json = { schema_name: "blah" }
+    context 'when invalid schema' do
+      it 'raise InvalidSchemaError if json schema_name is not known' do
+        no_schema_json = { schema_name: 'blah' }
         item = create(:dimensions_item, raw_json: no_schema_json)
         expect { item.get_content }.to raise_error(InvalidSchemaError)
       end
 
-      it "raises InvalidSchemaError if non-empty json does not have a schema_name" do
-        invalid_schema = { document_type: "answer" }
+      it 'raises InvalidSchemaError if non-empty json does not have a schema_name' do
+        invalid_schema = { document_type: 'answer' }
         item = create(:dimensions_item, raw_json: invalid_schema)
         expect { item.get_content }.to raise_error(InvalidSchemaError)
       end
@@ -124,6 +124,13 @@ RSpec.describe Dimensions::Item, type: :model do
       item.gone!
       expect(item.reload.status).to eq 'gone'
     end
+  end
+
+  it 'stores/read a Hash with the item JSON' do
+    item = create :dimensions_item, raw_json: { a: :b }
+    item.reload
+
+    expect(item.raw_json).to eq('a' => 'b')
   end
 
   describe '##create_empty' do

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -1,4 +1,8 @@
+require 'gds_api/test_helpers/content_store'
+
 RSpec.describe ItemsService do
+  include GdsApi::TestHelpers::ContentStore
+
   let(:publishing_api_client) { double('publishing_api_client') }
 
   before do
@@ -93,6 +97,14 @@ RSpec.describe ItemsService do
 
       expect(links[2].link_type).to eq("policies")
       expect(links[2].target_content_id).to eq("id-111")
+    end
+  end
+
+  describe "#fetch_raw_json" do
+    it "returns a hash with the content item attributes" do
+      content_store_has_item('/the-base-path', { the: :body }, {})
+
+      expect(subject.fetch_raw_json('/the-base-path')).to eq('the' => 'body')
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/rwVCk9Vd/132-5-collect-quality-metrics-through-time)

**As a** data informed decision team
**We want** to store quality metrics through time
**So that** usesr can make informed decisions around content

### What

As per card https://trello.com/c/B3Qfxq5f/145-build-service-in-heroku-to-build-quality-metrics, we need to consume the service, and store quality metrics through time.

### Why

We are still not clear about the next steps for `Siteimprove`, nor what is the long term plan for our quality metrics. But we need to start collecting metrics so we are able to understand better our data and make decisions around the next steps.

We will be able to recalculate the metrics backwards as we are storing the content, so we don't need to have the perfect quality metric for each Content Item.

### Who knows about it

- Pablo
- Kelvin