### PR TITLE
Import the 'is this page useful?' user feedback metric

### DIFF
--- a/app/etl/ga/service.rb
+++ b/app/etl/ga/service.rb
@@ -1,6 +1,6 @@
 class GA::Service
   def client
-    @client ||= GoogleAnalytics::Client.new.build
+    @client ||= Clients::GoogleAnalytics.new.build
   end
 
   def find_in_batches(date:, batch_size: 10_000)
@@ -14,7 +14,28 @@ class GA::Service
       .each_slice(batch_size) { |slice| yield slice }
   end
 
+  def find_user_feedback_in_batches(date:, batch_size: 10_000)
+    user_feedback_data(date: date)
+      .lazy
+      .map(&:to_h)
+      .flat_map(&method(:extract_rows))
+      .map(&method(:extract_dimensions_and_metrics))
+      .map(&method(:append_user_feedback_labels))
+      .map { |h| h['date'] = date.strftime('%F'); h }
+      .group_by { |h| h['page_path'] }
+      .map { |h| format_user_feedback_data(h) }
+      .each_slice(batch_size) { |slice| yield slice }
+  end
+
 private
+
+  def append_user_feedback_labels(values)
+    page_path, event_action, value = *values
+    {
+      'page_path' => page_path,
+      event_action.to_s => value,
+    }
+  end
 
   def append_data_labels(values)
     page_path, pageviews, unique_pageviews = *values
@@ -52,6 +73,19 @@ private
     end
   end
 
+  def user_feedback_data(date:)
+    @data ||= client.fetch_all(items: :data) do |page_token, service|
+      service
+        .batch_get_reports(
+          Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
+            report_requests: [user_feedback_request(date: date).merge(page_token: page_token)]
+          )
+        )
+        .reports
+        .first
+    end
+  end
+
   def report_request(date:)
     {
       date_ranges: [
@@ -68,6 +102,38 @@ private
       ],
       page_size: 10_000,
       view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+    }
+  end
+
+  def user_feedback_request(date:)
+    {
+      date_ranges: [
+        { start_date: date.to_s("%Y-%m-%d"), end_date: date.to_s("%Y-%m-%d") },
+      ],
+      dimensions: [
+        { name: 'ga:pagePath' },
+        { name: 'ga:eventAction' }
+      ],
+      hide_totals: true,
+      hide_value_ranges: true,
+      metrics: [
+        { expression: 'ga:uniqueDimensionCombinations' },
+      ],
+      filters_expression: 'ga:eventAction==ffNoClick,ga:eventAction==ffYesClick',
+      page_size: 10_000,
+      view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+    }
+  end
+
+  def format_user_feedback_data(hash)
+    key, value = *hash
+    no = value.find { |v| v['ffNoClick'] }
+    yes = value.find { |v| v['ffYesClick'] }
+    {
+      "page_path" => key,
+      "is_this_useful_yes" => yes['ffYesClick'],
+      "is_this_useful_no" => no['ffNoClick'],
+      "date" => value.first['date']
     }
   end
 end

--- a/app/etl/ga/user_feedback_processor.rb
+++ b/app/etl/ga/user_feedback_processor.rb
@@ -1,0 +1,87 @@
+class GA::UserFeedbackProcessor
+  include Concerns::Traceable
+
+  def self.process(*args)
+    new(*args).process
+  end
+
+  def initialize(date:)
+    @date = date
+  end
+
+  def process
+    time(process: :ga) do
+      extract_events
+      transform_events
+      load_metrics
+    end
+  end
+
+private
+
+  def extract_events
+    batch = 1
+    ga_service.find_user_feedback_in_batches(date: date) do |events|
+      log process: :ga, message: "Processing #{events.length} events in batch #{batch}"
+      Events::GA.import(events, batch_size: 10_000)
+      batch += 1
+    end
+  end
+
+  def transform_events
+    fix_invalid_prefix_in_page_paths
+  end
+
+  def load_metrics
+    conn = ActiveRecord::Base.connection
+    date_to_s = date.strftime("%F")
+    conn.execute(load_metrics_query(date_to_s))
+    conn.execute(clean_up_query)
+  end
+
+  def load_metrics_query(date_to_s)
+    <<~SQL
+      UPDATE facts_metrics
+      SET is_this_useful_no = s.is_this_useful_no,
+          is_this_useful_yes = s.is_this_useful_yes
+      FROM (
+        SELECT is_this_useful_no,
+               is_this_useful_yes,
+               dimensions_items.id
+        FROM events_gas, dimensions_items
+        WHERE page_path = base_path
+              AND events_gas.date = '#{date_to_s}'
+      ) AS s
+      WHERE dimensions_item_id = s.id AND dimensions_date_id = '#{date_to_s}'
+    SQL
+  end
+
+  def clean_up_query
+    date_to_s = date.strftime("%F")
+    <<~SQL
+      DELETE FROM events_gas
+      WHERE date = '#{date_to_s}' AND
+        page_path in (
+           SELECT base_path
+           FROM dimensions_items, facts_metrics
+           WHERE dimensions_items.id = facts_metrics.dimensions_item_id
+           AND facts_metrics.dimensions_date_id = '#{date_to_s}'
+        )
+    SQL
+  end
+
+  def fix_invalid_prefix_in_page_paths
+    events_with_prefix = Events::GA.where("page_path ~ '^\/https:\/\/www.gov.uk'")
+    log(process: :ga, message: "Transforming #{events_with_prefix.count} events with page_path starting https://gov.uk")
+    events_with_prefix.find_each do |event|
+      page_path_without_prefix = event.page_path.remove '/https://www.gov.uk'
+      event.update_attributes(page_path: page_path_without_prefix)
+    end
+  end
+
+  attr_reader :date
+
+  def ga_service
+    @ga_service ||= GA::Service.new
+  end
+end

--- a/app/etl/master/master_processor.rb
+++ b/app/etl/master/master_processor.rb
@@ -15,6 +15,7 @@ class Master::MasterProcessor
       Items::OutdatedItemsProcessor.process(date: dimensions_date.date)
       Master::MetricsProcessor.process(date: dimensions_date.date)
       GA::Processor.process(date: dimensions_date.date)
+      GA::UserFeedbackProcessor.process(date: dimensions_date.date)
       Feedex::Processor.process(date: dimensions_date.date)
     end
   end

--- a/db/migrate/20180418135558_add_is_this_useful_columns_to_events_gas.rb
+++ b/db/migrate/20180418135558_add_is_this_useful_columns_to_events_gas.rb
@@ -1,0 +1,6 @@
+class AddIsThisUsefulColumnsToEventsGas < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events_gas, :is_this_useful_yes, :integer
+    add_column :events_gas, :is_this_useful_no, :integer
+  end
+end

--- a/db/migrate/20180418135632_add_is_this_useful_columns_to_facts_metrics.rb
+++ b/db/migrate/20180418135632_add_is_this_useful_columns_to_facts_metrics.rb
@@ -1,0 +1,6 @@
+class AddIsThisUsefulColumnsToFactsMetrics < ActiveRecord::Migration[5.1]
+  def change
+    add_column :facts_metrics, :is_this_useful_yes, :integer
+    add_column :facts_metrics, :is_this_useful_no, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323170720) do
+ActiveRecord::Schema.define(version: 20180418135632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,8 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.integer "unique_pageviews"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "is_this_useful_yes"
+    t.integer "is_this_useful_no"
     t.index ["page_path", "date"], name: "index_events_gas_on_page_path_and_date"
   end
 
@@ -102,6 +104,8 @@ ActiveRecord::Schema.define(version: 20180323170720) do
     t.integer "pageviews", default: 0
     t.integer "unique_pageviews", default: 0
     t.integer "feedex_comments", default: 0
+    t.integer "is_this_useful_yes"
+    t.integer "is_this_useful_no"
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "index_facts_metrics_date_item_id"
     t.index ["dimensions_item_id"], name: "index_facts_metrics_on_dimensions_item_id"
   end

--- a/spec/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/etl/ga/user_feedback_processor_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+require 'gds-api-adapters'
+
+RSpec.describe GA::UserFeedbackProcessor do
+  subject { described_class }
+
+  let!(:item1) { create :dimensions_item, base_path: '/path1', latest: true }
+  let!(:item2) { create :dimensions_item, base_path: '/path2', latest: true }
+
+  let(:date) { Date.new(2018, 2, 20) }
+  let(:dimensions_date) { Dimensions::Date.for(date) }
+
+
+  context 'When the base_path matches the GA path' do
+    before { allow_any_instance_of(GA::Service).to receive(:find_user_feedback_in_batches).and_yield(ga_response) }
+
+    it 'update the facts with the GA metrics' do
+      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+      fact2 = create :metric, dimensions_item: item2, dimensions_date: dimensions_date
+
+      described_class.process(date: date)
+
+      expect(fact1.reload).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 1)
+      expect(fact2.reload).to have_attributes(is_this_useful_no: 5, is_this_useful_yes: 10)
+    end
+
+    it 'does not update metrics for other days' do
+      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date, is_this_useful_no: 20, is_this_useful_yes: 10
+
+      day_before = date - 1
+      described_class.process(date: day_before)
+
+      expect(fact1.reload).to have_attributes(is_this_useful_no: 20, is_this_useful_yes: 10)
+    end
+
+    it 'does not update metrics for other items' do
+      item = create :dimensions_item, base_path: '/non-matching-path', latest: true
+      fact = create :metric, dimensions_item: item, dimensions_date: dimensions_date, is_this_useful_no: 99, is_this_useful_yes: 90
+
+      described_class.process(date: date)
+
+      expect(fact.reload).to have_attributes(is_this_useful_no: 99, is_this_useful_yes: 90)
+    end
+
+    it 'deletes the events that matches the base_path of an item' do
+      item2.destroy
+      create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+      described_class.process(date: date)
+
+      expect(Events::GA.count).to eq(1)
+    end
+
+    context 'when there are events from other days' do
+      before do
+        create(:ga, date: date - 1, page_path: '/path1')
+        create(:ga, date: date - 2, page_path: '/path1')
+      end
+
+      it 'only updates metrics for the current day' do
+        fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+        described_class.process(date: date)
+
+        expect(fact1.reload).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 1)
+      end
+
+      it 'only deletes the events for the current day that matches' do
+        create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+        described_class.process(date: date)
+
+        expect(Events::GA.count).to eq(3)
+      end
+    end
+  end
+
+  context 'when page_path starts "/https://www.gov.uk"' do
+    it 'removes the "/https://www.gov.uk" from the GA::Event page_path' do
+      allow_any_instance_of(GA::Service).to receive(:find_in_batches).and_yield(ga_response_with_govuk_prefix)
+
+      described_class.process(date: date)
+      expect(Events::GA.where(page_path: '/https://gov.uk/path1').count).to eq 0
+      expect(Events::GA.where(page_path: '/path1').count).to eq 1
+    end
+  end
+
+private
+
+  def ga_response
+    [
+      {
+        'page_path' => '/path1',
+        'is_this_useful_no' => 1,
+        'is_this_useful_yes' => 1,
+        'date' => '2018-02-20',
+      },
+      {
+        'page_path' => '/path2',
+        'is_this_useful_no' => 5,
+        'is_this_useful_yes' => 10,
+        'date' => '2018-02-20',
+      },
+    ]
+  end
+
+  def ga_response_with_govuk_prefix
+    [
+      {
+        'page_path' => '/https://www.gov.uk/path1',
+        'pageviews' => 1,
+        'unique_pageviews' => 1,
+        'date' => '2018-02-20',
+      },
+      {
+        'page_path' => '/path2',
+        'pageviews' => 2,
+        'unique_pageviews' => 2,
+        'date' => '2018-02-20',
+      },
+    ]
+  end
+end

--- a/spec/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/etl/ga/user_feedback_processor_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe GA::UserFeedbackProcessor do
 
   context 'when page_path starts "/https://www.gov.uk"' do
     it 'removes the "/https://www.gov.uk" from the GA::Event page_path' do
-      allow_any_instance_of(GA::Service).to receive(:find_in_batches).and_yield(ga_response_with_govuk_prefix)
+      allow_any_instance_of(GA::Service).to receive(:find_user_feedback_in_batches).and_yield(ga_response_with_govuk_prefix)
 
       described_class.process(date: date)
       expect(Events::GA.where(page_path: '/https://gov.uk/path1').count).to eq 0
@@ -108,14 +108,14 @@ private
     [
       {
         'page_path' => '/https://www.gov.uk/path1',
-        'pageviews' => 1,
-        'unique_pageviews' => 1,
+        'is_this_useful_no' => 1,
+        'is_this_useful_yes' => 1,
         'date' => '2018-02-20',
       },
       {
         'page_path' => '/path2',
-        'pageviews' => 2,
-        'unique_pageviews' => 2,
+        'is_this_useful_no' => 5,
+        'is_this_useful_yes' => 10,
         'date' => '2018-02-20',
       },
     ]

--- a/spec/etl/master/master_spec.rb
+++ b/spec/etl/master/master_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Master::MasterProcessor do
 
   before do
     allow(GA::Processor).to receive(:process)
+    allow(GA::UserFeedbackProcessor).to receive(:process)
     allow(Feedex::Processor).to receive(:process)
     allow(Items::OutdatedItemsProcessor).to receive(:process)
     allow(Master::MetricsProcessor).to receive(:process)

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'PublishingAPI events' do
 
   before do
     stub_google_analytics_response
+    stub_google_analytics_user_feedback_response
     stub_feedex_response
     stub_quality_metrics_response
     stub_content_store_response(title: 'title1', base_path: base_path)
@@ -107,6 +108,10 @@ RSpec.describe 'PublishingAPI events' do
 
   def stub_google_analytics_response
     allow_any_instance_of(GA::Service).to receive(:find_in_batches).and_yield([])
+  end
+
+  def stub_google_analytics_user_feedback_response
+    allow_any_instance_of(GA::Service).to receive(:find_user_feedback_in_batches).and_yield([])
   end
 
   def stub_feedex_response

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Master process spec' do
 
   it 'orchestrates all ETL processes' do
     stub_google_analytics_response
+    stub_google_analytics_user_feedback_response
     stub_feedex_response
     stub_content_store_response
     stub_quality_metrics_response
@@ -139,6 +140,25 @@ RSpec.describe 'Master process spec' do
           'page_path' => '/path2',
           'pageviews' => 2,
           'unique_pageviews' => 2,
+          'date' => '2018-02-20',
+        },
+      ]
+    )
+  end
+
+  def stub_google_analytics_user_feedback_response
+    allow_any_instance_of(GA::Service).to receive(:find_user_feedback_in_batches).and_yield(
+      [
+        {
+          'page_path' => base_path,
+          'is_this_useful_no' => 1,
+          'is_this_useful_yes' => 12,
+          'date' => '2018-02-20',
+        },
+        {
+          'page_path' => base_path,
+          'is_this_useful_no' => 122,
+          'is_this_useful_yes' => 1,
           'date' => '2018-02-20',
         },
       ]

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -54,68 +54,68 @@ RSpec.describe GA::Service do
           .to yield_successive_args(arg1, arg2)
       end
     end
+  end
 
-    describe "#find_user_feedback_in_batches" do
-      let(:date) { Date.new(2018, 2, 20) }
+  describe "#find_user_feedback_in_batches" do
+    let(:date) { Date.new(2018, 2, 20) }
 
-      before do
-        allow(subject.client).to receive(:fetch_all) do
-          [
-            build_report_data(
-              build_report_row(dimensions: %w(/foo ffNoClick), metrics: %w(10))
-            ),
-            build_report_data(
-              build_report_row(dimensions: %w(/foo ffYesClick), metrics: %w(2))
-            ),
-            build_report_data(
-              build_report_row(dimensions: %w(/bar ffNoClick), metrics: %w(3))
-            ),
-            build_report_data(
-              build_report_row(dimensions: %w(/bar ffYesClick), metrics: %w(44))
-            ),
-          ]
-        end
+    before do
+      allow(subject.client).to receive(:fetch_all) do
+        [
+          build_report_data(
+            build_report_row(dimensions: %w(/foo ffNoClick), metrics: %w(10))
+          ),
+          build_report_data(
+            build_report_row(dimensions: %w(/foo ffYesClick), metrics: %w(2))
+          ),
+          build_report_data(
+            build_report_row(dimensions: %w(/bar ffNoClick), metrics: %w(3))
+          ),
+          build_report_data(
+            build_report_row(dimensions: %w(/bar ffYesClick), metrics: %w(44))
+          ),
+        ]
       end
-
-      context 'when #find_in_batches is called with a block' do
-        it 'should yield successive report data' do
-          arg1 = [
-            a_hash_including(
-              'page_path' => '/foo',
-              'is_this_useful_yes' => 2,
-              'is_this_useful_no' => 10,
-              'date' => '2018-02-20',
-            ),
-          ]
-          arg2 = [
-            a_hash_including(
-              'page_path' => '/cool',
-              'is_this_useful_yes' => 44,
-              'is_this_useful_no' => 3,
-              'date' => '2018-02-20',
-            )
-          ]
-
-          expect { |probe| subject.find_in_batches(date: date, batch_size: 2, &probe) }
-            .to yield_successive_args(arg1, arg2)
-        end
-      end
-
-    private
-
-    def build_report_data(*report_rows)
-      Google::Apis::AnalyticsreportingV4::ReportData.new(rows: report_rows)
     end
 
-    def build_report_row(dimensions:, metrics:)
-      Google::Apis::AnalyticsreportingV4::ReportRow.new(
-        dimensions: dimensions,
-        metrics: metrics.map do |metric|
-          Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
-            values: Array(metric)
+    context 'when #find_in_batches is called with a block' do
+      it 'should yield successive report data' do
+        arg1 = [
+          a_hash_including(
+            'page_path' => '/foo',
+            'is_this_useful_yes' => 2,
+            'is_this_useful_no' => 10,
+            'date' => '2018-02-20',
+          ),
+        ]
+        arg2 = [
+          a_hash_including(
+            'page_path' => '/bar',
+            'is_this_useful_yes' => 44,
+            'is_this_useful_no' => 3,
+            'date' => '2018-02-20',
           )
-        end
-      )
+        ]
+        expect { |probe| subject.find_user_feedback_in_batches(date: date, batch_size: 1, &probe) }
+          .to yield_successive_args(arg1, arg2)
+      end
     end
+  end
+
+  private
+
+  def build_report_data(*report_rows)
+    Google::Apis::AnalyticsreportingV4::ReportData.new(rows: report_rows)
+  end
+
+  def build_report_row(dimensions:, metrics:)
+    Google::Apis::AnalyticsreportingV4::ReportRow.new(
+      dimensions: dimensions,
+      metrics: metrics.map do |metric|
+        Google::Apis::AnalyticsreportingV4::DateRangeValues.new(
+          values: Array(metric)
+        )
+      end
+    )
   end
 end

--- a/spec/services/google_analytics_service_spec.rb
+++ b/spec/services/google_analytics_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GA::Service do
       end
     end
 
-    context 'when called with a block' do
+    context 'when #find_in_batches is called with a block' do
       it 'should yield successive report data' do
         arg1 = [
           a_hash_including(
@@ -54,6 +54,52 @@ RSpec.describe GA::Service do
           .to yield_successive_args(arg1, arg2)
       end
     end
+
+    describe "#find_user_feedback_in_batches" do
+      let(:date) { Date.new(2018, 2, 20) }
+
+      before do
+        allow(subject.client).to receive(:fetch_all) do
+          [
+            build_report_data(
+              build_report_row(dimensions: %w(/foo ffNoClick), metrics: %w(10))
+            ),
+            build_report_data(
+              build_report_row(dimensions: %w(/foo ffYesClick), metrics: %w(2))
+            ),
+            build_report_data(
+              build_report_row(dimensions: %w(/bar ffNoClick), metrics: %w(3))
+            ),
+            build_report_data(
+              build_report_row(dimensions: %w(/bar ffYesClick), metrics: %w(44))
+            ),
+          ]
+        end
+      end
+
+      context 'when #find_in_batches is called with a block' do
+        it 'should yield successive report data' do
+          arg1 = [
+            a_hash_including(
+              'page_path' => '/foo',
+              'is_this_useful_yes' => 2,
+              'is_this_useful_no' => 10,
+              'date' => '2018-02-20',
+            ),
+          ]
+          arg2 = [
+            a_hash_including(
+              'page_path' => '/cool',
+              'is_this_useful_yes' => 44,
+              'is_this_useful_no' => 3,
+              'date' => '2018-02-20',
+            )
+          ]
+
+          expect { |probe| subject.find_in_batches(date: date, batch_size: 2, &probe) }
+            .to yield_successive_args(arg1, arg2)
+        end
+      end
 
     private
 


### PR DESCRIPTION
The team has found, through user research, that adding in data to record user responses to 'is this page useful?' would be useful to help content publishers and managers make informed decisions about the content they publish.

The metrics come from GA events which are triggered when the user clicks one of the responses. We query GA for these events and follow the same pattern as we use when importing other GA metrics. We cannot however query for these metrics in the existing GA::Service query because, in order to identify which response the user has given, we need to query by event action as well as page path.

We follow the pattern of storing the GA data in a staging table called events_gas before inserting the data into our main facts_metrics table.

This work is based on the findings of [this spike ](https://trello.com/c/xoyhHjPb/238-3-spike-count-events-in-google-analytics-timeboxed-to-1-2-days)