### PR TITLE
Fix bug causing no method errors when running content_quality_service

### DIFF
--- a/app/etl/items/importers/quality_metrics.rb
+++ b/app/etl/items/importers/quality_metrics.rb
@@ -14,9 +14,10 @@ class Items::Importers::QualityMetrics
 
   def run
     item = Dimensions::Item.find(@item_id)
-
-    quality_metrics = content_quality_service.run(item.get_content)
-    item.facts_edition.update(**quality_metrics)
+    if item.get_content
+      quality_metrics = content_quality_service.run(item.get_content)
+      item.facts_edition.update(**quality_metrics)
+    end
   rescue InvalidSchemaError
     do_nothing
   end

--- a/spec/etl/items/importers/quality_metrics_spec.rb
+++ b/spec/etl/items/importers/quality_metrics_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe Items::Importers::QualityMetrics do
       )
     end
 
+    it 'returns without running content_quality_service if item has no content' do
+      item = create(:dimensions_item, raw_json: nil)
+      subject { Items::Importers::QualityMetrics.new(item.id) }
+      subject.run
+      expect(subject.content_quality_service).not_to receive(:run)
+    end
+
     it 'creates a fact record' do
       subject.run
 


### PR DESCRIPTION
If item.get_content returns nil then it causes an error to be thrown during our quality_metrics ETL process. This change
inserts a guard clause which tops the content_quality_service from running if item.get_content returns nil.