### PR TITLE
Add duplicate constraint on events_gas.

### DIFF
--- a/db/migrate/20180514152920_add_constraint_on_duplicate_events.rb
+++ b/db/migrate/20180514152920_add_constraint_on_duplicate_events.rb
@@ -1,0 +1,5 @@
+class AddConstraintOnDuplicateEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_index :events_gas, [:process_name, :date, :page_path], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180514085910) do
+ActiveRecord::Schema.define(version: 20180514152920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20180514085910) do
     t.integer "bounce_rate", default: 0
     t.integer "avg_time_on_page", default: 0
     t.index ["page_path", "date"], name: "index_events_gas_on_page_path_and_date"
+    t.index ["process_name", "date", "page_path"], name: "index_events_gas_on_process_name_and_date_and_page_path", unique: true
   end
 
   create_table "facts_editions", force: :cascade do |t|

--- a/spec/integration/master_process_spec.rb
+++ b/spec/integration/master_process_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Master process spec' do
           'process_name' => 'user_feedback',
         },
         {
-          'page_path' => base_path,
+          'page_path' => '/path2',
           'is_this_useful_no' => 122,
           'is_this_useful_yes' => 1,
           'date' => '2018-02-20',


### PR DESCRIPTION
Add duplicate constraint on events_gas on process_name, date and page_path.

Fixed a test which failed due to the setup for the test violating the new duplicate constraint.

