### PR TITLE
Do not calculate content quality metrics again if content has not changed

### DIFF
--- a/app/data/content/parser.rb
+++ b/app/data/content/parser.rb
@@ -39,7 +39,7 @@ module Content
         Parsers::Taxon,
         Parsers::Transaction,
         Parsers::TravelAdviceIndex,
-        Parsers::Unpublished
+        Parsers::Unpublished,
       ].each(&method(:register_parser))
     end
 

--- a/app/data/metadata/parser.rb
+++ b/app/data/metadata/parser.rb
@@ -5,7 +5,8 @@ class Metadata::Parser
       Metadata::Parsers::NumberOfPdfs,
       Metadata::Parsers::NumberOfWordFiles,
       Metadata::Parsers::Metadata,
-      Metadata::Parsers::PrimaryOrganisation
+      Metadata::Parsers::PrimaryOrganisation,
+      Metadata::Parsers::ContentHash
     ]
   end
 

--- a/app/data/metadata/parser.rb
+++ b/app/data/metadata/parser.rb
@@ -6,7 +6,7 @@ class Metadata::Parser
       Metadata::Parsers::NumberOfWordFiles,
       Metadata::Parsers::Metadata,
       Metadata::Parsers::PrimaryOrganisation,
-      Metadata::Parsers::ContentHash
+      Metadata::Parsers::ContentHash,
     ]
   end
 

--- a/app/data/metadata/parsers/content_hash.rb
+++ b/app/data/metadata/parsers/content_hash.rb
@@ -1,0 +1,7 @@
+class Metadata::Parsers::ContentHash
+  def self.parse(raw_json)
+    {
+      content_hash: Digest::SHA1.hexdigest(Content::Parser.extract_content(raw_json))
+    }
+  end
+end

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -22,9 +22,10 @@ class Importers::ContentDetails
 
         item_raw_json = items_service.fetch_raw_json(base_path)
         attributes = Metadata::Parser.parse(item_raw_json)
+        content_changed = item.content_hash != attributes[:content_hash]
         item.update_attributes(attributes)
 
-        ImportQualityMetricsJob.perform_async(item.id)
+        ImportQualityMetricsJob.perform_async(item.id) if content_changed
       end
     rescue GdsApi::HTTPGone
       item.gone!

--- a/db/migrate/20180319161814_add_content_hash_to_dimensions_item.rb
+++ b/db/migrate/20180319161814_add_content_hash_to_dimensions_item.rb
@@ -1,0 +1,5 @@
+class AddContentHashToDimensionsItem < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :content_hash, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180315144816) do
+ActiveRecord::Schema.define(version: 20180319161814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20180315144816) do
     t.string "primary_organisation_title"
     t.string "primary_organisation_content_id"
     t.boolean "primary_organisation_withdrawn"
+    t.string "content_hash"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
   end

--- a/spec/data/metadata/parser_spec.rb
+++ b/spec/data/metadata/parser_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Metadata::Parser do
   let(:raw_json) { { 'details' => 'the-json' } }
-
+  let(:content_hash) { '94e66df8cd09d410c62d9e0dc59d3a884e458e05' }
   subject { described_class.instance }
   before :each do
     allow(Metadata::Parsers::NumberOfPdfs).to receive(:parse).with(raw_json).and_return(number_of_pdfs: 99)
@@ -13,6 +13,7 @@ RSpec.describe Metadata::Parser do
       'first_published_at' => '2012-10-03T13:19:55.000+00:00',
       'public_updated_at' => '2015-06-03T11:13:44.000+00:00',
     )
+    allow(Metadata::Parsers::ContentHash).to receive(:parse).and_return(content_hash: content_hash)
   end
 
   it 'populates raw_json field of latest version of dimensions_items' do
@@ -45,5 +46,12 @@ RSpec.describe Metadata::Parser do
       'public_updated_at' => '2015-06-03T11:13:44.000+00:00'
     )
     expect(Metadata::Parsers::Metadata).to have_received(:parse).with(raw_json)
+  end
+
+  it 'populates the content hash' do
+    expect(subject.parse(raw_json)).to include(
+      content_hash: content_hash
+    )
+    expect(Metadata::Parsers::ContentHash).to have_received(:parse).with(raw_json)
   end
 end

--- a/spec/data/metadata/parsers/content_hash_spec.rb
+++ b/spec/data/metadata/parsers/content_hash_spec.rb
@@ -1,0 +1,18 @@
+require 'digest/sha1'
+RSpec.describe Metadata::Parsers::ContentHash do
+  subject { described_class }
+
+  let(:content) { 'some content' }
+  let(:raw_json) { { some: 'json' } }
+
+  before :each do
+    allow(Content::Parser).to receive(:extract_content).and_return(content)
+  end
+
+  it "returns the hash of the content as 'content_hash'" do
+    expect(subject.parse(raw_json)).to eq(
+      content_hash: Digest::SHA1.hexdigest(content)
+    )
+    expect(Content::Parser).to have_received(:extract_content).with(raw_json)
+  end
+end

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Importers::ContentDetails do
         public_updated_at: Time.new(2015, 6, 3, 11, 13, 44),
         primary_organisation_title: 'Home Office',
         primary_organisation_content_id: 'cont-id-1',
-        primary_organisation_withdrawn: false
+        primary_organisation_withdrawn: false,
+        content_hash: 'ContentHashContentHash'
       )
     end
 
@@ -49,7 +50,8 @@ RSpec.describe Importers::ContentDetails do
         public_updated_at: Time.new(2015, 6, 3, 11, 13, 44),
         primary_organisation_title: 'Home Office',
         primary_organisation_content_id: 'cont-id-1',
-        primary_organisation_withdrawn: false
+        primary_organisation_withdrawn: false,
+        content_hash: 'ContentHashContentHash'
       )
     end
 

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe 'Process content item' do
       primary_organisation_content_id: 'cont-id-1',
       primary_organisation_withdrawn: false
     )
+
+    expect(item).to have_attributes(
+      content_hash: 'bfce49ef213b4f9f82a6a46caae2d81a4bcda1f2'
+    )
   end
 
   def stub_item_metadata_in_content_store

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -13,8 +13,13 @@ RSpec.describe 'Process content item' do
   let(:content_id) { 'id1' }
   let(:base_path) { '/the-base-path' }
   let(:item_content) { 'This is the content.' }
+  let(:content_hash) { 'bfce49ef213b4f9f82a6a46caae2d81a4bcda1f2' }
 
-  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path }
+  let!(:item) {
+    create :dimensions_item,
+    content_id: content_id, base_path: base_path,
+    content_hash: 'OldContentHash'
+  }
 
   it 'stores metadata in quality metrics for a content item' do
     stub_item_metadata_in_content_store
@@ -57,7 +62,7 @@ RSpec.describe 'Process content item' do
     )
 
     expect(item).to have_attributes(
-      content_hash: 'bfce49ef213b4f9f82a6a46caae2d81a4bcda1f2'
+      content_hash: content_hash
     )
   end
 


### PR DESCRIPTION
There is no need to re-calculate the quality metrics unless the content has changed.

This work breaks down as follows.

* Store a SHA1 digest of the content parsed from the raw JSON in the Dimensions::Item.
* Check that digest against the new content retrieved from the content store.
* Only fire the ImportQualityMetricsJob if the content digest is different.

The Trello card is [Do not calculate content quality metrics again if content has not changed](https://trello.com/c/GliSXCSl/170-3-do-not-calculate-content-quality-metrics-again-if-content-has-not-changed).

As a dev/ops of the data warehouse
I want to calculate quality metrics only when the content has been updated
So that I don't waste GOV.UK resources on infrastructure