### PR TITLE
Refactor ETL and publishing API stream so we store every edition of a content item

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'listen'
   gem 'phantomjs'
+  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.2)
@@ -503,6 +506,7 @@ DEPENDENCIES
   pg
   phantomjs
   plek
+  pry-byebug
   pry-rails
   puma
   rack-proxy

--- a/app/etl/items/importers/content_details.rb
+++ b/app/etl/items/importers/content_details.rb
@@ -21,6 +21,10 @@ class Items::Importers::ContentDetails
       item_raw_json = items_service.fetch_raw_json(item.base_path)
       attributes = Item::Metadata::Parser.parse(item_raw_json)
       needs_quality_metrics = item.quality_metrics_required?(attributes)
+
+      # Reset the outdated flag to show that the content details are there
+      attributes[:outdated] = false
+
       item.update_attributes(attributes)
 
       Items::Jobs::ImportQualityMetricsJob.perform_async(item.id) if needs_quality_metrics

--- a/app/etl/items/outdated_items_processor.rb
+++ b/app/etl/items/outdated_items_processor.rb
@@ -11,7 +11,7 @@ class Items::OutdatedItemsProcessor
 
   def process
     time(process: :outdated_items) do
-      create_new_version_for_outdated_items
+      populate_outdated_items
     end
   end
 
@@ -19,21 +19,11 @@ private
 
   attr_reader :date
 
-  def create_new_version_for_outdated_items
+  def populate_outdated_items
     Dimensions::Item.outdated_before(date).find_in_batches.with_index do |items, index|
       log process: :outdated_items, message: "processing #{items.length} items in batch: #{index}"
-      new_items = create_new_items(items)
-      import_content_details(new_items)
+      import_content_details(items)
     end
-  end
-
-  def create_new_items(items)
-    new_items = items.map(&:new_version)
-    ActiveRecord::Base.transaction do
-      Dimensions::Item.import(new_items)
-      Dimensions::Item.where(id: items.pluck('id')).update_all(outdated: false, latest: false)
-    end
-    new_items
   end
 
   def import_content_details(items)

--- a/app/etl/items/preload_items_processor.rb
+++ b/app/etl/items/preload_items_processor.rb
@@ -27,6 +27,7 @@ private
         content_id: item[:content_id],
         base_path: item[:base_path],
         locale: item[:locale],
+        publishing_api_payload_version: 0,
         latest: true,
       }
     end

--- a/app/models/concerns/outdateable.rb
+++ b/app/models/concerns/outdateable.rb
@@ -4,7 +4,7 @@ module Concerns::Outdateable
   extend ActiveSupport::Concern
 
   included do
-    scope :outdated, -> { where(outdated: true, latest: true) }
+    scope :outdated, -> { where(outdated: true) }
     scope :outdated_before, ->(date) { outdated.where('outdated_at < ?', date) }
 
     def outdate!

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -14,7 +14,7 @@ class Dimensions::Item < ApplicationRecord
     Item::Content::Parser.extract_content(raw_json)
   end
 
-  def copy_to_new_outdated_version!(current_base_path)
+  def copy_to_new_outdated_version!(base_path:, payload_version:)
     # Create a new version of this content item, assuming that a document's
     # content_id and locale are fixed, but the base_path may change.
     #
@@ -30,8 +30,9 @@ class Dimensions::Item < ApplicationRecord
 
     new_version = Dimensions::Item.create_empty(
       content_id: content_id,
-      base_path: current_base_path,
-      locale: locale
+      base_path: base_path,
+      locale: locale,
+      payload_version: payload_version
     )
 
     update_attributes(latest: false)
@@ -47,14 +48,15 @@ class Dimensions::Item < ApplicationRecord
     attributes[:locale] == 'en' && attributes[:content_hash] != content_hash
   end
 
-  def self.create_empty(content_id:, base_path:, locale:)
+  def self.create_empty(content_id:, base_path:, locale:, payload_version:)
     create(
       content_id: content_id,
       base_path: base_path,
       locale: locale,
       latest: true,
       outdated: true,
-      outdated_at: Time.zone.now
+      outdated_at: Time.zone.now,
+      publishing_api_payload_version: payload_version
     )
   end
 end

--- a/app/streams/publishing_api_consumer.rb
+++ b/app/streams/publishing_api_consumer.rb
@@ -11,24 +11,51 @@ class PublishingApiConsumer
 private
 
   def process_message(message)
-    content_id = message.payload['content_id']
-    base_path = message.payload['base_path']
+    content_id = message.payload.fetch('content_id')
+    base_path = message.payload.fetch('base_path')
+    payload_version = message.payload.fetch('payload_version')
     locale = message.payload['locale'] || 'en'
 
     item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
+
     if item
-      handle_existing(item, base_path, message.delivery_info.routing_key)
+      existing_payload_version = item.publishing_api_payload_version || 0
+
+      if payload_version > existing_payload_version
+        handle_existing(
+          item: item,
+          base_path: base_path,
+          routing_key: message.delivery_info.routing_key,
+          payload_version: payload_version
+        )
+      else
+        # Skip out of date and repeated messages from the publishing API.
+        # This is to ensure that our "latest" record is actually the latest.
+        #
+        # RabbitMQ guarantees at-least-once delivery when using acknowledgements,
+        # so messages can be duplicated, plus we can't guarantee the order of
+        # processing because we can have multiple consumers working in parallel.
+        #
+        # This logic could later be extended to also process out of date messages,
+        # as long as we preserve the latest flag on the existing item.
+        logger.info "Skipping message from publishing API: published with #{payload_version} but we've already received a message with #{item.publishing_api_payload_version}"
+      end
     else
-      Dimensions::Item.create_empty(content_id: content_id, base_path: base_path, locale: locale)
+      Dimensions::Item.create_empty(
+        content_id: content_id,
+        base_path: base_path,
+        locale: locale,
+        payload_version: payload_version
+      )
     end
   end
 
-  def handle_existing(item, base_path, routing_key)
+  def handle_existing(item:, base_path:, routing_key:, payload_version:)
     case routing_key
     when /major|minor/
-      item.copy_to_new_outdated_version!(base_path)
+      item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
     when /unpublished/
-      new_item = item.copy_to_new_outdated_version!(base_path)
+      new_item = item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
       new_item.gone!
     else
       # If we get a links update, or an item is republished for technical reasons,

--- a/app/streams/publishing_api_consumer.rb
+++ b/app/streams/publishing_api_consumer.rb
@@ -1,66 +1,9 @@
 class PublishingApiConsumer
   def process(message)
-    process_message(message)
-
+    PublishingApiMessageProcessor.new(message).process
     message.ack
   rescue StandardError => e
     GovukError.notify(e)
     message.discard
-  end
-
-private
-
-  def process_message(message)
-    content_id = message.payload.fetch('content_id')
-    base_path = message.payload.fetch('base_path')
-    payload_version = message.payload.fetch('payload_version')
-    locale = message.payload['locale'] || 'en'
-
-    item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
-
-    if item
-      existing_payload_version = item.publishing_api_payload_version
-
-      if payload_version > existing_payload_version
-        handle_existing(
-          item: item,
-          base_path: base_path,
-          routing_key: message.delivery_info.routing_key,
-          payload_version: payload_version
-        )
-      else
-        # Skip out of date and repeated messages from the publishing API.
-        # This is to ensure that our "latest" record is actually the latest.
-        #
-        # RabbitMQ guarantees at-least-once delivery when using acknowledgements,
-        # so messages can be duplicated, plus we can't guarantee the order of
-        # processing because we can have multiple consumers working in parallel.
-        #
-        # This logic could later be extended to also process out of date messages,
-        # as long as we preserve the latest flag on the existing item.
-        logger.info "Skipping message from publishing API: published with #{payload_version} but we've already received a message with #{item.publishing_api_payload_version}"
-      end
-    else
-      Dimensions::Item.create_empty(
-        content_id: content_id,
-        base_path: base_path,
-        locale: locale,
-        payload_version: payload_version
-      )
-    end
-  end
-
-  def handle_existing(item:, base_path:, routing_key:, payload_version:)
-    case routing_key
-    when /major|minor/
-      item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
-    when /unpublished/
-      new_item = item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
-      new_item.gone!
-    else
-      # If we get a links update, or an item is republished for technical reasons,
-      # don't store a new version, but update the outdated time on the previous one.
-      item.outdate!
-    end
   end
 end

--- a/app/streams/publishing_api_consumer.rb
+++ b/app/streams/publishing_api_consumer.rb
@@ -19,7 +19,7 @@ private
     item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
 
     if item
-      existing_payload_version = item.publishing_api_payload_version || 0
+      existing_payload_version = item.publishing_api_payload_version
 
       if payload_version > existing_payload_version
         handle_existing(

--- a/app/streams/publishing_api_message_processor.rb
+++ b/app/streams/publishing_api_message_processor.rb
@@ -1,0 +1,58 @@
+class PublishingApiMessageProcessor
+  def initialize(message)
+    @content_id = message.payload.fetch('content_id')
+    @base_path = message.payload.fetch('base_path')
+    @payload_version = message.payload.fetch('payload_version')
+    @locale = message.payload['locale'] || 'en'
+    @routing_key = message.delivery_info.routing_key
+  end
+
+  def process
+    item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
+
+    if item
+      existing_payload_version = item.publishing_api_payload_version
+
+      if payload_version > existing_payload_version
+        handle_existing(item)
+      else
+        # Skip out of date and repeated messages from the publishing API.
+        # This is to ensure that our "latest" record is actually the latest.
+        #
+        # RabbitMQ guarantees at-least-once delivery when using acknowledgements,
+        # so messages can be duplicated, plus we can't guarantee the order of
+        # processing because we can have multiple consumers working in parallel.
+        logger.info "Skipping message from publishing API: published with #{payload_version} but we've already received a message with #{item.publishing_api_payload_version}"
+      end
+    else
+      Dimensions::Item.create_empty(
+        content_id: content_id,
+        base_path: base_path,
+        locale: locale,
+        payload_version: payload_version
+      )
+    end
+  end
+
+private
+
+  attr_reader :content_id
+  attr_reader :base_path
+  attr_reader :payload_version
+  attr_reader :locale
+  attr_reader :routing_key
+
+  def handle_existing(item)
+    case routing_key
+    when /major|minor/
+      item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
+    when /unpublished/
+      new_item = item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
+      new_item.gone!
+    else
+      # If we get a links update, or an item is republished for technical reasons,
+      # don't store a new version, but update the outdated time on the previous one.
+      item.outdate!
+    end
+  end
+end

--- a/db/migrate/20180417102741_add_payload_version_to_dimensions_items.rb
+++ b/db/migrate/20180417102741_add_payload_version_to_dimensions_items.rb
@@ -1,5 +1,6 @@
 class AddPayloadVersionToDimensionsItems < ActiveRecord::Migration[5.1]
   def change
-    add_column :dimensions_items, :publishing_api_payload_version, :bigint
+    add_column :dimensions_items, :publishing_api_payload_version, :bigint, default: 0, null: false
+    change_column_default :dimensions_items, :publishing_api_payload_version, nil
   end
 end

--- a/db/migrate/20180417102741_add_payload_version_to_dimensions_items.rb
+++ b/db/migrate/20180417102741_add_payload_version_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddPayloadVersionToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :publishing_api_payload_version, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20180417102741) do
     t.string "content_hash"
     t.datetime "outdated_at"
     t.string "locale", default: "en", null: false
-    t.bigint "publishing_api_payload_version"
+    t.bigint "publishing_api_payload_version", null: false
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323170720) do
+ActiveRecord::Schema.define(version: 20180417102741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,8 +70,9 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.string "primary_organisation_content_id"
     t.boolean "primary_organisation_withdrawn"
     t.string "content_hash"
-    t.string "locale", default: "en", null: false
     t.datetime "outdated_at"
+    t.string "locale", default: "en", null: false
+    t.bigint "publishing_api_payload_version"
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
@@ -92,6 +93,35 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["page_path", "date"], name: "index_events_gas_on_page_path_and_date"
+  end
+
+  create_table "facts_editions", force: :cascade do |t|
+    t.date "dimensions_date_id"
+    t.bigint "dimensions_item_id"
+    t.integer "number_of_pdfs"
+    t.integer "number_of_word_files"
+    t.integer "readability_score"
+    t.integer "contractions_count"
+    t.integer "equality_count"
+    t.integer "indefinite_article_count"
+    t.integer "passive_count"
+    t.integer "profanities_count"
+    t.integer "redundant_acronyms_count"
+    t.integer "repeated_words_count"
+    t.integer "simplify_count"
+    t.integer "spell_count"
+    t.integer "string_length", default: 0
+    t.integer "sentence_count", default: 0
+    t.integer "word_count", default: 0
+    t.json "raw_json"
+    t.string "status", default: "live"
+    t.string "description"
+    t.datetime "first_published_at"
+    t.datetime "public_updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dimensions_date_id"], name: "index_facts_editions_on_dimensions_date_id"
+    t.index ["dimensions_item_id"], name: "index_facts_editions_on_dimensions_item_id"
   end
 
   create_table "facts_metrics", force: :cascade do |t|
@@ -120,6 +150,8 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "facts_editions", "dimensions_dates", primary_key: "date"
+  add_foreign_key "facts_editions", "dimensions_items"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_items"
 end

--- a/spec/etl/items/importers/content_details_spec.rb
+++ b/spec/etl/items/importers/content_details_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Items::Importers::ContentDetails do
     let!(:latest_dimension_item_fr) do
       create(:dimensions_item,
         content_id: content_id, base_path: base_path, locale: 'fr',
-        raw_json: nil, content_hash: existing_content_hash)
+        raw_json: nil, content_hash: existing_content_hash,
+        publishing_api_payload_version: 1)
     end
     let!(:latest_dimension_item) do
       create(:dimensions_item,
         content_id: content_id, base_path: base_path, locale: 'en',
-        raw_json: nil, content_hash: existing_content_hash)
+        raw_json: nil, content_hash: existing_content_hash,
+        publishing_api_payload_version: 1)
     end
     let!(:older_dimension_item) { create(:dimensions_item, content_id: content_id, base_path: base_path, latest: false, raw_json: nil) }
     let(:raw_json) { { 'details' => 'the-json' } }

--- a/spec/etl/items/importers/content_details_spec.rb
+++ b/spec/etl/items/importers/content_details_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe Items::Importers::ContentDetails do
       )
     end
 
+    it 'resets the outdated flag on the item' do
+      subject.run
+
+      expect(latest_dimension_item.reload.outdated).to be false
+    end
+
+
     context "when the locale is 'en'" do
       let(:locale) { 'en' }
 

--- a/spec/etl/items/outdated_items_spec.rb
+++ b/spec/etl/items/outdated_items_spec.rb
@@ -29,15 +29,6 @@ RSpec.describe Items::OutdatedItemsProcessor do
     subject.process
   end
 
-  it 'resets the outdated flag on the item' do
-    expect(Dimensions::Item.where(content_id: content_id, outdated: true, locale: locale).count).to eq(0)
-  end
-
-  it 'resets the latest flag on the old item' do
-    expect(Dimensions::Item.where(content_id: content_id, latest: true, locale: locale).count).to eq(1)
-    expect(Dimensions::Item.where(content_id: content_id, latest: false, locale: locale).count).to eq(1)
-  end
-
   it 'fires a Sidekiq job for the new item' do
     latest_id = Dimensions::Item.find_by(content_id: content_id, latest: true).id
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     sequence(:base_path) { |i| "link - #{i}" }
     sequence(:description) { |i| "description - #{i}" }
     sequence(:raw_json) { |i| "json - #{i}" }
+    sequence(:publishing_api_payload_version)
     number_of_pdfs 0
 
     factory :outdated_item do

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Master process spec' do
 
   let(:content_id) { 'id1' }
   let(:base_path) { '/the-base-path' }
+  let(:old_base_path) { '/old/base/path' }
   let(:locale) { 'en' }
   let(:item_content) { 'This is the content.' }
 
@@ -23,7 +24,7 @@ RSpec.describe 'Master process spec' do
   let!(:an_item) { create :dimensions_item, content_id: 'a-content-id', locale: locale }
   let!(:outdated_item) do
     create :outdated_item, content_id: content_id,
-      base_path: '/old/base/path', locale: locale, latest: false
+      base_path: old_base_path, locale: locale, latest: false
   end
   let!(:item) do
     create :outdated_item,
@@ -64,7 +65,7 @@ RSpec.describe 'Master process spec' do
   end
 
   def validate_outdated_items!
-    expect(Dimensions::Item.count).to eq(4)
+    expect(Dimensions::Item.count).to eq(3)
 
     expect(Dimensions::Item.where(latest: true, content_id: 'id1', base_path: base_path).count).to eq(1)
   end
@@ -107,6 +108,7 @@ RSpec.describe 'Master process spec' do
       }
     )
     content_store_has_item(base_path, response, {})
+    content_store_has_item(old_base_path, response, {})
   end
 
   def stub_quality_metrics_response

--- a/spec/models/concerns/outdateable_spec.rb
+++ b/spec/models/concerns/outdateable_spec.rb
@@ -6,44 +6,16 @@ RSpec.describe Concerns::Outdateable, type: :model do
   describe '.oudated' do
     let(:item) { create(:dimensions_item) }
 
-    it 'returns true if outdated? and latest?' do
-      item.update(latest: true, outdated: true)
+    it 'returns true if outdated?' do
+      item.update(outdated: true)
 
       expect(subject.outdated).to match_array(item)
     end
 
-    it 'returns false if outdated? and not latest?' do
-      item.update(latest: false, outdated: true)
+    it 'returns false if not outdated?' do
+      item.update(outdated: false)
 
       expect(subject.outdated).to be_empty
-    end
-
-    it 'returns false if not outdated? and latest?' do
-      item.update(latest: true, outdated: false)
-
-      expect(subject.outdated).to be_empty
-    end
-  end
-
-  describe '.outdated_before' do
-    let(:date) { Date.new(2018, 2, 2) }
-    let(:before_date) { Time.utc(2018, 2, 1, 23, 59, 59) }
-
-    let!(:outdated_item_1) { create(:outdated_item, outdated_at: before_date) }
-    let!(:outdated_item_2) { create(:outdated_item, outdated_at: date) }
-
-    it 'only returns outdated items in their latest version' do
-      outdated_item_1.update latest: false
-      outdated_item_2.update latest: true
-
-      expect(Dimensions::Item.outdated_before(date)).to be_empty
-    end
-
-    it 'returns the outdated items updated before the given date' do
-      outdated_item_1.update latest: true
-      outdated_item_2.update latest: true
-
-      expect(Dimensions::Item.outdated_before(date)).to match_array(outdated_item_1)
     end
   end
 
@@ -57,7 +29,7 @@ RSpec.describe Concerns::Outdateable, type: :model do
       expect(item.reload.outdated?).to be true
     end
 
-    it 'sets the oudated_at time' do
+    it 'sets the outdated_at time' do
       Timecop.freeze(Time.new(2018, 3, 3)) { item.outdate! }
 
       expect(item.reload.outdated_at).to eq(Time.new(2018, 3, 3))

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -16,22 +16,31 @@ RSpec.describe Dimensions::Item, type: :model do
     end
   end
 
-  describe '#new_version' do
-    it 'duplicates the old item with latest: true, outdated: false but does not save' do
-      old_item = build(:outdated_item,
+  describe '#copy_to_new_outdated_version!' do
+    it 'creates a new item with latest: true, and clears this flag on the old one' do
+      old_version = build(:outdated_item,
         latest: true,
         raw_json: { 'the' => 'content' },
         content_id: 'c-id',
         base_path: '/the/path')
-      new_version = old_item.new_version
+
+      new_version = old_version.copy_to_new_outdated_version!('/the/new/path')
+
       expect(new_version).to have_attributes(
-        outdated: false,
+        outdated: true,
         latest: true,
+        raw_json: nil,
+        content_id: 'c-id',
+        base_path: '/the/new/path'
+      )
+
+      expect(old_version).to have_attributes(
+        outdated: true,
+        latest: false,
         raw_json: { 'the' => 'content' },
         content_id: 'c-id',
         base_path: '/the/path'
       )
-      expect(new_version.new_record?).to eq(true)
     end
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Dimensions::Item, type: :model do
         content_id: 'c-id',
         base_path: '/the/path')
 
-      new_version = old_version.copy_to_new_outdated_version!('/the/new/path')
+      new_version = old_version.copy_to_new_outdated_version!(base_path: '/the/new/path', payload_version: 2)
 
       expect(new_version).to have_attributes(
         outdated: true,
@@ -82,7 +82,7 @@ RSpec.describe Dimensions::Item, type: :model do
     let(:base_path) { '/path/to/new-item' }
     it 'creates a new item with the correct attributes' do
       item = Timecop.freeze(now) do
-        Dimensions::Item.create_empty content_id: content_id, base_path: base_path, locale: 'fr'
+        Dimensions::Item.create_empty content_id: content_id, base_path: base_path, locale: 'fr', payload_version: 1
       end
       expect(item.reload).to have_attributes(
         content_id: content_id,

--- a/spec/streams/publishing_api_consumer_spec.rb
+++ b/spec/streams/publishing_api_consumer_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe PublishingApiConsumer do
       {
         'base_path' => updated_base_path,
         'content_id' => latest_item_de.content_id,
-        'locale' => 'de'
+        'locale' => 'de',
+        'payload_version' => 1
       }
     end
     let!(:message) do
@@ -69,7 +70,8 @@ RSpec.describe PublishingApiConsumer do
       {
         'base_path' => latest_item_en.base_path,
         'content_id' => latest_item_en.content_id,
-        'locale' => 'en'
+        'locale' => 'en',
+        'payload_version' => 1
       }
     end
     let!(:message) do
@@ -106,6 +108,7 @@ RSpec.describe PublishingApiConsumer do
         'base_path' => '/path/to/new/content',
         'content_id' => 'does-not-exist-yet',
         'locale' => 'en',
+        'payload_version' => 1
       }
     end
     let!(:message) { double('message', payload: payload) }
@@ -135,7 +138,8 @@ RSpec.describe PublishingApiConsumer do
       double('message',
         payload: {
           'base_path' => '/path/to/new/content',
-          'content_id' => 'the_content_id'
+          'content_id' => 'the_content_id',
+          'payload_version' => 1
         })
     end
 
@@ -159,7 +163,8 @@ RSpec.describe PublishingApiConsumer do
       double('message',
         payload: {
           'base_path' => '/path/to/new/content',
-          'content_id' => 'the_content_id'
+          'content_id' => 'the_content_id',
+          'payload_version' => 1
         })
     end
 

--- a/spec/streams/publishing_api_consumer_spec.rb
+++ b/spec/streams/publishing_api_consumer_spec.rb
@@ -120,7 +120,11 @@ RSpec.describe PublishingApiConsumer do
         'payload_version' => 1
       }
     end
-    let!(:message) { double('message', payload: payload) }
+    let!(:message) do
+      double('message',
+        payload: payload,
+        delivery_info: double('del_info', routing_key: 'news_story.major'))
+    end
 
     before :each do
       allow(message).to receive(:ack)
@@ -149,7 +153,8 @@ RSpec.describe PublishingApiConsumer do
           'base_path' => '/path/to/new/content',
           'content_id' => 'the_content_id',
           'payload_version' => 1
-        })
+        },
+        delivery_info: double('del_info', routing_key: 'news_story.major'))
     end
 
     it "creates a new item with the 'en' locale" do
@@ -174,7 +179,8 @@ RSpec.describe PublishingApiConsumer do
           'base_path' => '/path/to/new/content',
           'content_id' => 'the_content_id',
           'payload_version' => 1
-        })
+        },
+        delivery_info: double('del_info', routing_key: 'news_story.major'))
     end
 
     before do

--- a/spec/streams/publishing_api_consumer_spec.rb
+++ b/spec/streams/publishing_api_consumer_spec.rb
@@ -8,15 +8,20 @@ RSpec.describe PublishingApiConsumer do
   it_behaves_like 'a message queue processor'
 
   context 'when the Dimensions::Item already exists - all events but unpublish' do
-    let!(:latest_item_en) { create(:dimensions_item, locale: 'en', outdated: true) }
-    let!(:latest_item_de) { create(:dimensions_item, locale: 'de', outdated: false) }
+    let!(:latest_item_en) do
+      create(:dimensions_item, locale: 'en', outdated: true, publishing_api_payload_version: 1)
+    end
+    let!(:latest_item_de) do
+      create(:dimensions_item, locale: 'de', outdated: false, publishing_api_payload_version: 1)
+    end
 
     let!(:older_item) do
       create(:dimensions_item,
         content_id: latest_item_en.content_id,
         base_path: latest_item_en.base_path,
         latest: false,
-        outdated: false)
+        outdated: false,
+        publishing_api_payload_version: 1)
     end
     let!(:different_item) { create(:dimensions_item, outdated: false) }
     let!(:updated_base_path) { '/updated/base/path' }
@@ -25,7 +30,7 @@ RSpec.describe PublishingApiConsumer do
         'base_path' => updated_base_path,
         'content_id' => latest_item_de.content_id,
         'locale' => 'de',
-        'payload_version' => 1
+        'payload_version' => 2
       }
     end
     let!(:message) do
@@ -64,14 +69,18 @@ RSpec.describe PublishingApiConsumer do
   end
 
   context 'on an unpublish event' do
-    let!(:latest_item_en) { create(:dimensions_item, locale: 'en') }
-    let!(:latest_item_fr) { create(:dimensions_item, locale: 'fr') }
+    let!(:latest_item_en) do
+      create(:dimensions_item, locale: 'en', publishing_api_payload_version: 1)
+    end
+    let!(:latest_item_fr) do
+      create(:dimensions_item, locale: 'fr', publishing_api_payload_version: 1)
+    end
     let!(:payload) do
       {
         'base_path' => latest_item_en.base_path,
         'content_id' => latest_item_en.content_id,
         'locale' => 'en',
-        'payload_version' => 1
+        'payload_version' => 2
       }
     end
     let!(:message) do


### PR DESCRIPTION
# Summary
This changes both the nightly ETL process and the publishing API consumer so that multiple editions of a content item can be tracked per day. At the moment, we update `Dimensions::Item` records whenever we see multiple messages for the same content item in the same day, instead of inserting a new record.

This will have implications if we want to show historical quality metrics within publishing apps, because publishing apps show users a complete version history, rather than daily snapshots.

We're also storing fact-like data on the dimension itself, which is not following proper conventions and may make it harder to adopt 3rd party tools.

The solution we agreed upon was to create a new facts table with edition-level granularity, in addition to the current facts table that is a daily snapshot of every content item. This PR doesn't add that facts table - I'll do this in a future PR.

Trello: https://trello.com/c/SWlCL8xI/240-5-track-content-editions-metrics-through-time

# How it works now
- The publishing API consumer creates a new `Dimensions::Item` if there is no existing item for the same content_id with `latest: true`
- Otherwise, it marks the existing item as `outdated: true` and updates its base path in place
- Overnight, the `OutdatedItemsProcessor` processes every item that has `outdated: true` and `latest: true`
  - It creates a new version of the item with `latest: true, outdated: false`
  - It updates the previous version to be `latest: false, updated: false`
  - It triggers an async job to set the content details and quality metrics on the new version
- Then, `MetricsProcessor` creates a `Facts::Metric` record for every item with `latest: true`

# How it should work after this PR
- The publishing API consumer creates `Dimensions::Item` records for every edition, and marks them as `outdated`.
- The publishing API consumer marks the latest item per content id per day using `latest=true`
- Overnight, the `OutdatedItemsProcessor` processes every item that has `outdated: true`
  - It triggers an async job to set the content details and quality metrics on the new version
  - That job sets `outdated: false` on the item
- Then, `MetricsProcessor` creates a `Facts::Metric` record for every item with `latest: true`

# How it should work when we're done with this story
We can remove the `outdated` flag and `OutdatedItemsProcessor` from the codebase.

- The publishing API consumer creates `Dimensions::Item` records for every edition
- The consumer creates a `Facts::Version` record for each edition
  - It populates it with content details from the message
  - It fetches the quality metrics and records those too
- It marks the latest item per content id per day using `latest=true`
- Overnight, `MetricsProcessor` creates a `Facts::Metric` record for every item with `latest: true`
  - (Optional) It takes a snapshot of the version facts to make it easier to query daily metrics

# Things to fix
- [x] At the moment the "latest" version is whatever version we happened to process last. However, RabbitMQ can send us messages out of order, or duplicate messages. We should read the publishing API version and/or message creation time so that we can reconcile our concept of latest with the publishing API's concept of latest, and avoid creating multiple records for the same edition. 

  See [Rummager ADR 002](https://github.com/alphagov/rummager/blob/master/doc/arch/adr-002-handle-race-conditions-in-govuk-index.md) for a discussion of this problem in the context of search.

- [x] I need to add in an integration test that makes sure `Facts::Metric` has the right granularity when there are multiple editions per day
