### PR TITLE
Use partial unique index for unique base_paths

### DIFF
--- a/db/migrate/20180430104334_add_unique_index_items.rb
+++ b/db/migrate/20180430104334_add_unique_index_items.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexItems < ActiveRecord::Migration[5.1]
   def change
-    add_index :dimensions_items, %i(latest base_path), unique: true
+    add_index :dimensions_items, %i(latest base_path), unique: true, where: "latest = 'true'"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20180430110607) do
     t.string "locale", default: "en", null: false
     t.datetime "outdated_at"
     t.bigint "publishing_api_payload_version", null: false
-    t.index ["latest", "base_path"], name: "index_dimensions_items_on_latest_and_base_path", unique: true
+    t.index ["latest", "base_path"], name: "index_dimensions_items_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "content_id"], name: "index_dimensions_items_on_latest_and_content_id"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/NP5Z1G0g/272-3-prevent-duplicated-items-in-the-dimensionsitems)

We could have multiple base_paths when the `latest` attribute is false, 
but only one when `latest` is true.

This index guarantees that our database is consistent with the way we
model the data. I have decided to add a constraint in the database as 
the performance of the operations is much faster, and it is likely that
other processes that might not depend on AR, perform operations on the 
database creating situations with inaccurate data that are not easy to 
detect.

For example, we could insert `pageviews` to the same `base_path` multiple
times causing that all calculations to be inaccurate.