### PR TITLE
Update API documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -162,7 +162,7 @@ paths:
       tags:
         - Aggregations
       parameters:
-        - name: 'base path'
+        - name: 'base_path'
           in: path
           required: true
           description: |
@@ -223,7 +223,7 @@ paths:
       tags:
         - Time series
       parameters:
-        - name: 'base path'
+        - name: 'base_path'
           in: path
           required: true
           description: |


### PR DESCRIPTION
Small change required. Changed parameter name from 'base path' to 'base_path'. 
This PR relates to [Trello:Update API to filter by base-path](https://trello.com/c/gU0lwEBx/357-3-update-api-to-filter-by-base-path)