### PR TITLE
Make healthcheck always return ok if the app is responding

### DIFF
--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -8,7 +8,7 @@ class Api::HealthcheckController < ApiController
       checks: {
         database: database
       },
-      status: database
+      status: :ok
     }
 
     render json: healthcheck


### PR DESCRIPTION
ActiveRecord::Base.connected? can be false if the app hasn't
tried to connect to the DB yet. I think this happens often because
the app isn't used much yet.