### PR TITLE
Remove index without migration

### DIFF
--- a/db/migrate/20180327150046_drop_content_items_base_path_created_without_migration.rb
+++ b/db/migrate/20180327150046_drop_content_items_base_path_created_without_migration.rb
@@ -1,0 +1,7 @@
+class DropContentItemsBasePathCreatedWithoutMigration < ActiveRecord::Migration[5.1]
+  def up
+    if index_exists?(:dimensions_items, [:base_path], name: 'idx_cnt_bp')
+      remove_index :dimensions_items, name: 'idx_cnt_bp'
+    end
+  end
+end

--- a/db/migrate/20180327150403_add_index_on_dimensions_items_base_path.rb
+++ b/db/migrate/20180327150403_add_index_on_dimensions_items_base_path.rb
@@ -1,0 +1,5 @@
+class AddIndexOnDimensionsItemsBasePath < ActiveRecord::Migration[5.1]
+  def change
+    add_index :dimensions_items, [:base_path], name: 'index_dimensions_items_on_base_path'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323170720) do
+ActiveRecord::Schema.define(version: 20180327150403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.boolean "primary_organisation_withdrawn"
     t.string "content_hash"
     t.datetime "outdated_at"
+    t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["latest", "content_id"], name: "idx_latest_content_id"
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["latest"], name: "index_dimensions_items_on_latest"


### PR DESCRIPTION
Remove index added to prod database without migration as an
emergency measure and then add the index in properly.