### PR TITLE
Rescue publishing api consumer rake tasks to prevent sigterm errors b…

### DIFF
--- a/lib/tasks/publishing_api_consumer.rake
+++ b/lib/tasks/publishing_api_consumer.rake
@@ -3,17 +3,25 @@ require_relative '../../app/streams/publishing_api/consumer'
 namespace :publishing_api do
   desc "Run worker to publishing API from rabbitmq"
   task consumer: :environment do
-    GovukMessageQueueConsumer::Consumer.new(
-      queue_name: "content_performance_manager",
-      processor: PublishingAPI::Consumer.new,
-    ).run
+    begin
+      GovukMessageQueueConsumer::Consumer.new(
+        queue_name: "content_performance_manager",
+        processor: PublishingAPI::Consumer.new,
+      ).run
+    rescue SignalException
+      logger.info "SignalException suppressed"
+    end
   end
 
   desc "Run worker to publishing API from rabbitmq for bulk import"
   task bulk_import_consumer: :environment do
-    GovukMessageQueueConsumer::Consumer.new(
-      queue_name: "content_performance_manager_govuk_importer",
-      processor: PublishingAPI::Consumer.new,
-    ).run
+    begin
+      GovukMessageQueueConsumer::Consumer.new(
+        queue_name: "content_performance_manager_govuk_importer",
+        processor: PublishingAPI::Consumer.new,
+      ).run
+    rescue SignalException
+      logger.info "SignalException suppressed"
+    end
   end
 end


### PR DESCRIPTION
…eing raised

As discussed with @MatMoore, this PR includes no tests due to the fact that there is no good way to test this functionality, and any test written to do so would just be testing the ruby `rescue` method.