### PR TITLE
CSV to export data from sandbox

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -5,10 +5,40 @@ class SandboxController < ApplicationController
       .between(from, to)
       .by_base_path(base_path)
 
-    @summary = @metrics.metric_summary
+    respond_to do |format|
+      format.html { @summary = @metrics.metric_summary }
+      format.csv { stream_data_as_csv(@metrics) }
+    end
   end
 
 private
+
+  def stream_data_as_csv(scope)
+    set_file_headers
+    set_streaming_headers
+
+    response.status = 200
+
+    self.response_body = enumerator_of_csv_lines(scope)
+  end
+
+  def enumerator_of_csv_lines(scope)
+    CSVExport.run(scope, Facts::Metric.csv_fields)
+  end
+
+  def set_file_headers
+    file_name = "metrics.csv"
+    headers["Content-Type"] = "text/csv"
+    headers["Content-disposition"] = "attachment; filename=\"#{file_name}\""
+  end
+
+  def set_streaming_headers
+    #nginx doc: Setting this to "no" will allow unbuffered responses suitable for Comet and HTTP streaming applications
+    headers['X-Accel-Buffering'] = 'no'
+
+    headers["Cache-Control"] ||= "no-cache"
+    headers.delete("Content-Length")
+  end
 
   def from
     params[:from] ||= 5.days.ago.to_date

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -41,6 +41,28 @@ class Facts::Metric < ApplicationRecord
     }
   end
 
+  def self.csv_fields
+    %i[
+      date
+      content_id
+      base_path
+      title
+      description
+      document_type
+      content_purpose_document_supertype
+      first_published_at
+      public_updated_at
+      status
+      pageviews
+      unique_pageviews
+      number_of_issues
+      number_of_pdfs
+      number_of_word_files
+      readability_score
+      spell_count
+    ]
+  end
+
   def self.valid_metric?(metric)
     METRIC_WHITELIST.include? metric
   end

--- a/app/views/sandbox/index.html.erb
+++ b/app/views/sandbox/index.html.erb
@@ -4,5 +4,6 @@
 
 <%= render 'summary' %>
 
-<%= render 'charts' %>
+<%= link_to 'Export to CSV', sandbox_path(format: :csv) %>
 
+<%= render 'charts' %>

--- a/lib/csv_export.rb
+++ b/lib/csv_export.rb
@@ -1,0 +1,31 @@
+class CSVExport
+  def self.run(*args)
+    new(*args).run
+  end
+
+  def initialize(scope, fields)
+    @scope = scope
+    @fields = fields
+  end
+
+  def run
+    Enumerator.new do |enum|
+      write_header(enum)
+      scope.in_batches { |batch| write_batch(enum, batch) }
+    end
+  end
+
+private
+
+  def write_batch(enum, items)
+    items.pluck(*fields).each do |item|
+      enum << CSV::Row.new(fields, item).to_s
+    end
+  end
+
+  attr_reader :scope, :fields
+
+  def write_header(enum)
+    enum << CSV::Row.new(fields, fields, true).to_s
+  end
+end

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -44,6 +44,29 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.number_of_word_files', text: '1.5 Word files (avg)')
   end
 
+  scenario 'Download metrics as csv' do
+    item1.update(
+      title: 'Really interesting',
+      description: 'desc',
+      content_id: 'cont-id',
+      base_path: '/really-interesing'
+    )
+    metric1.update pageviews: 10
+    metric2.update pageviews: 10
+    visit '/sandbox'
+    fill_in 'From:', with: '2018-01-13'
+    fill_in 'To:', with: '2018-01-15'
+
+    click_button 'Filter'
+
+    click_on 'Export to CSV'
+
+    expect(page.response_headers['Content-Type']).to eq "text/csv"
+    expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="metrics.csv"'
+    expect(page.body).to include('2018-01-12,cont-id,/really-interesing,Really interesting,desc,')
+    expect(page.body).to include('2018-01-13,cont-id,/really-interesing,Really interesting,desc,')
+  end
+
   describe 'Charts' do
     scenario 'Show charts' do
       visit '/sandbox'


### PR DESCRIPTION
There is a need to export filtered data as a CSV file.

The approch taken here is to pass an enumerator as the response body.
This enumerator will retrieve the data in batches and send it to the
client. This is to avoid loading the entire dataset into memory.

The appropriate headers have been set to allow this.

The Trello card is [CSV to export data from sandbox](https://trello.com/c/WP15RbnO/146-2-csv-to-export-data-from-sandbox)