### PR TITLE
Add missing process name for Internal Search

### DIFF
--- a/app/etl/ga/internal_search_service.rb
+++ b/app/etl/ga/internal_search_service.rb
@@ -24,7 +24,8 @@ private
     page_path, number_of_internal_searches = *values
     {
       'page_path' => page_path,
-      'number_of_internal_searches' => number_of_internal_searches
+      'number_of_internal_searches' => number_of_internal_searches,
+      'process_name' => 'number_of_internal_searches'
     }
   end
 


### PR DESCRIPTION
The service was missing the hardcoded process name
and the process for importing the data fails.

This is a quick fix. Will update tests later.