### PR TITLE
Add user feedback data to api endpoint

### DIFF
--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -65,6 +65,14 @@ default: &default
   word_count:
     description: "Total number of words detected in the text"
 
+  is_this_useful_no:
+    description: "Total number of people who did not find the page helpful"
+    source: Google Analytics
+
+  is_this_useful_yes:
+    description: "Total number of people who found the page helpful"
+    source: Google Analytics
+
 development:
   <<: *default
 


### PR DESCRIPTION
Add `is_this_useful_yes` and `is_this_useful_no` to the list of metrics that the metrics api renders. No need to change any documentation as it does not specify the fields that the api returns.

Have not added a satisfaction rate metric. After talking to @pmanrubia about it he decided that it needs more thought.