### PR TITLE
Default events_gas pageviews and unique_pageviews columns to 0

### DIFF
--- a/db/migrate/20180518133900_change_events_gas_page_views_to_default_to_zero.rb
+++ b/db/migrate/20180518133900_change_events_gas_page_views_to_default_to_zero.rb
@@ -1,0 +1,11 @@
+class ChangeEventsGasPageViewsToDefaultToZero < ActiveRecord::Migration[5.1]
+  def up
+    change_column :events_gas, :pageviews, :integer, default: 0
+    change_column :events_gas, :unique_pageviews, :integer, default: 0
+  end
+
+  def down
+    change_column :events_gas, :pageviews, :integer, default: nil
+    change_column :events_gas, :unique_pageviews, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180515105428) do
+ActiveRecord::Schema.define(version: 20180518133900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,8 +88,8 @@ ActiveRecord::Schema.define(version: 20180515105428) do
   create_table "events_gas", force: :cascade do |t|
     t.date "date"
     t.string "page_path"
-    t.integer "pageviews"
-    t.integer "unique_pageviews"
+    t.integer "pageviews", default: 0
+    t.integer "unique_pageviews", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "is_this_useful_yes", default: 0


### PR DESCRIPTION
A bug exists in our codebase which raises errors when we import GA metrics that do not
include `pageviews` or `unique_pageviews` in their responses. This is because we attempt
to aggregate these metrics when we check for duplication. When we don't receive either of
these metrics in the response from GA our database stores them as `nil` then the code
attempts to add `nil` to an integer and we get an error.

In this PR we change these metrics to default to 0 to fix this bug.