### PR TITLE
Do not send Sentry error for invalid messages

### DIFF
--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -2,11 +2,15 @@ module PublishingAPI
   class Consumer
     def process(message)
       if is_invalid_message?(message)
-        GovukError.notify(StandardError.new, extra: { payload: message.payload })
         message.discard
-        return
+      else
+        do_process(message)
       end
+    end
 
+  private
+
+    def do_process(message)
       PublishingAPI::MessageHandler.process(message)
 
       message.ack
@@ -14,8 +18,6 @@ module PublishingAPI
       GovukError.notify(e)
       message.discard
     end
-
-  private
 
     def is_invalid_message?(message)
       mandatory_fields = message.payload.values_at('base_path', 'schema_name')

--- a/spec/integration/streams/errors_spec.rb
+++ b/spec/integration/streams/errors_spec.rb
@@ -33,13 +33,6 @@ RSpec.describe PublishingAPI::Consumer do
     }
 
     context "missing field is base_path" do
-      it "logs the error" do
-        message.payload.delete('base_path')
-
-        expect(GovukError).to receive(:notify).with(StandardError.new, extra: { payload: message.payload })
-        expect { subject.process(message) }.to_not raise_error
-      end
-
       it "discards the message" do
         expect(message).to receive(:discard)
 
@@ -48,13 +41,6 @@ RSpec.describe PublishingAPI::Consumer do
     end
 
     context "missing field is schema_name" do
-      it "logs the error" do
-        message.payload.delete('schema_name')
-
-        expect(GovukError).to receive(:notify).with(StandardError.new, extra: { payload: message.payload })
-        expect { subject.process(message) }.to_not raise_error
-      end
-
       it "discards the message" do
         expect(message).to receive(:discard)
 


### PR DESCRIPTION
We don’t have to take any action if a message is invalid, so
it is better to not raise an exception and send it to Sentry.