### PR TITLE
Prevent Content Items with no 'base_path' being stored

### DIFF
--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -1,12 +1,24 @@
 module PublishingAPI
   class Consumer
     def process(message)
+      if is_invalid_message?(message)
+        GovukError.notify(StandardError.new, extra: { payload: message })
+        message.discard
+        return
+      end
+
       PublishingAPI::MessageHandler.process(message)
 
       message.ack
     rescue StandardError => e
       GovukError.notify(e)
       message.discard
+    end
+
+  private
+
+    def is_invalid_message?(message)
+      !message.payload['base_path'].present?
     end
   end
 end

--- a/spec/integration/streams/errors_spec.rb
+++ b/spec/integration/streams/errors_spec.rb
@@ -7,14 +7,35 @@ RSpec.describe PublishingAPI::Consumer do
 
   it_behaves_like 'a message queue processor'
 
-  context 'when an error happens' do
-    let!(:message) { build :message }
+  let!(:message) { build :message }
 
-    before { expect(PublishingAPI::MessageHandler).to receive(:process).and_raise(StandardError.new("An error")) }
+  context 'when an error happens' do
+    before {
+      expect(PublishingAPI::MessageHandler).to receive(:process).and_raise(StandardError.new)
+    }
 
     it "logs the error" do
       expect(GovukError).to receive(:notify).with(instance_of(StandardError))
 
+      expect { subject.process(message) }.to_not raise_error
+    end
+
+    it "discards the message" do
+      expect(message).to receive(:discard)
+
+      subject.process(message)
+    end
+  end
+
+  context "when message has missing mandatory field 'base_path'" do
+    before {
+      allow(PublishingAPI::MessageHandler).to receive(:process).and_raise(StandardError)
+    }
+
+    it "logs the error" do
+      message.payload.delete('base_path')
+
+      expect(GovukError).to receive(:notify).with(StandardError.new, extra: { payload: message })
       expect { subject.process(message) }.to_not raise_error
     end
 


### PR DESCRIPTION
[Trello: Prevent Content Items with no base_path to be stored](https://trello.com/c/4K9bfITJ/416-2-prevent-content-items-with-no-basepath-to-be-stored)

We need to store specific fields from content items into the Data Warehouse. One of the mandatory fields we need to store is 'base_path'. This commit ensures that we only store the content items where there is a 'base_path' field, otherwise we ignore it.