### PR TITLE
Fix charts not being rendered in Sandbox

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -1,10 +1,11 @@
 class SandboxController < ApplicationController
   def index
-    @summary = Facts::Metric
+    @metrics = Facts::Metric
       .joins(:dimensions_item)
       .between(from, to)
       .by_base_path(base_path)
-      .metric_summary
+
+    @summary = @metrics.metric_summary
   end
 
 private

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -44,6 +44,20 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.number_of_word_files', text: '1.5 Word files (avg)')
   end
 
+  describe 'Charts' do
+    scenario 'Show charts' do
+      visit '/sandbox'
+
+      fill_in 'From:', with: '2018-01-13'
+      fill_in 'To:', with: '2018-01-15'
+      check 'total_items'
+
+      click_button 'Filter'
+
+      expect(page).to have_selector('.trends .total_items', text: 'Number of Content Items')
+    end
+  end
+
   describe 'Filtering' do
     scenario 'by base_path' do
       item1.update base_path: '/path'


### PR DESCRIPTION
We need the @metrics variable as the partial to render trends depends on
this variable. I have added a feature test to ensure that this issue
does not happen again.