### PR TITLE
Move `with_editions_metrics` logic to series model

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -3,19 +3,15 @@ class SandboxController < ApplicationController
 
   def index
     report = build_series_report
+    @metrics = report.run
 
     respond_to do |format|
       format.html do
-        report = report.with_edition_metrics if is_edition_metric?
-
-        @metrics = report.run
         @content_items = report.content_items
         @query_params = query_params
       end
 
       format.csv do
-        @metrics = report.with_edition_metrics.run
-
         export_to_csv enum: CSVExport.run(@metrics, Facts::Metric.csv_fields)
       end
     end
@@ -54,10 +50,5 @@ private
   def query_params
     params.permit(:from, :to, :base_path, :utf8, :organisation, :filter,
       :metric1, :metric2, :metric3, :metric, :document_type)
-  end
-
-  def is_edition_metric?
-    selected_metrics = [params[:metric1], params[:metric2], params[:metric3]]
-    selected_metrics.any? { |metric| Metric.is_edition_metric?(metric) }
   end
 end

--- a/app/domain/reports/series.rb
+++ b/app/domain/reports/series.rb
@@ -6,12 +6,6 @@ class Reports::Series
     self
   end
 
-  def with_edition_metrics
-    @with_edition_metrics = true
-
-    self
-  end
-
   def by_organisation_id(org_id)
     @org_id = org_id
 
@@ -38,8 +32,7 @@ class Reports::Series
     dates = slice_dates
     items = slice_content_items
 
-    metrics = Facts::Metric.all
-    metrics = metrics.with_edition_metrics if @with_edition_metrics
+    metrics = Facts::Metric.all.with_edition_metrics
     metrics
       .joins(:dimensions_item).merge(items)
       .joins(:dimensions_date).merge(dates)

--- a/spec/domain/reports/series_spec.rb
+++ b/spec/domain/reports/series_spec.rb
@@ -3,7 +3,9 @@ RSpec.describe Reports::Series do
     it "returns a series of all metrics" do
       item = create(:dimensions_item)
       create(:metric, dimensions_item: item)
-      described_class.new
+      today = Dimensions::Date.for(Date.today)
+      create(:facts_edition, dimensions_item: item,
+                             dimensions_date: today)
 
       expect(described_class.new.run.one?).to eq(true)
     end
@@ -13,9 +15,12 @@ RSpec.describe Reports::Series do
     it "returns metrics for a given date range" do
       date_from = Dimensions::Date.for(Date.new(2018, 5, 13))
       date_to = Dimensions::Date.for(Date.new(2018, 5, 14))
-      metric1 = create(:metric, dimensions_date: date_from)
-      metric2 = create(:metric, dimensions_date: date_to)
-      create(:metric, dimensions_date: Dimensions::Date.for(Date.new(2018, 5, 24)))
+      item = create(:dimensions_item)
+      create(:facts_edition, dimensions_item: item,
+                             dimensions_date: date_to)
+      metric1 = create(:metric, dimensions_date: date_from, dimensions_item: item)
+      metric2 = create(:metric, dimensions_date: date_to, dimensions_item: item)
+      create(:metric, dimensions_date: Dimensions::Date.for(Date.new(2018, 5, 24)), dimensions_item: item)
       series = described_class.new.between(from: date_from, to: date_to).run
 
       expect(series).to_not be_nil
@@ -56,7 +61,7 @@ RSpec.describe Reports::Series do
       metric2 = create(:metric, dimensions_item: item2, dimensions_date: tomorrow)
       metric3 = create(:metric, dimensions_item: item3, dimensions_date: tomorrow)
 
-      series = described_class.new.with_edition_metrics.run
+      series = described_class.new.run
 
       expect(series).to match_array([metric1, metric2, metric3])
     end
@@ -69,6 +74,8 @@ RSpec.describe Reports::Series do
       day2 = create(:dimensions_date, date: Date.new(2018, 1, 14))
       item1 = create(:dimensions_item, primary_organisation_content_id: 'org-1')
       item2 = create(:dimensions_item, primary_organisation_content_id: 'org-2')
+      create(:facts_edition, dimensions_item: item1, dimensions_date: day0)
+
 
       metric1 = create(:metric, dimensions_item: item1, dimensions_date: day0)
       metric2 = create(:metric, dimensions_item: item1, dimensions_date: day1)
@@ -80,7 +87,11 @@ RSpec.describe Reports::Series do
     end
 
     it 'ignores parameters when blank' do
-      metric = create :metric
+      item = create(:dimensions_item)
+      metric = create(:metric, dimensions_item: item)
+      today = Dimensions::Date.for(Date.today)
+      create(:facts_edition, dimensions_item: item,
+                             dimensions_date: today)
 
       expect(described_class.new.by_organisation_id('').run).to match_array([metric])
     end
@@ -93,6 +104,7 @@ RSpec.describe Reports::Series do
       day2 = create(:dimensions_date, date: Date.new(2018, 1, 14))
       item1 = create(:dimensions_item, base_path: '/path1')
       item2 = create(:dimensions_item, base_path: '/path2')
+      create(:facts_edition, dimensions_item: item1, dimensions_date: day0)
 
       metric1 = create(:metric, dimensions_item: item1, dimensions_date: day0)
       metric2 = create(:metric, dimensions_item: item1, dimensions_date: day1)
@@ -106,7 +118,11 @@ RSpec.describe Reports::Series do
     end
 
     it 'ignores parameters when blank' do
-      metric = create :metric
+      item = create(:dimensions_item)
+      metric = create(:metric, dimensions_item: item)
+      today = Dimensions::Date.for(Date.today)
+      create(:facts_edition, dimensions_item: item,
+                             dimensions_date: today)
 
       expect(described_class.new.by_base_path('').run).to match_array([metric])
     end
@@ -119,6 +135,7 @@ RSpec.describe Reports::Series do
       day2 = create(:dimensions_date, date: Date.new(2018, 1, 14))
       item1 = create(:dimensions_item, base_path: '/path1')
       item2 = create(:dimensions_item, base_path: '/path2')
+      create(:facts_edition, dimensions_item: item1, dimensions_date: day0)
 
       create(:metric, dimensions_item: item1, dimensions_date: day0)
       create(:metric, dimensions_item: item1, dimensions_date: day1)

--- a/spec/features/sandbox/filtering_spec.rb
+++ b/spec/features/sandbox/filtering_spec.rb
@@ -10,7 +10,14 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
   let(:day1) { create :dimensions_date, date: Date.new(2018, 1, 12) }
   let(:day2) { create :dimensions_date, date: Date.new(2018, 1, 13) }
 
+
   describe 'Filtering' do
+    before(:each) do
+      create :facts_edition, dimensions_item: item1,
+                             dimensions_date: day1
+      create :facts_edition, dimensions_item: item2,
+                             dimensions_date: day1
+    end
     let(:item1) { create :dimensions_item, base_path: '/path' }
     let(:item2) { create :dimensions_item, base_path: '/path2' }
 

--- a/spec/features/sandbox/performance_metrics_spec.rb
+++ b/spec/features/sandbox/performance_metrics_spec.rb
@@ -48,6 +48,8 @@ RSpec.feature 'Performance metrics', type: :feature do
       scenario "Show Stats for #{metric_name}" do
         create :metric, dimensions_item: item1, dimensions_date: day0, metric_name => 10
         create :metric, dimensions_item: item2, dimensions_date: day1, metric_name => 10
+        create :facts_edition, dimensions_item: item1, dimensions_date: day0
+        create :facts_edition, dimensions_item: item2, dimensions_date: day0
 
         visit '/sandbox'
 

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20
       create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30
       create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40
+      create :facts_edition, dimensions_item: item, dimensions_date: day1
     end
 
     it 'returns `pageviews` values between two dates' do


### PR DESCRIPTION
In order to give the controller less responsibility, and keep the business logic within the model,
this PR moves the logic around whether or not to provide edition metric to the Reports::Series model.