### PR TITLE
Allow new postgres features in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ library("govuk")
 
 node {
   govuk.buildProject(
+    postgres96Lint: false,
     beforeTest: {
       govuk.setEnvar("TEST_COVERAGE", "true")
     }


### PR DESCRIPTION
https://github.com/alphagov/govuk-jenkinslib/pull/16 is going to add a check to CI to forbid using JSONB and BRIN, as postgres 9.3 doesn't have them.

But this is a special new thing which is allowed to use new features, so we want to disable that check.

---

[Trello card](https://trello.com/c/sX8BEAR3/199-postgres-96-on-integration-follow-up)