### PR TITLE
Use PAAS url for content quality metrics

### DIFF
--- a/app/services/content_quality_service.rb
+++ b/app/services/content_quality_service.rb
@@ -8,7 +8,7 @@ class ContentQualityService
 
 private
 
-  URL = 'https://gov-quality-metrics.herokuapp.com/metrics'.freeze
+  URL = 'https://govuk-content-quality-metrics.cloudapps.digital/metrics'.freeze
 
   def fetch(content)
     response = HTTParty.post(

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Master process spec' do
       passive: { 'count' => 5 },
       repeated_words: { 'count' => 8 },
     }
-    stub_request(:post, 'https://gov-quality-metrics.herokuapp.com/metrics').
+    stub_request(:post, 'https://govuk-content-quality-metrics.cloudapps.digital/metrics').
       with(
         body: { content: item_content }.to_json,
         headers: { 'Content-Type' => 'application/json' }

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Process content item' do
       simplify: { 'count' => 9 },
       spell: { 'count' => 10 }
     }
-    stub_request(:post, 'https://gov-quality-metrics.herokuapp.com/metrics').
+    stub_request(:post, 'https://govuk-content-quality-metrics.cloudapps.digital/metrics').
       with(
         body: "{\"content\":\"#{item_content}\"}",
         headers: { 'Content-Type' => 'application/json' }


### PR DESCRIPTION
Use PAAS rather than heroku to host the service for increased performance. 
I have checked that all is running as expected in Integration.