### PR TITLE
Define metric metadata for use by the API

### DIFF
--- a/app/models/api/metric.rb
+++ b/app/models/api/metric.rb
@@ -9,7 +9,7 @@ class Api::Metric
 
   attr_reader :metric, :from, :to, :content_id
 
-  validates :metric, presence: true, inclusion: { in: Facts::Metric::METRIC_WHITELIST }
+  validates :metric, presence: true, inclusion: { in: Rails.configuration.valid_metric_names }
   validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
   validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
   validates :content_id, presence: true, format: { with: CONTENT_ID_REGEX, message: "Content ID must be a UUID." }

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -62,6 +62,4 @@ class Facts::Metric < ApplicationRecord
       spell_count
     ]
   end
-
-  METRIC_WHITELIST = %w[pageviews unique_pageviews number_of_pdfs number_of_issues number_of_word_files].freeze
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,9 @@ module ContentPerformanceManager
 
     config.autoload_paths += additional_paths
     config.eager_load_paths += additional_paths
+
+    # Metadata about the metrics we collect
+    config.metrics = config_for(:metrics)
+    config.valid_metric_names = config.metrics.keys.map(&:to_s)
   end
 end

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -1,0 +1,75 @@
+default: &default
+  pageviews:
+    description: "Number of pageviews"
+    source: Google Analytics
+
+  unique_pageviews:
+    description: "Number of unique pageviews"
+    source: Google Analytics
+
+  number_of_issues:
+    description: "Number of reported content issues"
+    source: Feedback explorer
+
+  number_of_pdfs:
+    description: "Number of .pdf attachments"
+    source: Publishing API
+
+  number_of_word_files:
+    description: "Number of .doc attachments"
+    source: Publishing API
+
+  readability_score:
+    description: "Flesch-Kincaid Reading Ease score"
+
+  contractions_count:
+    description: "Count of improper apostrophe use in contractions."
+    source: retext
+
+  equality_count:
+    description: "Number of times potentially insensitive language is used"
+    source: retext
+
+  indefinite_article_count:
+    description: "Number of times the indefinite articles (a, an) are used incorrectly"
+    source: retext
+
+  passive_count:
+    description: "Number of times the passive voice is used"
+    source: retext
+
+  profanities_count:
+    description: "Number of times profanities are used"
+    source: retext
+
+  redundant_acronyms_count:
+    description: "Number of times redundant acronyms are used (like ATM machine instead of ATM)"
+    source: retext
+
+  repeated_words_count:
+    description: 'Number of times a word is repeated (like "for for")'
+    source: retext
+
+  simplify_count:
+    description: "Count of complicated words that have a simpler alternative"
+
+  spell_count:
+    description: "Number of spelling errors"
+
+  string_length:
+    description: "Total number of characters used in the text"
+
+  sentence_count:
+    description: "Total number of sentences detected in the text"
+
+  word_count:
+    description: "Total number of words detected in the text"
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default


### PR DESCRIPTION
This replaces the `METRIC_WHITELIST` constant and adds in `dimensions_items`
columns, which will allow the API to return any quality metric.

My intention is to serve the metric names and descriptions at a separate
endpoint (`GET /metrics`).

Benefits of this:

- we don't have to exhaustively document all the available metrics for each
  endpoint and keep multiple things in sync
- api users can discover what's available through the API itself
- api clients can programatically generate ui controls for
  filtering/displaying/exporting metrics (the API doesn't support all this yet,
but I'm thinking it should eventually)

Part of https://trello.com/c/MOAQhWJZ/154-finalise-api-endpoints-for-querying-a-single-item