### PR TITLE
Add missing rake task

### DIFF
--- a/lib/tasks/publishing_api_consumer.rake
+++ b/lib/tasks/publishing_api_consumer.rake
@@ -1,10 +1,19 @@
 require_relative '../../app/streams/publishing_api_consumer'
+require_relative '../../app/streams/publishing_api_bulk_import_consumer'
 namespace :publishing_api do
   desc "Run worker to publishing API from rabbitmq"
   task consumer: :environment do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "content_performance_manager",
       processor: PublishingApiConsumer.new,
-      ).run
+    ).run
+  end
+
+  desc "Run worker to publishing API from rabbitmq for bulk import"
+  task bulk_import_consumer: :environment do
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "content_performance_manager_govuk_importer",
+      processor: PublishingApiBulkImportConsumer.new,
+    ).run
   end
 end


### PR DESCRIPTION
Would help if the rake task to start a message queue consumer was
included.