### PR TITLE
Skip auth for the healthcheck endpoint

### DIFF
--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -1,4 +1,6 @@
 class Api::HealthcheckController < ApiController
+  skip_before_action :authenticate_user!
+
   def index
     database = ActiveRecord::Base.connected? ? :ok : :critical
 


### PR DESCRIPTION
At the moment the API is behind signon auth. This will be removed soon but until it is we need to skip the action here.