### PR TITLE
Add stubbed consumer for bulk import RabbitMQ

### DIFF
--- a/app/streams/publishing_api_bulk_import_consumer.rb
+++ b/app/streams/publishing_api_bulk_import_consumer.rb
@@ -1,0 +1,10 @@
+class PublishingApiBulkImportConsumer
+  def process(message)
+    # TODO: this is just a stubbed consumer to stop Icinga alerts
+    # PublishingApiMessageProcessor.new(message).process
+    message.ack
+  rescue StandardError => e
+    GovukError.notify(e)
+    message.discard
+  end
+end

--- a/spec/streams/publishing_api_bulk_import_consumer_spec.rb
+++ b/spec/streams/publishing_api_bulk_import_consumer_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+require 'publishing_api_bulk_import_consumer'
+require 'govuk_message_queue_consumer/test_helpers'
+
+RSpec.describe PublishingApiBulkImportConsumer do
+  let(:subject) { described_class.new }
+
+  it_behaves_like 'a message queue processor'
+end


### PR DESCRIPTION
We added a new RabbitMQ queue but didn't set up a consumer. We aren't
ready yet for the consumer to do anything, but we are stubbing it
so that we don't get Icinga alerts that check that message queues
aren't being consumed.