### PR TITLE
Add base_path to InvalidSchemaError

### DIFF
--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -11,11 +11,12 @@ class Item::Content::Parser
 
   def extract_content(json)
     schema = json.dig("schema_name")
+    base_path = json.dig("base_path")
     parser = for_schema(schema)
     if parser.present?
       parse_html parser.parse(json)
     else
-      GovukError.notify(InvalidSchemaError.new("Schema does not exist: #{schema}"))
+      GovukError.notify(InvalidSchemaError.new("Schema does not exist: #{schema}"), extra: { base_path: base_path.to_s })
 
       nil
     end


### PR DESCRIPTION
[Trello: Store the base_path when logging InvalidSchemaErrors in Sentry](https://trello.com/c/6ARiy1up/273-store-the-basepath-when-logging-invalidschemaerrors-in-sentry)

This commit is part of a story to 'Support all schemas when parsing
content items' - [Trello](https://trello.com/c/Pjp3RUGu/241-3-support-all-schemas-when-parsing-content-items-to-extract-content). Currently content schemas wer are not extracting
are being recorded as InvalidSchemaErrors.

We need to make a decision as to whether we want to store the
content from these 'Invalid' content schemas or not. Storing the
base_path will help us make decisions as we can access the specific
content relating to the error message.