### PR TITLE
Only test PublishingAPI events in integration test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       omniauth (~> 1.2)
     os (0.9.6)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.3)
       ast (~> 2.4.0)
     pg (1.0.0)
     phantomjs (2.1.1.0)

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -17,6 +17,7 @@ private
     Facts::Metric
       .between(from, to)
       .by_content_id(content_id)
+      .by_locale('en')
       .order('dimensions_dates.date asc')
       .group('dimensions_dates.date')
       .sum(metric)

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -4,6 +4,7 @@ class SandboxController < ApplicationController
   def index
     @metrics = Facts::Metric
       .joins(:dimensions_item)
+      .by_locale('en')
       .between(from, to)
       .by_base_path(base_path)
       .by_organisation_id(organisation)

--- a/app/data/etl/outdated_items.rb
+++ b/app/data/etl/outdated_items.rb
@@ -39,7 +39,7 @@ private
   def import_content_details(items)
     log process: :import_content_details, message: "creating #{items.length} ImportContentDetailsJobs"
     items.each do |item|
-      ImportContentDetailsJob.perform_async(item.content_id, item.base_path, item.locale)
+      ImportContentDetailsJob.perform_async(item.id)
     end
   end
 end

--- a/app/data/etl/outdated_items.rb
+++ b/app/data/etl/outdated_items.rb
@@ -39,7 +39,7 @@ private
   def import_content_details(items)
     log process: :import_content_details, message: "creating #{items.length} ImportContentDetailsJobs"
     items.each do |item|
-      ImportContentDetailsJob.perform_async(item.content_id, item.base_path)
+      ImportContentDetailsJob.perform_async(item.content_id, item.base_path, item.locale)
     end
   end
 end

--- a/app/data/etl/preload_items.rb
+++ b/app/data/etl/preload_items.rb
@@ -18,8 +18,7 @@ class ETL::PreloadItems
 private
 
   def extract
-    fields = %w[content_id base_path title description]
-    ItemsService.new.fetch_all_with_default_locale_only(fields)
+    ItemsService.new.fetch_all
   end
 
   def transform(raw_data)
@@ -27,6 +26,7 @@ private
       {
         content_id: item[:content_id],
         base_path: item[:base_path],
+        locale: item[:locale],
         latest: true,
       }
     end

--- a/app/data/metadata/parsers/metadata.rb
+++ b/app/data/metadata/parsers/metadata.rb
@@ -2,6 +2,8 @@ class Metadata::Parsers::Metadata
   def self.parse(formatted_response)
     formatted_response.slice(
       'content_id',
+      'base_path',
+      'locale',
       'title',
       'document_type',
       'content_purpose_document_supertype',

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -2,15 +2,16 @@ require 'odyssey'
 
 class Importers::ContentDetails
   include Concerns::Traceable
-  attr_reader :items_service, :content_id, :base_path
+  attr_reader :items_service, :content_id, :base_path, :locale
 
   def self.run(*args)
     new(*args).run
   end
 
-  def initialize(content_id, base_path, _ = {})
+  def initialize(content_id, base_path, locale, _ = {})
     @content_id = content_id
     @base_path = base_path
+    @locale = locale
     @items_service = ItemsService.new
   end
 
@@ -18,14 +19,13 @@ class Importers::ContentDetails
     item = nil
     begin
       time(process: :content_details) do
-        item = Dimensions::Item.find_by(content_id: content_id, latest: true)
-
+        item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale).first
         item_raw_json = items_service.fetch_raw_json(base_path)
         attributes = Metadata::Parser.parse(item_raw_json)
         content_changed = item.content_hash != attributes[:content_hash]
         item.update_attributes(attributes)
 
-        ImportQualityMetricsJob.perform_async(item.id) if content_changed
+        import_quality_metrics_for_en(item) if content_changed
       end
     rescue GdsApi::HTTPGone
       item.gone!
@@ -36,6 +36,10 @@ class Importers::ContentDetails
   end
 
 private
+
+  def import_quality_metrics_for_en(item)
+    ImportQualityMetricsJob.perform_async(item.id) if locale == 'en'
+  end
 
   def handle_not_found
     log process: :content_details, message: "NotFound when retrieving '#{base_path}' from content store"

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -19,7 +19,7 @@ class Importers::ContentDetails
     item = nil
     begin
       time(process: :content_details) do
-        item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale).first
+        item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
         item_raw_json = items_service.fetch_raw_json(base_path)
         attributes = Metadata::Parser.parse(item_raw_json)
         content_changed = item.content_hash != attributes[:content_hash]

--- a/app/domain/importers/content_details.rb
+++ b/app/domain/importers/content_details.rb
@@ -2,16 +2,14 @@ require 'odyssey'
 
 class Importers::ContentDetails
   include Concerns::Traceable
-  attr_reader :items_service, :content_id, :base_path, :locale
+  attr_reader :items_service, :id,
 
   def self.run(*args)
     new(*args).run
   end
 
-  def initialize(content_id, base_path, locale, _ = {})
-    @content_id = content_id
-    @base_path = base_path
-    @locale = locale
+  def initialize(id, _ = {})
+    @id = id
     @items_service = ItemsService.new
   end
 
@@ -19,8 +17,8 @@ class Importers::ContentDetails
     item = nil
     begin
       time(process: :content_details) do
-        item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
-        item_raw_json = items_service.fetch_raw_json(base_path)
+        item = Dimensions::Item.find(id)
+        item_raw_json = items_service.fetch_raw_json(item.base_path)
         attributes = Metadata::Parser.parse(item_raw_json)
         content_changed = item.content_hash != attributes[:content_hash]
         item.update_attributes(attributes)
@@ -29,23 +27,23 @@ class Importers::ContentDetails
       end
     rescue GdsApi::HTTPGone
       item.gone!
-      handle_gone
+      handle_gone base_path: item.base_path
     rescue GdsApi::HTTPNotFound
-      handle_not_found
+      handle_not_found base_path: item.base_path
     end
   end
 
 private
 
   def import_quality_metrics_for_en(item)
-    ImportQualityMetricsJob.perform_async(item.id) if locale == 'en'
+    ImportQualityMetricsJob.perform_async(item.id) if item.locale == 'en'
   end
 
-  def handle_not_found
+  def handle_not_found(base_path:)
     log process: :content_details, message: "NotFound when retrieving '#{base_path}' from content store"
   end
 
-  def handle_gone
+  def handle_gone(base_path)
     log process: :content_details, message: "Item '#{base_path}' has gone!"
   end
 end

--- a/app/models/concerns/outdateable.rb
+++ b/app/models/concerns/outdateable.rb
@@ -7,8 +7,8 @@ module Concerns::Outdateable
     scope :outdated, -> { where(outdated: true, latest: true) }
     scope :outdated_before, ->(date) { outdated.where('outdated_at < ?', date) }
 
-    def outdate!
-      update_attributes!(outdated: true, outdated_at: Time.zone.now)
+    def outdate!(base_path:)
+      update_attributes!(outdated: true, outdated_at: Time.zone.now, base_path: base_path)
     end
   end
 end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -20,6 +20,10 @@ class Dimensions::Item < ApplicationRecord
     new_version
   end
 
+  def outdated!(base_path:)
+    update_attributes!(outdated: true, base_path: base_path)
+  end
+
   def gone!
     update_attributes(status: 'gone')
   end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -5,8 +5,8 @@ class Dimensions::Item < ApplicationRecord
 
   validates :content_id, presence: true
 
-  scope :by_natural_key, ->(content_id:, locale:) do
-    where(content_id: content_id, locale: locale, latest: true)
+  def self.by_natural_key(content_id:, locale:)
+    find_by(content_id: content_id, locale: locale, latest: true)
   end
 
   def get_content

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -24,10 +24,11 @@ class Dimensions::Item < ApplicationRecord
     update_attributes(status: 'gone')
   end
 
-  def self.create_empty(content_id, base_path)
+  def self.create_empty(content_id:, base_path:, locale:)
     create(
       content_id: content_id,
       base_path: base_path,
+      locale: locale,
       latest: true,
       outdated: true
     )

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -20,10 +20,6 @@ class Dimensions::Item < ApplicationRecord
     new_version
   end
 
-  def outdated!(base_path:)
-    update_attributes!(outdated: true, base_path: base_path)
-  end
-
   def gone!
     update_attributes(status: 'gone')
   end
@@ -34,7 +30,8 @@ class Dimensions::Item < ApplicationRecord
       base_path: base_path,
       locale: locale,
       latest: true,
-      outdated: true
+      outdated: true,
+      outdated_at: Time.zone.now
     )
   end
 end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -5,6 +5,10 @@ class Dimensions::Item < ApplicationRecord
 
   validates :content_id, presence: true
 
+  scope :by_natural_key, ->(content_id:, locale:) do
+    where(content_id: content_id, locale: locale, latest: true)
+  end
+
   def get_content
     return if raw_json.blank?
     Content::Parser.extract_content(raw_json)

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -29,6 +29,11 @@ class Facts::Metric < ApplicationRecord
     end
   end
 
+  scope :by_locale, ->(locale) do
+    joins(:dimensions_item)
+      .where(dimensions_items: { locale: locale })
+  end
+
   scope :metric_summary, -> do
     array = pluck(
       'COUNT(DISTINCT dimensions_items.content_id)',
@@ -57,6 +62,7 @@ class Facts::Metric < ApplicationRecord
       date
       content_id
       base_path
+      locale
       title
       description
       document_type

--- a/app/services/items_service.rb
+++ b/app/services/items_service.rb
@@ -1,20 +1,13 @@
 require 'gds_api/content_store'
 class ItemsService
-  attr_accessor :publishing_api_client, :content_store_client
-
   def initialize
-    self.publishing_api_client = Clients::PublishingAPI.new
-    self.content_store_client = GdsApi::ContentStore.new(Plek.new.find('content-store'))
+    @publishing_api_client = Clients::PublishingAPI.new
+    @content_store_client = GdsApi::ContentStore.new(Plek.new.find('content-store'))
   end
 
-  def fetch_all_with_default_locale_only(fields)
+  def fetch_all
     publishing_api_client
-      .fetch_all(fields)
-      .group_by { |content_item| content_item[:content_id] }
-      .values
-      .map do |content_items_with_the_same_id|
-        content_item_with_en_locale_or_first_other(content_items_with_the_same_id)
-      end
+      .fetch_all(%w[content_id base_path locale])
   end
 
   def fetch_raw_json(base_path)
@@ -23,11 +16,5 @@ class ItemsService
 
 private
 
-  def content_item_with_en_locale_or_first_other(content_items)
-    en_content_item = content_items
-      .select { |content_item| content_item[:locale] == "en" }
-      .first
-
-    en_content_item || content_items.first
-  end
+  attr_reader :publishing_api_client, :content_store_client
 end

--- a/db/migrate/20180321152146_add_locale_to_dimensions_items.rb
+++ b/db/migrate/20180321152146_add_locale_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddLocaleToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :locale, :string
+  end
+end

--- a/db/migrate/20180322104809_add_index_dimensions_items_locale.rb
+++ b/db/migrate/20180322104809_add_index_dimensions_items_locale.rb
@@ -1,6 +1,0 @@
-class AddIndexDimensionsItemsLocale < ActiveRecord::Migration[5.1]
-  def change
-    add_index :dimensions_items, :locale,
-      name: :index_dimensions_items_locale
-  end
-end

--- a/db/migrate/20180322104809_add_index_dimensions_items_locale.rb
+++ b/db/migrate/20180322104809_add_index_dimensions_items_locale.rb
@@ -1,0 +1,6 @@
+class AddIndexDimensionsItemsLocale < ActiveRecord::Migration[5.1]
+  def change
+    add_index :dimensions_items, :locale,
+      name: :index_dimensions_items_locale
+  end
+end

--- a/db/migrate/20180322134606_drop_indexes_created_without_migration.rb
+++ b/db/migrate/20180322134606_drop_indexes_created_without_migration.rb
@@ -1,10 +1,10 @@
 class DropIndexesCreatedWithoutMigration < ActiveRecord::Migration[5.1]
   def up
-    if index_exists?(:dimensions_items, [:latest, :content_id], name: 'idx_latest_content_id')
+    if index_exists?(:dimensions_items, %i[latest content_id], name: 'idx_latest_content_id')
       remove_index :dimensions_items, name: 'idx_latest_content_id'
     end
 
-    if index_exists?(:facts_metrics, [:dimensions_date_id, :dimensions_item_id], name: 'idx_facts_metrics_on_dimensions_date_id_dimensios_items_id')
+    if index_exists?(:facts_metrics, %i[dimensions_date_id dimensions_item_id], name: 'idx_facts_metrics_on_dimensions_date_id_dimensios_items_id')
       remove_index :facts_metrics, name: 'idx_facts_metrics_on_dimensions_date_id_dimensios_items_id'
     end
   end

--- a/db/migrate/20180322140016_add_indexes_for_master_process.rb
+++ b/db/migrate/20180322140016_add_indexes_for_master_process.rb
@@ -1,6 +1,6 @@
 class AddIndexesForMasterProcess < ActiveRecord::Migration[5.1]
   def change
-    add_index :dimensions_items, [:latest, :content_id]
-    add_index :facts_metrics, [:dimensions_date_id, :dimensions_item_id], name: 'index_facts_metrics_date_item_id'
+    add_index :dimensions_items, %i[latest content_id]
+    add_index :facts_metrics, %i[dimensions_date_id dimensions_item_id], name: 'index_facts_metrics_date_item_id'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,8 +70,8 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.string "primary_organisation_content_id"
     t.boolean "primary_organisation_withdrawn"
     t.string "content_hash"
+    t.string "locale"
     t.datetime "outdated_at"
-    t.index ["latest", "content_id"], name: "idx_latest_content_id"
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
@@ -102,7 +102,6 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.integer "pageviews", default: 0
     t.integer "unique_pageviews", default: 0
     t.integer "feedex_comments", default: 0
-    t.index ["dimensions_date_id", "dimensions_item_id"], name: "idx_facts_metrics_on_dimensions_date_id_dimensios_items_id"
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "index_facts_metrics_date_item_id"
     t.index ["dimensions_item_id"], name: "index_facts_metrics_on_dimensions_item_id"
   end

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -2,8 +2,9 @@ class PublishingApiConsumer
   def process(message)
     content_id = message.payload['content_id']
     base_path = message.payload['base_path']
+    locale = message.payload['locale']
 
-    item = Dimensions::Item.find_by(content_id: content_id, latest: true)
+    item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale).first
     if item
       handle_existing(item, message.delivery_info.routing_key)
     else

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -4,7 +4,7 @@ class PublishingApiConsumer
     base_path = message.payload['base_path']
     locale = message.payload['locale']
 
-    item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale).first
+    item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
     if item
       handle_existing(item, message.delivery_info.routing_key)
     else

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -8,7 +8,7 @@ class PublishingApiConsumer
     if item
       handle_existing(item, message.delivery_info.routing_key)
     else
-      Dimensions::Item.create_empty(content_id, base_path)
+      Dimensions::Item.create_empty(content_id: content_id, base_path: base_path, locale: locale)
     end
 
     message.ack

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -6,7 +6,7 @@ class PublishingApiConsumer
 
     item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
     if item
-      handle_existing(item, message.delivery_info.routing_key)
+      handle_existing(item, base_path, message.delivery_info.routing_key)
     else
       Dimensions::Item.create_empty(content_id: content_id, base_path: base_path, locale: locale)
     end
@@ -16,8 +16,9 @@ class PublishingApiConsumer
 
 private
 
-  def handle_existing(item, routing_key)
-    item.outdate!
+
+  def handle_existing(item, base_path, routing_key)
+    item.outdated! base_path: base_path
     item.gone! if routing_key.include? 'unpublished'
   end
 end

--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -18,7 +18,7 @@ private
 
 
   def handle_existing(item, base_path, routing_key)
-    item.outdated! base_path: base_path
+    item.outdate! base_path: base_path
     item.gone! if routing_key.include? 'unpublished'
   end
 end

--- a/spec/data/metadata/parsers/metadata_spec.rb
+++ b/spec/data/metadata/parsers/metadata_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Metadata::Parsers::Metadata do
   subject { described_class }
   let(:raw_json) do
     { 'content_id' => '09hjasdfoj234',
+      'base_path' => '/the/path',
+      'locale' => 'en',
       'title' => 'A guide to coding',
       'document_type' => 'answer',
       'content_purpose_document_supertype' => 'guide',
@@ -13,6 +15,8 @@ RSpec.describe Metadata::Parsers::Metadata do
     expect(subject.parse(raw_json)).to eq(
       title: 'A guide to coding',
       content_id: '09hjasdfoj234',
+      base_path: '/the/path',
+      locale: 'en',
       document_type: 'answer',
       content_purpose_document_supertype: 'guide',
       first_published_at: '2012-10-03T13:19:55.000+00:00',

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe Importers::ContentDetails do
   let(:content_id) { 'content_id' }
 
 
-  subject { Importers::ContentDetails.new(content_id, base_path, locale) }
 
   context 'Import contents' do
+    subject { Importers::ContentDetails.new(latest_dimension_item.id) }
     let(:locale) { 'en' }
     let!(:existing_content_hash) { 'ContentHashContentHash' }
     let!(:parsed_content_hash) { 'NewContentHash' }
@@ -102,6 +102,7 @@ RSpec.describe Importers::ContentDetails do
   end
 
   context 'when GdsApi::HTTPGone is raised' do
+    subject { Importers::ContentDetails.new(existing_content_item.id) }
     let(:locale) { 'en' }
     let!(:existing_content_item) { create :dimensions_item, content_id: content_id, status: 'something', locale: locale }
 
@@ -117,6 +118,7 @@ RSpec.describe Importers::ContentDetails do
   end
 
   context 'when GdsApi::HTTPNotFound is raised' do
+    subject { Importers::ContentDetails.new(existing_content_item.id) }
     let(:locale) { 'en' }
     let!(:existing_content_item) do
       create :dimensions_item, content_id: content_id, status: 'something', raw_json: { existing: 'content' }

--- a/spec/domain/importers/content_details_spec.rb
+++ b/spec/domain/importers/content_details_spec.rb
@@ -2,14 +2,21 @@ RSpec.describe Importers::ContentDetails do
   let(:base_path) { '/base_path' }
   let(:content_id) { 'content_id' }
 
-  subject { Importers::ContentDetails.new(content_id, base_path) }
+
+  subject { Importers::ContentDetails.new(content_id, base_path, locale) }
 
   context 'Import contents' do
-    let(:existing_content_hash) { 'ContentHashContentHash' }
-    let(:parsed_content_hash) { 'NewContentHash' }
+    let(:locale) { 'en' }
+    let!(:existing_content_hash) { 'ContentHashContentHash' }
+    let!(:parsed_content_hash) { 'NewContentHash' }
+    let!(:latest_dimension_item_fr) do
+      create(:dimensions_item,
+        content_id: content_id, base_path: base_path, locale: 'fr',
+        latest: true, raw_json: nil, content_hash: existing_content_hash)
+    end
     let!(:latest_dimension_item) do
       create(:dimensions_item,
-        content_id: content_id, base_path: base_path,
+        content_id: content_id, base_path: base_path, locale: 'en',
         latest: true, raw_json: nil, content_hash: existing_content_hash)
     end
     let!(:older_dimension_item) { create(:dimensions_item, content_id: content_id, base_path: base_path, latest: false, raw_json: nil) }
@@ -23,6 +30,7 @@ RSpec.describe Importers::ContentDetails do
         number_of_pdfs: 99,
         number_of_word_files: 94,
         content_id: '09hjasdfoj234',
+        locale: locale,
         title: 'A guide to coding',
         document_type: 'answer',
         content_purpose_document_supertype: 'guide',
@@ -61,25 +69,41 @@ RSpec.describe Importers::ContentDetails do
       )
     end
 
-    context 'when the content has changed' do
-      let(:parsed_content_hash) { 'ADifferentContentHash' }
-      it 'triggers a quality metrics job' do
-        subject.run
-        expect(ImportQualityMetricsJob).to have_received(:perform_async).with(latest_dimension_item.id)
+    context "when the locale is 'en'" do
+      let(:locale) { 'en' }
+
+      context 'and the content has changed' do
+        let(:parsed_content_hash) { 'ADifferentContentHash' }
+        it 'triggers a quality metrics job' do
+          subject.run
+          expect(ImportQualityMetricsJob).to have_received(:perform_async).with(latest_dimension_item.id)
+          expect(ImportQualityMetricsJob).not_to have_received(:perform_async).with(latest_dimension_item_fr.id)
+        end
+      end
+
+      context 'and the content has not changed' do
+        let(:parsed_content_hash) { existing_content_hash }
+        it "doesn't run a quality metrics job" do
+          subject.run
+          expect(ImportQualityMetricsJob).not_to have_received(:perform_async)
+        end
       end
     end
 
-    context 'when the content has not changed' do
-      let(:parsed_content_hash) { existing_content_hash }
+    context "when the locale is not 'en' and the content has changed" do
+      let(:locale) { 'fr' }
+      let(:parsed_content_hash) { 'ADifferentContentHash' }
       it "doesn't run a quality metrics job" do
         subject.run
-        expect(ImportQualityMetricsJob).not_to have_received(:perform_async)
+        expect(ImportQualityMetricsJob).not_to have_received(:perform_async).with(latest_dimension_item.id)
+        expect(ImportQualityMetricsJob).not_to have_received(:perform_async).with(latest_dimension_item_fr.id)
       end
     end
   end
 
   context 'when GdsApi::HTTPGone is raised' do
-    let!(:existing_content_item) { create :dimensions_item, content_id: content_id, status: 'something' }
+    let(:locale) { 'en' }
+    let!(:existing_content_item) { create :dimensions_item, content_id: content_id, status: 'something', locale: locale }
 
     before :each do
       expect(subject.items_service).to receive(:fetch_raw_json).and_raise(GdsApi::HTTPGone.new(410))
@@ -93,6 +117,7 @@ RSpec.describe Importers::ContentDetails do
   end
 
   context 'when GdsApi::HTTPNotFound is raised' do
+    let(:locale) { 'en' }
     let!(:existing_content_item) do
       create :dimensions_item, content_id: content_id, status: 'something', raw_json: { existing: 'content' }
     end

--- a/spec/etl/outdated_items_spec.rb
+++ b/spec/etl/outdated_items_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ETL::OutdatedItems do
   let(:content_id) { 'outdated1' }
   let(:later_content_id) { 'outdated_next_day' }
   let(:base_path) { '/the/base/path' }
+  let(:locale) { 'en' }
   let(:date) { Date.new(2018, 2, 20) }
   let(:subject) { described_class.new(date: date + 1.second) }
 
@@ -15,7 +16,9 @@ RSpec.describe ETL::OutdatedItems do
       outdated: true,
       content_id: content_id,
       base_path: base_path,
-      outdated_at: date
+
+      locale: locale,
+      updated_at: date
     )
     create(
       :dimensions_item,
@@ -23,22 +26,24 @@ RSpec.describe ETL::OutdatedItems do
       outdated: true,
       content_id: later_content_id,
       base_path: base_path,
-      outdated_at: date + 1.day
+      outdated_at: date + 1.day,
+      locale: locale
     )
     subject.process
   end
 
   it 'resets the outdated flag on the item' do
-    expect(Dimensions::Item.where(content_id: content_id, outdated: true).count).to eq(0)
+    p Dimensions::Item.where(content_id: content_id, outdated: true, locale: locale).all
+    expect(Dimensions::Item.where(content_id: content_id, outdated: true, locale: locale).count).to eq(0)
   end
 
   it 'resets the latest flag on the old item' do
-    expect(Dimensions::Item.where(content_id: content_id, latest: true).count).to eq(1)
-    expect(Dimensions::Item.where(content_id: content_id, latest: false).count).to eq(1)
+    expect(Dimensions::Item.where(content_id: content_id, latest: true, locale: locale).count).to eq(1)
+    expect(Dimensions::Item.where(content_id: content_id, latest: false, locale: locale).count).to eq(1)
   end
 
   it 'fires a Sidekiq job for the new item' do
-    expect(ImportContentDetailsJob).to have_received(:perform_async).with(content_id, base_path)
+    expect(ImportContentDetailsJob).to have_received(:perform_async).with(content_id, base_path, locale)
   end
 
   it 'does not touch content from later than the given date' do

--- a/spec/etl/outdated_items_spec.rb
+++ b/spec/etl/outdated_items_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe ETL::OutdatedItems do
   end
 
   it 'fires a Sidekiq job for the new item' do
-    expect(ImportContentDetailsJob).to have_received(:perform_async).with(content_id, base_path, locale)
+    latest_id = Dimensions::Item.find_by(content_id: content_id, latest: true).id
+
+    expect(ImportContentDetailsJob).to have_received(:perform_async).with(latest_id)
   end
 
   it 'does not touch content from later than the given date' do

--- a/spec/etl/outdated_items_spec.rb
+++ b/spec/etl/outdated_items_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe ETL::OutdatedItems do
       outdated: true,
       content_id: content_id,
       base_path: base_path,
-
       locale: locale,
-      updated_at: date
+      outdated_at: date
     )
     create(
       :dimensions_item,
@@ -33,7 +32,6 @@ RSpec.describe ETL::OutdatedItems do
   end
 
   it 'resets the outdated flag on the item' do
-    p Dimensions::Item.where(content_id: content_id, outdated: true, locale: locale).all
     expect(Dimensions::Item.where(content_id: content_id, outdated: true, locale: locale).count).to eq(0)
   end
 

--- a/spec/etl/preload_items_spec.rb
+++ b/spec/etl/preload_items_spec.rb
@@ -4,7 +4,7 @@ require 'gds-api-adapters'
 RSpec.describe ETL::PreloadItems do
   include GdsApi::TestHelpers::PublishingApiV2
   subject { described_class }
-  let(:fields) { %i[base_path content_id description title] }
+  let(:fields) { %i[base_path content_id locale] }
   let(:content_items) do
     [
       {

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/testing'
 require 'gds_api/test_helpers/content_store'
 
-RSpec.describe 'new content from the publishing feed' do
+RSpec.describe 'PublishingAPI events' do
   include GdsApi::TestHelpers::ContentStore
 
   around do |example|

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -57,12 +57,8 @@ RSpec.describe 'new content from the publishing feed' do
         base_path: base_path,
         locale: locale
       )
-      validate_facts_metrics!(count: 1, dates: [Date.new(2018, 2, 21)], ids: [latest_version.id])
       validate_outdated_items!(total: 2, base_path: base_path)
       validate_metadata!(title: 'title1')
-      validate_quality_metrics!(passive_count: 6, repeated_count: 8)
-      validate_google_analytics!(pageviews: 11, unique_pageviews: 5)
-      validate_feedex!(comments: 21)
     end
   end
 
@@ -99,14 +95,8 @@ RSpec.describe 'new content from the publishing feed' do
         locale: locale
       )
 
-      validate_facts_metrics!(count: 2,
-        dates: [Date.new(2018, 2, 21), Date.new(2018, 2, 22)],
-        ids: [original_version_id, latest_version.id])
       validate_outdated_items!(total: 3, base_path: new_base_path)
       validate_metadata!(title: 'updated title')
-      validate_quality_metrics!(passive_count: 10, repeated_count: 5)
-      validate_google_analytics!(pageviews: 25, unique_pageviews: 12)
-      validate_feedex!(comments: 18)
     end
   end
 
@@ -121,12 +111,6 @@ RSpec.describe 'new content from the publishing feed' do
       .first
   end
 
-  def validate_facts_metrics!(count:, dates:, ids:)
-    expect(Facts::Metric.count).to eq(count)
-    expect(Facts::Metric.pluck(:dimensions_item_id)).to match_array(ids)
-    expect(Facts::Metric.pluck(:dimensions_date_id).uniq).to match_array(dates)
-  end
-
   def validate_outdated_items!(total:, base_path:)
     expect(Dimensions::Item.count).to eq(total)
     expect(Dimensions::Item.where(latest: true, content_id: content_id, base_path: base_path).count).to eq(1)
@@ -136,24 +120,6 @@ RSpec.describe 'new content from the publishing feed' do
     expect(latest_version).to have_attributes(
       title: title,
       document_type: 'document_type1',
-    )
-  end
-
-  def validate_google_analytics!(pageviews:, unique_pageviews:)
-    expect(latest_metric).to have_attributes(
-      pageviews: pageviews,
-      unique_pageviews: unique_pageviews,
-    )
-  end
-
-  def validate_feedex!(comments:)
-    expect(latest_metric).to have_attributes(feedex_comments: comments)
-  end
-
-  def validate_quality_metrics!(passive_count:, repeated_count:)
-    expect(latest_version).to have_attributes(
-      repeated_words_count: repeated_count,
-      passive_count: passive_count,
     )
   end
 

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -4,12 +4,6 @@ require 'gds_api/test_helpers/content_store'
 RSpec.describe 'new content from the publishing feed' do
   include GdsApi::TestHelpers::ContentStore
 
-  let(:content_id) { 'id1' }
-  let(:base_path) { '/the-base-path' }
-  let(:locale) { 'en' }
-  let(:today) { Date.new(2018, 2, 21) }
-  let(:item_content) { 'the content' }
-
   around do |example|
     Sidekiq::Testing.inline! do
       Timecop.freeze(today) do
@@ -17,6 +11,12 @@ RSpec.describe 'new content from the publishing feed' do
       end
     end
   end
+
+  let(:content_id) { 'id1' }
+  let(:base_path) { '/the-base-path' }
+  let(:locale) { 'en' }
+  let(:today) { Date.new(2018, 2, 21) }
+  let(:item_content) { 'the content' }
 
   let!(:payload) do
     {

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -36,9 +36,15 @@ RSpec.describe 'new content from the publishing feed' do
     Timecop.freeze(today - 1.day) do
       PublishingApiConsumer.new.process(message)
     end
-    stub_google_analytics_response base_path: base_path, date: '2018-02-21', request_date: today
+    stub_google_analytics_response(
+      base_path: base_path,
+      date: '2018-02-21',
+      request_date: today,
+      pageviews: 11,
+      unique_pageviews: 5
+    )
     stub_feedex_response(base_path: base_path, date: '2018-02-20', request_date: "2018-02-21", comments: 21)
-    stub_quality_metrics_response
+    stub_quality_metrics_response(content: item_content, passive_count: 6, repeated_count: 8)
     stub_content_store_response(title: 'title1', content: item_content, base_path: base_path)
 
     ETL::Master.process date: today
@@ -53,15 +59,16 @@ RSpec.describe 'new content from the publishing feed' do
       )
       validate_facts_metrics!(count: 1, dates: [Date.new(2018, 2, 21)], ids: [latest_version.id])
       validate_outdated_items!(total: 2, base_path: base_path)
-      validate_metadata!
-      validate_quality_metrics!
-      validate_google_analytics!
+      validate_metadata!(title: 'title1')
+      validate_quality_metrics!(passive_count: 6, repeated_count: 8)
+      validate_google_analytics!(pageviews: 11, unique_pageviews: 5)
       validate_feedex!(comments: 21)
     end
   end
 
   context 'once updated by another publishing event' do
     let(:new_base_path) { '/updated/base/path' }
+    let(:updated_content) { 'updated content' }
     let(:new_message) do
       double('new_message',
         payload: payload.merge('base_path' => new_base_path),
@@ -70,9 +77,16 @@ RSpec.describe 'new content from the publishing feed' do
     before do
       allow(new_message).to receive(:ack)
       PublishingApiConsumer.new.process(new_message)
-      stub_google_analytics_response base_path: new_base_path, date: '2018-02-22', request_date: today + 1.day
+      stub_google_analytics_response(
+        base_path: new_base_path,
+        date: '2018-02-22',
+        request_date: today + 1.day,
+        pageviews: 25,
+        unique_pageviews: 12
+      )
       stub_feedex_response(base_path: new_base_path, date: '2018-02-21', request_date: "2018-02-22", comments: 18)
-      stub_content_store_response(title: 'title1', content: item_content, base_path: new_base_path)
+      stub_quality_metrics_response(content: updated_content, passive_count: 10, repeated_count: 5)
+      stub_content_store_response(title: 'updated title', content: updated_content, base_path: new_base_path)
     end
 
     it 'creates a new item with the updated data' do
@@ -89,9 +103,9 @@ RSpec.describe 'new content from the publishing feed' do
         dates: [Date.new(2018, 2, 21), Date.new(2018, 2, 22)],
         ids: [original_version_id, latest_version.id])
       validate_outdated_items!(total: 3, base_path: new_base_path)
-      validate_metadata!
-      validate_quality_metrics!
-      validate_google_analytics!
+      validate_metadata!(title: 'updated title')
+      validate_quality_metrics!(passive_count: 10, repeated_count: 5)
+      validate_google_analytics!(pageviews: 25, unique_pageviews: 12)
       validate_feedex!(comments: 18)
     end
   end
@@ -114,22 +128,21 @@ RSpec.describe 'new content from the publishing feed' do
   end
 
   def validate_outdated_items!(total:, base_path:)
-    # p Dimensions::Item.all.map{|i|{id: i.id, content_id: i.content_id, title: i.title, base_path: i.base_path}}
     expect(Dimensions::Item.count).to eq(total)
     expect(Dimensions::Item.where(latest: true, content_id: content_id, base_path: base_path).count).to eq(1)
   end
 
-  def validate_metadata!
+  def validate_metadata!(title:)
     expect(latest_version).to have_attributes(
-      title: 'title1',
+      title: title,
       document_type: 'document_type1',
     )
   end
 
-  def validate_google_analytics!
+  def validate_google_analytics!(pageviews:, unique_pageviews:)
     expect(latest_metric).to have_attributes(
-      pageviews: 11,
-      unique_pageviews: 12,
+      pageviews: pageviews,
+      unique_pageviews: unique_pageviews,
     )
   end
 
@@ -137,10 +150,10 @@ RSpec.describe 'new content from the publishing feed' do
     expect(latest_metric).to have_attributes(feedex_comments: comments)
   end
 
-  def validate_quality_metrics!
+  def validate_quality_metrics!(passive_count:, repeated_count:)
     expect(latest_version).to have_attributes(
-      repeated_words_count: 8,
-      passive_count: 6,
+      repeated_words_count: repeated_count,
+      passive_count: passive_count,
     )
   end
 
@@ -159,14 +172,14 @@ RSpec.describe 'new content from the publishing feed' do
     content_store_has_item(base_path, response, {})
   end
 
-  def stub_quality_metrics_response
+  def stub_quality_metrics_response(content:, passive_count:, repeated_count:)
     quality_metrics_response = {
-      passive: { 'count' => 6 },
-      repeated_words: { 'count' => 8 },
+      passive: { 'count' => passive_count },
+      repeated_words: { 'count' => repeated_count },
     }
     stub_request(:post, 'https://govuk-content-quality-metrics.cloudapps.digital/metrics').
       with(
-        body: { content: item_content }.to_json,
+        body: { content: content }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
       .to_return(
@@ -176,13 +189,13 @@ RSpec.describe 'new content from the publishing feed' do
       )
   end
 
-  def stub_google_analytics_response(base_path:, date:, request_date:)
+  def stub_google_analytics_response(base_path:, date:, request_date:, pageviews:, unique_pageviews:)
     allow_any_instance_of(GoogleAnalyticsService).to receive(:find_in_batches).with(date: request_date).and_yield(
       [
         {
           'page_path' => base_path,
-          'pageviews' => 11,
-          'unique_pageviews' => 12,
+          'pageviews' => pageviews,
+          'unique_pageviews' => unique_pageviews,
           'date' => date,
         },
         {

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe 'new content from the publishing feed' do
     end
   end
 
+  before do
+    stub_google_analytics_response
+    stub_feedex_response
+    stub_quality_metrics_response
+    stub_content_store_response(title: 'title1', base_path: base_path)
+  end
+
   let(:content_id) { 'id1' }
   let(:base_path) { '/the-base-path' }
   let(:locale) { 'en' }
@@ -23,10 +30,6 @@ RSpec.describe 'new content from the publishing feed' do
     Timecop.freeze(today - 1.day) do
       PublishingApiConsumer.new.process(message)
     end
-    stub_google_analytics_response
-    stub_feedex_response
-    stub_quality_metrics_response
-    stub_content_store_response(title: 'title1', content: item_content, base_path: base_path)
 
     ETL::Master.process date: today
   end
@@ -50,10 +53,6 @@ RSpec.describe 'new content from the publishing feed' do
 
     before do
       PublishingApiConsumer.new.process(new_message)
-      stub_google_analytics_response
-      stub_feedex_response
-      stub_quality_metrics_response
-      stub_content_store_response(title: 'updated title', content: updated_content, base_path: new_base_path)
     end
 
     it 'creates a new item with the updated data' do

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -1,0 +1,221 @@
+require 'sidekiq/testing'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe 'new content from the publishing feed' do
+  include GdsApi::TestHelpers::ContentStore
+
+  let(:content_id) { 'id1' }
+  let(:base_path) { '/the-base-path' }
+  let(:locale) { 'en' }
+  let(:today) { Date.new(2018, 2, 21) }
+  let(:item_content) { 'the content' }
+
+  around do |example|
+    Sidekiq::Testing.inline! do
+      Timecop.freeze(today) do
+        example.run
+      end
+    end
+  end
+
+  let!(:payload) do
+    {
+      'base_path' => base_path,
+      'content_id' => content_id,
+      'locale' => locale
+    }
+  end
+  let!(:message) do
+    double('message',
+      payload: payload,
+      delivery_info: double('del_info', routing_key: 'news_story.major'))
+  end
+
+  before do
+    allow(message).to receive(:ack)
+    Timecop.freeze(today - 1.day) do
+      PublishingApiConsumer.new.process(message)
+    end
+    stub_google_analytics_response date: '2018-02-21', request_date: today
+    stub_feedex_response(date: '2018-02-20', request_date: "2018-02-21", comments: 21)
+    stub_quality_metrics_response
+    stub_content_store_response(title: 'title1', content: item_content)
+
+    ETL::Master.process date: today
+  end
+
+  context 'after the initial load' do
+    it 'creates the latest item with the correct attributes' do
+      expect(latest_version).to have_attributes(
+        content_id: content_id,
+        base_path: base_path,
+        locale: locale
+      )
+      validate_facts_metrics!(count: 1, dates: [Date.new(2018, 2, 21)], ids: [latest_version.id])
+      validate_outdated_items!(total: 2)
+      validate_metadata!
+      validate_google_analytics!
+      validate_feedex!(comments: 21)
+    end
+  end
+
+  context 'once updated by another publishing event' do
+    let(:new_base_path) { '/updated/base/path' }
+    let(:new_message) do
+      double('new_message',
+        payload: payload.merge('base_path' => new_base_path),
+        delivery_info: message.delivery_info
+        )
+    end
+    before do
+      allow(new_message).to receive(:ack)
+      PublishingApiConsumer.new.process(new_message)
+      stub_google_analytics_response date: '2018-02-22', request_date: today + 1.day
+      stub_feedex_response(date: '2018-02-21', request_date: "2018-02-22", comments: 18)
+    end
+
+    it 'creates a new item with the updated data' do
+      original_version_id = latest_version.id
+      ETL::Master.process date: today + 1.day
+
+      expect(latest_version).to have_attributes(
+        content_id: content_id,
+        base_path: base_path,
+        locale: locale
+      )
+
+      validate_facts_metrics!(count: 2,
+        dates: [Date.new(2018, 2, 21), Date.new(2018, 2, 22)],
+        ids: [original_version_id, latest_version.id])
+      validate_outdated_items!(total: 3)
+      validate_metadata!
+      validate_google_analytics!
+      validate_feedex!(comments: 18)
+    end
+  end
+
+  def latest_version
+    Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
+  end
+
+  def latest_metric
+    Facts::Metric
+      .joins(:dimensions_item)
+      .where(dimensions_items: { latest: true, content_id: content_id })
+      .first
+  end
+
+  def validate_facts_metrics!(count:, dates:, ids:)
+    expect(Facts::Metric.count).to eq(count)
+    expect(Facts::Metric.pluck(:dimensions_item_id)).to match_array(ids)
+    expect(Facts::Metric.pluck(:dimensions_date_id).uniq).to match_array(dates)
+  end
+
+  def validate_outdated_items!(total:)
+    # p Dimensions::Item.all.map{|i|{id: i.id, content_id: i.content_id, title: i.title, base_path: i.base_path}}
+    expect(Dimensions::Item.count).to eq(total)
+    expect(Dimensions::Item.where(latest: true, content_id: content_id, base_path: base_path).count).to eq(1)
+  end
+
+  def validate_metadata!
+    expect(latest_version).to have_attributes(
+      title: 'title1',
+      document_type: 'document_type1',
+    )
+  end
+
+  def validate_google_analytics!
+    expect(latest_metric).to have_attributes(
+      pageviews: 11,
+      unique_pageviews: 12,
+    )
+  end
+
+  def validate_feedex!(comments:)
+    expect(latest_metric).to have_attributes(feedex_comments: comments)
+  end
+
+  def validate_quality_metrics
+    expect(latest_metric).to have_attributes(
+      repeated_words_count: 8,
+      passive_count: 6,
+    )
+  end
+
+  def stub_content_store_response(title:, content:)
+    response = content_item_for_base_path(base_path)
+    response.merge!(
+      'content_id' => content_id,
+      'base_path' => base_path,
+      'schema_name' => 'news_article',
+      'title' => title,
+      'document_type' => 'document_type1',
+      'details' => {
+        'body' => content,
+      }
+    )
+    content_store_has_item(base_path, response, {})
+  end
+
+  def stub_quality_metrics_response
+    quality_metrics_response = {
+      passive: { 'count' => 5 },
+      repeated_words: { 'count' => 8 },
+    }
+    stub_request(:post, 'https://govuk-content-quality-metrics.cloudapps.digital/metrics').
+      with(
+        body: { content: item_content }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+      .to_return(
+        status: 200,
+        body: quality_metrics_response.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def stub_google_analytics_response(date:, request_date:)
+    allow_any_instance_of(GoogleAnalyticsService).to receive(:find_in_batches).with(date: request_date).and_yield(
+      [
+        {
+          'page_path' => base_path,
+          'pageviews' => 11,
+          'unique_pageviews' => 12,
+          'date' => date,
+        },
+        {
+          'page_path' => '/path2',
+          'pageviews' => 2,
+          'unique_pageviews' => 2,
+          'date' => date,
+        },
+      ]
+    )
+  end
+
+  def stub_feedex_response(date:, comments:, request_date:)
+    response = {
+      'results': [{
+        'date': date,
+        'path': base_path,
+        'count': comments
+      }, {
+        'date': date,
+        'path': '/path2',
+        'count': 1
+      }, {
+        'date': date,
+        'path': '/path3',
+        'count': 1
+      }],
+      'total_count': 3,
+      'current_page': 1,
+      'pages': 1,
+      'page_size': 3
+    }.to_json
+
+    stub_request(:get, "http://support-api.dev.gov.uk/feedback-by-day/#{request_date}?page=1&per_page=10000").
+      to_return(status: 200, body: response, headers: {})
+  end
+
+end

--- a/spec/integration/initial_load_spec.rb
+++ b/spec/integration/initial_load_spec.rb
@@ -1,0 +1,24 @@
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe 'Initial load from publishing api' do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  let(:editions) do
+    [
+      { content_id: 'cont-1', base_path: '/one', locale: 'en' },
+      { content_id: 'cont-1', base_path: '/one.de', locale: 'de' },
+      { content_id: 'cont-3', base_path: '/two', locale: 'en' },
+    ]
+  end
+
+  before :each do
+    publishing_api_get_editions(editions, fields: %i[base_path content_id locale], per_page: 350, states: ['published'])
+  end
+
+  it 'something' do
+    ETL::Items.process
+
+    expect(Dimensions::Item.where(content_id: 'cont-1').count).to eq(2)
+    expect(Dimensions::Item.where(locale: 'en').count).to eq(2)
+  end
+end

--- a/spec/integration/initial_load_spec.rb
+++ b/spec/integration/initial_load_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Initial load from publishing api' do
   end
 
   it 'something' do
-    ETL::Items.process
+    ETL::PreloadItems.process
 
     expect(Dimensions::Item.where(content_id: 'cont-1').count).to eq(2)
     expect(Dimensions::Item.where(locale: 'en').count).to eq(2)

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Master process spec' do
   let!(:item) do
     create :dimensions_item,
       content_id: content_id, base_path: base_path,
-      locale: locale, outdated: true, updated_at: 2.days.ago
+      locale: locale, outdated: true, outdated_at: 2.days.ago
   end
 
   it 'orchestrates all ETL processes' do

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -14,18 +14,20 @@ RSpec.describe 'Process content item' do
   let(:base_path) { '/the-base-path' }
   let(:item_content) { 'This is the content.' }
   let(:content_hash) { 'bfce49ef213b4f9f82a6a46caae2d81a4bcda1f2' }
+  let(:locale) { 'en' }
 
   let!(:item) {
     create :dimensions_item,
-    content_id: content_id, base_path: base_path,
-    content_hash: 'OldContentHash'
+      content_id: content_id, base_path: '/old/base/path',
+      locale: locale,
+      content_hash: 'OldContentHash'
   }
 
   it 'stores metadata in quality metrics for a content item' do
     stub_item_metadata_in_content_store
     stub_quality_metrics_in_heroku
 
-    Importers::ContentDetails.run(content_id, base_path)
+    Importers::ContentDetails.run(content_id, base_path, locale)
 
     expect(item.reload).to have_attributes(
       content_id: content_id,

--- a/spec/integration/process_content_item_spec.rb
+++ b/spec/integration/process_content_item_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Process content item' do
 
   let!(:item) {
     create :dimensions_item,
-      content_id: content_id, base_path: '/old/base/path',
+      content_id: content_id, base_path: base_path,
       locale: locale,
       content_hash: 'OldContentHash'
   }
@@ -27,7 +27,7 @@ RSpec.describe 'Process content item' do
     stub_item_metadata_in_content_store
     stub_quality_metrics_in_heroku
 
-    Importers::ContentDetails.run(content_id, base_path, locale)
+    Importers::ContentDetails.run(item.id)
 
     expect(item.reload).to have_attributes(
       content_id: content_id,

--- a/spec/lib/publishing_api_consumer_spec.rb
+++ b/spec/lib/publishing_api_consumer_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe PublishingApiConsumer do
       {
         'base_path' => '/path/to/new/content',
         'content_id' => 'does-not-exist-yet',
+        'locale' => 'en',
       }
     end
     let!(:message) { double('message', payload: payload) }

--- a/spec/lib/publishing_api_consumer_spec.rb
+++ b/spec/lib/publishing_api_consumer_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe PublishingApiConsumer do
         outdated: false)
     end
     let!(:different_item) { create(:dimensions_item, latest: true, outdated: false) }
-    let!(:base_path) { '/some/path/to' }
+    let!(:updated_base_path) { '/updated/base/path' }
     let!(:payload) do
       {
-        'base_path' => latest_item_de.base_path,
+        'base_path' => updated_base_path,
         'content_id' => latest_item_de.content_id,
         'locale' => 'de'
       }
@@ -43,6 +43,10 @@ RSpec.describe PublishingApiConsumer do
       expect(latest_item_en.reload.outdated?).to be false
       expect(older_item.reload.outdated?).to be false
       expect(different_item.reload.outdated?).to be false
+    end
+
+    it 'sets the new base path on the outdated item' do
+      expect(latest_item_de.reload.base_path).to eq(updated_base_path)
     end
 
     it 'leaves the status as "live"' do

--- a/spec/models/concerns/outdateable_spec.rb
+++ b/spec/models/concerns/outdateable_spec.rb
@@ -48,20 +48,26 @@ RSpec.describe Concerns::Outdateable, type: :model do
   end
 
   describe '#outdate!' do
+    let(:new_base_path) { '/new/base/path' }
     let(:item) { create(:dimensions_item, outdated: false) }
 
     it 'sets the outdated? flag to true' do
-      item.outdate!
+      item.outdate! base_path: new_base_path
 
       expect(item.reload.outdated?).to be true
     end
 
     it 'sets the oudated_at time' do
       Timecop.freeze(Time.new(2018, 3, 3)) do
-        item.outdate!
+        item.outdate! base_path: new_base_path
 
         expect(item.reload.outdated_at).to eq(Time.new(2018, 3, 3))
       end
+    end
+
+    it 'sets the new base path' do
+      item.outdate! base_path: new_base_path
+      expect(item.reload.base_path).to eq(new_base_path)
     end
   end
 end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -53,12 +53,13 @@ RSpec.describe Dimensions::Item, type: :model do
     let(:content_id) { 'new-item' }
     let(:base_path) { '/path/to/new-item' }
     it 'creates a new item with the correct attributes' do
-      item = Dimensions::Item.create_empty content_id, base_path
+      item = Dimensions::Item.create_empty content_id: content_id, base_path: base_path, locale: 'fr'
       expect(item.reload).to have_attributes(
         content_id: content_id,
         base_path: base_path,
+        locale: 'fr',
         outdated: true,
-        latest: true
+        latest: true,
       )
     end
   end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe Dimensions::Item, type: :model do
       expect(new_version.new_record?).to eq(true)
     end
   end
+  
+  describe '#outdated!' do
+    it 'sets the outdated? flag to true and sets the base path' do
+      item = create(:dimensions_item, outdated: false)
+      item.outdated! base_path: '/new/base/path'
+      expect(item.reload).to have_attributes(
+        outdated: true,
+        base_path: '/new/base/path'
+      )
+    end
+  end
 
   describe '#gone!' do
     it 'sets the status  to "gone"' do

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Dimensions::Item, type: :model do
+  let(:now) { Time.new(2018, 2, 21, 12, 31, 2) }
+
   it { is_expected.to validate_presence_of(:content_id) }
 
   describe '##by_natural_key' do
@@ -33,17 +35,6 @@ RSpec.describe Dimensions::Item, type: :model do
       expect(new_version.new_record?).to eq(true)
     end
   end
-  
-  describe '#outdated!' do
-    it 'sets the outdated? flag to true and sets the base path' do
-      item = create(:dimensions_item, outdated: false)
-      item.outdated! base_path: '/new/base/path'
-      expect(item.reload).to have_attributes(
-        outdated: true,
-        base_path: '/new/base/path'
-      )
-    end
-  end
 
   describe '#gone!' do
     it 'sets the status  to "gone"' do
@@ -64,13 +55,16 @@ RSpec.describe Dimensions::Item, type: :model do
     let(:content_id) { 'new-item' }
     let(:base_path) { '/path/to/new-item' }
     it 'creates a new item with the correct attributes' do
-      item = Dimensions::Item.create_empty content_id: content_id, base_path: base_path, locale: 'fr'
+      item = Timecop.freeze(now) do
+        Dimensions::Item.create_empty content_id: content_id, base_path: base_path, locale: 'fr'
+      end
       expect(item.reload).to have_attributes(
         content_id: content_id,
         base_path: base_path,
         locale: 'fr',
         outdated: true,
         latest: true,
+        outdated_at: now,
       )
     end
   end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dimensions::Item, type: :model do
       create(:dimensions_item, content_id: content_id, latest: false, locale: 'en')
       create(:dimensions_item, content_id: content_id, latest: true, locale: 'de')
       create(:dimensions_item, content_id: content_id, latest: true, locale: 'fr')
-      expect(Dimensions::Item.by_natural_key(content_id: content_id, locale: 'en')).to match_array(expected_item)
+      expect(Dimensions::Item.by_natural_key(content_id: content_id, locale: 'en')).to eq(expected_item)
     end
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -3,6 +3,17 @@ require 'rails_helper'
 RSpec.describe Dimensions::Item, type: :model do
   it { is_expected.to validate_presence_of(:content_id) }
 
+  describe '##by_natural_key' do
+    it 'returns the latest item of the correct locale' do
+      content_id = 'the-one-we-want'
+      expected_item = create(:dimensions_item, content_id: content_id, latest: true, locale: 'en')
+      create(:dimensions_item, content_id: content_id, latest: false, locale: 'en')
+      create(:dimensions_item, content_id: content_id, latest: true, locale: 'de')
+      create(:dimensions_item, content_id: content_id, latest: true, locale: 'fr')
+      expect(Dimensions::Item.by_natural_key(content_id: content_id, locale: 'en')).to match_array(expected_item)
+    end
+  end
+
   describe '#new_version' do
     it 'duplicates the old item with latest: true, outdated: false but does not save' do
       old_item = build(:dimensions_item,

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe Facts::Metric, type: :model do
       results = subject.by_organisation_id('org-1')
       expect(results).to match_array([metric1, metric2])
     end
+
+    it '.by_locale' do
+      item1 = create(:dimensions_item, locale: 'fr')
+      item2 = create(:dimensions_item, locale: 'de')
+      metric1 = create(:metric, dimensions_item: item1, dimensions_date: day0)
+      create(:metric, dimensions_item: item2, dimensions_date: day0)
+      results = subject.by_locale('fr')
+      expect(results).to match_array(metric1)
+    end
   end
 
   describe '.metric_summary' do

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
   let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
   let!(:content_id) { SecureRandom.uuid }
 
-  let!(:item) { create :dimensions_item, content_id: content_id }
+  let!(:item) { create :dimensions_item, content_id: content_id, locale: 'en' }
+  let!(:item_fr) { create :dimensions_item, content_id: content_id, locale: 'de' }
 
   it 'returns an error for metrics not on the whitelist' do
     get "/api/v1/metrics/number_of_puns/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
@@ -79,6 +80,7 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
   describe 'Daily metrics' do
     before do
       create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10
+      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200
       create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20
       create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30
       create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40
@@ -127,10 +129,13 @@ RSpec.describe '/api/v1/metrics/:content_id', type: :request do
 
   describe 'Content metrics' do
     before do
-      item1_old = create :dimensions_item, content_id: content_id, number_of_pdfs: 30, number_of_word_files: 30, latest: false
+      item1_old = create :dimensions_item,
+        content_id: content_id, locale: 'en', number_of_pdfs: 30, number_of_word_files: 30, latest: false
       item.update number_of_pdfs: 20, number_of_word_files: 20
+      item_fr.update number_of_pdfs: 200, number_of_word_files: 100
 
       create :metric, dimensions_item: item1_old, dimensions_date: day1
+      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 10, feedex_comments: 10
       create :metric, dimensions_item: item, dimensions_date: day2
       create :metric, dimensions_item: item, dimensions_date: day3
       create :metric, dimensions_item: item, dimensions_date: day4

--- a/spec/services/content_items_service_spec.rb
+++ b/spec/services/content_items_service_spec.rb
@@ -3,53 +3,6 @@ require 'gds_api/test_helpers/content_store'
 RSpec.describe ItemsService do
   include GdsApi::TestHelpers::ContentStore
 
-  let(:publishing_api_client) { double('publishing_api_client') }
-
-  before do
-    subject.publishing_api_client = publishing_api_client
-  end
-
-  describe "#fetch_all_with_default_locale_only" do
-    let(:editions) do
-      [
-        { content_id: "a", locale: "en" },
-        { content_id: "a", locale: "cy" },
-
-        { content_id: "b", locale: "cy" },
-        { content_id: "b", locale: "en" },
-
-        { content_id: "c", locale: "cy" },
-        { content_id: "c", locale: "cs" },
-      ]
-    end
-    let(:fields) { %w[content_id locale user_facing_version] }
-
-    before do
-      allow(publishing_api_client).to receive(:fetch_all)
-        .with(fields)
-        .and_return(editions)
-    end
-
-    it "only returns one of each content id" do
-      content_ids = subject.fetch_all_with_default_locale_only(fields)
-        .map { |content_item| content_item[:content_id] }
-      expect(content_ids).to contain_exactly("a", "b", "c")
-    end
-
-    it "returns 'en' locales where available" do
-      expect(subject.fetch_all_with_default_locale_only(fields)).to include(
-        { content_id: "a", locale: "en" },
-        content_id: "b", locale: "en",
-      )
-    end
-
-    it "returns the first locale if 'en' is not available" do
-      expect(subject.fetch_all_with_default_locale_only(fields)).to include(
-        content_id: "c", locale: "cy"
-      )
-    end
-  end
-
   describe "#fetch_raw_json" do
     it "returns a hash with the content item attributes" do
       content_store_has_item('/the-base-path', { the: :body }, {})


### PR DESCRIPTION
@peteglondon:

We can have confidence in our integration tests (end_to_end tests) by:

1. Testing the master process and the data acquisition
2. Testing how the Items dimension grows when handling events from `PublishingAPI`

This PR removes all assertions and set up from #603 related to data acquisition and 
limits the scope to the Items dimension and its relationship with the events that come
from the `PublishingAPI`

These are the benefits that I find:

1. We still have end to end tests, as we simulate events from Publishing API, and we 
make our code assertions after running the master process
2. Improves readability and long-term maintainability as it only needs to grow when we
change how we handle events