### PR TITLE
Add response definitions to the API reference

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,7 +20,7 @@ components:
       scheme: bearer
 
   schemas:
-    MetricInfo:
+    Metric:
       description: |
         Information about a metric returned by the API.
       type: object
@@ -38,6 +38,54 @@ components:
           type: string
           description: "Where this metric comes from"
 
+    Summary:
+      description: |
+        Summarised metric data for a defined time period
+      type: object
+      required:
+        - total
+        - latest
+      properties:
+        total:
+          type: integer
+          description: "Sum of all recorded metric values within the date range."
+        latest:
+          type: integer
+          description: "The latest recorded metric value within the date range."
+
+    Value:
+      description: |
+        A single observation of a metric.
+      type: object
+      required:
+        - date
+        - value
+      properties:
+        date:
+          type: date
+          description: "Date of measurement, in the form YYYY-MM-DD."
+        value:
+          type: integer
+          description: "The value of the metric."
+
+    TimeSeries:
+      description: |
+        A series of values for a metric.
+      type: array
+      items:
+        $ref: "#/components/schemas/Value"
+
+    TimeSeriesResponse:
+        description: "An object where each key is a metric ID and each value is a time series."
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/TimeSeries'
+
+    SummaryResponse:
+        description: "Summary information keyed by metric ID."
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Summary'
 
 # Apply the security globally to all operations
 security:
@@ -48,22 +96,21 @@ paths:
     get:
       summary: List all available metrics.
       description: |
-        Returns a list of metric metadata.
+        Returns a list of metrics that the API can return.
       tags:
         - Metadata
 
       responses:
         200:
           description: |
-            A list of metric metadata.
+            Success response
           content:
             application/json:
               schema:
-                description: "List of metrics returned by the API"
+                description: "A list of metrics that the API can return"
                 type: array
                 items:
-                  description: "Metric information"
-                  $ref: '#/components/schemas/MetricInfo'
+                  $ref: '#/components/schemas/Metric'
       x-code-samples:
         "/metrics/":
           lang: shell
@@ -112,7 +159,11 @@ paths:
       responses:
         200:
           description: |
-            A summary of each metric.
+            Success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SummaryResponse"
         400:
           description: The API request is invalid.
       x-code-samples:
@@ -164,7 +215,11 @@ paths:
       responses:
         200:
           description: |
-            A time series for each metric. Each series is an array of objects containing the value of the metric at a single point in time. The array may be empty.
+            Success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TimeSeriesResponse"
         400:
           description: The API request is invalid.
       x-code-samples:


### PR DESCRIPTION
This generates example responses for each endpoint.

It also adds an object reference at the bottom of the page that shows
what each field means. This doesn't work very well at the moment
because widdershins renders "additionalProperties" as if it is a
literal field called "additionalProperties". I'll see if we
can fix this separately.