### PR TITLE
Clarify docs for generating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ docker-compose exec app rake
 
 * [GOVUK-LINT-RUBY](doc/govuk-lint.md)
 * [Set up Google Analytics credentials in development](doc/google_analytics_setup.md)
-
+* [Generate API documentation](doc/api/README.md)
 
 [docker]: https://www.docker.com/
 [docker compose]: https://docs.docker.com/compose/overview/

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -40,14 +40,7 @@ Read [the changelog for the gem][gem-changelog] for the latest changes.
 
 ## Running documentation locally
 
-### Installing dependencies
-
-Setting up the documentation requires Ruby and Node. Run the following to
-install the necessary dependencies:
-
-```
-make requirements
-```
+All commands should be run from `doc/api`.
 
 ### Preview changes
 


### PR DESCRIPTION
- Remove unnecessary dependency step
- Link to the docs from the main readme
- Clarify that you need to run all the commands from the `docs/api` directory