### PR TITLE
Add Internal searches metric sandbox

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -42,6 +42,6 @@ private
     params.permit(:from, :to, :base_path, :utf8,
       :total_items, :pageviews, :unique_pageviews, :feedex_issues,
       :number_of_pdfs, :number_of_word_files, :filter, :organisation, :spell_count,
-      :readability_score, :is_this_useful_yes, :is_this_useful_no)
+      :readability_score, :is_this_useful_yes, :is_this_useful_no, :number_of_internal_searches)
   end
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -35,18 +35,17 @@ class Facts::Metric < ApplicationRecord
   end
 
   scope :metric_summary, -> do
-    array = pluck(
-      'COUNT(DISTINCT dimensions_items.content_id)',
-      'SUM(pageviews)',
-      'AVG(unique_pageviews)',
-      'SUM(feedex_comments)',
-      'AVG(number_of_pdfs)',
-      'AVG(number_of_word_files)',
-      'AVG(spell_count)',
-      'AVG(readability_score)',
-      'AVG(is_this_useful_yes)',
-      'AVG(is_this_useful_no)',
-    ).first
+    array = pluck('COUNT(DISTINCT dimensions_items.content_id)',
+                  'SUM(pageviews)',
+                  'AVG(unique_pageviews)',
+                  'SUM(feedex_comments)',
+                  'AVG(number_of_pdfs)',
+                  'AVG(number_of_word_files)',
+                  'AVG(spell_count)',
+                  'AVG(readability_score)',
+                  'AVG(is_this_useful_yes)',
+                  'AVG(is_this_useful_no)',
+                  'AVG(number_of_internal_searches)').first
     {
       total_items: array[0],
       pageviews: array[1],
@@ -57,7 +56,8 @@ class Facts::Metric < ApplicationRecord
       spell_count: array[6],
       readability_score: array[7],
       is_this_useful_yes: array[8],
-      is_this_useful_no: array[9]
+      is_this_useful_no: array[9],
+      number_of_internal_searches: array[10]
     }
   end
 
@@ -85,6 +85,7 @@ class Facts::Metric < ApplicationRecord
       spell_count
       is_this_useful_yes
       is_this_useful_no
+      number_of_internal_searches
     ]
   end
 end

--- a/app/views/sandbox/_charts.html.erb
+++ b/app/views/sandbox/_charts.html.erb
@@ -59,4 +59,10 @@
         <%= line_chart(@metrics.group(:dimensions_date_id).sum(:is_this_useful_no), height: '150px') %>
       </div>
   <% end %>
+  <% if params[:number_of_internal_searches].present? %>
+      <div class="number_of_internal_searches">
+        <h3>Internal Searches</h3>
+        <%= line_chart(@metrics.group(:dimensions_date_id).sum(:number_of_internal_searches), height: '150px') %>
+      </div>
+  <% end %>
 </div>

--- a/app/views/sandbox/_sidebar.html.erb
+++ b/app/views/sandbox/_sidebar.html.erb
@@ -77,6 +77,12 @@
         <% end %>
       </div>
       <div class="form-group">
+        <%= label_tag do %>
+            <%= check_box_tag 'number_of_internal_searches', params[:number_of_internal_searches], params[:number_of_internal_searches].present? %>
+            Number of Internal Searches
+        <% end %>
+      </div>
+      <div class="form-group">
         <%= submit_tag 'Filter', name: 'filter', class: "btn btn-default btn-block" %>
       </div>
   <% end %>

--- a/app/views/sandbox/_summary.html.erb
+++ b/app/views/sandbox/_summary.html.erb
@@ -46,5 +46,9 @@
       <span class="summary-item-value"><%= number_with_precision((@summary[:is_this_useful_no] || 0), precision: 2) %></span>
       <span class="summary-item-label">Not Useful (avg)</span>
     </div>
+    <div class="summary-item col-xs-3 number_of_internal_searches">
+      <span class="summary-item-value"><%= number_with_precision((@summary[:number_of_internal_searches] || 0), precision: 2) %></span>
+      <span class="summary-item-label">Number of Internal Searches (avg)</span>
+    </div>
   </div>
 </div>

--- a/spec/features/sandbox/show_metrics_spec.rb
+++ b/spec/features/sandbox/show_metrics_spec.rb
@@ -23,12 +23,12 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
   let(:metric5) { create :metric, dimensions_item: item2, dimensions_date: day2 }
 
   scenario 'Show aggregated metrics' do
-    metric1.update pageviews: 10, unique_pageviews: 10, feedex_comments: 2, is_this_useful_no: 1, is_this_useful_yes: 2
-    metric2.update pageviews: 10, unique_pageviews: 10, feedex_comments: 4, is_this_useful_no: 3, is_this_useful_yes: 4
-    metric3.update pageviews: 20, unique_pageviews: 20, feedex_comments: 6, is_this_useful_no: 5, is_this_useful_yes: 6
-    metric4.update pageviews: 20, unique_pageviews: 20, feedex_comments: 8, is_this_useful_no: 7, is_this_useful_yes: 8
-    metric5.update pageviews: 30, unique_pageviews: 30, feedex_comments: 10, is_this_useful_no: 9, is_this_useful_yes: 10
-    metric2_fr.update pageviews: 5, unique_pageviews: 5, feedex_comments: 25, is_this_useful_no: 11, is_this_useful_yes: 12
+    metric1.update pageviews: 10, unique_pageviews: 10, feedex_comments: 2, is_this_useful_no: 1, is_this_useful_yes: 2, number_of_internal_searches: 12
+    metric2.update pageviews: 10, unique_pageviews: 10, feedex_comments: 4, is_this_useful_no: 3, is_this_useful_yes: 4, number_of_internal_searches: 22
+    metric3.update pageviews: 20, unique_pageviews: 20, feedex_comments: 6, is_this_useful_no: 5, is_this_useful_yes: 6, number_of_internal_searches: 32
+    metric4.update pageviews: 20, unique_pageviews: 20, feedex_comments: 8, is_this_useful_no: 7, is_this_useful_yes: 8, number_of_internal_searches: 42
+    metric5.update pageviews: 30, unique_pageviews: 30, feedex_comments: 10, is_this_useful_no: 9, is_this_useful_yes: 10, number_of_internal_searches: 52
+    metric2_fr.update pageviews: 5, unique_pageviews: 5, feedex_comments: 25, is_this_useful_no: 11, is_this_useful_yes: 12, number_of_internal_searches: 62
 
     item1.update number_of_pdfs: 2, number_of_word_files: 1, spell_count: 2, readability_score: 1
     item2.update number_of_pdfs: 4, number_of_word_files: 2, spell_count: 6, readability_score: 5
@@ -49,6 +49,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.readability_score', text: '3.00 Readability score (avg)')
     expect(page).to have_selector('.is_this_useful_yes', text: '7.00 Useful (avg)')
     expect(page).to have_selector('.is_this_useful_no', text: '6.00 Not Useful (avg)')
+    expect(page).to have_selector('.number_of_internal_searches', text: '37.00 Number of Internal Searches (avg)')
   end
 
   scenario 'Summary panel when no data' do
@@ -68,6 +69,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page).to have_selector('.number_of_word_files', text: '0 Word (avg)')
     expect(page).to have_selector('.is_this_useful_yes', text: '0 Useful (avg)')
     expect(page).to have_selector('.is_this_useful_no', text: '0 Not Useful (avg)')
+    expect(page).to have_selector('.number_of_internal_searches', text: '0 Number of Internal Searches (avg)')
   end
 
   scenario 'Download metrics as csv' do
@@ -78,7 +80,7 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
       base_path: '/really-interesting'
     )
     metric1.update pageviews: 10
-    metric2.update pageviews: 10, is_this_useful_yes: 22, is_this_useful_no: 23
+    metric2.update pageviews: 10, is_this_useful_yes: 22, is_this_useful_no: 23, number_of_internal_searches: 99
     metric3.update pageviews: 5
     metric2_fr.update pageviews: 5, unique_pageviews: 5, feedex_comments: 25
 
@@ -95,7 +97,9 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page.body).to include('2018-01-13,cont-id,/really-interesting,en,Really interesting,desc,')
     expect(page.body).to include('is_this_useful_yes')
     expect(page.body).to include('is_this_useful_no')
+    expect(page.body).to include('number_of_internal_searches')
     expect(page.body).to include('22,23')
+    expect(page.body).to include('99')
     expect(page.body).not_to include('2018-01-14')
     expect(page.body).not_to include('fr')
   end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -82,9 +82,12 @@ RSpec.describe Facts::Metric, type: :model do
       item1 = create(:dimensions_item, latest: false, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 3, readability_score: 4)
       item2 = create(:dimensions_item, base_path: base_path, number_of_pdfs: 3, number_of_word_files: 1, spell_count: 3, readability_score: 4)
 
-      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2, feedex_comments: 4, is_this_useful_yes: 1, is_this_useful_no: 1)
-      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2, feedex_comments: 3, is_this_useful_yes: 2, is_this_useful_no: 2)
-      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2, feedex_comments: 2, is_this_useful_yes: 3, is_this_useful_no: 3)
+      create(:metric, dimensions_item: item1, dimensions_date: day0, pageviews: 3, unique_pageviews: 2,
+                      feedex_comments: 4, is_this_useful_yes: 1, is_this_useful_no: 1, number_of_internal_searches: 9)
+      create(:metric, dimensions_item: item2, dimensions_date: day0, pageviews: 5, unique_pageviews: 2,
+                      feedex_comments: 3, is_this_useful_yes: 2, is_this_useful_no: 2, number_of_internal_searches: 9)
+      create(:metric, dimensions_item: item2, dimensions_date: day1, pageviews: 2, unique_pageviews: 2,
+                      feedex_comments: 2, is_this_useful_yes: 3, is_this_useful_no: 3, number_of_internal_searches: 9)
 
       results = subject.between(day0, day1).by_base_path(base_path).metric_summary
 
@@ -98,7 +101,8 @@ RSpec.describe Facts::Metric, type: :model do
         spell_count: 3,
         readability_score: 4,
         is_this_useful_yes: 2,
-        is_this_useful_no: 2
+        is_this_useful_no: 2,
+        number_of_internal_searches: 9
       )
     end
   end


### PR DESCRIPTION
Add `number_of_internal_searches` metric to the sandbox views, ensuring the charting functionality and the `download as csv` works as expected.