### PR TITLE
Content Schema Parser Integration Test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'govuk-lint', '3.8.0'
+  gem 'govuk_schemas', '3.1.0'
   gem 'guard-rspec', require: false
   gem 'listen'
   gem 'phantomjs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
       unicorn (~> 5.4.0)
     govuk_message_queue_consumer (3.2.0)
       bunny (~> 2.2.0)
+    govuk_schemas (3.1.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (3.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -197,6 +199,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -492,6 +496,7 @@ DEPENDENCIES
   govuk_admin_template (~> 6.5)
   govuk_app_config
   govuk_message_queue_consumer (~> 3.2)
+  govuk_schemas (= 3.1.0)
   govuk_sidekiq (~> 3)
   groupdate
   guard-rspec

--- a/app/etl/item/content/parsers/contact.rb
+++ b/app/etl/item/content/parsers/contact.rb
@@ -2,9 +2,9 @@ class Item::Content::Parsers::Contact
   def parse(json)
     html = []
     html << json.dig('details', 'description')
-    html << get_email(json)
-    html << get_postal(json)
-    html << get_phone(json)
+    html << get_email(json) unless get_email(json).nil?
+    html << get_postal(json) unless get_postal(json).nil?
+    html << get_phone(json) unless get_phone(json).nil?
     html.join(" ")
   end
 
@@ -16,31 +16,40 @@ private
 
   def get_phone(json)
     html = []
-    json.dig('details', 'phone_numbers').each do |phone|
-      html << phone['title']
-      html << phone['description']
+    phones = json.dig('details', 'phone_numbers')
+    unless phones.nil?
+      phones.each do |phone|
+        html << phone['title']
+        html << phone['description']
+      end
     end
-    html << json.dig('details', 'more_info_phone_number')
-    html
+    more_info = json.dig('details', 'more_info_phone_number')
+    html << more_info unless more_info.nil?
   end
 
   def get_postal(json)
     html = []
-    json.dig('details', 'post_addresses').each do |addr|
-      html << addr['title']
-      html << addr['description']
+    postal = json.dig('details', 'post_addresses')
+    unless postal.nil?
+      postal.each do |addr|
+        html << addr['title']
+        html << addr['description']
+      end
     end
-    html << json.dig('details', 'more_info_post_address')
-    html
+    more_info = json.dig('details', 'more_info_post_address')
+    html << more_info unless more_info.nil?
   end
 
   def get_email(json)
     html = []
-    json.dig('details', 'email_addresses').each do |addr|
-      html << addr['title']
-      html << addr['description']
+    emails = json.dig('details', 'email_addresses')
+    unless emails.nil?
+      emails.each do |addr|
+        html << addr['title']
+        html << addr['description']
+      end
     end
-    html << json.dig('details', 'more_info_email_address')
-    html
+    more_info = json.dig('details', 'more_info_email_address')
+    html << more_info unless more_info.nil?
   end
 end

--- a/app/etl/item/content/parsers/email_alert_signup.rb
+++ b/app/etl/item/content/parsers/email_alert_signup.rb
@@ -1,8 +1,11 @@
 class Item::Content::Parsers::EmailAlertSignup
   def parse(json)
     html = []
-    json.dig("details", "breadcrumbs").each do |crumb|
-      html << crumb["title"]
+    breadcrumbs = json.dig("details", "breadcrumbs")
+    unless breadcrumbs.nil?
+      breadcrumbs.each do |crumb|
+        html << crumb["title"]
+      end
     end
     html << json.dig("details", "summary")
     html.join(" ")

--- a/app/etl/item/content/parsers/finder_email_signup.rb
+++ b/app/etl/item/content/parsers/finder_email_signup.rb
@@ -1,8 +1,11 @@
 class Item::Content::Parsers::FinderEmailSignup
   def parse(json)
     html = []
-    json.dig("details", "email_signup_choice").each do |choice|
-      html << choice["radio_button_name"]
+    choices = json.dig("details", "email_signup_choice")
+    unless choices.nil?
+      choices.each do |choice|
+        html << choice["radio_button_name"]
+      end
     end
     html << json.dig("description")
     html.join(" ")

--- a/app/etl/item/content/parsers/generic_with_links.rb
+++ b/app/etl/item/content/parsers/generic_with_links.rb
@@ -2,10 +2,12 @@ class Item::Content::Parsers::GenericWithLinks
   def parse(json)
     html = []
     links = json.dig("details", "external_related_links")
-    links.each do |link|
-      html << link["title"]
+    unless links.nil?
+      links.each do |link|
+        html << link["title"]
+      end
+      html.join(" ")
     end
-    html.join(" ")
   end
 
   def schemas

--- a/app/etl/item/content/parsers/parts.rb
+++ b/app/etl/item/content/parsers/parts.rb
@@ -1,7 +1,9 @@
 class Item::Content::Parsers::Parts
   def parse(json)
     html = []
-    json.dig("details", "parts").each do |part|
+    parts = json.dig("details", "parts")
+    return if parts.nil?
+    parts.each do |part|
       html << part["title"]
       html << part["body"]
     end

--- a/app/etl/item/content/parsers/service_manual_service_toolkit.rb
+++ b/app/etl/item/content/parsers/service_manual_service_toolkit.rb
@@ -1,15 +1,21 @@
 class Item::Content::Parsers::ServiceManualServiceToolkit
   def parse(json)
     html = []
-    json.dig('details', 'collections').each do |item|
-      html << item['title']
-      html << item['description']
-      item.dig('links').each do |link|
-        html << link['title']
-        html << link['description']
+    items = json.dig('details', 'collections')
+    unless items.nil?
+      items.each do |item|
+        html << item['title']
+        html << item['description']
+        links = item.dig('links')
+        unless links.nil?
+          links.each do |link|
+            html << link['title']
+            html << link['description']
+          end
+        end
       end
+      html.join(' ')
     end
-    html.join(' ')
   end
 
   def schemas

--- a/app/etl/item/content/parsers/service_manual_standard.rb
+++ b/app/etl/item/content/parsers/service_manual_standard.rb
@@ -3,9 +3,12 @@ class Item::Content::Parsers::ServiceManualStandard
     html = []
     html << json.dig('title')
     html << json.dig('details', 'body')
-    json.dig('links', 'children').each do |child|
-      html << child['title']
-      html << child['description']
+    children = json.dig('links', 'children')
+    unless children.nil?
+      children.each do |child|
+        html << child['title']
+        html << child['description']
+      end
     end
     html.join(" ")
   end

--- a/app/etl/item/content/parsers/service_manual_topic.rb
+++ b/app/etl/item/content/parsers/service_manual_topic.rb
@@ -2,9 +2,12 @@ class Item::Content::Parsers::ServiceManualTopic
   def parse(json)
     html = []
     html << json.dig("description")
-    json.dig("details", "groups").each do |group|
-      html << group["name"]
-      html << group["description"]
+    groups = json.dig("details", "groups")
+    unless groups.nil?
+      groups.each do |group|
+        html << group["name"]
+        html << group["description"]
+      end
     end
     html.join(" ")
   end

--- a/app/etl/item/content/parsers/taxon.rb
+++ b/app/etl/item/content/parsers/taxon.rb
@@ -2,11 +2,12 @@ class Item::Content::Parsers::Taxon
   def parse(json)
     html = []
     html << json.dig("description")
-    return unless json.dig("links").include?("child_taxons")
     children = json.dig("links", "child_taxons")
-    children.each do |child|
-      html << child["title"]
-      html << child["description"]
+    unless children.nil?
+      children.each do |child|
+        html << child["title"]
+        html << child["description"]
+      end
     end
     html.join(" ")
   end

--- a/app/etl/item/content/parsers/travel_advice_index.rb
+++ b/app/etl/item/content/parsers/travel_advice_index.rb
@@ -2,8 +2,10 @@ class Item::Content::Parsers::TravelAdviceIndex
   def parse(json)
     html = []
     children = json.dig("links", "children")
+    return if children.nil?
     children.each do |child|
-      html << child["country"]["name"]
+      country = child.dig("country", "name")
+      html << country unless country.nil?
     end
     html.join(" ")
   end

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -206,23 +206,48 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq('sm title the main body ch1 title ch1 desc ch2 title ch2 desc')
       end
 
-      it "returns content if schema name is 'service_manual_service_toolkit'" do
-        json = {
-          schema_name: 'service_manual_service_toolkit',
-          details: {
-            collections: [
-              {
-                title: 'main title 1',
-                description: 'main desc 1',
-                links: [
-                  { title: 'title link 1', description: 'desc link 1' },
-                  { title: 'title link 2', description: 'desc link 2' }
-                ]
-              }
-            ]
+      describe "ServiceManualServiceToolkit" do
+        it "returns nil if json does not have 'collection' key" do
+          json = {
+            schema_name: 'service_manual_service_toolkit',
+            details: {}
           }
-        }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq('main title 1 main desc 1 title link 1 desc link 1 title link 2 desc link 2')
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
+        end
+
+        it "returns 'title' and 'description' if json does not have 'links' key" do
+          json = {
+            schema_name: 'service_manual_service_toolkit',
+            details: {
+              collections: [
+                {
+                  title: 'main title 1',
+                  description: 'main desc 1'
+                }
+              ]
+            }
+          }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq('main title 1 main desc 1')
+        end
+
+        it "returns json content" do
+          json = {
+            schema_name: 'service_manual_service_toolkit',
+            details: {
+              collections: [
+                {
+                  title: 'main title 1',
+                  description: 'main desc 1',
+                  links: [
+                    { title: 'title link 1', description: 'desc link 1' },
+                    { title: 'title link 2', description: 'desc link 2' }
+                  ]
+                }
+              ]
+            }
+          }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq('main title 1 main desc 1 title link 1 desc link 1 title link 2 desc link 2')
+        end
       end
 
       describe "Contact" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -330,12 +330,20 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("No page here")
       end
 
-      it "returns content json if schema_name is 'generic_with_external_related_links'" do
-        json = { schema_name: "generic_with_external_related_links",
-          details: { external_related_links: [
-            { title: "Check your Council Tax band" }
-          ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq("Check your Council Tax band")
+      describe "GenericWithLinks" do
+        it "returns nil if json does not have 'external_related_links' key" do
+          json = { schema_name: "generic_with_external_related_links",
+            details: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
+        end
+
+        it "returns content json if schema_name is 'generic_with_external_related_links'" do
+          json = { schema_name: "generic_with_external_related_links",
+            details: { external_related_links: [
+              { title: "Check your Council Tax band" }
+            ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Check your Council Tax band")
+        end
       end
 
       it "returns content json if schema_name is 'travel_advice_index'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -137,15 +137,24 @@ RSpec.describe Item::Content::Parser do
         end
       end
 
-      it "returns content json if schema_name is 'finder_email_signup'" do
-        json = { schema_name: "finder_email_signup",
-          description: "Use buttons",
-          details: { email_signup_choice:
-            [
-              { radio_button_name: "Yes" },
-              { radio_button_name: "No" }
-            ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq("Yes No Use buttons")
+      describe "FinderEmailSignup" do
+        it "returns description if json does not have 'email_signup_choice' key" do
+          json = { schema_name: "finder_email_signup",
+            description: "Use buttons",
+            details: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Use buttons")
+        end
+
+        it "returns content json" do
+          json = { schema_name: "finder_email_signup",
+            description: "Use buttons",
+            details: { email_signup_choice:
+              [
+                { radio_button_name: "Yes" },
+                { radio_button_name: "No" }
+              ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Yes No Use buttons")
+        end
       end
 
       it "returns content json if schema_name is 'location_transaction'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -74,28 +74,42 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq('Introduction Enter your postcode')
       end
 
-      it "returns content json if schema_name is 'guide'" do
-        json = { schema_name: 'guide',
-          details: { parts:
-            [
-              { title: 'Schools',
-                body: 'Local council' },
-              { title: 'Appeal',
-                body: 'No placement' }
-            ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq('Schools Local council Appeal No placement')
-      end
+      describe "Parts" do
+        it "returns nil if 'guide' schema does not have 'parts' key" do
+          json = { schema_name: 'guide',
+            details: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
+        end
 
-      it "returns content json if schema_name is 'travel_advice'" do
-        json = { schema_name: 'travel_advice',
-          details: { parts:
-            [
-              { title: 'Some',
-                body: 'Advise' },
-              { title: 'For',
-                body: 'Some Travel' }
-            ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq('Some Advise For Some Travel')
+        it "returns content json if schema_name is 'guide'" do
+          json = { schema_name: 'guide',
+            details: { parts:
+              [
+                { title: 'Schools',
+                  body: 'Local council' },
+                { title: 'Appeal',
+                  body: 'No placement' }
+              ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq('Schools Local council Appeal No placement')
+        end
+
+        it "returns nil if 'travel_advice' schema does not have 'parts' key" do
+          json = { schema_name: 'travel_advice',
+            details: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
+        end
+
+        it "returns content json if schema_name is 'travel_advice'" do
+          json = { schema_name: 'travel_advice',
+            details: { parts:
+              [
+                { title: 'Some',
+                  body: 'Advise' },
+                { title: 'For',
+                  body: 'Some Travel' }
+              ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq('Some Advise For Some Travel')
+        end
       end
 
       it "returns content json if schema_name is 'transaction'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -155,17 +155,26 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("Greetings A Name An Address")
       end
 
-      it "returns content json if schema_name is 'service_manual_topic'" do
-        json = { schema_name: "service_manual_topic",
-          description: "Blogs",
-          details: { groups:
-            [
-              { name: "Design",
-                description: "thinking" },
-              { name: "Performance",
-                description: "analysis" }
-            ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs Design thinking Performance analysis")
+      describe "ServiceManualTopic" do
+        it "returns description if json does not have 'groups' key" do
+          json = { schema_name: "service_manual_topic",
+            description: "Blogs",
+            details: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs")
+        end
+
+        it "returns content json" do
+          json = { schema_name: "service_manual_topic",
+            description: "Blogs",
+            details: { groups:
+              [
+                { name: "Design",
+                  description: "thinking" },
+                { name: "Performance",
+                  description: "analysis" }
+              ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs Design thinking Performance analysis")
+        end
       end
 
       it "returns content json if schema_name is 'unpublishing'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -203,36 +203,105 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq('main title 1 main desc 1 title link 1 desc link 1 title link 2 desc link 2')
       end
 
-      it "returns content if schema name is 'contact'" do
-        json = {
-          schema_name: 'contact',
-          details: {
-            description: 'main desc',
-            email_addresses: [
-              { title: 'title 1', description: '<p>desc 1</p>' },
-              { title: 'title 2', description: '<p>desc 2</p>' }
-            ],
-            more_info_email_address: '<p>more info</p>',
-            post_addresses: [
-              { title: 'post1 title', description: '<p>post1 desc</p>' },
-              { title: 'post2 title', description: '<p>post2 desc</p>' }
-            ],
-            more_info_post_address: '<p>more info post</p>',
-            phone_numbers: [
-              { title: 'phone1 title', description: '<p>phone1 desc</p>' },
-              { title: 'phone2 title', description: '<p>phone2 desc</p>' }
-            ],
-            more_info_phone_number: '<p>more info phone</p>'
+      describe "Contact" do
+        it "does not return phone numbers if there is no 'phone_numbers' key" do
+          json = {
+            schema_name: 'contact',
+            details: {
+              description: 'main desc',
+              email_addresses: [
+                { title: 'title 1', description: '<p>desc 1</p>' },
+                { title: 'title 2', description: '<p>desc 2</p>' }
+              ],
+              more_info_email_address: '<p>more info</p>',
+              post_addresses: [
+                { title: 'post1 title', description: '<p>post1 desc</p>' },
+                { title: 'post2 title', description: '<p>post2 desc</p>' }
+              ],
+              more_info_post_address: '<p>more info post</p>'
+            }
           }
-        }
-        expected = [
-          'main desc title 1 desc 1 title 2 desc 2',
-          'more info',
-          'post1 title post1 desc post2 title post2 desc',
-          'more info post',
-          'phone1 title phone1 desc phone2 title phone2 desc more info phone'
-        ].join(' ')
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
+          expected = [
+            'main desc title 1 desc 1 title 2 desc 2',
+            'more info',
+            'post1 title post1 desc post2 title post2 desc',
+            'more info post'
+          ].join(' ')
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
+        end
+
+        it "does not return post_addresses if there is no 'post_addresses' key" do
+          json = {
+            schema_name: 'contact',
+            details: {
+              description: 'main desc',
+              email_addresses: [
+                { title: 'title 1', description: '<p>desc 1</p>' },
+                { title: 'title 2', description: '<p>desc 2</p>' }
+              ],
+              more_info_email_address: '<p>more info</p>',
+              more_info_post_address: '<p>more info post</p>'
+            }
+          }
+          expected = [
+            'main desc title 1 desc 1 title 2 desc 2',
+            'more info',
+            'more info post'
+          ].join(' ')
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
+        end
+
+        it "does not return email_addresses if there is no 'email_addresses' key" do
+          json = {
+            schema_name: 'contact',
+            details: {
+              description: 'main desc',
+              post_addresses: [
+                { title: 'post1 title', description: '<p>post1 desc</p>' },
+                { title: 'post2 title', description: '<p>post2 desc</p>' }
+              ],
+              more_info_post_address: '<p>more info post</p>'
+            }
+          }
+          expected = [
+            'main desc',
+            'post1 title post1 desc post2 title post2 desc',
+            'more info post'
+          ].join(' ')
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
+        end
+
+        it "returns content if schema name is 'contact'" do
+          json = {
+            schema_name: 'contact',
+            details: {
+              description: 'main desc',
+              email_addresses: [
+                { title: 'title 1', description: '<p>desc 1</p>' },
+                { title: 'title 2', description: '<p>desc 2</p>' }
+              ],
+              more_info_email_address: '<p>more info</p>',
+              post_addresses: [
+                { title: 'post1 title', description: '<p>post1 desc</p>' },
+                { title: 'post2 title', description: '<p>post2 desc</p>' }
+              ],
+              more_info_post_address: '<p>more info post</p>',
+              phone_numbers: [
+                { title: 'phone1 title', description: '<p>phone1 desc</p>' },
+                { title: 'phone2 title', description: '<p>phone2 desc</p>' }
+              ],
+              more_info_phone_number: '<p>more info phone</p>'
+            }
+          }
+          expected = [
+            'main desc title 1 desc 1 title 2 desc 2',
+            'more info',
+            'post1 title post1 desc post2 title post2 desc',
+            'more info post',
+            'phone1 title phone1 desc phone2 title phone2 desc more info phone'
+          ].join(' ')
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
+        end
       end
 
       it "returns content if schema name is 'need'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -199,14 +199,23 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("Announcement 25 December 2017 closed")
       end
 
-      it "returns content json if schema_name is 'taxon'" do
-        json = { schema_name: "taxon",
-          description: "Blogs",
-          links: { child_taxons: [
-            { title: "One", description: "first" },
-            { title: "Two", description: "second" }
-          ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs One first Two second")
+      describe "Taxon" do
+        it "returns description if json does not have any child_taxons" do
+          json = { schema_name: "taxon",
+            description: "Blogs",
+            links: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs")
+        end
+
+        it "returns content json if schema_name is 'taxon'" do
+          json = { schema_name: "taxon",
+            description: "Blogs",
+            links: { child_taxons: [
+              { title: "One", description: "first" },
+              { title: "Two", description: "second" }
+            ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs One first Two second")
+        end
       end
 
       describe "ServiceManualStandard" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -108,11 +108,19 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
       end
 
-      it "returns content json if schema_name is 'email_alert_signup'" do
-        json = { schema_name: "email_alert_signup",
-          details: { breadcrumbs: [{ title: "The title" }],
-            summary: "Summary" } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq("The title Summary")
+      describe "EmailAlertSignup" do
+        it "returns summary if json does not have 'breadcrumbs' key" do
+          json = { schema_name: "email_alert_signup",
+            details: { summary: "Summary" } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Summary")
+        end
+
+        it "returns content json if schema_name is 'email_alert_signup'" do
+          json = { schema_name: "email_alert_signup",
+            details: { breadcrumbs: [{ title: "The title" }],
+              summary: "Summary" } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("The title Summary")
+        end
       end
 
       it "returns content json if schema_name is 'finder_email_signup'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -424,13 +424,21 @@ RSpec.describe Item::Content::Parser do
         end
       end
 
-      it "returns content json if schema_name is 'travel_advice_index'" do
-        json = { schema_name: "travel_advice_index",
-          links: { children: [
-            { country: { name: "Portugal" } },
-            { country: { name: "Brazil" } }
-          ] } }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq("Portugal Brazil")
+      describe "TravelAdviceIndex" do
+        it "returns nil if json does not have children array" do
+          json = { schema_name: "travel_advice_index",
+            links: {} }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
+        end
+
+        it "returns content json" do
+          json = { schema_name: "travel_advice_index",
+            links: { children: [
+              { country: { name: "Portugal" } },
+              { country: { name: "Brazil" } }
+            ] } }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq("Portugal Brazil")
+        end
       end
 
       it "returns content json if schema_name is 'service_sign_in'" do

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -191,19 +191,31 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("Blogs One first Two second")
       end
 
-      it "returns content if schema_name is 'service_manual_service_standard'" do
-        json = {
-          schema_name: 'service_manual_service_standard',
-          title: 'sm title',
-          details: { body: 'the main body' },
-          links: {
-            children: [
-              { title: 'ch1 title', description: 'ch1 desc' },
-              { title: 'ch2 title', description: 'ch2 desc' }
-            ]
+      describe "ServiceManualStandard" do
+        it "returns title and body if json does not have 'children' key" do
+          json = {
+            schema_name: 'service_manual_service_standard',
+            title: 'sm title',
+            details: { body: 'the main body' },
+            links: {}
           }
-        }
-        expect(subject.extract_content(json.deep_stringify_keys)).to eq('sm title the main body ch1 title ch1 desc ch2 title ch2 desc')
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq('sm title the main body')
+        end
+
+        it "returns content if schema_name is 'service_manual_service_standard'" do
+          json = {
+            schema_name: 'service_manual_service_standard',
+            title: 'sm title',
+            details: { body: 'the main body' },
+            links: {
+              children: [
+                { title: 'ch1 title', description: 'ch1 desc' },
+                { title: 'ch2 title', description: 'ch2 desc' }
+              ]
+            }
+          }
+          expect(subject.extract_content(json.deep_stringify_keys)).to eq('sm title the main body ch1 title ch1 desc ch2 title ch2 desc')
+        end
       end
 
       describe "ServiceManualServiceToolkit" do

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe 'Process parser', type: :integration do
+  let(:invalid_schema_list) {
+    %w[
+      calendar
+      coming_soon
+      completed_transaction
+      external_content
+      finder
+      generic
+      hmrc_manual
+      homepage
+      local_transaction
+      mainstream_browse_page
+      policy
+      service_manual_homepage
+      special_route
+      step_by_step_nav
+      topic
+      world_location
+    ]
+  }
+
+  context 'with a list of content schemas' do
+    it 'extracts the content valid schemas' do
+      schemas = valid_schemas
+      schemas.each do |schema|
+        expect(Item::Content::Parser.extract_content(schema)).to be_a(String).or eq(nil)
+      end
+    end
+
+    it 'returns nil for unused schemas' do
+      schemas = invalid_schemas
+      schemas.each do |schema|
+        expect(Item::Content::Parser.extract_content(schema)).to be_nil
+      end
+    end
+  end
+
+  def get_schema_collection
+    schemas = GovukSchemas::Schema.all(schema_type: "frontend")
+    schemas.values
+  end
+
+  def invalid_schemas
+    schemas = get_schema_collection
+
+    schemas.each do |schema|
+      random_example = GovukSchemas::RandomExample.new(schema: schema).payload
+      schemas.delete(schema) unless invalid_schema_list.include?(random_example.dig("schema_name"))
+    end
+    schemas
+  end
+
+  def valid_schemas
+    schemas = get_schema_collection
+
+    schemas.each do |schema|
+      random_example = GovukSchemas::RandomExample.new(schema: schema).payload
+      schemas.delete(schema) if invalid_schema_list.include?(random_example.dig("schema_name"))
+    end
+    schemas
+  end
+end


### PR DESCRIPTION
[Trello: Ensure we extract content from all formats to apply Quality Metrics](https://trello.com/c/GXnKmtEP/218-2-ensure-we-extract-content-from-all-formats-to-apply-quality-metrics)

Add integration test to test the extraction process against the content schema JSON. To ensure that the extraction methods extract data that is a true reflection of what the Publishing API returns.

The integration tests revealed a number of potential errors with some of the schema extraction methods, which did not handle cases where keys specific to the schemas were not found. These have been fixed in this PR.