### PR TITLE
Do not store content items with no schema_name

### DIFF
--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -18,7 +18,8 @@ module PublishingAPI
   private
 
     def is_invalid_message?(message)
-      !message.payload['base_path'].present?
+      mandatory_fields = message.payload.values_at('base_path', 'schema_name')
+      mandatory_fields.any?(&:nil?)
     end
   end
 end

--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -2,7 +2,7 @@ module PublishingAPI
   class Consumer
     def process(message)
       if is_invalid_message?(message)
-        GovukError.notify(StandardError.new, extra: { payload: message })
+        GovukError.notify(StandardError.new, extra: { payload: message.payload })
         message.discard
         return
       end

--- a/spec/integration/streams/errors_spec.rb
+++ b/spec/integration/streams/errors_spec.rb
@@ -27,22 +27,39 @@ RSpec.describe PublishingAPI::Consumer do
     end
   end
 
-  context "when message has missing mandatory field 'base_path'" do
+  context "when message has missing mandatory fields" do
     before {
       allow(PublishingAPI::MessageHandler).to receive(:process).and_raise(StandardError)
     }
 
-    it "logs the error" do
-      message.payload.delete('base_path')
+    context "missing field is base_path" do
+      it "logs the error" do
+        message.payload.delete('base_path')
 
-      expect(GovukError).to receive(:notify).with(StandardError.new, extra: { payload: message })
-      expect { subject.process(message) }.to_not raise_error
+        expect(GovukError).to receive(:notify).with(StandardError.new, extra: { payload: message.payload })
+        expect { subject.process(message) }.to_not raise_error
+      end
+
+      it "discards the message" do
+        expect(message).to receive(:discard)
+
+        subject.process(message)
+      end
     end
 
-    it "discards the message" do
-      expect(message).to receive(:discard)
+    context "missing field is schema_name" do
+      it "logs the error" do
+        message.payload.delete('schema_name')
 
-      subject.process(message)
+        expect(GovukError).to receive(:notify).with(StandardError.new, extra: { payload: message.payload })
+        expect { subject.process(message) }.to_not raise_error
+      end
+
+      it "discards the message" do
+        expect(message).to receive(:discard)
+
+        subject.process(message)
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello: Prevent Content Items with no schema_name to be stored](https://trello.com/c/lMqMfAIW/417-2-prevent-content-items-with-no-schemaname-to-be-stored)

We need to store specific fields from content items in the Data Warehouse. One of the mandatory fields is 'schema_name'. We now ensure that we only store the content items where there is a 'schema_name', otherwise we ignore it.

This PR also fixes the payload passed as part of the error log to Sentry. Instead of passing the object we are now passing the actual payload.