### PR TITLE
Extract content from schemas: 'statistics_announcement', 'taxon' and 'unpublishing'

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -65,10 +65,13 @@ private
     specialist_document
     speech
     statistical_data_set
+    statistics_announcement
     take_part
+    taxon
     topical_event_about_page
     transaction
     travel_advice
+    unpublished
     working_group
     world_location_news_article
   ].freeze
@@ -96,6 +99,12 @@ private
       html = extract_location_transaction(json)
     when 'service_manual_topic'
       html = extract_manual_topic(json)
+    when 'unpublished'
+      html = extract_unpublished(json)
+    when 'statistics_announcement'
+      html = extract_statistics_announcement(json)
+    when 'taxon'
+      html = extract_taxon(json)
     else
       html = extract_main(json)
     end
@@ -163,6 +172,30 @@ private
     json.dig("details", "groups").each do |group|
       html << group["name"]
       html << group["description"]
+    end
+    html.join(" ")
+  end
+
+  def extract_unpublished(json)
+    json.dig("details", "explanation")
+  end
+
+  def extract_statistics_announcement(json)
+    html = []
+    html << json.dig("description")
+    html << json.dig("details", "display_date")
+    html << json.dig("details", "state")
+    html.join(" ")
+  end
+
+  def extract_taxon(json)
+    html = []
+    html << json.dig("description")
+    return unless json.dig("links").include?("child_taxons")
+    children = json.dig("links", "child_taxons")
+    children.each do |child|
+      html << child["title"]
+      html << child["description"]
     end
     html.join(" ")
   end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -104,6 +104,32 @@ RSpec.describe Dimensions::Item, type: :model do
         expect(item.get_content).to eq("Blogs Design thinking Performance analysis")
       end
 
+      it "returns content json if schema_name is 'unpublished'" do
+        json = { schema_name: "unpublished",
+                  details: { explanation: "This content has been removed" } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("This content has been removed")
+      end
+
+      it "returns content json if schema_name is 'statistics_announcement'" do
+        json = { schema_name: "statistics_announcement",
+                 description: "Announcement",
+                 details: { display_date: "25 December 2017", state: "closed" } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Announcement 25 December 2017 closed")
+      end
+
+      it "returns content json if schema_name is 'taxon'" do
+        json = { schema_name: "taxon",
+                 description: "Blogs",
+                 links: { child_taxons: [
+                            { title: "One", description: "first" },
+                            { title: "Two", description: "second" }
+                        ] } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Blogs One first Two second")
+      end
+
       def build_raw_json(body:)
         {
           schema_name: :detailed_guide,


### PR DESCRIPTION
[EPIC: Store content from all 45 formats](https://trello.com/c/QQW1upYa/156-epic-store-content-from-all-45-formats-71-complete)

This is the forth batch of schemas to be extracted that will enable us to apply content quality calculations. See [Trello: Store content from 3 formats batch 4](https://trello.com/c/nUcdyKmC/155-2-store-content-from-3-formats-batch-4). 
