### PR TITLE
Store content batch 4 new structure

### DIFF
--- a/app/models/content_extraction/parsers/statistics_announcement_parser.rb
+++ b/app/models/content_extraction/parsers/statistics_announcement_parser.rb
@@ -1,0 +1,11 @@
+class ContentExtraction::Parsers::StatisticsAnnouncementParser
+  def parse(json)
+    html = []
+    html << json.dig("description")
+    html << json.dig("details", "display_date")
+    html << json.dig("details", "state")
+    html.join(" ")
+  end
+end
+ContentExtraction::ContentParser.register('statistics_announcement',
+  ContentExtraction::Parsers::StatisticsAnnouncementParser.new)

--- a/app/models/content_extraction/parsers/taxon_parser.rb
+++ b/app/models/content_extraction/parsers/taxon_parser.rb
@@ -1,0 +1,15 @@
+class ContentExtraction::Parsers::TaxonParser
+  def parse(json)
+    html = []
+    html << json.dig("description")
+    return unless json.dig("links").include?("child_taxons")
+    children = json.dig("links", "child_taxons")
+    children.each do |child|
+      html << child["title"]
+      html << child["description"]
+    end
+    html.join(" ")
+  end
+end
+ContentExtraction::ContentParser.register('taxon',
+  ContentExtraction::Parsers::TaxonParser.new)

--- a/app/models/content_extraction/parsers/unpublished_parser.rb
+++ b/app/models/content_extraction/parsers/unpublished_parser.rb
@@ -1,0 +1,7 @@
+class ContentExtraction::Parsers::UnpublishedParser
+  def parse(json)
+    json.dig("details", "explanation")
+  end
+end
+ContentExtraction::ContentParser.register('unpublished',
+  ContentExtraction::Parsers::UnpublishedParser.new)

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -153,6 +153,32 @@ RSpec.describe Dimensions::Item, type: :model do
         expect(item.get_content).to eq("Blogs Design thinking Performance analysis")
       end
 
+      it "returns content json if schema_name is 'unpublished'" do
+        json = { schema_name: "unpublished",
+          details: { explanation: "This content has been removed" } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("This content has been removed")
+      end
+
+      it "returns content json if schema_name is 'statistics_announcement'" do
+        json = { schema_name: "statistics_announcement",
+          description: "Announcement",
+          details: { display_date: "25 December 2017", state: "closed" } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Announcement 25 December 2017 closed")
+      end
+
+      it "returns content json if schema_name is 'taxon'" do
+        json = { schema_name: "taxon",
+          description: "Blogs",
+          links: { child_taxons: [
+            { title: "One", description: "first" },
+            { title: "Two", description: "second" }
+          ] } }
+        item = create(:dimensions_item, raw_json: json)
+        expect(item.get_content).to eq("Blogs One first Two second")
+      end
+
       def build_raw_json(body:, schema_name:)
         {
           schema_name: schema_name,


### PR DESCRIPTION
This is the work Andrien has done for the batch 4 content.

I have moved the code into the new parsing structure.

The original story is [Store content from 3 formats (batch 4)](https://trello.com/c/nUcdyKmC/155-2-store-content-from-3-formats-batch-4)