### PR TITLE
Fix Schema error for  'placeholder_working_group' & 'placeholder_worldwide_organisation'

### DIFF
--- a/app/etl/item/content/parsers/no_content.rb
+++ b/app/etl/item/content/parsers/no_content.rb
@@ -17,9 +17,9 @@ class Item::Content::Parsers::NoContent
       placeholder_organisation
       placeholder_policy_area
       placeholder_topical_event
-      placeholer_working_group
+      placeholder_working_group
       placeholder_world_location
-      placehold_worldwide_organisation
+      placeholder_worldwide_organisation
       placeholder_person
       placeholder
       policy

--- a/spec/etl/item/content/no_content_spec.rb
+++ b/spec/etl/item/content/no_content_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Item::Content::Parser do
       placeholder_organisation
       placeholder_policy_area
       placeholder_topical_event
-      placeholer_working_group
+      placeholder_working_group
       placeholder_world_location
-      placehold_worldwide_organisation
+      placeholder_worldwide_organisation
       placeholder_person
       placeholder
       policy


### PR DESCRIPTION
[Trello: Fix: Schema does not exist placeholder_working_group and placeholder_worldwide_organisation](https://trello.com/c/W9lQAw4l/399-1-fix-schema-does-not-exist-placeholderworkinggroup)

Spelling error meant that placeholder_working_group and placeholder_worldwide_organisation were not being handled. This has now been fixed.