### PR TITLE
Add primary organisation

### DIFF
--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -46,10 +46,13 @@ private
   def format_response(item_raw_json)
     metadata = format_metadata(item_raw_json)
     metadata.merge(
-      raw_json: item_raw_json,
       number_of_pdfs: number_of_pdfs(item_raw_json['details']),
       number_of_word_files: number_of_word_files(item_raw_json['details'])
-    )
+    ).merge(extract_primary_organisation(item_raw_json['links']))
+  end
+
+  def extract_primary_organisation(links)
+    Importers::PrimaryOrganisation.parse(links)
   end
 
   def number_of_pdfs(response_details)

--- a/app/domain/importers/primary_organisation.rb
+++ b/app/domain/importers/primary_organisation.rb
@@ -1,0 +1,11 @@
+class Importers::PrimaryOrganisation
+  def self.parse(links)
+    return {} unless links && links['primary_publishing_organisation']
+    org = links['primary_publishing_organisation']
+    {
+      primary_organisation_content_id: org['content_id'],
+      primary_organisation_title: org['title'],
+      primary_organisation_withdrawn: org['withdrawn']
+    }
+  end
+end

--- a/db/migrate/20180309120223_add_primary_org_fields_to_dimensions_item.rb
+++ b/db/migrate/20180309120223_add_primary_org_fields_to_dimensions_item.rb
@@ -1,0 +1,7 @@
+class AddPrimaryOrgFieldsToDimensionsItem < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :primary_organisation_title, :string
+    add_column :dimensions_items, :primary_organisation_content_id, :string
+    add_column :dimensions_items, :primary_organisation_withdrawn, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180307113805) do
+ActiveRecord::Schema.define(version: 20180309120223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,9 @@ ActiveRecord::Schema.define(version: 20180307113805) do
     t.integer "string_length", default: 0
     t.integer "sentence_count", default: 0
     t.integer "word_count", default: 0
+    t.string "primary_organisation_title"
+    t.string "primary_organisation_content_id"
+    t.boolean "primary_organisation_withdrawn"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
   end
 

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe Importers::ContentDetails do
       expect(latest_dimension_item.first_published_at).to eq(Time.new.strftime('2012-10-03T13:19:55.000+00:00'))
       expect(latest_dimension_item.public_updated_at).to eq(Time.new.strftime('2015-06-03T11:13:44.000+00:00'))
     end
+
+    it 'populates the primary_organisation' do
+      allow(subject.items_service).to receive(:fetch_raw_json).and_return(
+        'links' => {
+          'primary_publishing_organisation' => {
+            'title' => 'Home Office',
+            'content_id' => 'cont-id-1',
+            'withdrawn' => false
+          }
+        }
+      )
+      subject.run
+      expect(latest_dimension_item.reload).to have_attributes(
+        primary_organisation_title: 'Home Office',
+        primary_organisation_content_id: 'cont-id-1',
+        primary_organisation_withdrawn: false
+      )
+    end
   end
 
   context 'when GdsApi::HTTPGone is raised' do

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe 'Process content item' do
       simplify_count: 9,
       spell_count: 10,
     )
+
+    expect(item).to have_attributes(
+      primary_organisation_title: 'Home Office',
+      primary_organisation_content_id: 'cont-id-1',
+      primary_organisation_withdrawn: false
+    )
   end
 
   def stub_item_metadata_in_content_store
@@ -72,6 +78,13 @@ RSpec.describe 'Process content item' do
           '<div class=\"attachment-details\">\n<a href=\"link.docx\">1</a>\n\n\n\n</div>',
         ],
         'body' => item_content,
+      },
+      'links' => {
+        'primary_publishing_organisation' => {
+          'title' => 'Home Office',
+          'content_id' => 'cont-id-1',
+          'withdrawn' => false
+        }
       }
     )
     content_store_has_item(base_path, response, {})


### PR DESCRIPTION
Extract the primary organisation details from
the raw_json returned by the content-store.

This is to enable the requirement for the CPM to filter by
organisation.

For the Trello card [Add Primary Org to the database](https://trello.com/c/GmuyPYBh/147-2-etl-add-primary-org-to-the-database)