### PR TITLE
Add endpoint to list available metrics

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -1,5 +1,5 @@
 class Api::MetricsController < Api::BaseController
-  before_action :validate_params!
+  before_action :validate_params!, except: :index
 
   def time_series
     @metrics = query_series
@@ -9,6 +9,11 @@ class Api::MetricsController < Api::BaseController
   def summary
     @metrics = query_series
     @metric_params = metric_params
+  end
+
+  def index
+    items = Rails.configuration.metrics.map { |k, v| v.merge(metric_id: k) }.sort_by { |item| item[:name] }
+    render json: items
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get '/audits', to: redirect(Plek.find('content-audit-tool', status: 302))
 
   namespace :api, defaults: { format: :json } do
+    get '/v1/metrics/', to: "metrics#index"
     get '/v1/metrics/:metric/:content_id/', to: "metrics#summary"
     get '/v1/metrics/:metric/:content_id/time-series', to: "metrics#time_series"
     get '/v1/healthcheck', to: "healthcheck#index"

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -160,4 +160,18 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
       }
     end
   end
+
+  describe "metrics index" do
+    it "describes the available metrics" do
+      get "/api/v1/metrics"
+
+      json = JSON.parse(response.body)
+
+      expect(json.count).to eq(Rails.configuration.metrics.count)
+
+      expect(json).to include("metric_id" => "pageviews",
+        "description" => "Number of pageviews",
+        "source" => "Google Analytics")
+    end
+  end
 end


### PR DESCRIPTION
See description in https://github.com/alphagov/content-performance-manager/pull/561

This is still missing documentation.

Trello: https://trello.com/c/MOAQhWJZ/154-finalise-api-endpoints-for-querying-a-single-item