### PR TITLE
Include the query params on the CSV download link

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -6,7 +6,10 @@ class SandboxController < ApplicationController
       .by_base_path(base_path)
 
     respond_to do |format|
-      format.html { @summary = @metrics.metric_summary }
+      format.html do
+        @summary = @metrics.metric_summary
+        @query_params = params.permit(:from, :to, :base_path)
+      end
       format.csv { stream_data_as_csv(@metrics) }
     end
   end

--- a/app/views/sandbox/index.html.erb
+++ b/app/views/sandbox/index.html.erb
@@ -4,6 +4,6 @@
 
 <%= render 'summary' %>
 
-<%= link_to 'Export to CSV', sandbox_path(format: :csv) %>
+<%= link_to 'Export to CSV', sandbox_path({format: :csv}.merge(@query_params)) %>
 
 <%= render 'charts' %>

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -53,9 +53,10 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     )
     metric1.update pageviews: 10
     metric2.update pageviews: 10
+    metric3.update pageviews: 5
     visit '/sandbox'
-    fill_in 'From:', with: '2018-01-13'
-    fill_in 'To:', with: '2018-01-15'
+    fill_in 'From:', with: '2018-01-12'
+    fill_in 'To:', with: '2018-01-13'
 
     click_button 'Filter'
 
@@ -65,6 +66,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="metrics.csv"'
     expect(page.body).to include('2018-01-12,cont-id,/really-interesing,Really interesting,desc,')
     expect(page.body).to include('2018-01-13,cont-id,/really-interesing,Really interesting,desc,')
+    expect(page.body).not_to include('2018-01-14')
   end
 
   describe 'Charts' do


### PR DESCRIPTION
I forgot to put the query parameters on the CSV download link for trello card:
[CSV to export data from sandbox](https://trello.com/c/WP15RbnO/146-2-csv-to-export-data-from-sandbox).

This caused it to download all the data. Fixed now.