### PR TITLE
Add additional validation and return error responses

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -1,4 +1,4 @@
-class Api::MetricsController < ApplicationController
+class Api::MetricsController < ApiController
   before_action :validate_params!
 
   def show
@@ -12,14 +12,6 @@ class Api::MetricsController < ApplicationController
                  .sum(metric)
 
     @metric_params = metric_params
-  end
-
-  rescue_from(ActionController::UnpermittedParameters) do |pme|
-    error_response(
-      "unknown-parameter",
-      title: "One or more parameter names are invalid",
-      invalid_params: pme.params
-    )
   end
 
 private
@@ -38,10 +30,5 @@ private
         invalid_params: metric_params.errors.to_hash
       )
     end
-  end
-
-  def error_response(type, error_hash)
-    error_hash.merge!(type: "https://content-performance-api.publishing.service.gov.uk/errors/##{type}")
-    render json: error_hash, status: :bad_request, content_type: "application/problem+json"
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,19 @@
+class ApiController < ApplicationController
+  rescue_from(ActionController::UnpermittedParameters) do |pme|
+    error_response(
+      "unknown-parameter",
+      title: "One or more parameter names are invalid",
+      invalid_params: pme.params
+    )
+  end
+
+private
+
+  def error_response(type, error_hash)
+    # Type is an arbitrary URI identifying the error type
+    # https://tools.ietf.org/html/rfc7807#section-3.1 recommends using
+    # human-readable documentation for this, so point to our API docs.
+    error_hash[:type] = "https://content-performance-api.publishing.service.gov.uk/errors/##{type}"
+    render json: error_hash, status: :bad_request, content_type: "application/problem+json"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+
+  # Raise ActionController::UnpermittedParameters if there are unpermitted
+  # parameters, so we can return better errors for invalid API requests
+  ActionController::Parameters.action_on_unpermitted_parameters = :raise
 end

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -8,7 +8,9 @@ class SandboxController < ApplicationController
     respond_to do |format|
       format.html do
         @summary = @metrics.metric_summary
-        @query_params = params.permit(:from, :to, :base_path)
+        @query_params = params.permit(:from, :to, :base_path, :utf8,
+          :total_items, :pageviews, :unique_pageviews, :feedex_issues,
+          :number_of_pdfs, :number_of_word_files, :filter)
       end
       format.csv { stream_data_as_csv(@metrics) }
     end

--- a/app/models/api/metric.rb
+++ b/app/models/api/metric.rb
@@ -6,14 +6,14 @@ class Api::Metric
 
   attr_reader :metric, :from, :to, :content_id
 
-  validates :metric, presence: true, inclusion: {in: Facts::Metric::METRIC_WHITELIST}
-  validates :from, presence: true, format: {with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD"}
-  validates :to, presence: true, format: {with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD"}
-  validates :content_id, presence: true, format: {with: CONTENT_ID_REGEX, message: "Content ID must be a UUID."}
+  validates :metric, presence: true, inclusion: { in: Facts::Metric::METRIC_WHITELIST }
+  validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
+  validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
+  validates :content_id, presence: true, format: { with: CONTENT_ID_REGEX, message: "Content ID must be a UUID." }
   validate :from_before_to, if: :have_a_date_range?
 
   def initialize(params)
-    @metric  = params[:metric]
+    @metric = params[:metric]
     @from = params[:from]
     @to = params[:to]
     @content_id = params[:content_id]

--- a/app/models/api/metric.rb
+++ b/app/models/api/metric.rb
@@ -2,6 +2,9 @@ class Api::Metric
   DATE_REGEX = /\A\d\d\d\d-\d\d-\d\d\Z/
   CONTENT_ID_REGEX = /\A[0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\Z/i
 
+  private_constant :DATE_REGEX
+  private_constant :CONTENT_ID_REGEX
+
   include ActiveModel::Validations
 
   attr_reader :metric, :from, :to, :content_id

--- a/app/models/api/metric.rb
+++ b/app/models/api/metric.rb
@@ -1,0 +1,34 @@
+class Api::Metric
+  DATE_REGEX = /\A\d\d\d\d-\d\d-\d\d\Z/
+  CONTENT_ID_REGEX = /\A[0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\Z/i
+
+  include ActiveModel::Validations
+
+  attr_reader :metric, :from, :to, :content_id
+
+  validates :metric, presence: true, inclusion: {in: Facts::Metric::METRIC_WHITELIST}
+  validates :from, presence: true, format: {with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD"}
+  validates :to, presence: true, format: {with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD"}
+  validates :content_id, presence: true, format: {with: CONTENT_ID_REGEX, message: "Content ID must be a UUID."}
+  validate :from_before_to, if: :have_a_date_range?
+
+  def initialize(params)
+    @metric  = params[:metric]
+    @from = params[:from]
+    @to = params[:to]
+    @content_id = params[:content_id]
+  end
+
+private
+
+  def have_a_date_range?
+    from.present? && to.present? && from =~ DATE_REGEX && to =~ DATE_REGEX
+  end
+
+  def from_before_to
+    # This is a string comparison, but the sort order is the same as for dates.
+    if from > to
+      errors.add("from,to", "`from` parameter can't be after the `to` parameter")
+    end
+  end
+end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -63,10 +63,5 @@ class Facts::Metric < ApplicationRecord
     ]
   end
 
-  def self.valid_metric?(metric)
-    METRIC_WHITELIST.include? metric
-  end
-
   METRIC_WHITELIST = %w[pageviews unique_pageviews number_of_pdfs number_of_issues number_of_word_files].freeze
-  private_constant :METRIC_WHITELIST
 end

--- a/app/views/api/metrics/show.json.jbuilder
+++ b/app/views/api/metrics/show.json.jbuilder
@@ -1,12 +1,12 @@
 json.metadata do
-  json.metric @metric
+  json.metric @metric_params.metric
   json.total @metrics.values.sum
-  json.from @from
-  json.to @to
-  json.content_id @content_id
+  json.from @metric_params.from
+  json.to @metric_params.to
+  json.content_id @metric_params.content_id
 end
 json.results @metrics.each do |date, value|
-  json.content_id @content_id
+  json.content_id @metric_params.content_id
   json.date date
   json.value value
 end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
     expected_error_response = {
       "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
       "title" => "One or more parameters is invalid",
-      "invalid_params" => {"metric" => ["is not included in the list"]}
+      "invalid_params" => { "metric" => ["is not included in the list"] }
     }
 
     expect(json).to eq(expected_error_response)
@@ -38,7 +38,7 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
     expected_error_response = {
       "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
       "title" => "One or more parameters is invalid",
-      "invalid_params" => {"from" => ["Dates should use the format YYYY-MM-DD"]}
+      "invalid_params" => { "from" => ["Dates should use the format YYYY-MM-DD"] }
     }
 
     expect(json).to eq(expected_error_response)
@@ -54,7 +54,23 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
     expected_error_response = {
       "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
       "title" => "One or more parameters is invalid",
-      "invalid_params" => {"from,to" => ["`from` parameter can't be after the `to` parameter"]}
+      "invalid_params" => { "from,to" => ["`from` parameter can't be after the `to` parameter"] }
+    }
+
+    expect(json).to eq(expected_error_response)
+  end
+
+  it 'returns an error for unknown parameters' do
+    get "/api/v1/metrics/#{content_id}", params: { metric: "pageviews", from: '2018-01-14', to: '2018-01-15', extra: "bla" }
+
+    expect(response.status).to eq(400)
+
+    json = JSON.parse(response.body)
+
+    expected_error_response = {
+      "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#unknown-parameter",
+      "title" => "One or more parameter names are invalid",
+      "invalid_params" => ["extra"]
     }
 
     expect(json).to eq(expected_error_response)

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -1,4 +1,6 @@
 require 'rails_helper'
+require 'securerandom'
+
 RSpec.describe '/api/v1/metrics/:content_id', type: :request do
   before { create(:user) }
 
@@ -6,13 +8,56 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
   let!(:day2) { create :dimensions_date, date: Date.new(2018, 1, 14) }
   let!(:day3) { create :dimensions_date, date: Date.new(2018, 1, 15) }
   let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
+  let!(:content_id) { SecureRandom.uuid }
 
-  let!(:item) { create :dimensions_item, content_id: 'id1' }
+  let!(:item) { create :dimensions_item, content_id: content_id }
 
-  it 'returns `bad request` for metrics not on the whitelist' do
-    get '/api/v1/metrics/id1', params: { metric: 'something-else', from: '2018-01-13', to: '2018-01-15' }
+  it 'returns an error for metrics not on the whitelist' do
+    get "/api/v1/metrics/#{content_id}", params: { metric: 'something-else', from: '2018-01-13', to: '2018-01-15' }
 
     expect(response.status).to eq(400)
+
+    json = JSON.parse(response.body)
+
+    expected_error_response = {
+      "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+      "title" => "One or more parameters is invalid",
+      "invalid_params" => {"metric" => ["is not included in the list"]}
+    }
+
+    expect(json).to eq(expected_error_response)
+  end
+
+  it 'returns an error for badly formatted dates' do
+    get "/api/v1/metrics/#{content_id}", params: { metric: "pageviews", from: 'today', to: '2018-01-15' }
+
+    expect(response.status).to eq(400)
+
+    json = JSON.parse(response.body)
+
+    expected_error_response = {
+      "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+      "title" => "One or more parameters is invalid",
+      "invalid_params" => {"from" => ["Dates should use the format YYYY-MM-DD"]}
+    }
+
+    expect(json).to eq(expected_error_response)
+  end
+
+  it 'returns an error for bad date ranges' do
+    get "/api/v1/metrics/#{content_id}", params: { metric: "pageviews", from: '2018-01-16', to: '2018-01-15' }
+
+    expect(response.status).to eq(400)
+
+    json = JSON.parse(response.body)
+
+    expected_error_response = {
+      "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+      "title" => "One or more parameters is invalid",
+      "invalid_params" => {"from,to" => ["`from` parameter can't be after the `to` parameter"]}
+    }
+
+    expect(json).to eq(expected_error_response)
   end
 
   describe 'Daily metrics' do
@@ -24,14 +69,14 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
     end
 
     it 'returns `pageviews` values between two dates' do
-      get '/api/v1/metrics/id1', params: { metric: 'pageviews', from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{content_id}", params: { metric: 'pageviews', from: '2018-01-13', to: '2018-01-15' }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json).to eq(build_api_response('pageviews'))
     end
 
     it 'returns `feedex issues` between two dates' do
-      get '/api/v1/metrics/id1', params: { metric: 'number_of_issues', from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{content_id}", params: { metric: 'number_of_issues', from: '2018-01-13', to: '2018-01-15' }
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(build_api_response('number_of_issues'))
@@ -44,12 +89,12 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
           total: 60,
           from: '2018-01-13',
           to: '2018-01-15',
-          content_id: 'id1',
+          content_id: content_id,
         },
         results: [
-          { content_id: 'id1', date: '2018-01-13', value: 10 },
-          { content_id: 'id1', date: '2018-01-14', value: 20 },
-          { content_id: 'id1', date: '2018-01-15', value: 30 },
+          { content_id: content_id, date: '2018-01-13', value: 10 },
+          { content_id: content_id, date: '2018-01-14', value: 20 },
+          { content_id: content_id, date: '2018-01-15', value: 30 },
         ]
       }
     end
@@ -57,7 +102,7 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
 
   describe 'Content metrics' do
     before do
-      item1_old = create :dimensions_item, content_id: 'id1', number_of_pdfs: 30, number_of_word_files: 30, latest: false
+      item1_old = create :dimensions_item, content_id: content_id, number_of_pdfs: 30, number_of_word_files: 30, latest: false
       item.update number_of_pdfs: 20, number_of_word_files: 20
 
       create :metric, dimensions_item: item1_old, dimensions_date: day1
@@ -67,14 +112,14 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
     end
 
     it 'returns the `number of pdfs` between two dates' do
-      get '/api/v1/metrics/id1', params: { metric: 'number_of_pdfs', from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{content_id}", params: { metric: 'number_of_pdfs', from: '2018-01-13', to: '2018-01-15' }
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_pdfs'))
     end
 
     it 'returns the `number of word documents` between two dates' do
-      get '/api/v1/metrics/id1', params: { metric: 'number_of_word_files', from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{content_id}", params: { metric: 'number_of_word_files', from: '2018-01-13', to: '2018-01-15' }
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
@@ -87,12 +132,12 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
           total: 70,
           from: '2018-01-13',
           to: '2018-01-15',
-          content_id: 'id1',
+          content_id: content_id,
         },
         results: [
-          { content_id: 'id1', date: '2018-01-13', value: 30 },
-          { content_id: 'id1', date: '2018-01-14', value: 20 },
-          { content_id: 'id1', date: '2018-01-15', value: 20 },
+          { content_id: content_id, date: '2018-01-13', value: 30 },
+          { content_id: content_id, date: '2018-01-14', value: 20 },
+          { content_id: content_id, date: '2018-01-15', value: 20 },
         ]
       }
     end


### PR DESCRIPTION
I've tried to follow the "Problem details" semantics (https://tools.ietf.org/html/rfc7807) because I don't think we have any other convention we use within GDS. If I'm wrong this can be changed fairly easily.

All the validation logic is extracted to a new class, to make use of `ActiveModel::Validation` without cluttering up the controller. This was inspired by this blog post https://coderwall.com/p/ea5vtw/validating-rest-queries-with-rails

In theory we should be able to validate requests against the same OpenAPI schema we use for the docs, but I don't think there is a good ruby library for this yet (though I did notice @kevindew is building https://github.com/kevindew/openapi3_parser !)

Trello: https://trello.com/c/K80isIdI/100-3-add-error-handling-to-api-endpoint