### PR TITLE
Fix database healthcheck

### DIFF
--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -3,7 +3,7 @@ class Api::HealthcheckController < Api::BaseController
   skip_before_action :set_cache_headers
 
   def index
-    database = ActiveRecord::Base.connected? ? :ok : :critical
+    database = ActiveRecord::Base.establish_connection ? :ok : :critical
 
     healthcheck = {
       checks: {


### PR DESCRIPTION
We were using ActiveRecord::Base.connected? which appears to be
deprecated. We have no tests at this point as it's not clear
how we would take a good approach to testing this endpoint.