### PR TITLE
Fix etl rake task calling wrong classname

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -1,7 +1,7 @@
 namespace :etl do
   desc 'Run ETL master process'
   task master: :environment do
-    Master.process
+    Master::MasterProcessor.process
   end
 
   desc 'Populate GA metrics for a date'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 
 require "rspec/rails"
 require "support/authentication"
+require "rake"
 require "webmock/rspec"
 require "gds_api/test_helpers/publishing_api_v2"
 require "pry"

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'rake etl:master', type: task do
+  it "calls Master::MasterProcessor.process" do
+    processor = class_double(Master::MasterProcessor, process: true).as_stubbed_const
+    expect(processor).to receive(:process)
+
+    Rake::Task['etl:master'].invoke
+  end
+end


### PR DESCRIPTION
The Master process was refactored previously and renamed but the
calling rake task was not updated.