### PR TITLE
Ensure ETL::Master only runs once per date

### DIFF
--- a/app/data/etl/master.rb
+++ b/app/data/etl/master.rb
@@ -10,6 +10,7 @@ class ETL::Master
   end
 
   def process
+    raise DuplicateDateError if Dimensions::Date.exists?(date)
     time(process: :master) do
       ETL::OutdatedItems.process(date: dimensions_date.date)
       ETL::Metrics.process(date: dimensions_date.date)
@@ -25,4 +26,7 @@ private
   end
 
   attr_reader :date
+
+  class DuplicateDateError < StandardError;
+  end
 end

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -30,6 +30,10 @@ class Dimensions::Date < ApplicationRecord
     end
   end
 
+  def self.exists?(date)
+    Dimensions::Date.where(date: date).exists?
+  end
+
   validates :date, presence: true
 
   validates :date_name, presence: true

--- a/spec/etl/master_spec.rb
+++ b/spec/etl/master_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe ETL::Master do
     allow(ETL::Metrics).to receive(:process)
   end
 
+  it 'does not process if already processed for date' do
+    create(:dimensions_date, date: Date.yesterday)
+
+    expect { subject.process }.to raise_error(ETL::Master::DuplicateDateError)
+  end
 
   it 'creates a Metrics fact per content item' do
     subject.process

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Dimensions::Date, type: :model do
+  let(:date) { ::Date.new(2017, 12, 21) }
   it { is_expected.to validate_presence_of(:date) }
 
   it { is_expected.to validate_presence_of(:date_name) }
@@ -82,8 +83,6 @@ RSpec.describe Dimensions::Date, type: :model do
   describe '.build' do
     subject { described_class.build(date) }
 
-    let(:date) { ::Date.new(2017, 12, 21) }
-
     it "builds a date dimension from the date" do
       is_expected.to have_attributes(
         date: ::Date.new(2017, 12, 21),
@@ -124,6 +123,20 @@ RSpec.describe Dimensions::Date, type: :model do
 
         expect(Dimensions::Date.count).to eq(1)
         expect(dimension_date.date).to eq(date)
+      end
+    end
+  end
+
+  describe '.exists?' do
+    context 'when a dimension exists for the the given date' do
+      it 'returns true' do
+        create(:dimensions_date, date: date)
+        expect(Dimensions::Date.exists?(date)).to eq true
+      end
+    end
+    context 'when a dimension does not exist for the the given date' do
+      it 'returns false' do
+        expect(Dimensions::Date.exists?(date)).to eq false
       end
     end
   end


### PR DESCRIPTION
In order to ensure that we do not have duplicate
Dimensions::Date objects in our database.