### PR TITLE
Rename Schemas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.4p296
 
 BUNDLED WITH
    1.16.1

--- a/app/data/content/parsers/body_content.rb
+++ b/app/data/content/parsers/body_content.rb
@@ -12,7 +12,7 @@ class Content::Parsers::BodyContent
     detailed_guide
     document_collection
     fatality_notice
-    help
+    help_page
     hmrc_manual_section
     html_publication
     manual

--- a/app/data/content/parsers/unpublished.rb
+++ b/app/data/content/parsers/unpublished.rb
@@ -4,6 +4,6 @@ class Content::Parsers::Unpublished
   end
 
   def schemas
-    %w[unpublished gone]
+    %w[unpublishing gone]
   end
 end

--- a/spec/data/parser_spec.rb
+++ b/spec/data/parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Content::Parser do
           detailed_guide
           document_collection
           fatality_notice
-          help
+          help_page
           hmrc_manual_section
           html_publication
           manual
@@ -146,8 +146,8 @@ RSpec.describe Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs Design thinking Performance analysis")
       end
 
-      it "returns content json if schema_name is 'unpublished'" do
-        json = { schema_name: "unpublished",
+      it "returns content json if schema_name is 'unpublishing'" do
+        json = { schema_name: "unpublishing",
           details: { explanation: "This content has been removed" } }
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("This content has been removed")
       end


### PR DESCRIPTION
[Trello: Change Schema Names](https://trello.com/c/Quzqj0cw/225-change-schema-names)

An initial check of the extracted schemas have identified that there
are naming errors of the following schema types that will result
in data not being extracted for these types:
"help" should be "help_page"
"unpublished" should be "unpublishing"

The schema names have been changed and the tests updated.