### PR TITLE
Add concern to set downloadable headers

### DIFF
--- a/app/controllers/concerns/exportable_to_csv.rb
+++ b/app/controllers/concerns/exportable_to_csv.rb
@@ -1,0 +1,30 @@
+require 'active_support/concern'
+
+module Concerns::ExportableToCSV
+  extend ActiveSupport::Concern
+
+  included do
+    def export_to_csv(enum:)
+      set_file_headers
+      set_streaming_headers
+
+      response.status = 200
+      self.response_body = enum
+    end
+
+  private
+
+    def set_file_headers
+      headers['Content-Type'] = 'text/csv'
+      headers['Content-disposition'] = "attachment; filename=\"download.csv\""
+    end
+
+    def set_streaming_headers
+      #nginx doc: Setting this to "no" will allow unbuffered responses suitable for Comet and HTTP streaming applications
+      headers['X-Accel-Buffering'] = 'no'
+
+      headers['Cache-Control'] ||= 'no-cache'
+      headers.delete('Content-Length')
+    end
+  end
+end

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -1,4 +1,6 @@
 class SandboxController < ApplicationController
+  include Concerns::ExportableToCSV
+
   def index
     @metrics = Facts::Metric
       .joins(:dimensions_item)
@@ -9,43 +11,15 @@ class SandboxController < ApplicationController
     respond_to do |format|
       format.html do
         @summary = @metrics.metric_summary
-        @query_params = params.permit(:from, :to, :base_path, :utf8,
-          :total_items, :pageviews, :unique_pageviews, :feedex_issues,
-          :number_of_pdfs, :number_of_word_files, :filter, :organisation, :spell_count,
-          :readability_score)
+        @query_params = query_params
       end
-      format.csv { stream_data_as_csv(@metrics) }
+      format.csv do
+        export_to_csv enum: CSVExport.run(@metrics, Facts::Metric.csv_fields)
+      end
     end
   end
 
 private
-
-  def stream_data_as_csv(scope)
-    set_file_headers
-    set_streaming_headers
-
-    response.status = 200
-
-    self.response_body = enumerator_of_csv_lines(scope)
-  end
-
-  def enumerator_of_csv_lines(scope)
-    CSVExport.run(scope, Facts::Metric.csv_fields)
-  end
-
-  def set_file_headers
-    file_name = "metrics.csv"
-    headers["Content-Type"] = "text/csv"
-    headers["Content-disposition"] = "attachment; filename=\"#{file_name}\""
-  end
-
-  def set_streaming_headers
-    #nginx doc: Setting this to "no" will allow unbuffered responses suitable for Comet and HTTP streaming applications
-    headers['X-Accel-Buffering'] = 'no'
-
-    headers["Cache-Control"] ||= "no-cache"
-    headers.delete("Content-Length")
-  end
 
   def from
     params[:from] ||= 5.days.ago.to_date
@@ -61,5 +35,12 @@ private
 
   def organisation
     params[:organisation]
+  end
+
+  def query_params
+    params.permit(:from, :to, :base_path, :utf8,
+      :total_items, :pageviews, :unique_pageviews, :feedex_issues,
+      :number_of_pdfs, :number_of_word_files, :filter, :organisation, :spell_count,
+      :readability_score)
   end
 end

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     click_on 'Export to CSV'
 
     expect(page.response_headers['Content-Type']).to eq "text/csv"
-    expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="metrics.csv"'
+    expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="download.csv"'
     expect(page.body).to include('2018-01-12,cont-id,/really-interesting,Really interesting,desc')
     expect(page.body).to include('2018-01-13,cont-id,/really-interesting,Really interesting,desc,')
     expect(page.body).not_to include('2018-01-14')


### PR DESCRIPTION
Increases readability by extracting a concern to hide the 
details of how the metrics are downloaded.