### PR TITLE
Make bulk load consumer preload data

### DIFF
--- a/app/streams/publishing_api/bulk_import_consumer.rb
+++ b/app/streams/publishing_api/bulk_import_consumer.rb
@@ -1,10 +1,30 @@
 class PublishingAPI::BulkImportConsumer
   def process(message)
-    # TODO: this is just a stubbed consumer to stop Icinga alerts
-    # PublishingApiMessageProcessor.new(message).process
+    content_item = PublishingAPI::ContentItem.parse_message(message.payload)
+    metadata = content_item.metadata
+
+    # When preloading data, we always create an item
+    item = Dimensions::Item.create_empty(
+      content_id: content_item.content_id,
+      base_path: content_item.base_path,
+      locale: content_item.locale,
+      payload_version: content_item.payload_version,
+      raw_json: message,
+      **metadata
+    )
+
+    # Do the rest of the import
+    Items::Importers::ContentDetails.run(item.id, current_date.day, current_date.month, current_date.year)
+
     message.ack
   rescue StandardError => e
     GovukError.notify(e)
     message.discard
+  end
+
+private
+
+  def current_date
+    Time.zone.now.to_date
   end
 end

--- a/app/streams/publishing_api/bulk_import_consumer.rb
+++ b/app/streams/publishing_api/bulk_import_consumer.rb
@@ -4,14 +4,20 @@ class PublishingAPI::BulkImportConsumer
     metadata = content_item.metadata
 
     # When preloading data, we always create an item
-    item = Dimensions::Item.create_empty(
-      content_id: content_item.content_id,
-      base_path: content_item.base_path,
-      locale: content_item.locale,
-      payload_version: content_item.payload_version,
-      raw_json: message,
-      **metadata
-    )
+    begin
+      item = Dimensions::Item.create(
+        latest: true,
+        content_id: content_item.content_id,
+        base_path: content_item.base_path,
+        locale: content_item.locale,
+        publishing_api_payload_version: content_item.payload_version,
+        raw_json: message,
+        **metadata
+      )
+    rescue ActiveRecord::RecordNotUnique
+      logger.info "Ignoring duplicate item with content id #{content_item.content_id}. Payload version is #{content_item.payload_version}"
+      return
+    end
 
     # Do the rest of the import
     Items::Importers::ContentDetails.run(item.id, current_date.day, current_date.month, current_date.year)

--- a/app/streams/publishing_api/content_item.rb
+++ b/app/streams/publishing_api/content_item.rb
@@ -1,0 +1,45 @@
+class PublishingAPI::ContentItem
+  attr_reader :content_id
+  attr_reader :base_path
+  attr_reader :payload_version
+  attr_reader :locale
+  attr_reader :metadata
+  attr_reader :details
+  attr_reader :links
+
+  def self.parse_message(message_payload)
+    content_id = message_payload.fetch('content_id')
+    base_path = message_payload.fetch('base_path')
+    payload_version = message_payload.fetch('payload_version')
+    locale = message_payload['locale'] || 'en'
+    metadata = Item::Metadata::Parsers::Metadata.parse(message_payload)
+    details = message_payload.fetch('details')
+    links = message_payload.fetch('expanded_links')
+
+    new(
+      content_id: content_id,
+      base_path: base_path,
+      payload_version: payload_version,
+      locale: locale,
+      links: links,
+      details: details,
+      metadata: metadata,
+    )
+  end
+
+  def initialize(content_id:, base_path:, payload_version:, locale:, links:, details:, metadata:)
+    @content_id = content_id
+    @base_path = base_path
+    @payload_version = payload_version
+    @locale = locale
+    @links = links
+    @details = details
+    @metadata = metadata
+  end
+
+private
+
+  def current_date
+    Time.zone.now.to_date
+  end
+end

--- a/app/streams/publishing_api/message_processor.rb
+++ b/app/streams/publishing_api/message_processor.rb
@@ -1,19 +1,16 @@
 class PublishingAPI::MessageProcessor
   def initialize(message)
-    @content_id = message.payload.fetch('content_id')
-    @base_path = message.payload.fetch('base_path')
-    @payload_version = message.payload.fetch('payload_version')
-    @locale = message.payload['locale'] || 'en'
+    @incoming_content_item = PublishingAPI::ContentItem.parse_message(message.payload)
     @routing_key = message.delivery_info.routing_key
   end
 
   def process
-    item = Dimensions::Item.by_natural_key(content_id: content_id, locale: locale)
+    item = Dimensions::Item.by_natural_key(content_id: incoming_content_item.content_id, locale: incoming_content_item.locale)
 
     if item
       existing_payload_version = item.publishing_api_payload_version
 
-      if payload_version > existing_payload_version
+      if incoming_content_item.payload_version > existing_payload_version
         handle_existing(item)
       else
         # Skip out of date and repeated messages from the publishing API.
@@ -22,24 +19,21 @@ class PublishingAPI::MessageProcessor
         # RabbitMQ guarantees at-least-once delivery when using acknowledgements,
         # so messages can be duplicated, plus we can't guarantee the order of
         # processing because we can have multiple consumers working in parallel.
-        logger.info "Skipping message from publishing API: published with #{payload_version} but we've already received a message with #{item.publishing_api_payload_version}"
+        logger.info "Skipping message from publishing API: published with #{incoming_content_item.payload_version} but we've already received a message with #{item.publishing_api_payload_version}"
       end
     else
       Dimensions::Item.create_empty(
-        content_id: content_id,
-        base_path: base_path,
-        locale: locale,
-        payload_version: payload_version
+        content_id: incoming_content_item.content_id,
+        base_path: incoming_content_item.base_path,
+        locale: incoming_content_item.locale,
+        payload_version: incoming_content_item.payload_version
       )
     end
   end
 
 private
 
-  attr_reader :content_id
-  attr_reader :base_path
-  attr_reader :payload_version
-  attr_reader :locale
+  attr_reader :incoming_content_item
   attr_reader :routing_key
 
   def handle_existing(item)
@@ -54,13 +48,13 @@ private
   end
 
   def handle_new_version(item)
-    new_item = item.copy_to_new_version!(base_path: base_path, payload_version: payload_version)
+    new_item = item.copy_to_new_version!(base_path: incoming_content_item.base_path, payload_version: incoming_content_item.payload_version)
 
     Items::Importers::ContentDetails.run(new_item.id, current_date.day, current_date.month, current_date.year)
   end
 
   def handle_unpublish(item)
-    new_item = item.copy_to_new_version!(base_path: base_path, payload_version: payload_version)
+    new_item = item.copy_to_new_version!(base_path: incoming_content_item.base_path, payload_version: incoming_content_item.payload_version)
     new_item.gone!
   end
 

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe 'PublishingAPI events' do
         'base_path' => base_path,
         'content_id' => content_id,
         'locale' => locale,
-        'payload_version' => payload_version
+        'payload_version' => payload_version,
+        'expanded_links' => {},
+        'details' => {}
       },
       delivery_info: double('del_info', routing_key: 'news_story.major'))
     allow(message).to receive(:ack)

--- a/spec/streams/publishing_api/bulk_import_consumer_spec.rb
+++ b/spec/streams/publishing_api/bulk_import_consumer_spec.rb
@@ -1,7 +1,85 @@
 require 'govuk_message_queue_consumer/test_helpers'
+require 'gds_api/test_helpers/content_store'
 
 RSpec.describe PublishingAPI::BulkImportConsumer do
+  include GdsApi::TestHelpers::ContentStore
+
   let(:subject) { described_class.new }
 
   it_behaves_like 'a message queue processor'
+
+  context "given a detailed guide" do
+    let!(:payload) do
+      GovukSchemas::RandomExample.for_schema(notification_schema: "detailed_guide") do |payload|
+        payload.merge('document_type' => 'detailed_guide', 'locale' => 'en')
+      end
+    end
+
+    # Remove this once we no longer call content store
+    let(:content_store_payload) do
+      GovukSchemas::RandomExample.for_schema(frontend_schema: "detailed_guide") do |example|
+        example.merge!(
+          payload.slice("content_id", "base_path", "document_type", "schema_name", "locale", "public_updated_at", "first_published_at", "title")
+        )
+      end
+    end
+
+    let(:message) do
+      double(
+        'message',
+        payload: payload,
+        delivery_info: double('del_info', routing_key: 'detailed_guide.bulk.data-warehouse')
+      )
+    end
+
+    before do
+      content_store_has_item(content_store_payload["base_path"], content_store_payload, {})
+
+      allow(message).to receive(:ack)
+    end
+
+    it "creates a new item record with format detailed guide and latest=True" do
+      subject.process(message)
+
+      expect(Dimensions::Item.count).to eq(1)
+      item = Dimensions::Item.first
+      expect(item.document_type).to eq('detailed_guide')
+      expect(item.latest).to be true
+    end
+
+    it "schedules a quality metric update job" do
+      expect(Items::Jobs::ImportQualityMetricsJob).to receive(:perform_async)
+
+      subject.process(message)
+    end
+
+    it "hashes the content" do
+      subject.process(message)
+
+      item = Dimensions::Item.first
+      expect(item.content_hash).to be_present
+    end
+
+    it "stores metadata about the content" do
+      subject.process(message)
+
+      item = Dimensions::Item.first
+
+      expect(item).to have_attributes(
+        content_id: payload["content_id"],
+        base_path: payload["base_path"],
+        locale: payload["locale"],
+        title: payload["title"],
+      )
+    end
+
+    it "is idempotent" do
+      subject.process(message)
+      subject.process(message)
+
+      expect(Dimensions::Item.count).to eq(1)
+    end
+  end
+
+  context "given a multi-part guide"
 end

--- a/spec/streams/publishing_api/consumer_spec.rb
+++ b/spec/streams/publishing_api/consumer_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe PublishingAPI::Consumer do
         payload: {
           'base_path' => '/path/to/new/content',
           'content_id' => 'the_content_id',
-          'payload_version' => 1
+          'payload_version' => 1,
+          'expanded_links' => {},
+          'details' => {}
         },
         delivery_info: double('del_info', routing_key: 'news_story.major'))
     end

--- a/spec/streams/publishing_api/content_item_spec.rb
+++ b/spec/streams/publishing_api/content_item_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe PublishingAPI::ContentItem do
+  it "parses a valid message queue message" do
+    payload = GovukSchemas::RandomExample.for_schema(notification_schema: "detailed_guide")
+    item = PublishingAPI::ContentItem.parse_message(payload)
+
+    expect(item.content_id).to eq(payload['content_id'])
+    expect(item.base_path).to eq(payload['base_path'])
+    expect(item.locale).to eq(payload['locale'])
+    expect(item.payload_version).to eq(payload['payload_version'])
+    expect(item.details).to eq(payload['details'])
+    expect(item.links).to eq(payload['expanded_links'])
+    expect(item.metadata[:title]).to eq(payload['title'])
+  end
+
+  it "rejects an invalid message queue message" do
+    payload = { "content_id": "fake-content" }
+    expect { PublishingAPI::ContentItem.parse_message(payload) }.to raise_error(KeyError)
+  end
+end

--- a/spec/streams/publishing_api/message_processor_spec.rb
+++ b/spec/streams/publishing_api/message_processor_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe PublishingAPI::MessageProcessor do
         'locale' => 'de',
         'payload_version' => 2,
         'title' => updated_title,
-        'document_type' => updated_document_type
+        'document_type' => updated_document_type,
+        "expanded_links" => {},
+        "details" => {}
       }
     end
     let!(:message) do
@@ -99,7 +101,8 @@ RSpec.describe PublishingAPI::MessageProcessor do
         'payload_version' => 2,
         'title' => latest_item_en.title,
         'document_type' => latest_item_en.document_type,
-        'expanded_links' => links
+        'expanded_links' => links,
+        'details' => {}
       }
     end
 
@@ -149,7 +152,9 @@ RSpec.describe PublishingAPI::MessageProcessor do
         'base_path' => latest_item_en.base_path,
         'content_id' => latest_item_en.content_id,
         'locale' => 'en',
-        'payload_version' => 2
+        'payload_version' => 2,
+        'details' => {},
+        'expanded_links' => {}
       }
     end
     let!(:message) do
@@ -181,7 +186,9 @@ RSpec.describe PublishingAPI::MessageProcessor do
         'base_path' => '/path/to/new/content',
         'content_id' => 'does-not-exist-yet',
         'locale' => 'en',
-        'payload_version' => 1
+        'payload_version' => 1,
+        'details' => {},
+        'expanded_links' => {}
       }
     end
     let!(:message) do
@@ -210,7 +217,9 @@ RSpec.describe PublishingAPI::MessageProcessor do
         payload: {
           'base_path' => '/path/to/new/content',
           'content_id' => 'the_content_id',
-          'payload_version' => 1
+          'payload_version' => 1,
+          'details' => {},
+          'expanded_links' => {}
         },
         delivery_info: double('del_info', routing_key: 'news_story.major'))
     end
@@ -290,7 +299,9 @@ RSpec.describe PublishingAPI::MessageProcessor do
         'base_path' => base_path,
         'content_id' => content_id,
         'locale' => locale,
-        'payload_version' => payload_version
+        'payload_version' => payload_version,
+        'details' => {},
+        'expanded_links' => {}
       },
       delivery_info: double('del_info', routing_key: 'news_story.major'))
   end


### PR DESCRIPTION
Paired with @chao-xian

This is the first step towards removing the content store integration, and processing multi part documents.

We're going to implement multi parts in the bulk load process first, but we will refactor as we go so that bulk loading doesn't diverge too much from the regular processing.

We've introduced a new class so we can easily extract data from the message queue representation of a content item, instead of the content store one. The next step is to pull out some logic from the existing parsers so that we can tell if an item is multi part or not.