### PR TITLE
Remove 'gov.uk' prefix from ga base path

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -3,4 +3,10 @@ namespace :etl do
   task master: :environment do
     ETL::Master.process
   end
+
+  desc 'Populate GA metrics for a date'
+  task :ga, [:date] => [:environment] do |_t, args|
+    date = args[:date]
+    ETL::GA.process(date: date.to_date)
+  end
 end


### PR DESCRIPTION
Remove prefix `/https://www.gov.uk/` from Google Analytics if needed so we
can match the GA events with the dimension item.