### PR TITLE
User feedback in sandbox

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -42,6 +42,6 @@ private
     params.permit(:from, :to, :base_path, :utf8,
       :total_items, :pageviews, :unique_pageviews, :feedex_issues,
       :number_of_pdfs, :number_of_word_files, :filter, :organisation, :spell_count,
-      :readability_score)
+      :readability_score, :is_this_useful_yes, :is_this_useful_no)
   end
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -43,7 +43,9 @@ class Facts::Metric < ApplicationRecord
       'AVG(number_of_pdfs)',
       'AVG(number_of_word_files)',
       'AVG(spell_count)',
-      'AVG(readability_score)'
+      'AVG(readability_score)',
+      'AVG(is_this_useful_yes)',
+      'AVG(is_this_useful_no)',
     ).first
     {
       total_items: array[0],
@@ -54,6 +56,8 @@ class Facts::Metric < ApplicationRecord
       number_of_word_files: array[5],
       spell_count: array[6],
       readability_score: array[7],
+      is_this_useful_yes: array[8],
+      is_this_useful_no: array[9]
     }
   end
 
@@ -79,6 +83,8 @@ class Facts::Metric < ApplicationRecord
       number_of_word_files
       readability_score
       spell_count
+      is_this_useful_yes
+      is_this_useful_no
     ]
   end
 end

--- a/app/views/sandbox/_charts.html.erb
+++ b/app/views/sandbox/_charts.html.erb
@@ -47,4 +47,16 @@
         <%= line_chart(@metrics.group(:dimensions_date_id).sum(:readability_score), height: '150px') %>
       </div>
   <% end %>
+  <% if params[:is_this_useful_yes].present? %>
+      <div class="is_this_useful_yes">
+        <h3>Useful</h3>
+        <%= line_chart(@metrics.group(:dimensions_date_id).sum(:is_this_useful_yes), height: '150px') %>
+      </div>
+  <% end %>
+  <% if params[:is_this_useful_no].present? %>
+      <div class="is_this_useful_no">
+        <h3>Not Useful</h3>
+        <%= line_chart(@metrics.group(:dimensions_date_id).sum(:is_this_useful_no), height: '150px') %>
+      </div>
+  <% end %>
 </div>

--- a/app/views/sandbox/_sidebar.html.erb
+++ b/app/views/sandbox/_sidebar.html.erb
@@ -65,6 +65,18 @@
         <% end %>
       </div>
       <div class="form-group">
+        <%= label_tag do %>
+            <%= check_box_tag 'is_this_useful_yes', params[:is_this_useful_yes], params[:is_this_useful_yes].present? %>
+            Useful
+        <% end %>
+      </div>
+      <div class="form-group">
+        <%= label_tag do %>
+            <%= check_box_tag 'is_this_useful_no', params[:is_this_useful_no], params[:is_this_useful_no].present? %>
+            Not Useful
+        <% end %>
+      </div>
+      <div class="form-group">
         <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
       </div>
   <% end %>

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -37,4 +37,14 @@
       <span class="summary-item-label">Readability score (avg)</span>
     </div>
   </div>
+  <div class="row">
+    <div class="summary-item col-xs-3 is_this_useful_yes">
+      <span class="summary-item-value"><%= number_with_precision((@summary[:is_this_useful_yes] || 0), precision: 2)  %></span>
+      <span class="summary-item-label">Useful (avg)</span>
+    </div>
+    <div class="summary-item col-xs-3 is_this_useful_no">
+      <span class="summary-item-value"><%= number_with_precision((@summary[:is_this_useful_no] || 0), precision: 2) %></span>
+      <span class="summary-item-label">Not Useful (avg)</span>
+    </div>
+  </div>
 </div>

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -23,12 +23,12 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
   let(:metric5) { create :metric, dimensions_item: item2, dimensions_date: day2 }
 
   scenario 'Show aggregated metrics' do
-    metric1.update pageviews: 10, unique_pageviews: 10, feedex_comments: 2
-    metric2.update pageviews: 10, unique_pageviews: 10, feedex_comments: 4
-    metric3.update pageviews: 20, unique_pageviews: 20, feedex_comments: 6
-    metric4.update pageviews: 20, unique_pageviews: 20, feedex_comments: 8
-    metric5.update pageviews: 30, unique_pageviews: 30, feedex_comments: 10
-    metric2_fr.update pageviews: 5, unique_pageviews: 5, feedex_comments: 25
+    metric1.update pageviews: 10, unique_pageviews: 10, feedex_comments: 2, is_this_useful_no: 1, is_this_useful_yes: 2
+    metric2.update pageviews: 10, unique_pageviews: 10, feedex_comments: 4, is_this_useful_no: 3, is_this_useful_yes: 4
+    metric3.update pageviews: 20, unique_pageviews: 20, feedex_comments: 6, is_this_useful_no: 5, is_this_useful_yes: 6
+    metric4.update pageviews: 20, unique_pageviews: 20, feedex_comments: 8, is_this_useful_no: 7, is_this_useful_yes: 8
+    metric5.update pageviews: 30, unique_pageviews: 30, feedex_comments: 10, is_this_useful_no: 9, is_this_useful_yes: 10
+    metric2_fr.update pageviews: 5, unique_pageviews: 5, feedex_comments: 25, is_this_useful_no: 11, is_this_useful_yes: 12
 
     item1.update number_of_pdfs: 2, number_of_word_files: 1, spell_count: 2, readability_score: 1
     item2.update number_of_pdfs: 4, number_of_word_files: 2, spell_count: 6, readability_score: 5
@@ -47,6 +47,8 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.number_of_word_files', text: '1.50 Word (avg)')
     expect(page).to have_selector('.spell_count', text: '4.0 Spelling errors')
     expect(page).to have_selector('.readability_score', text: '3.00 Readability score (avg)')
+    expect(page).to have_selector('.is_this_useful_yes', text: '7.00 Useful (avg)')
+    expect(page).to have_selector('.is_this_useful_no', text: '6.00 Not Useful (avg)')
   end
 
   scenario 'Summary panel when no data' do
@@ -64,6 +66,8 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.feedex_issues', text: '0 Feedex issues')
     expect(page).to have_selector('.number_of_pdfs', text: '0 PDFs (avg)')
     expect(page).to have_selector('.number_of_word_files', text: '0 Word (avg)')
+    expect(page).to have_selector('.is_this_useful_yes', text: '0 Useful (avg)')
+    expect(page).to have_selector('.is_this_useful_no', text: '0 Not Useful (avg)')
   end
 
   scenario 'Download metrics as csv' do
@@ -74,7 +78,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
       base_path: '/really-interesting'
     )
     metric1.update pageviews: 10
-    metric2.update pageviews: 10
+    metric2.update pageviews: 10, is_this_useful_yes: 22, is_this_useful_no: 23
     metric3.update pageviews: 5
     metric2_fr.update pageviews: 5, unique_pageviews: 5, feedex_comments: 25
 
@@ -85,12 +89,13 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     click_button 'Filter'
 
     click_on 'Export to CSV'
-
     expect(page.response_headers['Content-Type']).to eq "text/csv"
-
     expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="download.csv"'
     expect(page.body).to include('2018-01-12,cont-id,/really-interesting,en,Really interesting,desc')
     expect(page.body).to include('2018-01-13,cont-id,/really-interesting,en,Really interesting,desc,')
+    expect(page.body).to include('is_this_useful_yes')
+    expect(page.body).to include('is_this_useful_no')
+    expect(page.body).to include('22,23')
     expect(page.body).not_to include('2018-01-14')
     expect(page.body).not_to include('fr')
   end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Facts::Metric, type: :model do
       item1 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 3, readability_score: 4)
       item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 3, readability_score: 4)
 
-      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2, feedex_comments: 4)
-      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2, feedex_comments: 3)
-      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2, feedex_comments: 2)
+      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2, feedex_comments: 4, is_this_useful_yes: 1, is_this_useful_no: 1)
+      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2, feedex_comments: 3, is_this_useful_yes: 2, is_this_useful_no: 2)
+      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2, feedex_comments: 2, is_this_useful_yes: 3, is_this_useful_no: 3)
 
       results = subject.between(day0, day1).by_base_path(base_path).metric_summary
 
@@ -97,6 +97,8 @@ RSpec.describe Facts::Metric, type: :model do
         number_of_word_files: 1,
         spell_count: 3,
         readability_score: 4,
+        is_this_useful_yes: 2,
+        is_this_useful_no: 2
       )
     end
   end


### PR DESCRIPTION
Add `is_this_useful` metrics to the sandbox UI ensuring they show up on all necessary pages as well as being available in charts and in the CSV export.