### PR TITLE
Fix handling of unpublishing messages

### DIFF
--- a/app/streams/publishing_api_message_processor.rb
+++ b/app/streams/publishing_api_message_processor.rb
@@ -46,7 +46,7 @@ private
     case routing_key
     when /major|minor/
       item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
-    when /unpublished/
+    when /unpublish/
       new_item = item.copy_to_new_outdated_version!(base_path: base_path, payload_version: payload_version)
       new_item.gone!
     else

--- a/spec/streams/publishing_api_consumer_spec.rb
+++ b/spec/streams/publishing_api_consumer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe PublishingApiConsumer do
     let!(:message) do
       double('message',
         payload: payload,
-        delivery_info: double('del_info', routing_key: 'gone.unpublished'))
+        delivery_info: double('del_info', routing_key: 'gone.unpublish'))
     end
 
     before :each do


### PR DESCRIPTION
Publishing API seems to use "unpublish" in the routing key, not "unpublished".
This means unpublishing events aren't being processed properly.

https://github.com/alphagov/publishing-api/blob/master/app/commands/v2/unpublish.rb#L127

This wasn't caught because the unit test didn't reflect reality.