### PR TITLE
Add more GA metrics to the sandbox

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -45,6 +45,6 @@ private
       :contractions_count, :equality_count, :indefinite_article_count, :number_of_pdfs,
       :number_of_word_files, :passive_count, :profanities_count, :readability_score,
       :redundant_acronyms_count, :repeated_words_count, :sentence_count, :simplify_count,
-      :spell_count, :string_length, :word_count)
+      :spell_count, :string_length, :word_count, :entrances, :exits, :bounce_rate, :avg_time_on_page)
   end
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -72,6 +72,10 @@ class Facts::Metric < ApplicationRecord
       simplify_count
       string_length
       sentence_count
+      entrances
+      exits
+      bounce_rate
+      avg_time_on_page
     ]
   end
 end

--- a/app/views/sandbox/_body.html.erb
+++ b/app/views/sandbox/_body.html.erb
@@ -14,6 +14,10 @@
   <%= render 'section', metric: :is_this_useful_yes %>
   <%= render 'section', metric: :is_this_useful_no %>
   <%= render 'section', metric: :number_of_internal_searches %>
+  <%= render 'section', metric: :entrances %>
+  <%= render 'section', metric: :exits %>
+  <%= render 'section', metric: :bounce_rate %>
+  <%= render 'section', metric: :avg_time_on_page %>
   <%= render 'section', metric: :number_of_pdfs %>
   <%= render 'section', metric: :readability_score %>
   <%= render 'section', metric: :number_of_word_files %>

--- a/app/views/sandbox/_sidebar.html.erb
+++ b/app/views/sandbox/_sidebar.html.erb
@@ -26,6 +26,10 @@
         <%= render 'metric_option', metric: :is_this_useful_yes %>
         <%= render 'metric_option', metric: :is_this_useful_no %>
         <%= render 'metric_option', metric: :number_of_internal_searches %>
+        <%= render 'metric_option', metric: :entrances %>
+        <%= render 'metric_option', metric: :exits %>
+        <%= render 'metric_option', metric: :bounce_rate %>
+        <%= render 'metric_option', metric: :avg_time_on_page %>
       </div>
 
       <div class="input-group">

--- a/spec/features/sandbox/download_csv_spec.rb
+++ b/spec/features/sandbox/download_csv_spec.rb
@@ -44,6 +44,10 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     metric.pageviews = 19
     metric.unique_pageviews = 20
     metric.feedex_comments = 21
+    metric.entrances = 30
+    metric.exits = 31
+    metric.bounce_rate = 32
+    metric.avg_time_on_page = 33
     metric.save!
 
     visit '/sandbox'
@@ -56,10 +60,10 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page.response_headers['Content-Type']).to eq "text/csv"
     expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="download.csv"'
 
-    header = 'date,content_id,base_path,locale,title,description,document_type,content_purpose_document_supertype,content_purpose_supergroup,content_purpose_subgroup,first_published_at,public_updated_at,status,pageviews,primary_organisation_title,primary_organisation_content_id,unique_pageviews,feedex_comments,number_of_pdfs,number_of_word_files,readability_score,spell_count,is_this_useful_yes,is_this_useful_no,number_of_internal_searches,word_count,passive_count,simplify_count,string_length,sentence_count'
+    header = 'date,content_id,base_path,locale,title,description,document_type,content_purpose_document_supertype,content_purpose_supergroup,content_purpose_subgroup,first_published_at,public_updated_at,status,pageviews,primary_organisation_title,primary_organisation_content_id,unique_pageviews,feedex_comments,number_of_pdfs,number_of_word_files,readability_score,spell_count,is_this_useful_yes,is_this_useful_no,number_of_internal_searches,word_count,passive_count,simplify_count,string_length,sentence_count,entrances,exits,bounce_rate,avg_time_on_page'
     expect(page.body).to include(header)
 
-    row = "2018-01-12,content-id,/base-path,en,This is the title,This is the description,Guide,Super Guide,Guide,guidance,2018-02-03 00:00:00 UTC,2018-03-03 00:00:00 UTC,live,19,HMRC,the-organisation-id,20,21,22,23,9,10,11,12,13,14,15,16,17,18"
+    row = "2018-01-12,content-id,/base-path,en,This is the title,This is the description,Guide,Super Guide,Guide,guidance,2018-02-03 00:00:00 UTC,2018-03-03 00:00:00 UTC,live,19,HMRC,the-organisation-id,20,21,22,23,9,10,11,12,13,14,15,16,17,18,30,31,32,33"
     expect(page.body).to include(row)
   end
 end

--- a/spec/features/sandbox/performance_metrics_spec.rb
+++ b/spec/features/sandbox/performance_metrics_spec.rb
@@ -38,6 +38,10 @@ RSpec.feature 'Performance metrics', type: :feature do
        is_this_useful_yes
        is_this_useful_no
        number_of_internal_searches
+       entrances
+       exits
+       bounce_rate
+       avg_time_on_page
       )
 
     metrics.each do |metric_name|


### PR DESCRIPTION
Add `entrances`, `exits`, `bounce_rate` and `avg_time_on_page` to the sandbox ui and add necessary tests.