### PR TITLE
Extract content from schemas 'calendar', 'finder', 'hmrc_manual' and 'local_transaction'

### DIFF
--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -29,6 +29,7 @@ private
       Item::Content::Parsers::BodyContent,
       Item::Content::Parsers::Contact,
       Item::Content::Parsers::EmailAlertSignup,
+      Item::Content::Parsers::Finder,
       Item::Content::Parsers::FinderEmailSignup,
       Item::Content::Parsers::GenericWithLinks,
       Item::Content::Parsers::HmrcManual,

--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -31,6 +31,7 @@ private
       Item::Content::Parsers::EmailAlertSignup,
       Item::Content::Parsers::FinderEmailSignup,
       Item::Content::Parsers::GenericWithLinks,
+      Item::Content::Parsers::HmrcManual,
       Item::Content::Parsers::Licence,
       Item::Content::Parsers::LocalTransaction,
       Item::Content::Parsers::Need,

--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -32,7 +32,7 @@ private
       Item::Content::Parsers::FinderEmailSignup,
       Item::Content::Parsers::GenericWithLinks,
       Item::Content::Parsers::Licence,
-      Item::Content::Parsers::LocationTransaction,
+      Item::Content::Parsers::LocalTransaction,
       Item::Content::Parsers::Need,
       Item::Content::Parsers::Parts,
       Item::Content::Parsers::Place,

--- a/app/etl/item/content/parsers/body_content.rb
+++ b/app/etl/item/content/parsers/body_content.rb
@@ -6,6 +6,7 @@ class Item::Content::Parsers::BodyContent
   def schemas
     %w[
     answer
+    calendar
     case_study
     consultation
     corporate_information_page

--- a/app/etl/item/content/parsers/finder.rb
+++ b/app/etl/item/content/parsers/finder.rb
@@ -1,0 +1,18 @@
+class Item::Content::Parsers::Finder
+  def parse(json)
+    html = []
+    html << json.dig("title") unless json.dig("title").nil?
+    children = json.dig("links", "children")
+    unless children.nil?
+      children.each do |child|
+        html << child["title"]
+        html << child["description"]
+      end
+    end
+    html.join(" ") unless html.empty?
+  end
+
+  def schemas
+    ['finder']
+  end
+end

--- a/app/etl/item/content/parsers/hmrc_manual.rb
+++ b/app/etl/item/content/parsers/hmrc_manual.rb
@@ -1,0 +1,25 @@
+class Item::Content::Parsers::HmrcManual
+  def parse(json)
+    html = []
+    html << json.dig("title") unless json.dig("title").nil?
+    html << json.dig("description") unless json.dig("description").nil?
+    groups = json.dig("details", "child_section_groups")
+    unless groups.nil?
+      groups.each do |group|
+        html << group["title"] unless group["title"].nil?
+        sections = group["child_sections"]
+        unless sections.nil?
+          sections.each do |section|
+            html << section["section_id"]
+            html << section["title"]
+          end
+        end
+      end
+    end
+    html.join(" ") unless html.empty?
+  end
+
+  def schemas
+    ['hmrc_manual']
+  end
+end

--- a/app/etl/item/content/parsers/local_transaction.rb
+++ b/app/etl/item/content/parsers/local_transaction.rb
@@ -1,4 +1,4 @@
-class Item::Content::Parsers::LocationTransaction
+class Item::Content::Parsers::LocalTransaction
   def parse(json)
     html = []
     html << json.dig("details", "introduction")
@@ -8,6 +8,6 @@ class Item::Content::Parsers::LocationTransaction
   end
 
   def schemas
-    ['location_transaction']
+    ['local_transaction']
   end
 end

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -467,6 +467,26 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
       end
 
+      it "returns content json if schema_name is 'hmrc_manual'" do
+        json = { schema_name: "hmrc_manual",
+          title: "HMRC Manual",
+          description: "Manual of items",
+          details: {
+            child_section_groups: [{
+              child_sections: [
+                { section_id: "ARG6757", title: "Section 1" },
+                { section_id: "THP8972", title: "Section 2" }
+              ]
+            }, {
+              child_sections: [
+                { section_id: "UP4591", title: "Section 15" }
+                ], title: "Update"
+              }]
+            } }
+        expected = "HMRC Manual Manual of items ARG6757 Section 1 THP8972 Section 2 Update UP4591 Section 15"
+        expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
+      end
+
       def build_raw_json(body:, schema_name:)
         {
           schema_name: schema_name,

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Item::Content::Parser do
       it 'returns content json from :body for all valid formats' do
         valid_types = %w[
           answer
+          calendar
           case_study
           consultation
           corporate_information_page

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -169,8 +169,8 @@ RSpec.describe Item::Content::Parser do
         end
       end
 
-      it "returns content json if schema_name is 'location_transaction'" do
-        json = { schema_name: "location_transaction",
+      it "returns content json if schema_name is 'local_transaction'" do
+        json = { schema_name: "local_transaction",
           details: { introduction: "Greetings", need_to_know: "A Name",
             more_information: "An Address" } }
         expect(subject.extract_content(json.deep_stringify_keys)).to eq("Greetings A Name An Address")

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -487,6 +487,16 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
       end
 
+      it "returns content json if schema_name is 'finder'" do
+        json = { schema_name: "finder", title: "Contact HMRC",
+          links: { children: [
+            { title: "Personal Tax", description: "Email, write or phone us" },
+            { title: "Child Benefit", description: "Tweet us" }
+          ] } }
+        expected = "Contact HMRC Personal Tax Email, write or phone us Child Benefit Tweet us"
+        expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
+      end
+
       def build_raw_json(body:, schema_name:)
         {
           schema_name: schema_name,

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Process parser', type: :integration do
       external_content
       finder
       generic
-      hmrc_manual
       homepage
       local_transaction
       mainstream_browse_page

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'Process parser', type: :integration do
   let(:invalid_schema_list) {
     %w[
-      finder
       mainstream_browse_page
       service_manual_homepage
       step_by_step_nav

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -1,18 +1,9 @@
 RSpec.describe 'Process parser', type: :integration do
   let(:invalid_schema_list) {
     %w[
-      calendar
-      coming_soon
-      completed_transaction
-      external_content
       finder
-      generic
-      homepage
-      local_transaction
       mainstream_browse_page
-      policy
       service_manual_homepage
-      special_route
       step_by_step_nav
       topic
       world_location


### PR DESCRIPTION
[Trello: Create parsers for schemas 'calendar', 'finder', 'hmrc_manual' and 'local_transaction'](https://trello.com/c/nn1LHst8/286-2-create-parsers-for-schemas-calendar-finder-hmrcmanual-and-localtransaction)

We have made the decision that we DO want to extract content from the following schemas as they can be used to generate quality metrics:

Schemas
---------
Calendar
Finder
HMRC Manual
Local Transaction

There was a typo on 'local_transaction' which meant that it was not being extracted when it should have been. This has been fixed in this PR.

This is part of EPIC [Trello: Support all schemas when parsing content items to extract content](https://trello.com/c/Pjp3RUGu/241-3-epic-support-all-schemas-when-parsing-content-items-to-extract-content)