### PR TITLE
Fix bug with processing of primary organisation, now expecting an array

### DIFF
--- a/app/domain/importers/primary_organisation.rb
+++ b/app/domain/importers/primary_organisation.rb
@@ -1,7 +1,7 @@
 class Importers::PrimaryOrganisation
   def self.parse(links)
     return {} unless links && links['primary_publishing_organisation']
-    org = links['primary_publishing_organisation']
+    org = links['primary_publishing_organisation'].first
     {
       primary_organisation_content_id: org['content_id'],
       primary_organisation_title: org['title'],

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe Importers::ContentDetails do
     it 'populates the primary_organisation' do
       allow(subject.items_service).to receive(:fetch_raw_json).and_return(
         'links' => {
-          'primary_publishing_organisation' => {
+          'primary_publishing_organisation' => [{
             'title' => 'Home Office',
             'content_id' => 'cont-id-1',
             'withdrawn' => false
-          }
+          }]
         }
       )
       subject.run

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -80,11 +80,11 @@ RSpec.describe 'Process content item' do
         'body' => item_content,
       },
       'links' => {
-        'primary_publishing_organisation' => {
+        'primary_publishing_organisation' => [{
           'title' => 'Home Office',
           'content_id' => 'cont-id-1',
           'withdrawn' => false
-        }
+        }]
       }
     )
     content_store_has_item(base_path, response, {})


### PR DESCRIPTION
Our code didn't expect primary org under links to be an array.
Now we are just picking the first one.