### PR TITLE
Update API to filter by base_path

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -21,7 +21,7 @@ private
   def query_series
     series = Facts::Metric
       .between(from, to)
-      .by_content_id(content_id)
+      .by_base_path(format_base_path_param)
       .by_locale('en')
 
     if facts_metrics.include?(metric)
@@ -36,10 +36,15 @@ private
     end
   end
 
-  delegate :from, :to, :metric, :content_id, to: :metric_params
+  def format_base_path_param
+    #  add '/' as param is received without leading forward slash which is needed to query by base_path.
+    "/#{base_path}"
+  end
+
+  delegate :from, :to, :metric, :base_path, to: :metric_params
 
   def metric_params
-    @metric_params ||= Api::Metric.new(params.permit(:from, :to, :metric, :content_id, :format))
+    @metric_params ||= Api::Metric.new(params.permit(:from, :to, :metric, :base_path, :format))
   end
 
   def validate_params!

--- a/app/models/api/metric.rb
+++ b/app/models/api/metric.rb
@@ -1,25 +1,23 @@
 class Api::Metric
   DATE_REGEX = /\A\d\d\d\d-\d\d-\d\d\Z/
-  CONTENT_ID_REGEX = /\A[0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\Z/i
 
   private_constant :DATE_REGEX
-  private_constant :CONTENT_ID_REGEX
 
   include ActiveModel::Validations
 
-  attr_reader :metric, :from, :to, :content_id
+  attr_reader :metric, :from, :to, :content_id, :base_path
 
   validates :metric, presence: true, inclusion: { in: Rails.configuration.valid_metric_names }
   validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
   validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
-  validates :content_id, presence: true, format: { with: CONTENT_ID_REGEX, message: "Content ID must be a UUID." }
+  validates :base_path, presence: true
   validate :from_before_to, if: :have_a_date_range?
 
   def initialize(params)
     @metric = params[:metric]
     @from = params[:from]
     @to = params[:to]
-    @content_id = params[:content_id]
+    @base_path = params[:base_path]
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     get '/v1/metrics/', to: "metrics#index"
-    get '/v1/metrics/:metric/:content_id/', to: "metrics#summary"
-    get '/v1/metrics/:metric/:content_id/time-series', to: "metrics#time_series"
+    get '/v1/metrics/:metric/:base_path/', to: "metrics#summary"
+    get '/v1/metrics/:metric/:base_path/time-series', to: "metrics#time_series"
     get '/v1/healthcheck', to: "healthcheck#index"
   end
 

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -58,7 +58,9 @@ Type the following to start the server:
 make server API_SPEC=../../openapi.yaml
 ```
 
-You should now be able to view a live preview at http://localhost:4567.
+You should now be able to view a live preview at http://localhost:4567. For
+GOV.UK developers, if you are running this inside of your VM then you can view
+the live preview at dev.gov.uk:4567
 
 ## Publishing changes
 

--- a/doc/api/source/index.html.md.erb
+++ b/doc/api/source/index.html.md.erb
@@ -59,7 +59,8 @@ Contact the GOV.UK Content Performance API team through [Zendesk][].
 
 ### Query the API
 
-To query the API, you need to pass the base_path to the content performance API for the piece of content you are interested in.
+To query the API, you need to pass the base path (the part after 'www.gov.uk')
+to the content performance API for the piece of content you are interested in.
 
 For example, for https://www.gov.uk/vat-rates, the base_path will be "/vat-rates"
 
@@ -106,7 +107,7 @@ You can use the `/metrics/[metric-id]/[base_path]/` endpoint to get the value of
 To summarise the recorded data over a requested time frame:
 
 ```shell
-curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics//vat-rates?from=2018-02-28&to=2018-02-28&metric=pageviews
+curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/vat-rates?from=2018-02-28&to=2018-02-28&metric=pageviews
 ```
 
 The `from` and `to` query parameters specify the date range to query.
@@ -114,7 +115,7 @@ The `from` and `to` query parameters specify the date range to query.
 To get data points for each day in the requested time frame:
 
 ```shell
-curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/time-series//vat-rates?from=2018-02-28&to=2018-02-28&metric=pageviews
+curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/time-series/vat-rates?from=2018-02-28&to=2018-02-28&metric=pageviews
 ```
 
 ## API reference

--- a/doc/api/source/index.html.md.erb
+++ b/doc/api/source/index.html.md.erb
@@ -57,53 +57,11 @@ Contact us through #govuk-developers on [GOV.UK Slack][].
 
 Contact the GOV.UK Content Performance API team through [Zendesk][].
 
-### Find out Content IDs
+### Query the API
 
-To query the API, you need to know the content ID for the piece of content you are interested in.
+To query the API, you need to pass the base_path to the content performance API for the piece of content you are interested in.
 
-You can find out the content ID for GOV.UK pages using the [GOV.UK Content API][].
-
-For example, for https://www.gov.uk/vat-rates, you can query the Content API using the following code:
-
-```shell
-curl https://www.gov.uk/api/content/vat-rates | python -m json.tool # Pretty print JSON
-```
-
-```json
-{
-  "analytics_identifier": null,
-  "base_path": "/vat-rates",
-  "content_id": "f838c22a-b2aa-49be-bd95-153f593293a3",
-  "content_purpose_document_supertype": "guidance",
-  "content_purpose_supergroup": "guidance_and_regulation",
-  "content_purpose_subgroup": "guidance",
-  "document_type": "answer",
-  "email_document_supertype": "other",
-  "first_published_at": "2011-09-12T15:43:03.000+00:00",
-  "government_document_supertype": "other",
-  "locale": "en",
-  "navigation_document_supertype": "guidance",
-  "need_ids": [],
-  "phase": "live",
-  "public_updated_at": "2014-12-12T14:55:23.000+00:00",
-  "publishing_app": "publisher",
-  "publishing_scheduled_at": null,
-  "rendering_app": "government-frontend",
-  "scheduled_publishing_delay_seconds": null,
-  "schema_name": "answer",
-  "search_user_need_document_supertype": "core",
-  "title": "VAT rates",
-  "updated_at": "2018-03-26T16:21:14.213Z",
-  "user_journey_document_supertype": "thing",
-  "withdrawn_notice": {},
-  "publishing_request_id": "3592-1504179295.816-10.3.3.1-410",
-  "links": {...},
-  "description": "Current VAT rates - standard 20% and rates for reduced rate and zero-rated items",
-  "details": {...}
-}
-```
-
-Pass the content_id value to the content performance API.
+For example, for https://www.gov.uk/vat-rates, the base_path will be "/vat-rates"
 
 ## Getting started
 
@@ -143,12 +101,12 @@ curl -H 'Authorization: Bearer your-token-here' https://content-performance-mana
 
 ### Get metrics data for a single piece of content
 
-You can use the `/metrics/[metric-id]/[content-id]/` endpoint to get the value of any metric; for example, the number of page views.
+You can use the `/metrics/[metric-id]/[base_path]/` endpoint to get the value of any metric; for example, the number of page views.
 
 To summarise the recorded data over a requested time frame:
 
 ```shell
-curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/f838c22a-b2aa-49be-bd95-153f593293a3?from=2018-02-28&to=2018-02-28&metric=pageviews
+curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics//vat-rates?from=2018-02-28&to=2018-02-28&metric=pageviews
 ```
 
 The `from` and `to` query parameters specify the date range to query.
@@ -156,7 +114,7 @@ The `from` and `to` query parameters specify the date range to query.
 To get data points for each day in the requested time frame:
 
 ```shell
-curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/time-series/f838c22a-b2aa-49be-bd95-153f593293a3?from=2018-02-28&to=2018-02-28&metric=pageviews
+curl -H 'Authorization: Bearer your-token-here' https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/time-series//vat-rates?from=2018-02-28&to=2018-02-28&metric=pageviews
 ```
 
 ## API reference

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -212,7 +212,7 @@ paths:
       x-code-samples:
         "/metrics/f838c22a-b2aa-49be-bd95-153f593293a3":
           lang: shell
-          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/pageviews//vat-rates?from=2018-02-27&to=2018-02-27'
+          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/pageviews/vat-rates?from=2018-02-27&to=2018-02-27'
 
   /metrics/{metric}/{base_path}/time-series:
     get:
@@ -273,6 +273,6 @@ paths:
                 $ref: "#/components/examples/ErrorExample"
 
       x-code-samples:
-        "/metrics//vat-rates":
+        "/metrics/vat-rates":
           lang: shell
-          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics//vat-rates/time-series?from=2018-02-27&to=2018-02-27&metric=pageviews'
+          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/vat-rates/time-series?from=2018-02-27&to=2018-02-27&metric=pageviews'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -117,7 +117,7 @@ components:
   examples:
     ErrorExample:
       title: "One or more parameters is invalid"
-      invalid_params: {"from":["can't be blank","Dates should use the format YYYY-MM-DD"],"to":["can't be blank","Dates should use the format YYYY-MM-DD"],"content_id":["Content ID must be a UUID."]}
+      invalid_params: {"from":["can't be blank","Dates should use the format YYYY-MM-DD"],"to":["can't be blank","Dates should use the format YYYY-MM-DD"]}
       type: https://content-performance-api.publishing.service.gov.uk/errors/#validation-error
 
     MetricsExample:
@@ -154,7 +154,7 @@ paths:
           lang: shell
           source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/'
 
-  /metrics/{metric}/{content_id}:
+  /metrics/{metric}/{base_path}:
     get:
       summary: Get summarised metrics for a content item.
       description: |
@@ -162,14 +162,14 @@ paths:
       tags:
         - Aggregations
       parameters:
-        - name: 'content_id'
+        - name: 'base path'
           in: path
           required: true
           description: |
-            A GOV.UK content ID. This is a UUID value as used in the Content API.
+            A GOV.UK base path. A reserved URL on www.gov.uk that is associated with a content item.
           schema:
             type: string
-            example: 'f838c22a-b2aa-49be-bd95-153f593293a3'
+            example: '/vat-rates'
         - name: 'metric'
           in: path
           required: true
@@ -212,9 +212,9 @@ paths:
       x-code-samples:
         "/metrics/f838c22a-b2aa-49be-bd95-153f593293a3":
           lang: shell
-          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/pageviews/f838c22a-b2aa-49be-bd95-153f593293a3?from=2018-02-27&to=2018-02-27'
+          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/pageviews//vat-rates?from=2018-02-27&to=2018-02-27'
 
-  /metrics/{metric}/{content_id}/time-series:
+  /metrics/{metric}/{base_path}/time-series:
     get:
       summary: Get metric values for a single content item over a date range.
       description: |
@@ -223,14 +223,14 @@ paths:
       tags:
         - Time series
       parameters:
-        - name: 'content_id'
+        - name: 'base path'
           in: path
           required: true
           description: |
-            A GOV.UK content ID. This is a UUID value as used in the Content API.
+            A GOV.UK base path. A reserved URL on www.gov.uk that is associated with a content item.
           schema:
             type: string
-            example: 'f838c22a-b2aa-49be-bd95-153f593293a3'
+            example: '/vat-rates'
         - name: 'metric'
           in: path
           required: true
@@ -273,6 +273,6 @@ paths:
                 $ref: "#/components/examples/ErrorExample"
 
       x-code-samples:
-        "/metrics/f838c22a-b2aa-49be-bd95-153f593293a3":
+        "/metrics//vat-rates":
           lang: shell
-          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics/f838c22a-b2aa-49be-bd95-153f593293a3/time-series?from=2018-02-27&to=2018-02-27&metric=pageviews'
+          source: curl 'https://content-performance-manager.publishing.service.gov.uk/api/v1/metrics//vat-rates/time-series?from=2018-02-27&to=2018-02-27&metric=pageviews'

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   let!(:day3) { create :dimensions_date, date: Date.new(2018, 1, 15) }
   let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
   let!(:content_id) { SecureRandom.uuid }
+  let!(:base_path) { '/base_path' }
 
-  let!(:item_non_english) { create :dimensions_item, content_id: content_id, locale: 'de' }
+  let!(:item_non_english) { create :dimensions_item, base_path: base_path, locale: 'de', latest: false }
 
   before do
-    item_day1 = create :dimensions_item, content_id: content_id, locale: 'en', latest: true
-    item_day2 = create :dimensions_item, content_id: content_id, locale: 'en', latest: true
+    item_day1 = create :dimensions_item, base_path: base_path, locale: 'en', latest: false
+    item_day2 = create :dimensions_item, base_path: base_path, locale: 'en', latest: true
 
     create :facts_edition, dimensions_item: item_day1, dimensions_date: day1, number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123
     create :facts_edition, dimensions_item: item_day2, dimensions_date: day2, number_of_pdfs: 20, number_of_word_files: 20, readability_score: 5
@@ -31,21 +32,21 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   end
 
   it 'returns the `number of pdfs` between two dates' do
-    get "/api/v1/metrics/number_of_pdfs/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+    get "/api/v1/metrics/number_of_pdfs/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_pdfs'))
   end
 
   it 'returns the `number of word documents` between two dates' do
-    get "/api/v1/metrics/number_of_word_files/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+    get "/api/v1/metrics/number_of_word_files/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
   end
 
   it 'returns the `readability score` between two dates' do
-    get "/api/v1/metrics/readability_score/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+    get "/api/v1/metrics/readability_score/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   let!(:day3) { create :dimensions_date, date: Date.new(2018, 1, 15) }
   let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
   let!(:content_id) { SecureRandom.uuid }
+  let!(:base_path) { '/base_path' }
 
-  let!(:item) { create :dimensions_item, content_id: content_id, locale: 'en' }
+  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, locale: 'en' }
   let!(:item_fr) { create :dimensions_item, content_id: content_id, locale: 'de' }
 
   describe "an API response" do
@@ -44,7 +45,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
   describe "invalid requests" do
     it 'returns an error for metrics not on the whitelist' do
-      get "/api/v1/metrics/number_of_puns/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/number_of_puns/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
       expect(response.status).to eq(400)
 
@@ -60,7 +61,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for badly formatted dates' do
-      get "/api/v1/metrics/pageviews/#{content_id}/time-series", params: { from: 'today', to: '2018-01-15' }
+      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: 'today', to: '2018-01-15' }
 
       expect(response.status).to eq(400)
 
@@ -76,7 +77,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for bad date ranges' do
-      get "/api/v1/metrics/pageviews/#{content_id}/time-series", params: { from: '2018-01-16', to: '2018-01-15' }
+      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: '2018-01-16', to: '2018-01-15' }
 
       expect(response.status).to eq(400)
 
@@ -92,7 +93,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for unknown parameters' do
-      get "/api/v1/metrics/pageviews/#{content_id}/time-series", params: { from: '2018-01-14', to: '2018-01-15', extra: "bla" }
+      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: '2018-01-14', to: '2018-01-15', extra: "bla" }
 
       expect(response.status).to eq(400)
 
@@ -118,14 +119,14 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns `pageviews` values between two dates' do
-      get "/api/v1/metrics/pageviews/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json).to eq(build_time_series_response('pageviews'))
     end
 
     it 'returns `feedex issues` between two dates' do
-      get "/api/v1/metrics/feedex_comments/#{content_id}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/feedex_comments/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(build_time_series_response('feedex_comments'))
@@ -133,7 +134,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
     describe "Summary information" do
       it 'returns sums and latest values' do
-        get "//api/v1/metrics/feedex_comments/#{content_id}", params: { from: '2018-01-13', to: '2018-01-15' }
+        get "//api/v1/metrics/feedex_comments/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15' }
 
         json = JSON.parse(response.body)
 


### PR DESCRIPTION
We are now able to obtain metrics by querying the base_path instead of having to know the content_id of the base_path by which to filter.

We have added the `format_base_path_param` method to the MetricsController to ensure that the base_path is in the format that is expected by the database, so that we can query DimensionsItems by base_path.