### PR TITLE
Remove redundant `Reports::Series.for_en` method

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -20,7 +20,6 @@ private
 
   def query_series
     series = Reports::Series.new
-               .for_en
                .between(from: from, to: to)
                .by_base_path(format_base_path_param)
                .run

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -25,7 +25,6 @@ private
 
   def build_series_report
     Reports::Series.new
-      .for_en
       .between(from: from, to: to)
       .by_base_path(base_path)
       .by_organisation_id(organisation)

--- a/app/domain/reports/series.rb
+++ b/app/domain/reports/series.rb
@@ -1,8 +1,4 @@
 class Reports::Series
-  def for_en
-    self
-  end
-
   def between(from:, to:)
     @from = from
     @to = to

--- a/spec/domain/reports/series_spec.rb
+++ b/spec/domain/reports/series_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe Reports::Series do
     it "returns a series of all metrics" do
       item = create(:dimensions_item)
       create(:metric, dimensions_item: item)
-      described_class.new.for_en
+      described_class.new
 
-      expect(described_class.new.for_en.run.one?).to eq(true)
+      expect(described_class.new.run.one?).to eq(true)
     end
   end
 


### PR DESCRIPTION
Reports::Series already defaults to english so there is no need for an explicit for_en method