### PR TITLE
Store internal searches metrics

### DIFF
--- a/app/etl/ga/internal_search_processor.rb
+++ b/app/etl/ga/internal_search_processor.rb
@@ -1,0 +1,75 @@
+class GA::InternalSearchProcessor
+  include Concerns::Traceable
+  include GA::Concerns::TransformPath
+
+  def self.process(*args)
+    new(*args).process
+  end
+
+  def initialize(date:)
+    @date = date
+  end
+
+  def process
+    time(process: :ga) do
+      extract_events
+      transform_events
+      load_metrics
+    end
+  end
+
+private
+
+  def extract_events
+    batch = 1
+    GA::InternalSearchService.find_in_batches(date: date) do |events|
+      log process: :ga, message: "Processing #{events.length} events in batch #{batch}"
+      Events::GA.import(events, batch_size: 10_000)
+      batch += 1
+    end
+  end
+
+  def transform_events
+    remove_invalid_prefix
+  end
+
+  def load_metrics
+    conn = ActiveRecord::Base.connection
+    date_to_s = date.strftime("%F")
+
+    conn.execute(load_metrics_query(date_to_s))
+    conn.execute(clean_up_query)
+  end
+
+  def load_metrics_query(date_to_s)
+    <<~SQL
+      UPDATE facts_metrics
+      SET number_of_internal_searches = s.number_of_internal_searches
+      FROM (
+        SELECT number_of_internal_searches,
+               dimensions_items.id
+        FROM events_gas, dimensions_items
+        WHERE page_path = base_path
+              AND events_gas.date = '#{date_to_s}'
+      ) AS s
+      WHERE dimensions_item_id = s.id AND dimensions_date_id = '#{date_to_s}'
+    SQL
+  end
+
+  def clean_up_query
+    date_to_s = date.strftime("%F")
+    <<~SQL
+      DELETE FROM events_gas
+      WHERE date = '#{date_to_s}' AND
+            process_name = #{Events::GA.process_names['number_of_internal_searches']} AND
+        page_path in (
+           SELECT base_path
+           FROM dimensions_items, facts_metrics
+           WHERE dimensions_items.id = facts_metrics.dimensions_item_id
+           AND facts_metrics.dimensions_date_id = '#{date_to_s}'
+        )
+    SQL
+  end
+
+  attr_reader :date
+end

--- a/app/etl/ga/internal_search_service.rb
+++ b/app/etl/ga/internal_search_service.rb
@@ -1,0 +1,74 @@
+class GA::InternalSearchService
+  def self.find_in_batches(*args, &block)
+    new.find_in_batches(*args, &block)
+  end
+
+  def find_in_batches(date:, batch_size: 10_000)
+    fetch_data(date: date)
+      .lazy
+      .map(&:to_h)
+      .flat_map(&method(:extract_rows))
+      .map(&method(:extract_dimensions_and_metrics))
+      .map(&method(:append_labels))
+      .map { |h| h['date'] = date.strftime('%F'); h }
+      .each_slice(batch_size) { |slice| yield slice }
+  end
+
+  def client
+    @client ||= GA::Client.new.build
+  end
+
+private
+
+  def append_labels(values)
+    page_path, internal_search = *values
+    {
+      'page_path' => page_path,
+      'internal_search' => internal_search
+    }
+  end
+
+  def extract_dimensions_and_metrics(row)
+    dimensions = row.fetch(:dimensions)
+    metrics = row.fetch(:metrics).flat_map do |metric|
+      metric.fetch(:values).map(&:to_i)
+    end
+
+    dimensions + metrics
+  end
+
+  def extract_rows(report)
+    report.fetch(:rows)
+  end
+
+  def fetch_data(date:)
+    @data ||= client.fetch_all(items: :data) do |page_token, service|
+      service
+        .batch_get_reports(
+          Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
+            report_requests: [build_request(date: date).merge(page_token: page_token)]
+          )
+        )
+        .reports
+        .first
+    end
+  end
+
+  def build_request(date:)
+    {
+      date_ranges: [
+        { start_date: date.to_s("%Y-%m-%d"), end_date: date.to_s("%Y-%m-%d") },
+      ],
+      dimensions: [
+        { name: 'ga:searchStartPage' },
+      ],
+      hide_totals: true,
+      hide_value_ranges: true,
+      metrics: [
+        { expression: 'ga:searchUniques' }
+      ],
+      page_size: 10_000,
+      view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
+    }
+  end
+end

--- a/app/etl/ga/internal_search_service.rb
+++ b/app/etl/ga/internal_search_service.rb
@@ -21,10 +21,10 @@ class GA::InternalSearchService
 private
 
   def append_labels(values)
-    page_path, internal_search = *values
+    page_path, number_of_internal_searches = *values
     {
       'page_path' => page_path,
-      'internal_search' => internal_search
+      'number_of_internal_searches' => number_of_internal_searches
     }
   end
 

--- a/app/etl/ga/views_service.rb
+++ b/app/etl/ga/views_service.rb
@@ -4,7 +4,7 @@ class GA::ViewsService
   end
 
   def find_in_batches(date:, batch_size: 10_000)
-    paged_report_data(date: date)
+    fetch_data(date: date)
       .lazy
       .map(&:to_h)
       .flat_map(&method(:extract_rows))
@@ -44,12 +44,12 @@ private
     report.fetch(:rows)
   end
 
-  def paged_report_data(date:)
+  def fetch_data(date:)
     @data ||= client.fetch_all(items: :data) do |page_token, service|
       service
         .batch_get_reports(
           Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
-            report_requests: [report_request(date: date).merge(page_token: page_token)]
+            report_requests: [build_request(date: date).merge(page_token: page_token)]
           )
         )
         .reports
@@ -57,7 +57,7 @@ private
     end
   end
 
-  def report_request(date:)
+  def build_request(date:)
     {
       date_ranges: [
         { start_date: date.to_s("%Y-%m-%d"), end_date: date.to_s("%Y-%m-%d") },

--- a/app/etl/master/master_processor.rb
+++ b/app/etl/master/master_processor.rb
@@ -15,6 +15,7 @@ class Master::MasterProcessor
       Master::MetricsProcessor.process(date: dimensions_date.date)
       GA::ViewsProcessor.process(date: dimensions_date.date)
       GA::UserFeedbackProcessor.process(date: dimensions_date.date)
+      GA::InternalSearchProcessor.process(date: dimensions_date.date)
       Feedex::Processor.process(date: dimensions_date.date)
     end
   end

--- a/app/models/events/ga.rb
+++ b/app/models/events/ga.rb
@@ -1,3 +1,3 @@
 class Events::GA < ApplicationRecord
-  enum process_name: { user_feedback: 0, views: 1 }
+  enum process_name: { user_feedback: 0, views: 1, number_of_internal_searches: 2 }
 end

--- a/db/migrate/20180430100333_add_internal_search_to_events_gas.rb
+++ b/db/migrate/20180430100333_add_internal_search_to_events_gas.rb
@@ -1,0 +1,5 @@
+class AddInternalSearchToEventsGas < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events_gas, :number_of_internal_searches, :integer, default: 0
+  end
+end

--- a/db/migrate/20180430100349_add_internal_search_to_facts_metrics.rb
+++ b/db/migrate/20180430100349_add_internal_search_to_facts_metrics.rb
@@ -1,0 +1,5 @@
+class AddInternalSearchToFactsMetrics < ActiveRecord::Migration[5.1]
+  def change
+    add_column :facts_metrics, :number_of_internal_searches, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425132405) do
+ActiveRecord::Schema.define(version: 20180430100349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20180425132405) do
     t.boolean "primary_organisation_withdrawn"
     t.string "content_hash"
     t.string "locale", default: "en", null: false
+    t.datetime "outdated_at"
     t.bigint "publishing_api_payload_version", null: false
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
@@ -93,6 +94,7 @@ ActiveRecord::Schema.define(version: 20180425132405) do
     t.integer "is_this_useful_yes", default: 0
     t.integer "is_this_useful_no", default: 0
     t.integer "process_name", null: false
+    t.integer "number_of_internal_searches", default: 0
     t.index ["page_path", "date"], name: "index_events_gas_on_page_path_and_date"
   end
 
@@ -135,6 +137,7 @@ ActiveRecord::Schema.define(version: 20180425132405) do
     t.integer "feedex_comments", default: 0
     t.integer "is_this_useful_yes", default: 0
     t.integer "is_this_useful_no", default: 0
+    t.integer "number_of_internal_searches", default: 0
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "index_facts_metrics_date_item_id"
     t.index ["dimensions_item_id"], name: "index_facts_metrics_on_dimensions_item_id"
   end
@@ -153,8 +156,6 @@ ActiveRecord::Schema.define(version: 20180425132405) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
-  add_foreign_key "facts_editions", "dimensions_dates", primary_key: "date"
-  add_foreign_key "facts_editions", "dimensions_items"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_items"
 end

--- a/spec/etl/ga/internal_search_processor_spec.rb
+++ b/spec/etl/ga/internal_search_processor_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+require "gds-api-adapters"
+
+RSpec.describe GA::InternalSearchProcessor do
+  subject { described_class }
+
+  let!(:item1) { create :dimensions_item, base_path: "/path1", latest: true }
+  let!(:item2) { create :dimensions_item, base_path: "/path2", latest: true }
+
+  let(:date) { Date.new(2018, 2, 20) }
+  let(:dimensions_date) { Dimensions::Date.for(date) }
+
+  context "When the base_path matches the GA path" do
+    before { allow(GA::InternalSearchService).to receive(:find_in_batches).and_yield(ga_response) }
+
+    it "updates the facts with GA metrics" do
+      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+      fact2 = create :metric, dimensions_item: item2, dimensions_date: dimensions_date
+
+      described_class.process(date: date)
+
+      expect(fact1.reload).to have_attributes(number_of_internal_searches: 1)
+      expect(fact2.reload).to have_attributes(number_of_internal_searches: 2)
+    end
+
+    it "does not update metrics for other days" do
+      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date, number_of_internal_searches: 20
+
+      day_before = date - 1
+      described_class.process(date: day_before)
+
+      expect(fact1.reload).to have_attributes(number_of_internal_searches: 20)
+    end
+
+    it "does not update metrics for other items" do
+      item = create :dimensions_item, base_path: "/non-matching-path", latest: true
+      fact = create :metric, dimensions_item: item, dimensions_date: dimensions_date, number_of_internal_searches: 99
+
+      described_class.process(date: date)
+
+      expect(fact.reload).to have_attributes(number_of_internal_searches: 99)
+    end
+
+    it "deletes the events that matches the base_path of an item if it has number of internal search data" do
+      item2.destroy
+      create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+      described_class.process(date: date)
+
+      expect(Events::GA.count).to eq(1)
+    end
+
+    it "does not delete the events that match the base_path of an item if it does not have number of internal search data" do
+      create :ga_event, :with_views, date: date, page_path: item1.base_path
+      create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+      described_class.process(date: date)
+
+      expect(Events::GA.count).to eq(2)
+    end
+
+    context "when there are events from other days" do
+      before do
+        create :ga_event, :with_number_of_internal_searches, date: date - 1, page_path: '/path1'
+        create :ga_event, :with_number_of_internal_searches, date: date - 2, page_path: '/path1'
+      end
+
+      it "only updates metrics for the current day" do
+        fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+
+        described_class.process(date: date)
+
+        expect(fact1.reload).to have_attributes(number_of_internal_searches: 1)
+      end
+
+      it "deletes events for the current day if it has number of internal searches" do
+        create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+        create :metric, dimensions_item: item2, dimensions_date: dimensions_date
+        described_class.process(date: date)
+
+        expect(Events::GA.count).to eq(2)
+      end
+
+      it "does not delete events that are not from the current day" do
+        create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+        described_class.process(date: date)
+
+        expect(Events::GA.count).to eq(3)
+      end
+    end
+  end
+
+  context 'when page_path starts "/https://www.gov.uk"' do
+    before do
+      allow(GA::InternalSearchService).to receive(:find_in_batches)
+      .and_yield(ga_response_with_govuk_prefix)
+    end
+    include_examples "transform path examples"
+  end
+
+private
+
+  def ga_response
+    [
+      {
+        'page_path' => '/path1',
+        'number_of_internal_searches' => 1,
+        'date' => '2018-02-20',
+        'process_name' => 'number_of_internal_searches'
+      },
+      {
+        'page_path' => '/path2',
+        'number_of_internal_searches' => 2,
+        'date' => '2018-02-20',
+        'process_name' => 'number_of_internal_searches'
+      },
+    ]
+  end
+
+  def ga_response_with_govuk_prefix
+    [
+      {
+        'page_path' => '/https://www.gov.uk/path1',
+        'number_of_internal_searches' => 1,
+        'date' => '2018-02-20',
+        'process_name' => 'number_of_internal_searches'
+      },
+      {
+        'page_path' => '/path2',
+        'number_of_internal_searches' => 2,
+        'date' => '2018-02-20',
+        'process_name' => 'number_of_internal_searches'
+      },
+    ]
+  end
+end

--- a/spec/etl/ga/internal_search_service_spec.rb
+++ b/spec/etl/ga/internal_search_service_spec.rb
@@ -1,0 +1,58 @@
+require "google/apis/analyticsreporting_v4"
+
+RSpec.describe GA::InternalSearchService do
+  include GoogleAnalyticsRequests
+
+  subject { GA::InternalSearchService }
+
+  let(:google_client) { double('client') }
+  before { allow_any_instance_of(GA::InternalSearchService).to receive(:client).and_return(google_client) }
+
+  describe "#find_in_batches" do
+    let(:date) { Date.new(2018, 2, 20) }
+
+    before do
+      allow(google_client).to receive(:fetch_all) do
+        [
+          build_report_data(
+            build_report_row(dimensions: %w(/foo), metrics: %w(1))
+          ),
+          build_report_data(
+            build_report_row(dimensions: %w(/bar), metrics: %w(2))
+          ),
+          build_report_data(
+            build_report_row(dimensions: %w(/cool), metrics: %w(3))
+          ),
+        ]
+      end
+    end
+
+    context "when #find_in_batches is called with a block" do
+      it "yields successive report data" do
+        arg1 = [
+          a_hash_including(
+            'page_path' => '/foo',
+            'internal_search' => 1,
+            'date' => '2018-02-20',
+          ),
+          a_hash_including(
+            'page_path' => '/bar',
+            'internal_search' => 2,
+            'date' => '2018-02-20',
+          )
+        ]
+
+        arg2 = [
+          a_hash_including(
+            'page_path' => '/cool',
+            'internal_search' => 3,
+            'date' => '2018-02-20',
+          )
+        ]
+
+        expect { |probe| subject.find_in_batches(date: date, batch_size: 2, &probe) }
+          .to yield_successive_args(arg1, arg2)
+      end
+    end
+  end
+end

--- a/spec/etl/ga/internal_search_service_spec.rb
+++ b/spec/etl/ga/internal_search_service_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe GA::InternalSearchService do
         arg1 = [
           a_hash_including(
             'page_path' => '/foo',
-            'internal_search' => 1,
+            'number_of_internal_searches' => 1,
             'date' => '2018-02-20',
           ),
           a_hash_including(
             'page_path' => '/bar',
-            'internal_search' => 2,
+            'number_of_internal_searches' => 2,
             'date' => '2018-02-20',
           )
         ]
@@ -45,7 +45,7 @@ RSpec.describe GA::InternalSearchService do
         arg2 = [
           a_hash_including(
             'page_path' => '/cool',
-            'internal_search' => 3,
+            'number_of_internal_searches' => 3,
             'date' => '2018-02-20',
           )
         ]

--- a/spec/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/etl/ga/user_feedback_processor_spec.rb
@@ -120,21 +120,6 @@ private
     ]
   end
 
-  def ga_response_without_user_feedback_data
-    [
-      {
-        'page_path' => '/path1',
-        'date' => '2018-02-20',
-        'process_name' => 'user_feedback',
-      },
-      {
-        'page_path' => '/path2',
-        'date' => '2018-02-20',
-        'process_name' => 'user_feedback',
-      },
-    ]
-  end
-
   def ga_response_with_govuk_prefix
     [
       {

--- a/spec/etl/master/master_spec.rb
+++ b/spec/etl/master/master_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Master::MasterProcessor do
   before do
     allow(GA::ViewsProcessor).to receive(:process)
     allow(GA::UserFeedbackProcessor).to receive(:process)
+    allow(GA::InternalSearchProcessor).to receive(:process)
     allow(Feedex::Processor).to receive(:process)
     allow(Master::MetricsProcessor).to receive(:process)
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -48,6 +48,12 @@ FactoryBot.define do
       is_this_useful_no 6
       process_name 'user_feedback'
     end
+
+    trait :with_number_of_internal_searches do
+      number_of_internal_searches 100
+      process_name 'number_of_internal_searches'
+    end
+
     sequence(:page_path) { |i| "/path/#{i}" }
     sequence(:date) { |i| i.days.ago.to_date }
   end

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'PublishingAPI events' do
   before do
     stub_google_analytics_response
     stub_google_analytics_user_feedback_response
+    stub_google_analytics_internal_search_response
     stub_feedex_response
     stub_quality_metrics_response
     stub_content_store_response(title: 'title1', base_path: base_path)
@@ -102,6 +103,10 @@ RSpec.describe 'PublishingAPI events' do
 
   def stub_google_analytics_user_feedback_response
     allow(GA::UserFeedbackService).to receive(:find_in_batches).and_yield([])
+  end
+
+  def stub_google_analytics_internal_search_response
+    allow(GA::InternalSearchService).to receive(:find_in_batches).and_yield([])
   end
 
   def stub_feedex_response

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Master process spec' do
   it 'orchestrates all ETL processes' do
     stub_google_analytics_response
     stub_google_analytics_user_feedback_response
+    stub_google_analytics_internal_search_response
     stub_feedex_response
 
     Master::MasterProcessor.process
@@ -109,6 +110,25 @@ RSpec.describe 'Master process spec' do
           'is_this_useful_yes' => 1,
           'date' => '2018-02-20',
           'process_name' => 'user_feedback',
+        },
+      ]
+    )
+  end
+
+  def stub_google_analytics_internal_search_response
+    allow(GA::InternalSearchService).to receive(:find_in_batches).and_yield(
+      [
+        {
+          'page_path' => '/path1',
+          'number_of_internal_searches' => 1,
+          'date' => '2018-02-20',
+          'process_name' => 'number_of_internal_searches'
+        },
+        {
+          'page_path' => '/path2',
+          'number_of_internal_searches' => 2,
+          'date' => '2018-02-20',
+          'process_name' => 'number_of_internal_searches'
         },
       ]
     )


### PR DESCRIPTION
Track the number of times per page that the internal search within GOV.UK is being used.

This PR follows the approach of #664. We now reach a point where we have too much duplication, which I will address in a subsequent PR to keep the work separate.