### PR TITLE
Cache all API responses for a day

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,6 @@
 class Api::BaseController < ApplicationController
+  before_action :set_cache_headers
+
   rescue_from(ActionController::UnpermittedParameters) do |pme|
     error_response(
       "unknown-parameter",
@@ -8,6 +10,15 @@ class Api::BaseController < ApplicationController
   end
 
 private
+
+  def set_cache_headers
+    # Set cache headers to expire the page at 1am when we fetch new data.
+    expiry_time = Time.zone.tomorrow.at_beginning_of_day.change(hour: 1)
+    current_time = Time.zone.now
+    cache_time = (expiry_time - current_time) % 24.hour
+
+    expires_in cache_time, public: true
+  end
 
   def error_response(type, error_hash)
     # Type is an arbitrary URI identifying the error type

--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -1,5 +1,6 @@
 class Api::HealthcheckController < Api::BaseController
   skip_before_action :authenticate_user!
+  skip_before_action :set_cache_headers
 
   def index
     database = ActiveRecord::Base.connected? ? :ok : :critical

--- a/spec/requests/api/v1/healthcheck_spec.rb
+++ b/spec/requests/api/v1/healthcheck_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe '/api/v1/healthcheck/', type: :request do
+  it "is not cacheable" do
+    get "/api/v1/healthcheck/"
+
+    expect(response.headers['Cache-Control']).to eq "max-age=0, private, must-revalidate"
+  end
+end


### PR DESCRIPTION
Data is updated daily so we can set a long cache time.