### PR TITLE
Use `outdated_at` attribute to grow the Items dimension

### DIFF
--- a/app/models/concerns/outdateable.rb
+++ b/app/models/concerns/outdateable.rb
@@ -1,0 +1,14 @@
+require 'active_support/concern'
+
+module Concerns::Outdateable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :outdated, -> { where(outdated: true, latest: true) }
+    scope :outdated_before, ->(date) { outdated. where('updated_at < ?', date) }
+
+    def outdate!
+      update_attributes!(outdated: true, outdated_at: Time.zone.now)
+    end
+  end
+end

--- a/app/models/concerns/outdateable.rb
+++ b/app/models/concerns/outdateable.rb
@@ -5,7 +5,7 @@ module Concerns::Outdateable
 
   included do
     scope :outdated, -> { where(outdated: true, latest: true) }
-    scope :outdated_before, ->(date) { outdated. where('outdated_at < ?', date) }
+    scope :outdated_before, ->(date) { outdated.where('outdated_at < ?', date) }
 
     def outdate!
       update_attributes!(outdated: true, outdated_at: Time.zone.now)

--- a/app/models/concerns/outdateable.rb
+++ b/app/models/concerns/outdateable.rb
@@ -5,7 +5,7 @@ module Concerns::Outdateable
 
   included do
     scope :outdated, -> { where(outdated: true, latest: true) }
-    scope :outdated_before, ->(date) { outdated. where('updated_at < ?', date) }
+    scope :outdated_before, ->(date) { outdated. where('outdated_at < ?', date) }
 
     def outdate!
       update_attributes!(outdated: true, outdated_at: Time.zone.now)

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -3,10 +3,8 @@ require 'json'
 class Dimensions::Item < ApplicationRecord
   validates :content_id, presence: true
 
-
-  scope :outdated_before, ->(date) do
-    where('updated_at < ?', date).where(outdated: true, latest: true)
-  end
+  scope :outdated, -> { where(outdated: true, latest: true) }
+  scope :outdated_before, ->(date) { outdated. where('updated_at < ?', date) }
 
   def get_content
     return if raw_json.blank?

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -1,10 +1,9 @@
 require 'json'
 
 class Dimensions::Item < ApplicationRecord
-  validates :content_id, presence: true
+  include Concerns::Outdateable
 
-  scope :outdated, -> { where(outdated: true, latest: true) }
-  scope :outdated_before, ->(date) { outdated. where('updated_at < ?', date) }
+  validates :content_id, presence: true
 
   def get_content
     return if raw_json.blank?
@@ -15,10 +14,6 @@ class Dimensions::Item < ApplicationRecord
     new_version = self.dup
     new_version.assign_attributes(latest: true, outdated: false)
     new_version
-  end
-
-  def outdate!
-    update_attributes!(outdated: true, outdated_at: Time.zone.now)
   end
 
   def gone!

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -19,7 +19,7 @@ class Dimensions::Item < ApplicationRecord
     new_version
   end
 
-  def outdated!
+  def outdate!
     update_attributes!(outdated: true)
   end
 

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -5,7 +5,7 @@ class Dimensions::Item < ApplicationRecord
 
 
   scope :outdated_before, ->(date) do
-    where('updated_at < ?', date).where(outdated: true)
+    where('updated_at < ?', date).where(outdated: true, latest: true)
   end
 
   def get_content

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -20,7 +20,7 @@ class Dimensions::Item < ApplicationRecord
   end
 
   def outdate!
-    update_attributes!(outdated: true)
+    update_attributes!(outdated: true, outdated_at: Time.zone.now)
   end
 
   def gone!

--- a/db/migrate/20180323170720_add_oudated_at_to_dimensions_items.rb
+++ b/db/migrate/20180323170720_add_oudated_at_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddOudatedAtToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :outdated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180322140016) do
+ActiveRecord::Schema.define(version: 20180323170720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20180322140016) do
     t.string "primary_organisation_content_id"
     t.boolean "primary_organisation_withdrawn"
     t.string "content_hash"
+    t.datetime "outdated_at"
     t.index ["latest", "content_id"], name: "idx_latest_content_id"
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["latest"], name: "index_dimensions_items_on_latest"

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -16,7 +16,7 @@ class PublishingApiConsumer
 private
 
   def handle_existing(item, routing_key)
-    item.outdated!
+    item.outdate!
     item.gone! if routing_key.include? 'unpublished'
   end
 end

--- a/spec/etl/outdated_items_spec.rb
+++ b/spec/etl/outdated_items_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ETL::OutdatedItems do
       outdated: true,
       content_id: content_id,
       base_path: base_path,
-      updated_at: date
+      outdated_at: date
     )
     create(
       :dimensions_item,
@@ -23,7 +23,7 @@ RSpec.describe ETL::OutdatedItems do
       outdated: true,
       content_id: later_content_id,
       base_path: base_path,
-      updated_at: date + 1.day
+      outdated_at: date + 1.day
     )
     subject.process
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -25,6 +25,11 @@ FactoryBot.define do
     sequence(:description) { |i| "description - #{i}" }
     sequence(:raw_json) { |i| "json - #{i}" }
     number_of_pdfs 0
+
+    factory :outdated_item do
+      outdated true
+      outdated_at { 2.days.ago }
+    end
   end
 
   factory :metric, class: Facts::Metric do

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Master process spec' do
   let(:item_content) { 'This is the content.' }
 
   let!(:an_item) { create :dimensions_item, content_id: 'a-content-id' }
-  let!(:outdated_item) { create :dimensions_item, content_id: content_id, base_path: base_path, latest: false }
-  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, outdated: true, outdated_at: 2.days.ago }
+  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, latest: false }
+  let!(:outdated_item) { create :outdated_item, content_id: content_id, base_path: base_path }
 
   it 'orchestrates all ETL processes' do
     stub_google_analytics_response
@@ -57,6 +57,7 @@ RSpec.describe 'Master process spec' do
   def validate_outdated_items!
     expect(Dimensions::Item.count).to eq(4)
     expect(Dimensions::Item.where(latest: true, content_id: 'id1').count).to eq(1)
+    expect(Dimensions::Item.where(latest: false, content_id: 'id1').count).to eq(2)
   end
 
   def validate_metadata!

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Master process spec' do
 
   let!(:an_item) { create :dimensions_item, content_id: 'a-content-id' }
   let!(:outdated_item) { create :dimensions_item, content_id: content_id, base_path: base_path, latest: false }
-  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, outdated: true, updated_at: 2.days.ago }
+  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, outdated: true, outdated_at: 2.days.ago }
 
   it 'orchestrates all ETL processes' do
     stub_google_analytics_response

--- a/spec/models/concerns/outdateable_spec.rb
+++ b/spec/models/concerns/outdateable_spec.rb
@@ -27,19 +27,23 @@ RSpec.describe Concerns::Outdateable, type: :model do
 
   describe '.outdated_before' do
     let(:date) { Date.new(2018, 2, 2) }
+    let(:before_date) { Time.utc(2018, 2, 1, 23, 59, 59) }
+
+    let!(:outdated_item_1) { create(:dimensions_item, outdated: true, outdated_at: before_date) }
+    let!(:outdated_item_2) { create(:dimensions_item, outdated: true, outdated_at: date) }
 
     it 'only returns outdated items in their latest version' do
-      create(:dimensions_item, latest: false, outdated: true, outdated_at: Time.utc(2018, 2, 1, 23, 59, 59))
-      create(:dimensions_item, outdated: true, outdated_at: Time.utc(2018, 2, 2))
+      outdated_item_1.update latest: false
+      outdated_item_2.update latest: true
 
       expect(Dimensions::Item.outdated_before(date)).to be_empty
     end
 
     it 'returns the outdated items updated before the given date' do
-      expected_item = create(:dimensions_item, outdated: true, outdated_at: Time.utc(2018, 2, 1, 23, 59, 59))
-      create(:dimensions_item, outdated: true, outdated_at: Time.utc(2018, 2, 2))
+      outdated_item_1.update latest: true
+      outdated_item_2.update latest: true
 
-      expect(Dimensions::Item.outdated_before(date)).to match_array(expected_item)
+      expect(Dimensions::Item.outdated_before(date)).to match_array(outdated_item_1)
     end
   end
 
@@ -53,10 +57,10 @@ RSpec.describe Concerns::Outdateable, type: :model do
     end
 
     it 'sets the oudated_at time' do
-      Timecop.freeze(Time.new(2018,3,3)) do
+      Timecop.freeze(Time.new(2018, 3, 3)) do
         item.outdate!
 
-        expect(item.reload.outdated_at).to eq(Time.new(2018,3,3))
+        expect(item.reload.outdated_at).to eq(Time.new(2018, 3, 3))
       end
     end
   end

--- a/spec/models/concerns/outdateable_spec.rb
+++ b/spec/models/concerns/outdateable_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Dimensions::Item, type: :model do
+  describe '.oudated' do
+    subject { described_class.outdated }
+
+    let(:item) { create(:dimensions_item) }
+
+    it 'returns true if outdated? and latest?' do
+      item.update(latest: true, outdated: true)
+
+      expect(subject).to match_array(item)
+    end
+
+    it 'returns false if outdated? and not latest?' do
+      item.update(latest: false, outdated: true)
+
+      expect(subject).to be_empty
+    end
+
+    it 'returns false if not outdated? and latest?' do
+      item.update(latest: true, outdated: false)
+
+      expect(subject).to be_empty
+    end
+  end
+
+  describe '.outdated_before' do
+    let(:date) { Date.new(2018, 2, 2) }
+
+    it 'only returns outdated items in their latest version' do
+      create(:dimensions_item, latest: false, outdated: true, updated_at: Time.utc(2018, 2, 1, 23, 59, 59))
+
+      create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 2))
+      expect(Dimensions::Item.outdated_before(date)).to be_empty
+    end
+
+    it 'returns the outdated items updated before the given date' do
+      expected_item = create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 1, 23, 59, 59))
+      create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 2))
+      expect(Dimensions::Item.outdated_before(date)).to match_array(expected_item)
+    end
+  end
+
+  describe '#outdate!' do
+    let(:item) { create(:dimensions_item, outdated: false) }
+
+    it 'sets the outdated? flag to true' do
+      item.outdate!
+
+      expect(item.reload.outdated?).to be true
+    end
+
+    it 'sets the oudated_at time' do
+      time = Time.zone.now
+      Timecop.freeze(time) do
+        item.outdate!
+
+        expect(item.reload.outdated_at).to eq(time)
+      end
+    end
+  end
+end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Dimensions::Item, type: :model do
     end
   end
 
-  describe '#outdated!' do
+  describe '#outdate!' do
     it 'sets the outdated? flag to true' do
       item = create(:dimensions_item, outdated: false)
-      item.outdated!
+      item.outdate!
       expect(item.reload.outdated?).to be true
     end
   end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -3,47 +3,6 @@ require 'rails_helper'
 RSpec.describe Dimensions::Item, type: :model do
   it { is_expected.to validate_presence_of(:content_id) }
 
-  describe '.oudated' do
-    subject { described_class.outdated }
-
-    let(:item) { create(:dimensions_item) }
-
-    it 'returns true if outdated? and latest?' do
-      item.update(latest: true, outdated: true)
-
-      expect(subject).to match_array(item)
-    end
-
-    it 'returns false if outdated? and not latest?' do
-      item.update(latest: false, outdated: true)
-
-      expect(subject).to be_empty
-    end
-
-    it 'returns false if not outdated? and latest?' do
-      item.update(latest: true, outdated: false)
-
-      expect(subject).to be_empty
-    end
-  end
-
-  describe '.outdated_before' do
-    let(:date) { Date.new(2018, 2, 2) }
-
-    it 'only returns outdated items in their latest version' do
-      create(:dimensions_item, latest: false, outdated: true, updated_at: Time.utc(2018, 2, 1, 23, 59, 59))
-
-      create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 2))
-      expect(Dimensions::Item.outdated_before(date)).to be_empty
-    end
-
-    it 'returns the outdated items updated before the given date' do
-      expected_item = create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 1, 23, 59, 59))
-      create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 2))
-      expect(Dimensions::Item.outdated_before(date)).to match_array(expected_item)
-    end
-  end
-
   describe '#new_version' do
     it 'duplicates the old item with latest: true, outdated: false but does not save' do
       old_item = build(:dimensions_item,
@@ -61,25 +20,6 @@ RSpec.describe Dimensions::Item, type: :model do
         base_path: '/the/path'
       )
       expect(new_version.new_record?).to eq(true)
-    end
-  end
-
-  describe '#outdate!' do
-    let(:item) { create(:dimensions_item, outdated: false) }
-
-    it 'sets the outdated? flag to true' do
-      item.outdate!
-
-      expect(item.reload.outdated?).to be true
-    end
-
-    it 'sets the oudated_at time' do
-      time = Time.zone.now
-      Timecop.freeze(time) do
-        item.outdate!
-
-        expect(item.reload.outdated_at).to eq(time)
-      end
     end
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -33,10 +33,21 @@ RSpec.describe Dimensions::Item, type: :model do
   end
 
   describe '#outdate!' do
+    let(:item) { create(:dimensions_item, outdated: false) }
+
     it 'sets the outdated? flag to true' do
-      item = create(:dimensions_item, outdated: false)
       item.outdate!
+
       expect(item.reload.outdated?).to be true
+    end
+
+    it 'sets the oudated_at time' do
+      time = Time.zone.now
+      Timecop.freeze(time) do
+        item.outdate!
+
+        expect(item.reload.outdated_at).to eq(time)
+      end
     end
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Dimensions::Item, type: :model do
 
   describe '.outdated_before' do
     let(:date) { Date.new(2018, 2, 2) }
+
+    it 'only returns outdated items in their latest version' do
+      create(:dimensions_item, latest: false, outdated: true, updated_at: Time.utc(2018, 2, 1, 23, 59, 59))
+
+      create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 2))
+      expect(Dimensions::Item.outdated_before(date)).to be_empty
+    end
+
     it 'returns the outdated items updated before the given date' do
       expected_item = create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 1, 23, 59, 59))
       create(:dimensions_item, outdated: true, updated_at: Time.utc(2018, 2, 2))
@@ -52,7 +60,7 @@ RSpec.describe Dimensions::Item, type: :model do
   end
 
   describe '#gone!' do
-    it 'sets the status to "gone"' do
+    it 'sets the status  to "gone"' do
       item = create(:dimensions_item, outdated: false)
       item.gone!
       expect(item.reload.status).to eq 'gone'

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -3,6 +3,30 @@ require 'rails_helper'
 RSpec.describe Dimensions::Item, type: :model do
   it { is_expected.to validate_presence_of(:content_id) }
 
+  describe '.oudated' do
+    subject { described_class.outdated }
+
+    let(:item) { create(:dimensions_item) }
+
+    it 'returns true if outdated? and latest?' do
+      item.update(latest: true, outdated: true)
+
+      expect(subject).to match_array(item)
+    end
+
+    it 'returns false if outdated? and not latest?' do
+      item.update(latest: false, outdated: true)
+
+      expect(subject).to be_empty
+    end
+
+    it 'returns false if not outdated? and latest?' do
+      item.update(latest: true, outdated: false)
+
+      expect(subject).to be_empty
+    end
+  end
+
   describe '.outdated_before' do
     let(:date) { Date.new(2018, 2, 2) }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/a87NdSdb/191-2-use-outdatedat-time-to-calculate-when-to-apply-new-metrics-as-we-cant-rely-on-updatedat)

Store when the Items dimension is being marked as outdated
so the processes can use this date as a reference.
This is the way to do it, as we can't rely on the `updated_at` 
attribute for the Items dimension.

