### PR TITLE
Add integration test for Quality metrics and Metadata for a Content Item

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -44,11 +44,11 @@ private
   end
 
   def format_response(item_raw_json)
-    metadata = format_metadata(item_raw_json.to_h)
+    metadata = format_metadata(item_raw_json)
     metadata.merge(
       raw_json: item_raw_json,
-      number_of_pdfs: number_of_pdfs(item_raw_json.to_h['details']),
-      number_of_word_files: number_of_word_files(item_raw_json.to_h['details'])
+      number_of_pdfs: number_of_pdfs(item_raw_json['details']),
+      number_of_word_files: number_of_word_files(item_raw_json['details'])
     )
   end
 

--- a/app/domain/importers/quality_metrics.rb
+++ b/app/domain/importers/quality_metrics.rb
@@ -7,7 +7,7 @@ class Importers::QualityMetrics
     new(*args).run
   end
 
-  def initialize(item_id)
+  def initialize(item_id, _ = {})
     @item_id = item_id
     @content_quality_service = ContentQualityService.new
   end

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -1,0 +1,100 @@
+require 'sidekiq/testing'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe 'Process content item' do
+  include GdsApi::TestHelpers::ContentStore
+
+  around do |example|
+    Sidekiq::Testing.inline! do
+      example.run
+    end
+  end
+
+  let(:content_id) { 'id1' }
+  let(:base_path) { '/the-base-path' }
+  let(:item_content) { 'This is the content.' }
+
+  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path }
+
+  it 'stores metadata in quality metrics for a content item' do
+    stub_item_metadata_in_content_store
+    stub_quality_metrics_in_heroku
+
+    Importers::ContentDetails.run(content_id, base_path)
+
+    expect(item.reload).to have_attributes(
+      content_id: content_id,
+      base_path: base_path,
+      title: 'title1',
+      document_type: 'document_type1',
+      content_purpose_document_supertype: 'content_purpose_document_supertype1',
+      first_published_at: Time.new(2018, 2, 19),
+      public_updated_at: Time.new(2018, 2, 19),
+      number_of_pdfs: 2,
+      number_of_word_files: 2,
+    )
+
+    expect(item).to have_attributes(
+      readability_score: 97,
+      string_length: 20,
+      sentence_count: 1,
+      word_count: 4,
+      contractions_count: 2,
+      equality_count: 3,
+      indefinite_article_count: 4,
+      passive_count: 5,
+      profanities_count: 6,
+      redundant_acronyms_count: 7,
+      repeated_words_count: 8,
+      simplify_count: 9,
+      spell_count: 10,
+    )
+  end
+
+  def stub_item_metadata_in_content_store
+    response = content_item_for_base_path(base_path)
+    response.merge!(
+      'content_id' => content_id,
+      'base_path' => base_path,
+      'schema_name' => 'news_article',
+      'title' => 'title1',
+      'document_type' => 'document_type1',
+      'content_purpose_document_supertype' => 'content_purpose_document_supertype1',
+      'first_published_at' => Time.new(2018, 2, 19).to_s,
+      'public_updated_at' => Time.new(2018, 2, 19).to_s,
+      'details' => {
+        'documents' => [
+          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
+          '<div class=\"attachment-details\">\n<a href=\"link.docx\">1</a>\n\n\n\n</div>',
+        ],
+        'final_outcome_documents' => [
+          '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>',
+          '<div class=\"attachment-details\">\n<a href=\"link.docx\">1</a>\n\n\n\n</div>',
+        ],
+        'body' => item_content,
+      }
+    )
+    content_store_has_item(base_path, response, {})
+  end
+
+  def stub_quality_metrics_in_heroku
+    quality_metrics_response = {
+      readability: { 'count' => 1 },
+      contractions: { 'count' => 2 },
+      equality: { 'count' => 3 },
+      indefinite_article: { 'count' => 4 },
+      passive: { 'count' => 5 },
+      profanities: { 'count' => 6 },
+      redundant_acronyms: { 'count' => 7 },
+      repeated_words: { 'count' => 8 },
+      simplify: { 'count' => 9 },
+      spell: { 'count' => 10 }
+    }
+    stub_request(:post, 'https://gov-quality-metrics.herokuapp.com/metrics').
+      with(
+        body: "{\"content\":\"#{item_content}\"}",
+        headers: { 'Content-Type' => 'application/json' }
+      ).
+      to_return(status: 200, body: quality_metrics_response.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+end


### PR DESCRIPTION
Add an  integration test for metadata and quality metrics
acquisition. We need to ensure that our code is able to connect to the
sources of data and process it properly.

I have inlined the execution of Sidekiq so the delivery mechanism is 
transparent for the test.