### PR TITLE
Fix parsing body array

### DIFF
--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -83,6 +83,6 @@ private
     @parsers ||= {}
   end
 
-  class InvalidSchemaError < StandardError;
+  class InvalidSchemaError < StandardError
   end
 end

--- a/app/etl/item/content/parsers/body_content.rb
+++ b/app/etl/item/content/parsers/body_content.rb
@@ -1,6 +1,11 @@
 class Item::Content::Parsers::BodyContent
   def parse(json)
-    json.dig("details", "body")
+    parsed = json.dig("details", "body")
+    if parsed.present? && parsed.is_a?(Array)
+      parsed = Hash[*parsed.map(&:values).flatten].fetch("text/html", nil)
+    end
+
+    parsed
   end
 
   def schemas


### PR DESCRIPTION
Allow for parsing of body returned as array

The content schemas allow for body content to return as a string or
as an array for multiple content types [1] but we had only assumed the
case for strings. This caused issues when we tried to call string
methods on an array.

This was sending a lot of error messages in our logs.

[1]
https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/publishing_api_base.jsonnet#L125
and
https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/publishing_api_base.jsonnet#L129