### PR TITLE
Schema 'role' does not exist

### DIFF
--- a/app/etl/item/content/parsers/no_content.rb
+++ b/app/etl/item/content/parsers/no_content.rb
@@ -24,6 +24,7 @@ class Item::Content::Parsers::NoContent
       placeholder
       policy
       redirect
+      role
       special_route
       topic
       world_location

--- a/spec/etl/item/content/no_content_spec.rb
+++ b/spec/etl/item/content/no_content_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Item::Content::Parser do
       placeholder
       policy
       redirect
+      role
       special_route
       topic
       world_location


### PR DESCRIPTION
[Trello:  Fix: InvalidSchemaError for 'Role' schema](https://trello.com/c/22gQACZc/405-1-fix-invalidschemaerror-for-role-schema)

The schema_name 'role' is a newly created schema. At this stage,
it has been assessed that there is limited value in storing the
content for this schema. Therefore it has been added to the
list of schemas that we are not extracting content from.

This will eliminate any InvalidSchemaError messages for this schema.