### PR TITLE
Sandbox: use AVG instead of SUM for spelling errors

### DIFF
--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -37,7 +37,7 @@ class Facts::Metric < ApplicationRecord
       'SUM(feedex_comments)',
       'AVG(number_of_pdfs)',
       'AVG(number_of_word_files)',
-      'SUM(spell_count)',
+      'AVG(spell_count)',
       'AVG(readability_score)'
     ).first
     {

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.feedex_issues', text: '28 Feedex issues')
     expect(page).to have_selector('.number_of_pdfs', text: '3.00 PDFs (avg)')
     expect(page).to have_selector('.number_of_word_files', text: '1.50 Word (avg)')
-    expect(page).to have_selector('.spell_count', text: '16 Spelling errors')
+    expect(page).to have_selector('.spell_count', text: '4.0 Spelling errors')
     expect(page).to have_selector('.readability_score', text: '3.00 Readability score (avg)')
   end
 

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -66,29 +66,19 @@ RSpec.describe Facts::Metric, type: :model do
 
   describe '.metric_summary' do
     subject { described_class }
+
     let(:base_path) { '/the/base/path' }
+
     it 'returns the correct numbers' do
-      item1 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 5, readability_score: 4)
-      item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 1, readability_score: 4)
-      create(:metric,
-        dimensions_item: item1,
-        dimensions_date: day0,
-        pageviews: 3,
-        unique_pageviews: 2,
-        feedex_comments: 4)
-      create(:metric,
-        dimensions_item: item2,
-        dimensions_date: day0,
-        pageviews: 5,
-        unique_pageviews: 2,
-        feedex_comments: 3)
-      create(:metric,
-        dimensions_item: item2,
-        dimensions_date: day1,
-        pageviews: 2,
-        unique_pageviews: 2,
-        feedex_comments: 2)
+      item1 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 3, readability_score: 4)
+      item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 3, readability_score: 4)
+
+      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2, feedex_comments: 4)
+      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2, feedex_comments: 3)
+      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2, feedex_comments: 2)
+
       results = subject.between(day0, day1).by_base_path(base_path).metric_summary
+
       expect(results).to eq(
         total_items: 2,
         pageviews: 10,
@@ -96,7 +86,7 @@ RSpec.describe Facts::Metric, type: :model do
         feedex_comments: 9,
         number_of_pdfs: 3,
         number_of_word_files: 1,
-        spell_count: 7,
+        spell_count: 3,
         readability_score: 4,
       )
     end


### PR DESCRIPTION
[Trello card](https://trello.com/c/nYkEaDnC/202-1-sandbox-show-average-in-the-number-of-spelling-errors-part-of-reliability-epic)

If we use aggregation for spelling errors, then the result is misleading
because the value depends linearly of the number of days of the filter.