### PR TITLE
Api uses editions metrics

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -23,14 +23,16 @@ private
       .between(from, to)
       .by_content_id(content_id)
       .by_locale('en')
-      .joins("LEFT JOIN facts_editions ON dimensions_items.id = facts_editions.dimensions_item_id")
-      .order('dimensions_dates.date asc')
-      .group('dimensions_dates.date')
 
     if facts_metrics.include?(metric)
-      series.sum("facts_editions.#{metric}")
+      series
+        .with_edition_metrics
+        .order('dimensions_dates.date asc')
+        .pluck(:date, "facts_editions.#{metric}").to_h
     else
-      series.sum(metric)
+      series
+        .order('dimensions_dates.date asc')
+        .pluck(:date, metric).to_h
     end
   end
 

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -19,13 +19,19 @@ class Api::MetricsController < Api::BaseController
 private
 
   def query_series
-    Facts::Metric
+    series = Facts::Metric
       .between(from, to)
       .by_content_id(content_id)
       .by_locale('en')
+      .joins("LEFT JOIN facts_editions ON dimensions_items.id = facts_editions.dimensions_item_id")
       .order('dimensions_dates.date asc')
       .group('dimensions_dates.date')
-      .sum(metric)
+
+    if facts_metrics.include?(metric)
+      series.sum("facts_editions.#{metric}")
+    else
+      series.sum(metric)
+    end
   end
 
   delegate :from, :to, :metric, :content_id, to: :metric_params
@@ -42,5 +48,25 @@ private
         invalid_params: metric_params.errors.to_hash
       )
     end
+  end
+
+  def facts_metrics
+    %w(
+      number_of_pdfs
+      number_of_word_files
+      readability_score
+      contractions_count
+      equality_count
+      indefinite_article_count
+      passive_count
+      profanities_count
+      redundant_acronyms_count
+      repeated_words_count
+      simplify_count
+      spell_count
+      string_length
+      sentence_count
+      word_count
+    )
   end
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -2,6 +2,8 @@ class Facts::Metric < ApplicationRecord
   belongs_to :dimensions_date, class_name: 'Dimensions::Date'
   belongs_to :dimensions_item, class_name: 'Dimensions::Item'
 
+  has_one :facts_edition, through: :dimensions_item
+
   validates :dimensions_date, presence: true
   validates :dimensions_item, presence: true
 
@@ -32,6 +34,10 @@ class Facts::Metric < ApplicationRecord
   scope :by_locale, ->(locale) do
     joins(:dimensions_item)
       .where(dimensions_items: { locale: locale })
+  end
+
+  scope :with_edition_metrics, -> do
+    joins(:facts_edition)
   end
 
   scope :metric_summary, -> do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,9 @@ FactoryBot.define do
     number_of_pdfs 0
   end
 
+  factory :facts_edition, class: Facts::Edition do
+  end
+
   factory :metric, class: Facts::Metric do
     dimensions_date
     dimensions_item

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   let!(:content_id) { SecureRandom.uuid }
 
   let!(:item) { create :dimensions_item, content_id: content_id, locale: 'en' }
-  let!(:item_fr) { create :dimensions_item, content_id: content_id, locale: 'de' }
+  let!(:item_non_english) { create :dimensions_item, content_id: content_id, locale: 'de' }
 
   before do
     item1_old = create :dimensions_item,
-      content_id: content_id, locale: 'en', number_of_pdfs: 30, number_of_word_files: 30, latest: false
-    item.update number_of_pdfs: 20, number_of_word_files: 20
-    item_fr.update number_of_pdfs: 200, number_of_word_files: 100
+      content_id: content_id, locale: 'en', number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123, latest: false
+    item.update number_of_pdfs: 20, number_of_word_files: 20, readability_score: 5
+    item_non_english.update number_of_pdfs: 200, number_of_word_files: 100
 
     create :metric, dimensions_item: item1_old, dimensions_date: day1
-    create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 10, feedex_comments: 10
+    create :metric, dimensions_item: item_non_english, dimensions_date: day2, pageviews: 10, feedex_comments: 10
     create :metric, dimensions_item: item, dimensions_date: day2
     create :metric, dimensions_item: item, dimensions_date: day3
     create :metric, dimensions_item: item, dimensions_date: day4
@@ -38,6 +38,19 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
+  end
+
+  it 'returns the `readability score` between two dates' do
+    get "/api/v1/metrics/readability_score/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+
+    json = JSON.parse(response.body)
+    expect(json.deep_symbolize_keys).to eq({
+      readability_score: [
+        { date: '2018-01-13', value: 123 },
+        { date: '2018-01-14', value: 5 },
+        { date: '2018-01-15', value: 5 },
+      ]
+    })
   end
 
   def api_reponse(metric_name)

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'securerandom'
+
+RSpec.describe '/api/v1/metrics/', type: :request do
+  before { create(:user) }
+
+  let!(:day1) { create :dimensions_date, date: Date.new(2018, 1, 13) }
+  let!(:day2) { create :dimensions_date, date: Date.new(2018, 1, 14) }
+  let!(:day3) { create :dimensions_date, date: Date.new(2018, 1, 15) }
+  let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
+  let!(:content_id) { SecureRandom.uuid }
+
+  let!(:item) { create :dimensions_item, content_id: content_id, locale: 'en' }
+  let!(:item_fr) { create :dimensions_item, content_id: content_id, locale: 'de' }
+
+  before do
+    item1_old = create :dimensions_item,
+      content_id: content_id, locale: 'en', number_of_pdfs: 30, number_of_word_files: 30, latest: false
+    item.update number_of_pdfs: 20, number_of_word_files: 20
+    item_fr.update number_of_pdfs: 200, number_of_word_files: 100
+
+    create :metric, dimensions_item: item1_old, dimensions_date: day1
+    create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 10, feedex_comments: 10
+    create :metric, dimensions_item: item, dimensions_date: day2
+    create :metric, dimensions_item: item, dimensions_date: day3
+    create :metric, dimensions_item: item, dimensions_date: day4
+  end
+
+  it 'returns the `number of pdfs` between two dates' do
+    get "/api/v1/metrics/number_of_pdfs/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+
+    json = JSON.parse(response.body)
+    expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_pdfs'))
+  end
+
+  it 'returns the `number of word documents` between two dates' do
+    get "/api/v1/metrics/number_of_word_files/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+
+    json = JSON.parse(response.body)
+    expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
+  end
+
+  def api_reponse(metric_name)
+    {
+      metric_name.to_sym => [
+        { date: '2018-01-13', value: 30 },
+        { date: '2018-01-14', value: 20 },
+        { date: '2018-01-15', value: 20 },
+      ]
+    }
+  end
+end

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -10,20 +10,24 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
   let!(:content_id) { SecureRandom.uuid }
 
-  let!(:item) { create :dimensions_item, content_id: content_id, locale: 'en' }
   let!(:item_non_english) { create :dimensions_item, content_id: content_id, locale: 'de' }
 
   before do
-    item1_old = create :dimensions_item,
-      content_id: content_id, locale: 'en', number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123, latest: false
-    item.update number_of_pdfs: 20, number_of_word_files: 20, readability_score: 5
+    item_day1 = create :dimensions_item, content_id: content_id, locale: 'en', latest: true
+    item_day2 = create :dimensions_item, content_id: content_id, locale: 'en', latest: true
+
+    create :facts_edition, dimensions_item: item_day1, dimensions_date: day1, number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123
+    create :facts_edition, dimensions_item: item_day2, dimensions_date: day2, number_of_pdfs: 20, number_of_word_files: 20, readability_score: 5
+
+    create :dimensions_item, content_id: content_id, locale: 'en'
+
     item_non_english.update number_of_pdfs: 200, number_of_word_files: 100
 
-    create :metric, dimensions_item: item1_old, dimensions_date: day1
+    create :metric, dimensions_item: item_day1, dimensions_date: day1
     create :metric, dimensions_item: item_non_english, dimensions_date: day2, pageviews: 10, feedex_comments: 10
-    create :metric, dimensions_item: item, dimensions_date: day2
-    create :metric, dimensions_item: item, dimensions_date: day3
-    create :metric, dimensions_item: item, dimensions_date: day4
+    create :metric, dimensions_item: item_day2, dimensions_date: day2
+    create :metric, dimensions_item: item_day2, dimensions_date: day3
+    create :metric, dimensions_item: item_day2, dimensions_date: day4
   end
 
   it 'returns the `number of pdfs` between two dates' do
@@ -44,13 +48,13 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     get "/api/v1/metrics/readability_score/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
     json = JSON.parse(response.body)
-    expect(json.deep_symbolize_keys).to eq({
+    expect(json.deep_symbolize_keys).to eq(
       readability_score: [
         { date: '2018-01-13', value: 123 },
         { date: '2018-01-14', value: 5 },
         { date: '2018-01-15', value: 5 },
       ]
-    })
+    )
   end
 
   def api_reponse(metric_name)

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -158,45 +158,6 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
   end
 
-  describe 'Content metrics' do
-    before do
-      item1_old = create :dimensions_item,
-        content_id: content_id, locale: 'en', number_of_pdfs: 30, number_of_word_files: 30, latest: false
-      item.update number_of_pdfs: 20, number_of_word_files: 20
-      item_fr.update number_of_pdfs: 200, number_of_word_files: 100
-
-      create :metric, dimensions_item: item1_old, dimensions_date: day1
-      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 10, feedex_comments: 10
-      create :metric, dimensions_item: item, dimensions_date: day2
-      create :metric, dimensions_item: item, dimensions_date: day3
-      create :metric, dimensions_item: item, dimensions_date: day4
-    end
-
-    it 'returns the `number of pdfs` between two dates' do
-      get "/api/v1/metrics/number_of_pdfs/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
-
-      json = JSON.parse(response.body)
-      expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_pdfs'))
-    end
-
-    it 'returns the `number of word documents` between two dates' do
-      get "/api/v1/metrics/number_of_word_files/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
-
-      json = JSON.parse(response.body)
-      expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
-    end
-
-    def api_reponse(metric_name)
-      {
-        metric_name.to_sym => [
-          { date: '2018-01-13', value: 30 },
-          { date: '2018-01-14', value: 20 },
-          { date: '2018-01-15', value: 20 },
-        ]
-      }
-    end
-  end
-
   describe "metrics index" do
     it "describes the available metrics" do
       get "/api/v1/metrics"


### PR DESCRIPTION
Follow on from #655.

The API endpoint for metrics now uses the Facts::Edition values instead of the columns that are held directly in the Dimensions::Item object.

We do not remove the columns in the Dimensions::Item yet as we still need to add support for the Sandbox. Follow on PRs will include cleanup.

First 3 commits were from mob session. Final changes paired with @MatMoore 