### PR TITLE
Store content from 5 more formats

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -45,24 +45,29 @@ private
     corporate_information_page
     detailed_guide
     document_collection
+    email_alert_signup
     fatality_notice
+    finder_email_signup
     guide
     help
     hmrc_manual_section
     html_publication
     licence
+    location_transaction
     manual
     manual_section
     news_article
     place
     publication
     service_manual_guide
+    service_manual_topic
     simple_smart_answer
     specialist_document
     speech
     statistical_data_set
     take_part
     topical_event_about_page
+    transaction
     travel_advice
     working_group
     world_location_news_article
@@ -81,6 +86,16 @@ private
       html = extract_place(json)
     when 'guide', 'travel_advice'
       html = extract_parts(json)
+    when 'transaction'
+      html = extract_transaction(json)
+    when 'email_alert_signup'
+      html = extract_email_signup(json)
+    when 'finder_email_signup'
+      html = extract_finder(json)
+    when 'location_transaction'
+      html = extract_location_transaction(json)
+    when 'service_manual_topic'
+      html = extract_manual_topic(json)
     else
       html = extract_main(json)
     end
@@ -99,13 +114,57 @@ private
   end
 
   def extract_parts(json)
-    text = []
-    html = json.dig("details")
-    html["parts"].each do |part|
-      text << part["title"]
-      text << part["body"]
+    html = []
+    json.dig("details", "parts").each do |part|
+      html << part["title"]
+      html << part["body"]
     end
-    text.join(" ")
+    html.join(" ")
+  end
+
+  def extract_transaction(json)
+    html = []
+    html << json.dig("details", "introductory_paragraph")
+    html << json.dig("details", "start_button_text")
+    html << json.dig("details", "will_continue_on")
+    html << json.dig("details", "more_information")
+    html.join(" ")
+  end
+
+  def extract_email_signup(json)
+    html = []
+    json.dig("details", "breadcrumbs").each do |crumb|
+      html << crumb["title"]
+    end
+    html << json.dig("details", "summary")
+    html.join(" ")
+  end
+
+  def extract_finder(json)
+    html = []
+    json.dig("details", "email_signup_choice").each do |choice|
+      html << choice["radio_button_name"]
+    end
+    html << json.dig("description")
+    html.join(" ")
+  end
+
+  def extract_location_transaction(json)
+    html = []
+    html << json.dig("details", "introduction")
+    html << json.dig("details", "need_to_know")
+    html << json.dig("details", "more_information")
+    html.join(" ")
+  end
+
+  def extract_manual_topic(json)
+    html = []
+    html << json.dig("description")
+    json.dig("details", "groups").each do |group|
+      html << group["name"]
+      html << group["description"]
+    end
+    html.join(" ")
   end
 
   def extract_main(json)

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -56,6 +56,54 @@ RSpec.describe Dimensions::Item, type: :model do
         expect(item.get_content).to eq('Schools Local council Appeal No placement')
       end
 
+      it "returns content json if schema_name is 'transaction'" do
+        json = { schema_name: "transaction",
+          details: { introductory_paragraph: "Report changes",
+                    start_button_text: "Start",
+                    will_continue_on: "Carer's Allowance service",
+                    more_information: "Facts" } }
+        item = create(:dimensions_item, raw_json: json)
+        expected = "Report changes Start Carer's Allowance service Facts"
+        expect(item.get_content).to eq(expected)
+      end
+
+      it "returns content json if schema_name is 'email_alert_signup'" do
+        json = { schema_name: "email_alert_signup",
+          details: { breadcrumbs: [{ title: "The title" }],
+                     summary: "Summary" } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("The title Summary")
+      end
+
+      it "returns content json if schema_name is 'finder_email_signup'" do
+        json = { schema_name: "finder_email_signup",
+                 description: "Use buttons",
+                 details: { email_signup_choice:
+                   [{ radio_button_name: "Yes" },
+                    { radio_button_name: "No" }] } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Yes No Use buttons")
+      end
+
+      it "returns content json if schema_name is 'location_transaction'" do
+        json = { schema_name: "location_transaction",
+                 details: { introduction: "Greetings", need_to_know: "A Name",
+                            more_information: "An Address" } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Greetings A Name An Address")
+      end
+
+      it "returns content json if schema_name is 'service_manual_topic'" do
+        json = { schema_name: "service_manual_topic",
+                 description: "Blogs",
+                 details: { groups: [{ name: "Design",
+                                       description: "thinking" },
+                                     { name: "Performance",
+                                       description: "analysis" }] } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Blogs Design thinking Performance analysis")
+      end
+
       def build_raw_json(body:)
         {
           schema_name: :detailed_guide,


### PR DESCRIPTION
This story [Trello: Store content from 13 formats (batch 3)](https://trello.com/c/7F654bYW/149-5-store-content-from-add-number-formats-batch-3) is a continuation of work to store content from content types, enabling us to apply content quality calculations. I have broken the story into two parts, with five schema types in this commit.

The schemas that form part of this commit are:
'email_alert_signup', 'transaction', 'finder_email_signup', 'location_transaction' and service_manual_topic.

Previous Work:
[PR 521 - Extract content from schemas: guide, travel_advice, 'place' & 'licence'](https://github.com/alphagov/content-performance-manager/pull/521)
[PR 490 - Store content v2](https://github.com/alphagov/content-performance-manager/pull/490)