### PR TITLE
Add schemas to ignore

### DIFF
--- a/app/etl/item/content/parsers/no_content.rb
+++ b/app/etl/item/content/parsers/no_content.rb
@@ -10,14 +10,23 @@ class Item::Content::Parsers::NoContent
       external_content
       generic
       homepage
+      organisations_homepage
       person
       placeholder_corporate_information_page
+      placeholder_ministerial_role
+      placeholder_organisation
+      placeholder_policy_area
+      placeholder_topical_event
+      placeholer_working_group
+      placeholder_world_location
       placehold_worldwide_organisation
       placeholder_person
       placeholder
       policy
-      special_route
       redirect
+      special_route
+      topic
+      world_location
       vanish
     ]
   end

--- a/spec/etl/item/content/no_content_spec.rb
+++ b/spec/etl/item/content/no_content_spec.rb
@@ -8,14 +8,23 @@ RSpec.describe Item::Content::Parser do
       external_content
       generic
       homepage
+      organisations_homepage
       person
       placeholder_corporate_information_page
+      placeholder_ministerial_role
+      placeholder_organisation
+      placeholder_policy_area
+      placeholder_topical_event
+      placeholer_working_group
+      placeholder_world_location
       placehold_worldwide_organisation
       placeholder_person
       placeholder
       policy
-      special_route
       redirect
+      special_route
+      topic
+      world_location
       vanish
     ]
     no_content_schemas.each do |schema|


### PR DESCRIPTION
[Trello: Make a decision on the remaining schemas](https://trello.com/c/2enowzan/317-make-a-decision-on-the-remaining-schemas)

There are a number of schemas that we do not want to extract data from as they will not give us any useful content for quality metrics.

This PR adds the following schemas to the list that we do not want to extract content from: 

organisations_homepage
topic
world_location
placeholder_organisation
placeholder_world_location
placeholder_working_group
placeholder_topical_event
placeholder_policy_area 
placeholder_ministerial_role

Now that we have added these schemas we should not be seeing any InvalidSchemaErrors for any of these schemas.

This PR is part of the [EPIC - Trello: Support all schemas when parsing content items to extract content](https://trello.com/c/Pjp3RUGu/241-3-epic-support-all-schemas-when-parsing-content-items-to-extract-content)