### PR TITLE
Rename column name to mimic ContentStore response

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -36,7 +36,7 @@ private
       'content_id',
       'title',
       'document_type',
-      'content_purpose_supertype',
+      'content_purpose_document_supertype',
       'first_published_at',
       'public_updated_at',
     )

--- a/db/migrate/20180307113805_rename_column_dimensions_items_content_purpose_supertype.rb
+++ b/db/migrate/20180307113805_rename_column_dimensions_items_content_purpose_supertype.rb
@@ -1,0 +1,5 @@
+class RenameColumnDimensionsItemsContentPurposeSupertype < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :dimensions_items, :content_purpose_supertype, :content_purpose_document_supertype
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305161014) do
+ActiveRecord::Schema.define(version: 20180307113805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 20180305161014) do
     t.integer "number_of_pdfs"
     t.boolean "dirty", default: false
     t.string "document_type"
-    t.string "content_purpose_supertype"
+    t.string "content_purpose_document_supertype"
     t.datetime "first_published_at"
     t.datetime "public_updated_at"
     t.integer "number_of_word_files"

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Importers::ContentDetails do
     #     'content_id' => '09hjasdfoj234',
     #     'title' => 'A guide to coding',
     #     'document_type' => 'answer',
-    #     'content_purpose_supertype' => 'guide',
+    #     'content_purpose_document_supertype' => 'guide',
     #     'first_published_at' => '2012-10-03T13:19:55.000+00:00',
     #     'public_updated_at' => '2015-06-03T11:13:44.000+00:00',
     #   )
@@ -77,7 +77,7 @@ RSpec.describe Importers::ContentDetails do
     #   expect(latest_dimension_item.title).to eq('A guide to coding')
     #   expect(latest_dimension_item.content_id).to eq('09hjasdfoj234')
     #   expect(latest_dimension_item.document_type).to eq('answer')
-    #   expect(latest_dimension_item.content_purpose_supertype).to eq('guide')
+    #   expect(latest_dimension_item.content_purpose_document_supertype).to eq('guide')
     #   expect(latest_dimension_item.first_published_at).to eq(Time.new.strftime('2012-10-03T13:19:55.000+00:00'))
     #   expect(latest_dimension_item.public_updated_at).to eq(Time.new.strftime('2015-06-03T11:13:44.000+00:00'))
     # end


### PR DESCRIPTION
Content Store is using the name: `content_purpose_document_supertype` 
instead of `content_purpose_supertype`; this PR increases the consistency.