### PR TITLE
Omit extraction on schemas that do not contain useful content

### DIFF
--- a/app/etl/item/content/parsers/no_content.rb
+++ b/app/etl/item/content/parsers/no_content.rb
@@ -5,9 +5,20 @@ class Item::Content::Parsers::NoContent
 
   def schemas
     %w[
-    redirect
-    placeholder_person
-    placeholder
+      coming_soon
+      completed_transaction
+      external_content
+      generic
+      homepage
+      person
+      placeholder_corporate_information_page
+      placehold_worldwide_organisation
+      placeholder_person
+      placeholder
+      policy
+      special_route
+      redirect
+      vanish
     ]
   end
 end

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -35,11 +35,22 @@ RSpec.describe Item::Content::Parser do
         end
       end
 
-      it "handles schemas that don't have content" do
+      it "handles schemas that does not have useful content" do
         no_content_schemas = %w[
-          redirect
+          coming_soon
+          completed_transaction
+          external_content
+          generic
+          homepage
+          person
+          placeholder_corporate_information_page
+          placehold_worldwide_organisation
           placeholder_person
           placeholder
+          policy
+          special_route
+          redirect
+          vanish
         ]
         no_content_schemas.each do |schema|
           json = build_raw_json(schema_name: schema, body: "<p>Body for #{schema}</p>")


### PR DESCRIPTION
We have accessed the content that could be extracted from the schemas
below and have made the decision that no useful information could be
taken to produce useful quality metrics. [Trello: Add schemas we wish to ignore to NoContent Parser](https://trello.com/c/PwJv49wP/285-1add-schemas-we-wish-to-ignore-to-nocontent-parser)

Schemas:
----------
coming_soon
completed_transaction
external_content
generic
homepage
person
placeholder_corporate_information_page
placeholder_worldwide_organisation_policy
policy
special_route
vanish