### PR TITLE
Refactor sandbox to use single query

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -6,7 +6,6 @@ class SandboxController < ApplicationController
               .by_base_path(base_path)
 
     @summary = @metrics.metric_summary
-    @number_of_pdfs = @metrics.sum(:number_of_pdfs)
     @number_of_word_files = @metrics.sum(:number_of_word_files)
   end
 

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -5,8 +5,7 @@ class SandboxController < ApplicationController
               .between(from, to)
               .by_base_path(base_path)
 
-    @total_items = @metrics.select('dimensions_items.id').distinct.count
-    @pageviews = @metrics.sum(:pageviews)
+    @summary = @metrics.metric_summary
     @feedex_issues = @metrics.sum(:number_of_issues)
     @number_of_pdfs = @metrics.sum(:number_of_pdfs)
     @number_of_word_files = @metrics.sum(:number_of_word_files)

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -6,10 +6,8 @@ class SandboxController < ApplicationController
               .by_base_path(base_path)
 
     @summary = @metrics.metric_summary
-    @feedex_issues = @metrics.sum(:number_of_issues)
     @number_of_pdfs = @metrics.sum(:number_of_pdfs)
     @number_of_word_files = @metrics.sum(:number_of_word_files)
-    @unique_pageviews = @metrics.average(:unique_pageviews)
   end
 
 private

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -1,12 +1,10 @@
 class SandboxController < ApplicationController
   def index
-    @metrics = Facts::Metric
-              .joins(:dimensions_item)
-              .between(from, to)
-              .by_base_path(base_path)
-
-    @summary = @metrics.metric_summary
-    @number_of_word_files = @metrics.sum(:number_of_word_files)
+    @summary = Facts::Metric
+      .joins(:dimensions_item)
+      .between(from, to)
+      .by_base_path(base_path)
+      .metric_summary
   end
 
 private

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -22,6 +22,14 @@ class Facts::Metric < ApplicationRecord
       .where(dimensions_items: { content_id: content_id })
   end
 
+  scope :metric_summary, -> do
+    array = pluck('COUNT(DISTINCT dimensions_items.id)', 'SUM(pageviews)').first
+    {
+      total_items: array[0],
+      pageviews: array[1]
+    }
+  end
+
   def self.valid_metric?(metric)
     METRIC_WHITELIST.include? metric
   end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -23,11 +23,17 @@ class Facts::Metric < ApplicationRecord
   end
 
   scope :metric_summary, -> do
-    array = pluck('COUNT(DISTINCT dimensions_items.id)', 'SUM(pageviews)', 'AVG(unique_pageviews)').first
+    array = pluck(
+      'COUNT(DISTINCT dimensions_items.id)',
+      'SUM(pageviews)',
+      'AVG(unique_pageviews)',
+      'SUM(number_of_issues)'
+    ).first
     {
       total_items: array[0],
       pageviews: array[1],
-      unique_pageviews: array[2]
+      unique_pageviews: array[2],
+      number_of_issues: array[3]
     }
   end
 

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -23,10 +23,11 @@ class Facts::Metric < ApplicationRecord
   end
 
   scope :metric_summary, -> do
-    array = pluck('COUNT(DISTINCT dimensions_items.id)', 'SUM(pageviews)').first
+    array = pluck('COUNT(DISTINCT dimensions_items.id)', 'SUM(pageviews)', 'AVG(unique_pageviews)').first
     {
       total_items: array[0],
-      pageviews: array[1]
+      pageviews: array[1],
+      unique_pageviews: array[2]
     }
   end
 

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -24,16 +24,18 @@ class Facts::Metric < ApplicationRecord
 
   scope :metric_summary, -> do
     array = pluck(
-      'COUNT(DISTINCT dimensions_items.id)',
+      'COUNT(DISTINCT dimensions_items.content_id)',
       'SUM(pageviews)',
       'AVG(unique_pageviews)',
-      'SUM(number_of_issues)'
+      'SUM(number_of_issues)',
+      'AVG(number_of_pdfs)'
     ).first
     {
       total_items: array[0],
       pageviews: array[1],
       unique_pageviews: array[2],
-      number_of_issues: array[3]
+      number_of_issues: array[3],
+      number_of_pdfs: array[4]
     }
   end
 

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -28,14 +28,16 @@ class Facts::Metric < ApplicationRecord
       'SUM(pageviews)',
       'AVG(unique_pageviews)',
       'SUM(number_of_issues)',
-      'AVG(number_of_pdfs)'
+      'AVG(number_of_pdfs)',
+      'AVG(number_of_word_files)'
     ).first
     {
       total_items: array[0],
       pageviews: array[1],
       unique_pageviews: array[2],
       number_of_issues: array[3],
-      number_of_pdfs: array[4]
+      number_of_pdfs: array[4],
+      number_of_word_files: array[5]
     }
   end
 

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -19,8 +19,8 @@
       <span class="summary-item-label">Feedex issues (total)</span>
     </div>
     <div class="summary-item col-xs-3 number_of_pdfs">
-      <span class="summary-item-value"><%= number_with_delimiter @number_of_pdfs %></span>
-      <span class="summary-item-label">pdfs (total)</span>
+      <span class="summary-item-value"><%= number_with_delimiter @summary[:number_of_pdfs] %></span>
+      <span class="summary-item-label">pdfs (avg)</span>
     </div>
     <div class="summary-item col-xs-3 number_of_word_files">
       <span class="summary-item-value"><%= number_with_delimiter @number_of_word_files %></span>

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div class="row">
     <div class="summary-item col-xs-3 feedex_issues">
-      <span class="summary-item-value"><%= number_with_delimiter @feedex_issues %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @summary[:number_of_issues] %></span>
       <span class="summary-item-label">Feedex issues (total)</span>
     </div>
     <div class="summary-item col-xs-3 number_of_pdfs">

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -23,8 +23,8 @@
       <span class="summary-item-label">pdfs (avg)</span>
     </div>
     <div class="summary-item col-xs-3 number_of_word_files">
-      <span class="summary-item-value"><%= number_with_delimiter @number_of_word_files %></span>
-      <span class="summary-item-label">Word files (total)</span>
+      <span class="summary-item-value"><%= number_with_delimiter @summary[:number_of_word_files] %></span>
+      <span class="summary-item-label">Word files (avg)</span>
     </div>
   </div>
 </div>

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -9,7 +9,7 @@
       <span class="summary-item-label">pageviews (total)</span>
     </div>
     <div class="summary-item col-xs-3 unique_pageviews">
-      <span class="summary-item-value"><%= number_with_delimiter @unique_pageviews %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @summary[:unique_pageviews] %></span>
       <span class="summary-item-label">unique pageviews (avg)</span>
     </div>
   </div>

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -1,11 +1,11 @@
 <div class="summary">
   <div class="row">
     <div class="summary-item col-xs-3 total_items">
-      <span class="summary-item-value"><%= number_with_delimiter @total_items %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @summary[:total_items] %></span>
       <span class="summary-item-label">items</span>
     </div>
     <div class="summary-item col-xs-3 pageviews">
-      <span class="summary-item-value"><%= number_with_delimiter @pageviews %></span>
+      <span class="summary-item-value"><%= number_with_delimiter @summary[:pageviews] %></span>
       <span class="summary-item-label">pageviews (total)</span>
     </div>
     <div class="summary-item col-xs-3 unique_pageviews">

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.unique_pageviews', text: '20.0 unique pageviews (avg)')
     expect(page).to have_selector('.feedex_issues', text: '28 Feedex issues (total)')
     expect(page).to have_selector('.number_of_pdfs', text: '3.0 pdfs (avg)')
-    expect(page).to have_selector('.number_of_word_files', text: '6 Word files (total)')
+    expect(page).to have_selector('.number_of_word_files', text: '1.5 Word files (avg)')
   end
 
   describe 'Filtering' do

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.pageviews', text: '80 pageviews (total)')
     expect(page).to have_selector('.unique_pageviews', text: '20.0 unique pageviews (avg)')
     expect(page).to have_selector('.feedex_issues', text: '28 Feedex issues (total)')
-    expect(page).to have_selector('.number_of_pdfs', text: '12 pdfs (total)')
+    expect(page).to have_selector('.number_of_pdfs', text: '3.0 pdfs (avg)')
     expect(page).to have_selector('.number_of_word_files', text: '6 Word files (total)')
   end
 

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Facts::Metric, type: :model do
     subject { described_class }
     let(:base_path) { '/the/base/path' }
     it 'returns the correct numbers' do
-      item1 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3)
-      item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3)
+      item1 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1)
+      item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1)
       create(:metric,
         dimensions_item: item1,
         dimensions_date: day0,
@@ -80,7 +80,8 @@ RSpec.describe Facts::Metric, type: :model do
         pageviews: 10,
         unique_pageviews: 2,
         number_of_issues: 9,
-        number_of_pdfs: 3
+        number_of_pdfs: 3,
+        number_of_word_files: 1
       )
     end
   end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -56,14 +56,30 @@ RSpec.describe Facts::Metric, type: :model do
     it 'returns the correct numbers' do
       item1 = create(:dimensions_item, base_path: base_path)
       item2 = create(:dimensions_item, base_path: base_path)
-      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2)
-      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2)
-      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2)
+      create(:metric,
+        dimensions_item: item1,
+        dimensions_date: day0,
+        pageviews: 3,
+        unique_pageviews: 2,
+        number_of_issues: 4)
+      create(:metric,
+        dimensions_item: item2,
+        dimensions_date: day0,
+        pageviews: 5,
+        unique_pageviews: 2,
+        number_of_issues: 3)
+      create(:metric,
+        dimensions_item: item2,
+        dimensions_date: day1,
+        pageviews: 2,
+        unique_pageviews: 2,
+        number_of_issues: 2)
       results = subject.between(day0, day1).by_base_path(base_path).metric_summary
       expect(results).to eq(
         total_items: 2,
         pageviews: 10,
-        unique_pageviews: 2
+        unique_pageviews: 2,
+        number_of_issues: 9
       )
     end
   end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe Facts::Metric, type: :model do
   it { is_expected.to validate_presence_of(:dimensions_date) }
   it { is_expected.to validate_presence_of(:dimensions_item) }
 
+  let(:day0) { create(:dimensions_date, date: Date.new(2018, 1, 12)) }
+  let(:day1) { create(:dimensions_date, date: Date.new(2018, 1, 13)) }
+  let(:day2) { create(:dimensions_date, date: Date.new(2018, 1, 14)) }
   describe 'Filtering' do
     subject { described_class }
-
-    let(:day0) { create(:dimensions_date, date: Date.new(2018, 1, 12)) }
-    let(:day1) { create(:dimensions_date, date: Date.new(2018, 1, 13)) }
-    let(:day2) { create(:dimensions_date, date: Date.new(2018, 1, 14)) }
 
     it '.between' do
       item1 = create(:dimensions_item)
@@ -48,6 +47,23 @@ RSpec.describe Facts::Metric, type: :model do
 
       results = subject.by_content_id('id1')
       expect(results).to match_array([metric1, metric2, metric3])
+    end
+  end
+
+  describe '.metric_summary' do
+    subject { described_class }
+    let(:base_path) { '/the/base/path' }
+    it 'returns the correct numbers' do
+      item1 = create(:dimensions_item, base_path: base_path)
+      item2 = create(:dimensions_item, base_path: base_path)
+      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3)
+      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5)
+      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2)
+      results = subject.between(day0, day1).by_base_path(base_path).metric_summary
+      expect(results).to eq(
+        total_items: 2,
+        pageviews: 10
+      )
     end
   end
 end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Facts::Metric, type: :model do
     subject { described_class }
     let(:base_path) { '/the/base/path' }
     it 'returns the correct numbers' do
-      item1 = create(:dimensions_item, base_path: base_path)
-      item2 = create(:dimensions_item, base_path: base_path)
+      item1 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3)
+      item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3)
       create(:metric,
         dimensions_item: item1,
         dimensions_date: day0,
@@ -79,7 +79,8 @@ RSpec.describe Facts::Metric, type: :model do
         total_items: 2,
         pageviews: 10,
         unique_pageviews: 2,
-        number_of_issues: 9
+        number_of_issues: 9,
+        number_of_pdfs: 3
       )
     end
   end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -56,13 +56,14 @@ RSpec.describe Facts::Metric, type: :model do
     it 'returns the correct numbers' do
       item1 = create(:dimensions_item, base_path: base_path)
       item2 = create(:dimensions_item, base_path: base_path)
-      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3)
-      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5)
-      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2)
+      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2)
+      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2)
+      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2)
       results = subject.between(day0, day1).by_base_path(base_path).metric_summary
       expect(results).to eq(
         total_items: 2,
-        pageviews: 10
+        pageviews: 10,
+        unique_pageviews: 2
       )
     end
   end


### PR DESCRIPTION
Also use the AVG  number_of_pdfs and number_of_word_files not the SUM.

This is in preparation for exporting data as csv which is the Trello card 
[CSV to export data from sandbox](https://trello.com/c/WP15RbnO/146-2-csv-to-export-data-from-sandbox)

It should also should give us a performance improvement
as it will reduce the number of queries we need to run.