### PR TITLE
Remove Poltergeist from RSpec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'listen'
   gem 'phantomjs'
-  gem 'poltergeist'
   gem 'pry-rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
     chartkick (2.3.2)
-    cliver (0.3.2)
     coderay (1.1.2)
     coffee-script (2.4.1)
       coffee-script-source
@@ -278,10 +277,6 @@ GEM
     pg (1.0.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -509,7 +504,6 @@ DEPENDENCIES
   pg
   phantomjs
   plek
-  poltergeist
   pry-rails
   puma
   rack-proxy

--- a/config/initializers/silence_poltergeist.rb
+++ b/config/initializers/silence_poltergeist.rb
@@ -1,8 +1,0 @@
-# Silence the Poltergeist version warning.
-module Capybara
-  module Poltergeist
-    class Client
-      def warn(*); end
-    end
-  end
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "support/authentication"
 require "webmock/rspec"
-require "capybara/poltergeist"
 require "gds_api/test_helpers/publishing_api_v2"
 require "pry"
 require "database_cleaner"
@@ -35,16 +34,11 @@ RSpec.configure do |config|
     ActiveRecord::Migration.maintain_test_schema!
     Rails.application.load_tasks
     WebMock.disable_net_connect!(allow_localhost: true)
-    Capybara.javascript_driver = :poltergeist
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  def use_truncation?
-    Capybara.current_driver != :rack_test
-  end
-
   config.before(:each) do
-    DatabaseCleaner.strategy = use_truncation? ? :truncation : :transaction
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION

Speed up our tests 40%

There is no need to rely on Poltergeist to run our tests, as we have no JS.