### PR TITLE
Fix InvalidSchemaError for 'knowledge_alpha' schema

### DIFF
--- a/app/etl/item/content/parsers/no_content.rb
+++ b/app/etl/item/content/parsers/no_content.rb
@@ -10,6 +10,7 @@ class Item::Content::Parsers::NoContent
       external_content
       generic
       homepage
+      knowledge_alpha
       organisations_homepage
       person
       placeholder_corporate_information_page

--- a/spec/etl/item/content/no_content_spec.rb
+++ b/spec/etl/item/content/no_content_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Item::Content::Parser do
       external_content
       generic
       homepage
+      knowledge_alpha
       organisations_homepage
       person
       placeholder_corporate_information_page


### PR DESCRIPTION
[Trello: Fix: InvalidSchemaError for 'knowledge_alpha' schema](https://trello.com/c/7k0yHVKE/431-1-fix-invalidschemaerror-for-knowledgealpha-schema)

The schema_name 'knowledge_alpha' is part of an experimental project GOV.UK Voice. At this stage, there is limited value in storing the content for this schema.

This will eliminate any InvalidSchemaError messages for this schema_name.