### PR TITLE
Extract content from 4 more schemas

### DIFF
--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -35,6 +35,7 @@ private
       Item::Content::Parsers::HmrcManual,
       Item::Content::Parsers::Licence,
       Item::Content::Parsers::LocalTransaction,
+      Item::Content::Parsers::Mainstream,
       Item::Content::Parsers::Need,
       Item::Content::Parsers::Parts,
       Item::Content::Parsers::Place,

--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -39,6 +39,7 @@ private
       Item::Content::Parsers::Need,
       Item::Content::Parsers::Parts,
       Item::Content::Parsers::Place,
+      Item::Content::Parsers::ServiceManualHomepage,
       Item::Content::Parsers::ServiceManualStandard,
       Item::Content::Parsers::ServiceManualServiceToolkit,
       Item::Content::Parsers::ServiceManualTopic,

--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -45,6 +45,7 @@ private
       Item::Content::Parsers::ServiceManualTopic,
       Item::Content::Parsers::ServiceSignIn,
       Item::Content::Parsers::StatisticsAnnouncement,
+      Item::Content::Parsers::StepByStep,
       Item::Content::Parsers::Taxon,
       Item::Content::Parsers::Transaction,
       Item::Content::Parsers::TravelAdviceIndex,

--- a/app/etl/item/content/parsers/body_content.rb
+++ b/app/etl/item/content/parsers/body_content.rb
@@ -19,6 +19,7 @@ class Item::Content::Parsers::BodyContent
     manual
     manual_section
     news_article
+    organisation
     publication
     service_manual_guide
     simple_smart_answer

--- a/app/etl/item/content/parsers/mainstream.rb
+++ b/app/etl/item/content/parsers/mainstream.rb
@@ -1,0 +1,27 @@
+class Item::Content::Parsers::Mainstream
+  def parse(json)
+    html = []
+    html << json.dig("title") unless json.dig("title").nil?
+    html << json.dig("description") unless json.dig("description").nil?
+
+    children = json.dig("links", "children")
+    if children.present?
+      children.each do |child|
+        html << child["title"]
+      end
+    end
+
+    related_topics = json.dig("links", "related_topics")
+    if related_topics.present?
+      related_topics.each do |topic|
+        html << topic["title"]
+      end
+    end
+
+    html.compact.join(" ")
+  end
+
+  def schemas
+    %w[mainstream_browse_page]
+  end
+end

--- a/app/etl/item/content/parsers/service_manual_homepage.rb
+++ b/app/etl/item/content/parsers/service_manual_homepage.rb
@@ -1,0 +1,21 @@
+class Item::Content::Parsers::ServiceManualHomepage
+  def parse(json)
+    html = []
+    html << json.dig("title")
+    html << json.dig("description")
+
+    children = json.dig("links", "children")
+    if children.present?
+      children.each do |child|
+        html << child["title"]
+        html << child["description"]
+      end
+    end
+
+    html.compact.join(" ")
+  end
+
+  def schemas
+    ['service_manual_homepage']
+  end
+end

--- a/app/etl/item/content/parsers/step_by_step.rb
+++ b/app/etl/item/content/parsers/step_by_step.rb
@@ -1,0 +1,57 @@
+class Item::Content::Parsers::StepByStep
+  def parse(json)
+    html = []
+
+    steps = json.dig("details", "step_by_step_nav")
+
+    if steps.present?
+      html << steps["title"]
+      html << steps["introduction"]
+      chapters = steps["steps"]
+
+      if chapters.present?
+        html << get_chapters(chapters)
+      end
+    end
+
+    html.compact.join(" ")
+  end
+
+  def schemas
+    %w[step_by_step_nav]
+  end
+
+  def get_chapters(json_chapters)
+    html = []
+
+    json_chapters.each do |chapter|
+      html << chapter["title"]
+      contents = chapter["contents"]
+      html << get_steps(contents) if contents.present?
+    end
+
+    html.compact
+  end
+
+  def get_steps(json_content)
+    html = []
+
+    json_content.each do |content|
+      html << content["text"]
+      lists = content["contents"]
+      html << get_sub_steps(lists) if lists.present?
+    end
+
+    html.compact
+  end
+
+  def get_sub_steps(json_list)
+    html = []
+
+    json_list.each do |list|
+      html << list["text"]
+    end
+
+    html.compact
+  end
+end

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -498,6 +498,21 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
       end
 
+      it "returns content json if schema_name is 'mainstream_browse_page'" do
+        json = { schema_name: "mainstream_browse_page", title: "Travel Abroad",
+          description: "Go abroad",
+          links: { children: [
+            { title: "Driving Abroad" },
+            { title: "Forced Marriage" }
+            ],
+            related_topics: [
+              { title: "Pets" },
+              { title: "Help" }
+              ] } }
+        expected = "Travel Abroad Go abroad Driving Abroad Forced Marriage Pets Help"
+        expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
+      end
+
       def build_raw_json(body:, schema_name:)
         {
           schema_name: schema_name,

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -525,6 +525,19 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
       end
 
+      it "returns content json if schema_name is 'step_by_step_nav'" do
+        json = { schema_name: "step_by_step_nav", details: { step_by_step_nav: {
+          title: "Learn to drive a car: step by step", introduction: "It's easy",
+          steps: [{ title: "Step 1",
+            contents: [{ text: "Enter vehicle" }, contents: [{ text: "A" }, { text: "B" }, { text: "C" }]] },
+                  { title: "Step 2",
+              contents: [{ text: "Adjust seat" }, contents: [{ text: "Z" }, { text: "Y" }, { text: "X" }]] }]
+          } } }
+
+        expected = "Learn to drive a car: step by step It's easy Step 1 Enter vehicle A B C Step 2 Adjust seat Z Y X"
+        expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
+      end
+
       def build_raw_json(body:, schema_name:)
         {
           schema_name: schema_name,

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Item::Content::Parser do
           manual
           manual_section
           news_article
+          organisation
           publication
           service_manual_guide
           simple_smart_answer

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -513,6 +513,18 @@ RSpec.describe Item::Content::Parser do
         expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
       end
 
+      it "returns content json if schema_name is 'service_manual_homepage'" do
+        json = { schema_name: "service_manual_homepage", title: "Service Manual",
+          description: "Digital Service Standard",
+          links: { children: [
+            { title: "Design", description: "Naming your service" },
+            { title: "Technology", description: "Security and Maintenance" }
+            ] } }
+
+        expected = "Service Manual Digital Service Standard Design Naming your service Technology Security and Maintenance"
+        expect(subject.extract_content(json.deep_stringify_keys)).to eql(expected)
+      end
+
       def build_raw_json(body:, schema_name:)
         {
           schema_name: schema_name,

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'Process parser', type: :integration do
   let(:invalid_schema_list) {
     %w[
-      mainstream_browse_page
       service_manual_homepage
       step_by_step_nav
       topic

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'Process parser', type: :integration do
   let(:invalid_schema_list) {
     %w[
-      service_manual_homepage
       step_by_step_nav
       topic
       world_location

--- a/spec/integration/parser_process_spec.rb
+++ b/spec/integration/parser_process_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'Process parser', type: :integration do
   let(:invalid_schema_list) {
     %w[
-      step_by_step_nav
       topic
       world_location
     ]


### PR DESCRIPTION
[Trello: Create parsers for schemas (batch 2)](https://trello.com/c/S70veFeg/287-2-create-parsers-for-schemas-batch-2)

We have made the decision that we DO want to extract content from the following schemas as they can be used to generate quality metrics:

Schemas
---------
mainstream_browse_page
organisation
service_manual_homepage
step_by_step_nav

This is part of EPIC [Trello: Support all schemas when parsing content items to extract content](https://trello.com/c/Pjp3RUGu/241-3-epic-support-all-schemas-when-parsing-content-items-to-extract-content)