### PR TITLE
Fix `1 unique_pageviews` bug

### DIFF
--- a/app/etl/ga/concerns/transform_path.rb
+++ b/app/etl/ga/concerns/transform_path.rb
@@ -3,12 +3,29 @@ require 'active_support/concern'
 module GA::Concerns::TransformPath
   extend ActiveSupport::Concern
 
-  def remove_invalid_prefix
+  def format_events_with_invalid_prefix
     events_with_prefix = Events::GA.where("page_path ~ '^\/https:\/\/www.gov.uk'")
     log(process: :ga, message: "Transforming #{events_with_prefix.count} events with page_path starting https://gov.uk")
     events_with_prefix.find_each do |event|
-      page_path_without_prefix = event.page_path.remove '/https://www.gov.uk'
-      event.update_attributes(page_path: page_path_without_prefix)
+      transformed_attributes = transform_event_attributes(event)
+      event.update_attributes(transformed_attributes)
     end
+  end
+
+private
+
+  def transform_event_attributes(event)
+    sanitised_page_path = event.page_path.remove '/https://www.gov.uk'
+    duplicate_event = Events::GA.find_by(page_path: sanitised_page_path)
+    attributes = { page_path: sanitised_page_path }
+
+    if duplicate_event
+      attributes[:pageviews] = event.pageviews + duplicate_event.pageviews
+      attributes[:unique_pageviews] = event.unique_pageviews + duplicate_event.unique_pageviews
+
+      duplicate_event.destroy
+    end
+
+    attributes
   end
 end

--- a/app/etl/ga/internal_search_processor.rb
+++ b/app/etl/ga/internal_search_processor.rb
@@ -30,7 +30,7 @@ private
   end
 
   def transform_events
-    remove_invalid_prefix
+    format_events_with_invalid_prefix
   end
 
   def load_metrics

--- a/app/etl/ga/user_feedback_processor.rb
+++ b/app/etl/ga/user_feedback_processor.rb
@@ -30,7 +30,7 @@ private
   end
 
   def transform_events
-    remove_invalid_prefix
+    format_events_with_invalid_prefix
   end
 
   def load_metrics

--- a/app/etl/ga/views_processor.rb
+++ b/app/etl/ga/views_processor.rb
@@ -30,7 +30,7 @@ private
   end
 
   def transform_events
-    remove_invalid_prefix
+    format_events_with_invalid_prefix
   end
 
   def load_metrics

--- a/spec/etl/ga/concerns/transform_path_spec.rb
+++ b/spec/etl/ga/concerns/transform_path_spec.rb
@@ -11,9 +11,37 @@ RSpec.describe GA::Concerns::TransformPath do
     events_with_prefix = Events::GA.where("page_path ~ '^\/https:\/\/www.gov.uk'")
     expect(events_with_prefix.count).to eq 1
 
-    Dummy.new.remove_invalid_prefix
+    Dummy.new.format_events_with_invalid_prefix
 
     events_with_prefix = Events::GA.where("page_path ~ '^\/https:\/\/www.gov.uk'")
     expect(events_with_prefix.count).to eq 0
+  end
+
+  context 'when an event exists with the same page_path after formatting' do
+    subject { Dummy.new }
+
+    let!(:event2) { create(:ga_event, :with_views, page_path: "/https://www.gov.uk/topics", unique_pageviews: 1, pageviews: 1) }
+
+    before(:each) do
+      create(:ga_event, :with_views, page_path: "/topics", unique_pageviews: 100, pageviews: 200)
+    end
+
+    it 'updates events with their combined pageviews' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.pageviews).to eq 201
+    end
+
+    it 'updates events with their combined unique_pageviews' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.unique_pageviews).to eq 101
+    end
+
+    it 'deletes the duplicated event' do
+      subject.format_events_with_invalid_prefix
+
+      expect(Events::GA.count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
We have a bug in our codebase which shows unique_pageviews for some pages to be 1 occasionally, in our facts_metrics table, despite the true number usually being in the thousands.

The cause of this issue is that we expect to only have one GA event per page path which in turn feeds in to one facts_metric per base path. However, for some pages, GA returns us data for the base path (i.e '/tax') AND returns us data for the full url (i.e 'https://gov.uk/tax').

In our codebase we have been sanitising the events that contain the full url, transforming it into the base_path that our codebase requires. However, when this happens we sometimes have 2 GA events in our table with the same page path (one which had the basepath from GA, the other which had the full URL but we sanitised and which then was identical to the basepath of the original event). This meant that as we loaded the data from events_gas into facts_metrics the metrics from the event we loaded second would overwrite the metrics from the event that we loaded first, resulting in some unexpected metrics.

In this PR I have made changes to the logic to the transform stage of our GA ETL process so that after sanitising any page_paths that do not match our required format we also check that the newly sanitised page_path does not duplicate the page_path of any existing events. If it does then we update our event with the sum of the metrics of both events and we delete the duplicate event. This will fix the problem.

I have also written a test to check this functionality and changed some names to reflect the new functionality.