### PR TITLE
Fix multiple decimals in Reading score

### DIFF
--- a/app/views/sandbox/_charts.html.erb
+++ b/app/views/sandbox/_charts.html.erb
@@ -43,7 +43,7 @@
   <% end %>
   <% if params[:readability_score].present? %>
       <div class="readability_score">
-        <h3>Reading score (avg)</h3>
+        <h3>Reading score</h3>
         <%= line_chart(@metrics.group(:dimensions_date_id).sum(:readability_score), height: '150px') %>
       </div>
   <% end %>

--- a/app/views/sandbox/_sidebar.html.erb
+++ b/app/views/sandbox/_sidebar.html.erb
@@ -61,7 +61,7 @@
       <div class="form-group">
         <%= label_tag do %>
             <%= check_box_tag 'readability_score', params[:readability_score], params[:readability_score].present? %>
-            Readability score (avg)
+            Readability score
         <% end %>
       </div>
       <div class="form-group">

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -33,7 +33,7 @@
       <span class="summary-item-label">Spelling errors</span>
     </div>
     <div class="summary-item col-xs-3 readability_score">
-      <span class="summary-item-value"><%= number_with_delimiter (@summary[:readability_score] || 0), precision: 2 %></span>
+      <span class="summary-item-value"><%= number_with_precision (@summary[:readability_score] || 0), precision: 2 %></span>
       <span class="summary-item-label">Readability score (avg)</span>
     </div>
   </div>

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.number_of_pdfs', text: '3.00 PDFs (avg)')
     expect(page).to have_selector('.number_of_word_files', text: '1.50 Word (avg)')
     expect(page).to have_selector('.spell_count', text: '16 Spelling errors')
-    expect(page).to have_selector('.readability_score', text: '3.0 Readability score (avg)')
+    expect(page).to have_selector('.readability_score', text: '3.00 Readability score (avg)')
   end
 
   scenario 'Summary panel when no data' do


### PR DESCRIPTION
Add number format to prevent a too many decimals issue.