### PR TITLE
Add a healthcheck to the API

### DIFF
--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -1,0 +1,14 @@
+class Api::HealthcheckController < ApiController
+  def index
+    database = ActiveRecord::Base.connected? ? :ok : :critical
+
+    healthcheck = {
+      checks: {
+        database: database
+      },
+      status: database
+    }
+
+    render json: healthcheck
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     get '/v1/metrics/:metric/:content_id/', to: "metrics#summary"
     get '/v1/metrics/:metric/:content_id/time-series', to: "metrics#time_series"
+    get '/v1/healthcheck', to: "healthcheck#index"
   end
 
   get '/sandbox', to: 'sandbox#index'


### PR DESCRIPTION
We used to use the homepage of content performance manager as a healthcheck,
but this no longer exists.

This uses the JSON healthcheck format established by email alert API and whitehall.