### PR TITLE
Add docm, and docx extensions when parsing closed formats

### DIFF
--- a/app/data/metadata/parsers/number_of_pdfs.rb
+++ b/app/data/metadata/parsers/number_of_pdfs.rb
@@ -1,23 +1,9 @@
 module Metadata::Parsers
   class NumberOfPdfs
-    attr_accessor :content_item
-
-    PDF_XPATH = "//*[contains(@class, 'attachment-details')]//a[contains(@href, '.pdf')]".freeze
-
-    def initialize(content_item)
-      @content_item = content_item
-    end
-
-    def run
-      documents_string = NumberOfFiles.extract_documents(content_item.details)
-      documents = NumberOfFiles.parse documents_string
-      { number_of_pdfs: NumberOfFiles.number_of_files(documents, PDF_XPATH) }
-    end
-
     def self.parse(raw_json)
-      documents_string = NumberOfFiles.extract_documents(raw_json['details'])
-      documents = NumberOfFiles.parse documents_string
-      { number_of_pdfs: NumberOfFiles.number_of_files(documents, PDF_XPATH) }
+      extensions = %w(pdf)
+
+      { number_of_pdfs: NumberOfFiles.number_of_files(raw_json, extensions) }
     end
   end
 end

--- a/app/data/metadata/parsers/number_of_word_files.rb
+++ b/app/data/metadata/parsers/number_of_word_files.rb
@@ -1,23 +1,9 @@
 module Metadata::Parsers
   class NumberOfWordFiles
-    attr_accessor :content_item
-
-    DOC_XPATH = "//*[contains(@class, 'attachment-details')]//a[contains(@href, '.doc')]".freeze
-
-    def initialize(content_item)
-      @content_item = content_item
-    end
-
-    def run
-      documents_string = NumberOfFiles.extract_documents(content_item.details)
-      documents = NumberOfFiles.parse documents_string
-      { number_of_word_files: NumberOfFiles.number_of_files(documents, DOC_XPATH) }
-    end
-
     def self.parse(raw_json)
-      documents_string = NumberOfFiles.extract_documents(raw_json['details'])
-      documents = NumberOfFiles.parse documents_string
-      { number_of_word_files: NumberOfFiles.number_of_files(documents, DOC_XPATH) }
+      extensions = %w(doc docx docm)
+
+      { number_of_word_files: NumberOfFiles.number_of_files(raw_json, extensions) }
     end
   end
 end

--- a/spec/data/metadata/parsers/number_of_pdfs_spec.rb
+++ b/spec/data/metadata/parsers/number_of_pdfs_spec.rb
@@ -2,51 +2,39 @@ require 'gds_api/test_helpers/content_store'
 module Performance
   RSpec.describe Metadata::Parsers::NumberOfPdfs do
     include GdsApi::TestHelpers::ContentStore
-    subject { Metadata::Parsers::NumberOfPdfs }
 
-    let(:response_without_document_keys) do
-      {
-        details: {}
-      }.to_json
-    end
-    let(:response_without_details_key) do
-      {}.to_json
-    end
-    let(:content_store_response) { content_item_for_base_path('/base_path') }
+    subject { described_class }
 
-
-    def response_with_document_key(document = nil)
-      {
-        details: {
-          document: document
-        }
-      }.to_json
+    it "returns the number of pdfs present" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_pdfs: 1)
     end
 
-    context "#parse" do
-      it "returns the number of pdfs present" do
-        details = {
-          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>'
-        }
+    it "returns 0 if no pdfs are present" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_pdfs: 0)
+    end
 
-        expect(subject.parse('details' => details)).to eq(number_of_pdfs: 1)
-      end
+    it "returns 0 if no document keys are present" do
+      expect(subject.parse({})).to eq(number_of_pdfs: 0)
+    end
 
-      it "returns 0 if no pdfs are present" do
-        details = {
-          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>'
-        }
+    it "returns 0 if the details is nil" do
+      expect(subject.parse({})).to eq(number_of_pdfs: 0)
+    end
 
-        expect(subject.parse('details' => details)).to eq(number_of_pdfs: 0)
-      end
+    it "returns 0 if the attachment ends with `pdf`, but with no `dot`" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"linkpdf\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_pdfs: 0)
+    end
 
-      it "returns 0 if no document keys are present" do
-        expect(subject.parse('details' => {})).to eq(number_of_pdfs: 0)
-      end
+    it "returns 0 if the attachment file extension starts with `.pdf`, but ends with 'p'" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdfp\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_pdfs: 0)
+    end
 
-      it "returns 0 if the details is nil" do
-        expect(subject.parse({})).to eq(number_of_pdfs: 0)
-      end
+    def build_response(details)
+      content_item_for_base_path('/a-base-path').merge('details' => details)
     end
   end
 end

--- a/spec/data/metadata/parsers/number_of_word_files_spec.rb
+++ b/spec/data/metadata/parsers/number_of_word_files_spec.rb
@@ -1,31 +1,51 @@
+require 'gds_api/test_helpers/content_store'
+
 module Performance
   RSpec.describe Metadata::Parsers::NumberOfWordFiles do
-    subject { Metadata::Parsers::NumberOfWordFiles }
+    include GdsApi::TestHelpers::ContentStore
 
-    describe "#parse" do
-      it "returns the number of word files present" do
-        details = {
-          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.doc\">1</a>\n\n\n\n</div>'
-        }
+    subject { described_class }
 
-        expect(subject.parse('details' => details)).to eq(number_of_word_files: 1)
-      end
+    it "returns the number of '.doc' word files present" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.doc\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_word_files: 1)
+    end
 
-      it "returns 0 if no word files are present" do
-        details = {
-          'documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>'
-        }
+    it "returns the number of '.docm' word files present" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.docm\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_word_files: 1)
+    end
 
-        expect(subject.parse('details' => details)).to eq(number_of_word_files: 0)
-      end
+    it "returns the number of '.docx' word files present" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.docx\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_word_files: 1)
+    end
 
-      it "returns 0 if no document keys are present" do
-        expect(subject.parse('details' => {})).to eq(number_of_word_files: 0)
-      end
+    it "returns 0 if no word files are present" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_word_files: 0)
+    end
 
-      it "returns 0 if the details is nil" do
-        expect(subject.parse({})).to eq(number_of_word_files: 0)
-      end
+    it "returns 0 if no document keys are present" do
+      expect(subject.parse(build_response({}))).to eq(number_of_word_files: 0)
+    end
+
+    it "returns 0 if the details is nil" do
+      expect(subject.parse(build_response(nil))).to eq(number_of_word_files: 0)
+    end
+
+    it "returns 0 if the attachment ends with `doc`, but with no `dot`" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"linkdoc\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_word_files: 0)
+    end
+
+    it "returns 0 if the attachment file extension starts with '.doc', but ends in 'n' " do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.docn\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(number_of_word_files: 0)
+    end
+
+    def build_response(details)
+      content_item_for_base_path('/a-base-path').merge('details' => details)
     end
   end
 end


### PR DESCRIPTION
[Trello: Include extensions .docx, docm to count Word documents](https://trello.com/c/SEm5OomS/169-2-include-extensions-docx-docm-to-count-word-documents)

Previously our solution included these extensions, but it was not very 
robust as it would also accept an invalid word file extension if it ended
'.docj' for example.

Our solution now means that only the specified extensions will be accepted.

We have move the logic to extract the content to the `NumberOfFiles` so
when counting the number of closed formats, we only need to specify the
extensions.

These changes have impacted `NumberOfPdfs` which has also been 
adapted to adhere to the changes made.