### PR TITLE
Use single query to update `dirty` and `latest` flag

### DIFF
--- a/app/models/etl/outdated_items.rb
+++ b/app/models/etl/outdated_items.rb
@@ -26,7 +26,7 @@ private
     new_items = items.map(&:new_version)
     ActiveRecord::Base.transaction do
       Dimensions::Item.import(new_items)
-      Dimensions::Item.where(id: items.pluck('id')).update(dirty: false, latest: false)
+      Dimensions::Item.where(id: items.pluck('id')).update_all(dirty: false, latest: false)
     end
     new_items
   end


### PR DESCRIPTION
When using `update` ActiveRecord iterates, one by one, through the items
updating the attributes.

We need to improve the performance, as we are working with thousands
of records, so we will use `update_all` which uses a single query.