### PR TITLE
Log The Number of ImportContentDetailsJobs We Create

### DIFF
--- a/app/models/etl/outdated_items.rb
+++ b/app/models/etl/outdated_items.rb
@@ -37,6 +37,7 @@ private
   end
 
   def import_content_details(items)
+    log process: :import_content_details, message: "creating #{items.length} ImportContentDetailsJobs"
     items.each do |item|
       ImportContentDetailsJob.perform_async(item.content_id, item.base_path)
     end


### PR DESCRIPTION
Simple logging of the number of ImportContentDetailsJobs created as part of the ETL::OutdatedItems processing.

For the Trello card [Add monitoring and tracing information for content quality metrics acquisition process](https://trello.com/c/eE8IL0cV/174-2-add-monitoring-and-tracing-information-for-content-quality-metrics-acquisition-process-dependent-on-172)