### PR TITLE
Move exception closer to where it is used

### DIFF
--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -78,4 +78,7 @@ private
   def parsers
     @parsers ||= {}
   end
+
+  class InvalidSchemaError < StandardError;
+  end
 end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -37,6 +37,3 @@ protected
     update!(latest: false)
   end
 end
-
-class InvalidSchemaError < StandardError;
-end

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Item::Content::Parser do
       describe "has no schema_name and no base_path" do
         it "raises an InvalidSchemaError and returns nil" do
           subject.extract_content document_type: 'answer'
-          expect(GovukError).to receive(:notify).with(InvalidSchemaError.new("Schema does not exist: "), extra: { base_path: "" })
+          expect(GovukError).to receive(:notify).
+            with(Item::Content::Parser::InvalidSchemaError.new("Schema does not exist: "), extra: { base_path: "" })
           expect(subject.extract_content(document_type: 'answer')).to be_nil
         end
       end
@@ -15,7 +16,8 @@ RSpec.describe Item::Content::Parser do
         it "logs InvalidSchemaError with the schema_name" do
           json = { schema_name: "blah", links: {} }
 
-          expect(GovukError).to receive(:notify).with(InvalidSchemaError.new("Schema does not exist: blah"), extra: { base_path: "" })
+          expect(GovukError).to receive(:notify).
+            with(Item::Content::Parser::InvalidSchemaError.new("Schema does not exist: blah"), extra: { base_path: "" })
 
           result = subject.extract_content(json.deep_stringify_keys)
           expect(result).to be_nil
@@ -27,7 +29,8 @@ RSpec.describe Item::Content::Parser do
           json = { base_path: "/unknown/base_path", schema_name: "unknown",
             links: {} }
           subject.extract_content(json.deep_stringify_keys)
-          expect(GovukError).to receive(:notify).with(InvalidSchemaError.new("Schema does not exist: unknown"), extra: { base_path: "/unknown/base_path" })
+          expect(GovukError).to receive(:notify).
+            with(Item::Content::Parser::InvalidSchemaError.new("Schema does not exist: unknown"), extra: { base_path: "/unknown/base_path" })
           expect(subject.extract_content(json.deep_stringify_keys)).to be_nil
         end
       end


### PR DESCRIPTION
It is better to define the exception in the class where it is first
used.