### PR TITLE
Ensure RabbitMQ is always running

### DIFF
--- a/lib/publishing_api_consumer.rb
+++ b/lib/publishing_api_consumer.rb
@@ -18,6 +18,8 @@ private
 
 
   def handle_existing(item, base_path, routing_key)
+    # If we have an event to update the basepath, in order to get the latest
+    # version from from the content store we need to have the latest path
     item.update! base_path: base_path
     item.outdate!
     item.gone! if routing_key.include? 'unpublished'

--- a/spec/lib/publishing_api_consumer_spec.rb
+++ b/spec/lib/publishing_api_consumer_spec.rb
@@ -147,4 +147,31 @@ RSpec.describe PublishingApiConsumer do
       subject.process(message)
     end
   end
+
+  context "when an error happens" do
+    let!(:message) do
+      double('message',
+        payload: {
+          'base_path' => '/path/to/new/content',
+          'content_id' => 'the_content_id'
+        })
+    end
+
+    before do
+      allow(message).to receive(:discard)
+      expect(Dimensions::Item).to receive(:by_natural_key).and_raise(StandardError.new("An error"))
+    end
+
+    it "we log the error" do
+      expect(GovukError).to receive(:notify).with(instance_of(StandardError))
+
+      expect { subject.process(message) }.to_not raise_error
+    end
+
+    it "we discard the message" do
+      expect(message).to receive(:discard)
+
+      subject.process(message)
+    end
+  end
 end


### PR DESCRIPTION
If an error occurs when processing RabbitMQ events, then
we log the error and continue processing the events.

All errors are treated for the time being as need-to-fix 
problems in the codebase. Later on we will face retries, 
ideally by using the underlying support from the framework.