### PR TITLE
Fix bug with links updates

### DIFF
--- a/app/streams/publishing_api_message_processor.rb
+++ b/app/streams/publishing_api_message_processor.rb
@@ -63,7 +63,7 @@ private
     new_item.gone!
   end
 
-  def handle_existing_version(_item)
-    Items::Jobs::ImportContentDetailsJob.perform_async(new_item.id, quality_metrics: false)
+  def handle_existing_version(item)
+    Items::Jobs::ImportContentDetailsJob.perform_async(item.id, quality_metrics: false)
   end
 end


### PR DESCRIPTION
The intended behaviour when we get a links update is to update
the latest version rather than creating a new version.
We never fetch new quality metrics in this case, since there is
no new content.

Fixes https://sentry.io/govuk/app-content-performance-manager/issues/540131783/?query=is:unresolved