### PR TITLE
Delete all events after we import GA metrics

### DIFF
--- a/app/etl/ga/internal_search_processor.rb
+++ b/app/etl/ga/internal_search_processor.rb
@@ -38,7 +38,7 @@ private
     date_to_s = date.strftime("%F")
 
     conn.execute(load_metrics_query(date_to_s))
-    conn.execute(clean_up_query)
+    clean_up_events!
   end
 
   def load_metrics_query(date_to_s)
@@ -56,19 +56,8 @@ private
     SQL
   end
 
-  def clean_up_query
-    date_to_s = date.strftime("%F")
-    <<~SQL
-      DELETE FROM events_gas
-      WHERE date = '#{date_to_s}' AND
-            process_name = #{Events::GA.process_names['number_of_internal_searches']} AND
-        page_path in (
-           SELECT base_path
-           FROM dimensions_items, facts_metrics
-           WHERE dimensions_items.id = facts_metrics.dimensions_item_id
-           AND facts_metrics.dimensions_date_id = '#{date_to_s}'
-        )
-    SQL
+  def clean_up_events!
+    Events::GA.delete_all
   end
 
   attr_reader :date

--- a/app/etl/ga/user_feedback_processor.rb
+++ b/app/etl/ga/user_feedback_processor.rb
@@ -37,7 +37,7 @@ private
     conn = ActiveRecord::Base.connection
     date_to_s = date.strftime("%F")
     conn.execute(load_metrics_query(date_to_s))
-    conn.execute(clean_up_query)
+    clean_up_events!
   end
 
   def load_metrics_query(date_to_s)
@@ -57,19 +57,8 @@ private
     SQL
   end
 
-  def clean_up_query
-    date_to_s = date.strftime("%F")
-    <<~SQL
-      DELETE FROM events_gas
-      WHERE date = '#{date_to_s}' AND
-            process_name = #{Events::GA.process_names['user_feedback']} AND
-        page_path in (
-           SELECT base_path
-           FROM dimensions_items, facts_metrics
-           WHERE dimensions_items.id = facts_metrics.dimensions_item_id
-           AND facts_metrics.dimensions_date_id = '#{date_to_s}'
-        )
-    SQL
+  def clean_up_events!
+    Events::GA.delete_all
   end
 
   attr_reader :date

--- a/app/etl/ga/views_processor.rb
+++ b/app/etl/ga/views_processor.rb
@@ -38,7 +38,7 @@ private
     date_to_s = date.strftime("%F")
 
     conn.execute(load_metrics_query(date_to_s))
-    conn.execute(clean_up_query)
+    clean_up_events!
   end
 
   def load_metrics_query(date_to_s)
@@ -58,19 +58,8 @@ private
     SQL
   end
 
-  def clean_up_query
-    date_to_s = date.strftime("%F")
-    <<~SQL
-      DELETE FROM events_gas
-      WHERE date = '#{date_to_s}' AND
-            process_name = #{Events::GA.process_names['views']} AND
-        page_path in (
-           SELECT base_path
-           FROM dimensions_items, facts_metrics
-           WHERE dimensions_items.id = facts_metrics.dimensions_item_id
-           AND facts_metrics.dimensions_date_id = '#{date_to_s}'
-        )
-    SQL
+  def clean_up_events!
+    Events::GA.delete_all
   end
 
   attr_reader :date

--- a/spec/etl/ga/concerns/transform_path_spec.rb
+++ b/spec/etl/ga/concerns/transform_path_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe GA::Concerns::TransformPath do
+  class Dummy
+    include GA::Concerns::TransformPath
+    include Concerns::Traceable
+  end
+
+  it "events that have gov.uk prefix get formatted to remove prefix" do
+    create(:ga_event, page_path: "/https://www.gov.uk/topics", process_name: 'views')
+    events_with_prefix = Events::GA.where("page_path ~ '^\/https:\/\/www.gov.uk'")
+    expect(events_with_prefix.count).to eq 1
+
+    Dummy.new.remove_invalid_prefix
+
+    events_with_prefix = Events::GA.where("page_path ~ '^\/https:\/\/www.gov.uk'")
+    expect(events_with_prefix.count).to eq 0
+  end
+end

--- a/spec/etl/ga/internal_search_processor_spec.rb
+++ b/spec/etl/ga/internal_search_processor_spec.rb
@@ -41,22 +41,12 @@ RSpec.describe GA::InternalSearchProcessor do
       expect(fact.reload).to have_attributes(number_of_internal_searches: 99)
     end
 
-    it "deletes the events that matches the base_path of an item if it has number of internal search data" do
-      item2.destroy
-      create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+    it "deletes events after updating facts metrics" do
+      create :ga_event, :with_number_of_internal_searches, date: date - 1, page_path: '/path1'
 
       described_class.process(date: date)
 
-      expect(Events::GA.count).to eq(1)
-    end
-
-    it "does not delete the events that match the base_path of an item if it does not have number of internal search data" do
-      create :ga_event, :with_views, date: date, page_path: item1.base_path
-      create :metric, dimensions_item: item1, dimensions_date: dimensions_date
-
-      described_class.process(date: date)
-
-      expect(Events::GA.count).to eq(2)
+      expect(Events::GA.count).to eq(0)
     end
 
     context "when there are events from other days" do
@@ -73,29 +63,14 @@ RSpec.describe GA::InternalSearchProcessor do
         expect(fact1.reload).to have_attributes(number_of_internal_searches: 1)
       end
 
-      it "deletes events for the current day if it has number of internal searches" do
-        create :metric, dimensions_item: item1, dimensions_date: dimensions_date
-        create :metric, dimensions_item: item2, dimensions_date: dimensions_date
-        described_class.process(date: date)
-
+      it "deletes events after updating facts metrics" do
         expect(Events::GA.count).to eq(2)
-      end
 
-      it "does not delete events that are not from the current day" do
-        create :metric, dimensions_item: item1, dimensions_date: dimensions_date
         described_class.process(date: date)
 
-        expect(Events::GA.count).to eq(3)
+        expect(Events::GA.count).to eq(0)
       end
     end
-  end
-
-  context 'when page_path starts "/https://www.gov.uk"' do
-    before do
-      allow(GA::InternalSearchService).to receive(:find_in_batches)
-      .and_yield(ga_response_with_govuk_prefix)
-    end
-    include_examples "transform path examples"
   end
 
 private

--- a/spec/support/shared_examples/transform_path.rb
+++ b/spec/support/shared_examples/transform_path.rb
@@ -1,7 +1,0 @@
-RSpec.shared_examples "transform path examples" do
-  it 'removes the "/https://www.gov.uk" from the GA::Event page_path' do
-    subject.process(date: date)
-    expect(Events::GA.where(page_path: '/https://gov.uk/path1').count).to eq 0
-    expect(Events::GA.where(page_path: '/path1').count).to eq 1
-  end
-end


### PR DESCRIPTION
We have some discrepancies between the data we receive from GA and the data we store in our facts_metrics table, ideally the data in facts_metrics would accurately represent the metrics we receive from GA. We know that the correct data is imported into events_gas table from GA, however we have some discrepancies between facts_metrics and GA due to facts_metrics identifying pages by their base_path and GA using the page_path.

In this PR we are deleting all rows from events_gas table after they have been transformed and loaded into the facts_metrics table. We will work on representing the GA data accurately in the facts_metrics table in a later PR.

Note: We have removed the shared_examples previously used to test the TransformPath module because it was no longer possible to test it in that manner due to us deleting all GA::Events during the ETL process. We have added a unit test, testing the module in isolation, instead.