### PR TITLE
Support multi-part pages

### DIFF
--- a/app/etl/item/content/parser.rb
+++ b/app/etl/item/content/parser.rb
@@ -5,8 +5,8 @@ class Item::Content::Parser
     register_parsers
   end
 
-  def self.extract_content(*args)
-    instance.extract_content(*args)
+  def self.extract_content(*args, subpage: nil)
+    instance.extract_content(*args, subpage: subpage)
   end
 
   def extract_content(json, subpage: nil)

--- a/app/etl/item/content/parsers/parts.rb
+++ b/app/etl/item/content/parsers/parts.rb
@@ -1,13 +1,19 @@
 class Item::Content::Parsers::Parts
-  def parse(json)
-    html = []
+  def parse_subpage(json, subpage)
     parts = json.dig("details", "parts")
     return if parts.nil?
-    parts.each do |part|
-      html << part["title"]
-      html << part["body"]
+
+    current_part = parts.find { |part| part["slug"] == subpage }
+    return if current_part.nil?
+
+    body = current_part["body"]
+
+    if body.is_a?(Array)
+      body_by_content_type = body.map(&:values).to_h
+      body = body_by_content_type.fetch('text/html', nil)
     end
-    html.join(" ")
+
+    body
   end
 
   def schemas

--- a/app/etl/item/processor.rb
+++ b/app/etl/item/processor.rb
@@ -1,13 +1,14 @@
 class Item::Processor
   attr_reader :item, :date
 
-  def self.run(item, date)
-    new(item: item, date: date).run
+  def self.run(item, date, subpage:)
+    new(item: item, date: date, subpage: subpage).run
   end
 
-  def initialize(item:, date:)
+  def initialize(item:, date:, subpage:)
     @item = item
     @date = date
+    @subpage = subpage
   end
 
   def run

--- a/app/etl/item/processor.rb
+++ b/app/etl/item/processor.rb
@@ -17,7 +17,6 @@ class Item::Processor
       dimensions_date: Dimensions::Date.for(date),
       dimensions_item: item,
     )
-
     unless item.get_content.blank?
       edition.update(Item::Quality::Service.new.run(item.get_content))
     end

--- a/app/etl/item/processor.rb
+++ b/app/etl/item/processor.rb
@@ -1,14 +1,13 @@
 class Item::Processor
-  attr_reader :item, :date, :subpage
+  attr_reader :item, :date
 
-  def self.run(item, date, subpage:)
-    new(item: item, date: date, subpage: subpage).run
+  def self.run(item, date)
+    new(item: item, date: date).run
   end
 
-  def initialize(item:, date:, subpage:)
+  def initialize(item:, date:)
     @item = item
     @date = date
-    @subpage = subpage
   end
 
   def run
@@ -19,9 +18,8 @@ class Item::Processor
       dimensions_item: item,
     )
 
-    content = ::Item::Content::Parser.extract_content(item.raw_json, subpage: subpage)
-    unless content.blank?
-      edition.update(Item::Quality::Service.new.run(content))
+    if item.content.present?
+      edition.update(Item::Quality::Service.new.run(item.content))
     end
   end
 end

--- a/app/etl/item/processor.rb
+++ b/app/etl/item/processor.rb
@@ -1,5 +1,5 @@
 class Item::Processor
-  attr_reader :item, :date
+  attr_reader :item, :date, :subpage
 
   def self.run(item, date, subpage:)
     new(item: item, date: date, subpage: subpage).run
@@ -18,8 +18,10 @@ class Item::Processor
       dimensions_date: Dimensions::Date.for(date),
       dimensions_item: item,
     )
-    unless item.get_content.blank?
-      edition.update(Item::Quality::Service.new.run(item.get_content))
+
+    content = ::Item::Content::Parser.extract_content(item.raw_json, subpage: subpage)
+    unless content.blank?
+      edition.update(Item::Quality::Service.new.run(content))
     end
   end
 end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -12,9 +12,9 @@ class Dimensions::Item < ApplicationRecord
   scope :by_organisation_id, ->(organisation_id) { where(primary_organisation_content_id: organisation_id) }
   scope :by_document_type, ->(document_type) { where('document_type like (?)', document_type) }
   scope :by_locale, ->(locale) { where(locale: locale) }
-  scope :latest_by_content_id, ->(content_id) { where(content_id: content_id, latest: true) }
+  scope :latest_by_content_id, ->(content_id, locale) { where(content_id: content_id, locale: locale, latest: true) }
   scope :latest_by_base_path, ->(base_paths) { where(base_path: base_paths, latest: true) }
-  scope :existing_latest_items, ->(content_id, base_paths) { latest_by_content_id(content_id).or(latest_by_base_path(base_paths)) }
+  scope :existing_latest_items, ->(content_id, locale, base_paths) { latest_by_content_id(content_id, locale).or(latest_by_base_path(base_paths)) }
 
   def newer_than?(other)
     return true unless other

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -38,8 +38,6 @@ class Dimensions::Item < ApplicationRecord
     end
   end
 
-protected
-
   def deprecate!
     update!(latest: false)
   end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -13,12 +13,6 @@ class Dimensions::Item < ApplicationRecord
   scope :by_document_type, ->(document_type) { where('document_type like (?)', document_type) }
   scope :by_locale, ->(locale) { where(locale: locale) }
 
-  def get_content
-    return if raw_json.blank?
-
-    ::Item::Content::Parser.extract_content(raw_json)
-  end
-
   def newer_than?(other)
     return true unless other
 

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -12,6 +12,9 @@ class Dimensions::Item < ApplicationRecord
   scope :by_organisation_id, ->(organisation_id) { where(primary_organisation_content_id: organisation_id) }
   scope :by_document_type, ->(document_type) { where('document_type like (?)', document_type) }
   scope :by_locale, ->(locale) { where(locale: locale) }
+  scope :latest_by_content_id, ->(content_id) { where(content_id: content_id, latest: true) }
+  scope :latest_by_base_path, ->(base_paths) { where(base_path: base_paths, latest: true) }
+  scope :existing_latest_items, ->(content_id, base_paths) { latest_by_content_id(content_id).or(latest_by_base_path(base_paths)) }
 
   def newer_than?(other)
     return true unless other

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -19,7 +19,7 @@ class Dimensions::Item < ApplicationRecord
     ::Item::Content::Parser.extract_content(raw_json)
   end
 
-  def older_than?(other)
+  def newer_than?(other)
     return true unless other
 
     self.publishing_api_payload_version > other.publishing_api_payload_version

--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -1,8 +1,7 @@
 class PublishingAPI::ItemHandler
-  def initialize(old_item:, new_item:, subpage:)
+  def initialize(old_item:, new_item:)
     @old_item = old_item
     @new_item = new_item
-    @subpage = subpage
   end
 
   def process!
@@ -25,7 +24,6 @@ private
 
   attr_reader :old_item
   attr_reader :new_item
-  attr_reader :subpage
 
   def new_version?
     new_item && new_item.newer_than?(old_item)
@@ -42,6 +40,6 @@ private
 
   def grow_dimension!
     new_item.promote!(old_item)
-    Item::Processor.run(new_item, Date.today, subpage: subpage)
+    Item::Processor.run(new_item, Date.today)
   end
 end

--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -1,0 +1,55 @@
+class PublishingAPI::ItemHandler
+  def initialize(old_item:, new_item:, subpage:)
+    @old_item = old_item
+    @new_item = new_item
+    @subpage = subpage
+
+    # old_item may be nil if the item belongs to a brand new document
+    # new_item may be nil if a base_path is reused for a different content id
+    raise ArgumentError if old_item.nil? && new_item.nil?
+  end
+
+  def process!
+    if new_item
+      grow_dimension! if new_version?
+    else
+      deprecate_only!
+    end
+  end
+
+  def process_links!
+    if new_item
+      grow_dimension! if new_version? && links_have_changed?
+    else
+      deprecate_only!
+    end
+  end
+
+private
+
+  attr_reader :old_item
+  attr_reader :new_item
+  attr_reader :subpage
+
+  def new_version?
+    new_item && new_item.newer_than?(old_item)
+  end
+
+  def links_have_changed?
+    return true if old_item.nil?
+
+    HashDiff::Comparison.new(
+      old_item.expanded_links.deep_sort,
+      new_item.expanded_links.deep_sort
+    ).diff.present?
+  end
+
+  def grow_dimension!
+    new_item.promote!(old_item)
+    Item::Processor.run(new_item, Date.today, subpage: subpage)
+  end
+
+  def deprecate_only!
+    old_item.deprecate!
+  end
+end

--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -3,10 +3,6 @@ class PublishingAPI::ItemHandler
     @old_item = old_item
     @new_item = new_item
     @subpage = subpage
-
-    # old_item may be nil if the item belongs to a brand new document
-    # new_item may be nil if a base_path is reused for a different content id
-    raise ArgumentError if old_item.nil? && new_item.nil?
   end
 
   def process!

--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -9,7 +9,7 @@ class PublishingAPI::ItemHandler
     if new_item
       grow_dimension! if new_version?
     else
-      deprecate_only!
+      old_item.deprecate!
     end
   end
 
@@ -17,7 +17,7 @@ class PublishingAPI::ItemHandler
     if new_item
       grow_dimension! if new_version? && links_have_changed?
     else
-      deprecate_only!
+      old_item.deprecate!
     end
   end
 
@@ -43,9 +43,5 @@ private
   def grow_dimension!
     new_item.promote!(old_item)
     Item::Processor.run(new_item, Date.today, subpage: subpage)
-  end
-
-  def deprecate_only!
-    old_item.deprecate!
   end
 end

--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -5,19 +5,11 @@ class PublishingAPI::ItemHandler
   end
 
   def process!
-    if new_item
-      grow_dimension! if new_version?
-    else
-      old_item.deprecate!
-    end
+    grow_dimension! if new_version?
   end
 
   def process_links!
-    if new_item
-      grow_dimension! if new_version? && links_have_changed?
-    else
-      old_item.deprecate!
-    end
+    grow_dimension! if new_version? && links_have_changed?
   end
 
 private

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -16,62 +16,49 @@ module PublishingAPI
     end
 
     def to_dimension_items
-      items = []
       if has_multiple_parts?
-        parts.each do |part|
-          items << Dimensions::Item.new(
+        parts.map do |part|
+          Dimensions::Item.new(
             base_path: base_path_for_part(part),
-            content_id: message.payload.fetch('content_id'),
-            publishing_api_payload_version: message.payload.fetch('payload_version'),
-            document_type: message.payload.fetch('document_type'),
-            locale: message.payload['locale'],
             title: title_for_part(part),
-            content_purpose_document_supertype: message.payload['content_purpose_document_supertype'],
-            content_purpose_supergroup: message.payload['content_purpose_supergroup'],
-            content_purpose_subgroup: message.payload['content_purpose_subgroup'],
-            first_published_at: parse_time('first_published_at'),
-            primary_organisation_content_id: primary_organisation['content_id'],
-            primary_organisation_title: primary_organisation['title'],
-            primary_organisation_withdrawn: primary_organisation['withdrawn'],
-            public_updated_at: parse_time('public_updated_at'),
-            schema_name: message.payload.fetch('schema_name'),
-            latest: true,
-            raw_json: message.payload,
-            content: Item::Content::Parser.extract_content(message.payload, subpage: part['slug'])
+            content: Item::Content::Parser.extract_content(message.payload, subpage: part['slug']),
+            **attributes
           )
         end
       else
-        items << to_dimension_item(message)
+        [
+          Dimensions::Item.new(
+            base_path: base_path,
+            title: title,
+            content: Item::Content::Parser.extract_content(message.payload),
+            **attributes
+          )
+        ]
       end
-
-      items
     end
 
   private
 
     attr_reader :message
 
-    def to_dimension_item(item_message)
-      Dimensions::Item.new(
-        content_id: item_message.payload.fetch('content_id'),
-        base_path: item_message.payload.fetch('base_path'),
-        publishing_api_payload_version: item_message.payload.fetch('payload_version'),
-        document_type: item_message.payload.fetch('document_type'),
-        locale: item_message.payload['locale'],
-        title: item_message.payload['title'],
-        content_purpose_document_supertype: item_message.payload['content_purpose_document_supertype'],
-        content_purpose_supergroup: item_message.payload['content_purpose_supergroup'],
-        content_purpose_subgroup: item_message.payload['content_purpose_subgroup'],
+    def attributes
+      {
+        content_id: content_id,
+        publishing_api_payload_version: message.payload.fetch('payload_version'),
+        document_type: message.payload.fetch('document_type'),
+        locale: message.payload['locale'],
+        content_purpose_document_supertype: message.payload['content_purpose_document_supertype'],
+        content_purpose_supergroup: message.payload['content_purpose_supergroup'],
+        content_purpose_subgroup: message.payload['content_purpose_subgroup'],
         first_published_at: parse_time('first_published_at'),
         primary_organisation_content_id: primary_organisation['content_id'],
         primary_organisation_title: primary_organisation['title'],
         primary_organisation_withdrawn: primary_organisation['withdrawn'],
         public_updated_at: parse_time('public_updated_at'),
-        schema_name: item_message.payload.fetch('schema_name'),
-        latest: true,
-        raw_json: item_message.payload,
-        content: Item::Content::Parser.extract_content(item_message.payload)
-      )
+        schema_name: message.payload.fetch('schema_name'),
+        raw_json: message.payload,
+        latest: true
+      }
     end
 
     def primary_organisation
@@ -89,6 +76,10 @@ module PublishingAPI
 
     def base_path
       message.payload.fetch('base_path')
+    end
+
+    def title
+      message.payload['title']
     end
 
     def base_path_for_part(part)

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -8,6 +8,10 @@ module PublishingAPI
       message.payload["content_id"]
     end
 
+    def locale
+      message.payload['locale']
+    end
+
     def new_dimension_items
       if has_multiple_parts?
         parts.map do |part|
@@ -39,7 +43,7 @@ module PublishingAPI
         content_id: content_id,
         publishing_api_payload_version: message.payload.fetch('payload_version'),
         document_type: message.payload.fetch('document_type'),
-        locale: message.payload['locale'],
+        locale: locale,
         content_purpose_document_supertype: message.payload['content_purpose_document_supertype'],
         content_purpose_supergroup: message.payload['content_purpose_supergroup'],
         content_purpose_subgroup: message.payload['content_purpose_subgroup'],

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -34,7 +34,7 @@ module PublishingAPI
     end
 
     def to_dimension_items
-      if parts.present?
+      if has_multiple_parts?
         parts.each do |part|
           @items << Dimensions::Item.new(
             base_path: message.payload.fetch('base_path') + '/' + part.fetch('slug'),
@@ -63,8 +63,8 @@ module PublishingAPI
       items
     end
 
-    def parts
-      message.payload.dig('details', 'parts')
+    def has_multiple_parts?
+      parts.present?
     end
 
     def primary_organisation
@@ -78,6 +78,10 @@ module PublishingAPI
 
     def parse_time(attribute_name)
       message.payload.fetch(attribute_name, nil)
+    end
+
+    def parts
+      message.payload.dig('details', 'parts')
     end
   end
 end

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -1,33 +1,70 @@
 module PublishingAPI
   class MessageAdapter
-    def self.to_dimension_item(*args)
-      new(*args).to_dimension_item
+    attr_reader :items
+
+    def self.to_dimension_items(*args)
+      new(*args).to_dimension_items
     end
 
     def initialize(message)
       @message = message
+      @items = []
     end
 
-    def to_dimension_item
+    def to_dimension_item(item_message)
       Dimensions::Item.new(
-        content_id: message.payload.fetch('content_id'),
-        base_path: message.payload.fetch('base_path'),
-        publishing_api_payload_version: message.payload.fetch('payload_version'),
-        document_type: message.payload.fetch('document_type'),
-        locale: message.payload['locale'],
-        title: message.payload['title'],
-        content_purpose_document_supertype: message.payload['content_purpose_document_supertype'],
-        content_purpose_supergroup: message.payload['content_purpose_supergroup'],
-        content_purpose_subgroup: message.payload['content_purpose_subgroup'],
+        content_id: item_message.payload.fetch('content_id'),
+        base_path: item_message.payload.fetch('base_path'),
+        publishing_api_payload_version: item_message.payload.fetch('payload_version'),
+        document_type: item_message.payload.fetch('document_type'),
+        locale: item_message.payload['locale'],
+        title: item_message.payload['title'],
+        content_purpose_document_supertype: item_message.payload['content_purpose_document_supertype'],
+        content_purpose_supergroup: item_message.payload['content_purpose_supergroup'],
+        content_purpose_subgroup: item_message.payload['content_purpose_subgroup'],
         first_published_at: parse_time('first_published_at'),
         primary_organisation_content_id: primary_organisation['content_id'],
         primary_organisation_title: primary_organisation['title'],
         primary_organisation_withdrawn: primary_organisation['withdrawn'],
         public_updated_at: parse_time('public_updated_at'),
-        schema_name: message.payload.fetch('schema_name'),
+        schema_name: item_message.payload.fetch('schema_name'),
         latest: true,
-        raw_json: message.payload,
+        raw_json: item_message.payload,
       )
+    end
+
+    def to_dimension_items
+      if parts.present?
+        parts.each do |part|
+          @items << Dimensions::Item.new(
+            base_path: message.payload.fetch('base_path') + '/' + part.fetch('slug'),
+            content_id: message.payload.fetch('content_id'),
+            publishing_api_payload_version: message.payload.fetch('payload_version'),
+            document_type: message.payload.fetch('document_type'),
+            locale: message.payload['locale'],
+            title: message.payload['title'],
+            content_purpose_document_supertype: message.payload['content_purpose_document_supertype'],
+            content_purpose_supergroup: message.payload['content_purpose_supergroup'],
+            content_purpose_subgroup: message.payload['content_purpose_subgroup'],
+            first_published_at: parse_time('first_published_at'),
+            primary_organisation_content_id: primary_organisation['content_id'],
+            primary_organisation_title: primary_organisation['title'],
+            primary_organisation_withdrawn: primary_organisation['withdrawn'],
+            public_updated_at: parse_time('public_updated_at'),
+            schema_name: message.payload.fetch('schema_name'),
+            latest: true,
+            raw_json: message.payload
+          )
+        end
+      else
+        @items << to_dimension_item(message)
+      end
+
+      items
+    end
+
+    def parts
+      message.payload.dig('details', 'parts')
     end
 
     def primary_organisation

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -30,6 +30,7 @@ module PublishingAPI
         schema_name: item_message.payload.fetch('schema_name'),
         latest: true,
         raw_json: item_message.payload,
+        content: Item::Content::Parser.extract_content(item_message.payload)
       )
     end
 
@@ -53,7 +54,8 @@ module PublishingAPI
             public_updated_at: parse_time('public_updated_at'),
             schema_name: message.payload.fetch('schema_name'),
             latest: true,
-            raw_json: message.payload
+            raw_json: message.payload,
+            content: Item::Content::Parser.extract_content(message.payload, subpage: part['slug'])
           )
         end
       else

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -37,12 +37,12 @@ module PublishingAPI
       if has_multiple_parts?
         parts.each do |part|
           @items << Dimensions::Item.new(
-            base_path: message.payload.fetch('base_path') + '/' + part.fetch('slug'),
+            base_path: base_path_for_part(part),
             content_id: message.payload.fetch('content_id'),
             publishing_api_payload_version: message.payload.fetch('payload_version'),
             document_type: message.payload.fetch('document_type'),
             locale: message.payload['locale'],
-            title: message.payload['title'],
+            title: title_for_part(part),
             content_purpose_document_supertype: message.payload['content_purpose_document_supertype'],
             content_purpose_supergroup: message.payload['content_purpose_supergroup'],
             content_purpose_subgroup: message.payload['content_purpose_subgroup'],
@@ -63,6 +63,12 @@ module PublishingAPI
       items
     end
 
+    def subpages_by_base_path
+      return {} unless has_multiple_parts?
+
+      parts.map { |part| [base_path_for_part(part), part.fetch('slug')] }.to_h
+    end
+
     def has_multiple_parts?
       parts.present?
     end
@@ -75,6 +81,19 @@ module PublishingAPI
   private
 
     attr_reader :message
+
+    def base_path
+      message.payload.fetch('base_path')
+    end
+
+    def base_path_for_part(part)
+      slug = part.fetch('slug')
+      base_path + '/' + slug
+    end
+
+    def title_for_part(part)
+      part.fetch('title')
+    end
 
     def parse_time(attribute_name)
       message.payload.fetch(attribute_name, nil)

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -8,6 +8,13 @@ module PublishingAPI
       @message = message
     end
 
+    def existing_dimension_items
+      Dimensions::Item.existing_latest_items(
+        content_id,
+        to_dimension_items.map(&:base_path)
+      )
+    end
+
     def to_dimension_items
       items = []
       if has_multiple_parts?
@@ -74,6 +81,10 @@ module PublishingAPI
 
     def has_multiple_parts?
       parts.present?
+    end
+
+    def content_id
+      message.payload["content_id"]
     end
 
     def base_path

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -4,11 +4,8 @@ module PublishingAPI
       @message = message
     end
 
-    def existing_dimension_items
-      Dimensions::Item.existing_latest_items(
-        content_id,
-        new_dimension_items.map(&:base_path)
-      )
+    def content_id
+      message.payload["content_id"]
     end
 
     def new_dimension_items
@@ -64,10 +61,6 @@ module PublishingAPI
 
     def has_multiple_parts?
       parts.present?
-    end
-
-    def content_id
-      message.payload["content_id"]
     end
 
     def base_path

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -1,9 +1,5 @@
 module PublishingAPI
   class MessageAdapter
-    def self.to_dimension_items(*args)
-      new(*args).to_dimension_items
-    end
-
     def initialize(message)
       @message = message
     end
@@ -11,11 +7,11 @@ module PublishingAPI
     def existing_dimension_items
       Dimensions::Item.existing_latest_items(
         content_id,
-        to_dimension_items.map(&:base_path)
+        new_dimension_items.map(&:base_path)
       )
     end
 
-    def to_dimension_items
+    def new_dimension_items
       if has_multiple_parts?
         parts.map do |part|
           Dimensions::Item.new(

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -39,13 +39,11 @@ private
     new_items = adapter.to_dimension_items
 
     old_items = get_old_items(new_items.map(&:base_path))
-    subpages = adapter.subpages_by_base_path
     result = new_items.map do |new_item|
       old_item = Dimensions::Item.find_by(base_path: new_item.base_path, latest: true)
       PublishingAPI::ItemHandler.new(
         old_item: old_item,
         new_item: new_item,
-        subpage: new_item ? subpages[new_item.base_path] : nil
       )
     end
 

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -1,6 +1,4 @@
 class PublishingAPI::MessageHandler
-  require "deepsort"
-
   def self.process(*args)
     new(*args).process
   end

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -22,7 +22,11 @@ private
   def item_handlers
     adapter = PublishingAPI::MessageAdapter.new(message)
     new_items = adapter.new_dimension_items
-    old_items = adapter.existing_dimension_items
+
+    old_items = Dimensions::Item.existing_latest_items(
+      adapter.content_id,
+      new_items.map(&:base_path)
+    )
 
     result = new_items.map do |new_item|
       old_item = Dimensions::Item.find_by(base_path: new_item.base_path, latest: true)

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -23,7 +23,7 @@ private
 
   def items
     adapter = PublishingAPI::MessageAdapter.new(message)
-    new_items = adapter.to_dimension_items
+    new_items = adapter.new_dimension_items
     old_items = adapter.existing_dimension_items
 
     result = new_items.map do |new_item|

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -36,6 +36,7 @@ private
 
   def items
     adapter = PublishingAPI::MessageAdapter.new(message)
+    subpages = adapter.subpages_by_base_path
     new_items = adapter.to_dimension_items
     new_items_by_base_path = new_items.map { |item| [item.base_path, item] }.to_h
     new_base_paths = new_items_by_base_path.keys
@@ -47,10 +48,14 @@ private
     all_base_paths = new_base_paths.to_set + old_base_paths.to_set
 
     all_base_paths.map do |base_path|
+      old_item = old_items_by_base_path[base_path]
+      new_item = new_items_by_base_path[base_path]
+      subpage = new_item ? subpages[new_item.base_path] : nil
+
       PublishingAPI::ItemHandler.new(
-        old_item: old_items_by_base_path[base_path],
-        new_item: new_items_by_base_path[base_path],
-        subpage: adapter.has_multiple_parts?
+        old_item: old_item,
+        new_item: new_item,
+        subpage: subpage
       )
     end
   end

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -25,6 +25,7 @@ private
 
     old_items = Dimensions::Item.existing_latest_items(
       adapter.content_id,
+      adapter.locale,
       new_items.map(&:base_path)
     )
 

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -36,28 +36,22 @@ private
 
   def items
     adapter = PublishingAPI::MessageAdapter.new(message)
-    subpages = adapter.subpages_by_base_path
     new_items = adapter.to_dimension_items
-    new_items_by_base_path = new_items.map { |item| [item.base_path, item] }.to_h
-    new_base_paths = new_items_by_base_path.keys
 
-    old_items = get_old_items(new_base_paths)
-    old_items_by_base_path = old_items.map { |item| [item.base_path, item] }.to_h
-    old_base_paths = old_items_by_base_path.keys
-
-    all_base_paths = new_base_paths.to_set + old_base_paths.to_set
-
-    all_base_paths.map do |base_path|
-      old_item = old_items_by_base_path[base_path]
-      new_item = new_items_by_base_path[base_path]
-      subpage = new_item ? subpages[new_item.base_path] : nil
-
+    old_items = get_old_items(new_items.map(&:base_path))
+    subpages = adapter.subpages_by_base_path
+    result = new_items.map do |new_item|
+      old_item = Dimensions::Item.find_by(base_path: new_item.base_path, latest: true)
       PublishingAPI::ItemHandler.new(
         old_item: old_item,
         new_item: new_item,
-        subpage: subpage
+        subpage: new_item ? subpages[new_item.base_path] : nil
       )
     end
+
+    old_items.each(&:deprecate!)
+
+    result
   end
 
   def is_links_update?

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -8,12 +8,10 @@ class PublishingAPI::MessageHandler
   end
 
   def process
-    items.each do |item|
-      if is_links_update?
-        item.process_links!
-      else
-        item.process!
-      end
+    if is_links_update?
+      item_handlers.each(&:process_links!)
+    else
+      item_handlers.each(&:process!)
     end
   end
 
@@ -21,7 +19,7 @@ private
 
   attr_reader :message
 
-  def items
+  def item_handlers
     adapter = PublishingAPI::MessageAdapter.new(message)
     new_items = adapter.new_dimension_items
     old_items = adapter.existing_dimension_items

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -13,7 +13,7 @@ class PublishingAPI::MessageHandler
   end
 
   def process
-    return unless new_item.older_than?(old_item)
+    return unless new_item.newer_than?(old_item)
 
     if is_links_update?
       grow_dimension! if links_have_changed?

--- a/db/migrate/20180625120718_add_content_to_dimensions_items.rb
+++ b/db/migrate/20180625120718_add_content_to_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddContentToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180610081625) do
+ActiveRecord::Schema.define(version: 20180625120718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20180610081625) do
     t.string "content_purpose_supergroup"
     t.string "content_purpose_subgroup"
     t.string "schema_name", null: false
+    t.text "content"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"

--- a/spec/etl/item/content/parser_spec.rb
+++ b/spec/etl/item/content/parser_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Item::Content::Parser do
       end
     end
 
+    it 'returns nil if json is empty' do
+      content = subject.extract_content({})
+      expect(content).to be_nil
+    end
+
     context "when invalid schema" do
       describe "has no schema_name and no base_path" do
         it "raises an InvalidSchemaError and returns nil" do

--- a/spec/etl/item/content/parts_spec.rb
+++ b/spec/etl/item/content/parts_spec.rb
@@ -2,40 +2,30 @@ RSpec.describe Item::Content::Parser do
   subject { described_class.instance }
 
   describe "Parts" do
-    it "returns nil if 'guide' schema does not have 'parts' key" do
+    it "returns nil if the json does not have 'parts' key" do
       json = { schema_name: 'guide',
         details: {} }
       expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
     end
 
-    it "returns content json if schema_name is 'guide'" do
+    it "returns nil if the part slug is not present in the parts hash" do
+      json = { schema_name: 'guide',
+        details: { parts: [{ slug: 'bar', body: 'bar', title: 'bar' }] } }
+      expect(subject.extract_content(json.deep_stringify_keys, subpage: 'foo')).to eq(nil)
+    end
+
+    it "returns body text when extracting content for a single part" do
       json = { schema_name: 'guide',
         details: { parts:
           [
-            { title: 'Schools',
+            { slug: 'schools',
+              title: 'Schools',
               body: 'Local council' },
-            { title: 'Appeal',
+            { slug: 'appeal',
+              title: 'Appeal',
               body: 'No placement' }
           ] } }
-      expect(subject.extract_content(json.deep_stringify_keys)).to eq('Schools Local council Appeal No placement')
-    end
-
-    it "returns nil if 'travel_advice' schema does not have 'parts' key" do
-      json = { schema_name: 'travel_advice',
-        details: {} }
-      expect(subject.extract_content(json.deep_stringify_keys)).to eq(nil)
-    end
-
-    it "returns content json if schema_name is 'travel_advice'" do
-      json = { schema_name: 'travel_advice',
-        details: { parts:
-          [
-            { title: 'Some',
-              body: 'Advice' },
-            { title: 'For',
-              body: 'Some Travel' }
-          ] } }
-      expect(subject.extract_content(json.deep_stringify_keys)).to eq('Some Advice For Some Travel')
+      expect(subject.extract_content(json.deep_stringify_keys, subpage: 'schools')).to eq('Local council')
     end
   end
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -25,5 +25,60 @@ FactoryBot.define do
         result.merge! attributes
       end
     end
+
+    trait :with_parts do
+      schema_name 'guide'
+      document_type 'guide'
+      payload do
+        GovukSchemas::RandomExample.for_schema(notification_schema: schema_name) do |result|
+          result['base_path'] = base_path
+          result['payload_version'] = payload_version
+          result['details']['parts'] =
+            [
+              {
+                "title" => "Part 1",
+                "slug" => "part1",
+                "body" => [
+                  {
+                    "content_type" => "text/govspeak",
+                    "content" => "Here 1"
+                  }
+                ]
+              },
+              {
+                "title" => "Part 2",
+                "slug" => "part2",
+                "body" => [
+                  {
+                    "content_type" => "text/govspeak",
+                    "content" => "be 2"
+                  }
+                ]
+              },
+              {
+                "title" => "Part 3",
+                "slug" => "part3",
+                "body" => [
+                  {
+                    "content_type" => "text/govspeak",
+                    "content" => "some 3"
+                  }
+                ]
+              },
+              {
+                "title" => "Part 4",
+                "slug" => "part4",
+                "body" => [
+                  {
+                    "content_type" => "text/govspeak",
+                    "content" => "content 4."
+                  }
+                ]
+              }
+            ]
+          result.merge! attributes
+        end
+      end
+    end
   end
 end

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -7,17 +7,90 @@ RSpec.describe "Process sub-pages for multipart content types" do
 
   before { stub_quality_metrics }
 
-  it "grows dimension for each subpage" do
+  it "grows the dimension for each subpage" do
+    message = build(:message, :with_parts)
+
     expect {
-      subject.process(build(:message, :with_parts))
+      subject.process(message)
     }.to change(Dimensions::Item, :count).by(4)
   end
 
-  # TODO: Tests for
-  # ✅ creates new dimensions for an existing multipage content item
-  # adding a subpage
-  # removing a subpage
-  # renaming a basepath of a subpage
-  # promotes each
-  # demotes each
+  it "deprecates all existing parts even if only one item changed" do
+    message = build(:message, :with_parts)
+    subject.process(message)
+
+    message.payload["details"]["parts"][1]["body"] = "this is a change"
+    message.payload["payload_version"] = message.payload["payload_version"] + 1
+
+    subject.process(message)
+
+    expect(Dimensions::Item.count).to eq(8)
+    expect(Dimensions::Item.where(latest: true).count).to eq(4)
+  end
+
+  it "increases the number of latest items when a subpage is added" do
+    message = build(:message, :with_parts)
+    subject.process(message)
+
+    message.payload.dig("details", "parts") << {
+      "title" => "New thing",
+      "slug" => "new-thing",
+      "body" => [
+        {
+          "content_type" => "text/govspeak",
+          "content" => "New thing"
+        }
+      ]
+    }
+
+    message.payload["payload_version"] = message.payload["payload_version"] + 1
+
+    subject.process(message)
+
+    expect(Dimensions::Item.count).to eq(9)
+    expect(Dimensions::Item.where(latest: true).count).to eq(5)
+  end
+
+  it "decreases the number of latest items when a subpage is removed" do
+    message = build(:message, :with_parts)
+    subject.process(message)
+
+    message.payload.dig("details", "parts").pop
+    message.payload["payload_version"] = message.payload["payload_version"] + 1
+
+    subject.process(message)
+
+    expect(Dimensions::Item.count).to eq(7)
+    expect(Dimensions::Item.where(latest: true).count).to eq(3)
+  end
+
+  it "still grows the dimension if parts are renamed" do
+    message = build(:message, :with_parts)
+    subject.process(message)
+
+    message.payload.dig("details", "parts").first["slug"] = "new-slug"
+    message.payload["payload_version"] = message.payload["payload_version"] + 1
+
+    subject.process(message)
+
+    expect(Dimensions::Item.count).to eq(8)
+    expect(Dimensions::Item.where(latest: true).count).to eq(4)
+  end
+
+  context "when base paths in the message already belong to items with a different content id" do
+    it "deprecates the clashing items" do
+      message = build(:message, :with_parts)
+      message.payload["content_id"] = "df9b33a8-73ae-4504-91a1-4a397cf1f3c5"
+      message.payload["base_path"] = "/some-url"
+      subject.process(message)
+
+      another_message = build(:message, :with_parts)
+      another_message.payload["content_id"] = "db3df7bc-4315-496a-b3b7-4f0e705a2c1f"
+      another_message.payload["base_path"] = "/some-url"
+      subject.process(another_message)
+
+      expect(Dimensions::Item.count).to eq(8)
+      expect(Dimensions::Item.where(latest: true).count).to eq(4)
+    end
+  end
 end

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -29,22 +29,6 @@ RSpec.describe "Process sub-pages for multipart content types" do
     ]
   end
 
-  it "can incrementally reprocess messages containing multiple parts, if some of them fail" do
-    message = build(:message, :with_parts)
-
-    # Let's pretend that an error occurred while processing part 4 and it didn't get stored...
-    part4 = message.payload["details"]["parts"].pop
-    subject.process(message)
-
-    expect(Dimensions::Item.count).to eq(3)
-
-    # Now reprocess the full message
-    message.payload["details"]["parts"].push(part4)
-    subject.process(message)
-
-    expect(Dimensions::Item.count).to eq(4)
-  end
-
   it "deprecates all existing parts even if only one item changed" do
     message = build(:message, :with_parts)
     subject.process(message)

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -1,0 +1,23 @@
+require 'govuk_message_queue_consumer/test_helpers/mock_message'
+
+RSpec.describe "Process sub-pages for multipart content types" do
+  include QualityMetricsHelpers
+
+  let(:subject) { PublishingAPI::Consumer.new }
+
+  before { stub_quality_metrics }
+
+  it "grows dimension for each subpage" do
+    expect {
+      subject.process(build(:message, :with_parts))
+    }.to change(Dimensions::Item, :count).by(4)
+  end
+
+  # TODO: Tests for
+  # ✅ creates new dimensions for an existing multipage content item
+  # adding a subpage
+  # removing a subpage
+  # renaming a basepath of a subpage
+  # promotes each
+  # demotes each
+end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -79,20 +79,6 @@ RSpec.describe Dimensions::Item, type: :model do
     expect(item.raw_json).to eq('a' => 'b')
   end
 
-  describe '#get_content' do
-    it 'returns nil if json is empty' do
-      item = create(:dimensions_item, raw_json: {})
-      expect(item.get_content).to eq(nil)
-    end
-
-    it 'returns the content when json is valid' do
-      json = { 'schema_name' => 'valid' }
-      item = create(:dimensions_item, raw_json: json)
-      expect(Item::Content::Parser).to receive(:extract_content).with(json).and_return('the content')
-      expect(item.get_content).to eq('the content')
-    end
-  end
-
   describe '#promote!' do
     let(:item) { build :dimensions_item, latest: false }
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -50,25 +50,25 @@ RSpec.describe Dimensions::Item, type: :model do
     end
   end
 
-  describe '#older_than?' do
+  describe '#newer_than?' do
     let(:dimension_item) { build :dimensions_item, publishing_api_payload_version: 10 }
 
     it 'returns true when compared with `nil`' do
       other = nil
 
-      expect(dimension_item.older_than?(other)).to be true
+      expect(dimension_item.newer_than?(other)).to be true
     end
 
     it 'returns true if the payload version is bigger' do
       other = build :dimensions_item, publishing_api_payload_version: 9
 
-      expect(dimension_item.older_than?(other)).to be true
+      expect(dimension_item.newer_than?(other)).to be true
     end
 
     it 'returns false if the payload version is smaller' do
       other = build :dimensions_item, publishing_api_payload_version: 11
 
-      expect(dimension_item.older_than?(other)).to be false
+      expect(dimension_item.newer_than?(other)).to be false
     end
   end
 

--- a/spec/streams/publishing_api/message_adapter_spec.rb
+++ b/spec/streams/publishing_api/message_adapter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
       end
 
       event = build(:message, payload: payload, routing_key: 'the-key')
-      dimension_item = subject.to_dimension_item(event)
+      dimension_item = subject.to_dimension_items(event)[0]
 
       expect(dimension_item).to have_attributes(
         content_id: payload.fetch('content_id'),
@@ -54,7 +54,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
       end
 
       event = build(:message, payload: payload, routing_key: 'the-key')
-      dimension_item = subject.to_dimension_item(event)
+      dimension_item = subject.to_dimension_items(event)[0]
 
       expect(dimension_item).to have_attributes(
         primary_organisation_content_id: 'ce91c056-8165-49fe-b318-b71113ab4a30',
@@ -72,7 +72,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         it "transfom schema: `#{schema_name}` with no errors" do
           event = build(:message, payload: payload, routing_key: 'the-key')
 
-          expect { subject.to_dimension_item(event) }.to_not raise_error
+          expect { subject.to_dimension_items(event) }.to_not raise_error
         end
       end
     end

--- a/spec/streams/publishing_api/message_adapter_spec.rb
+++ b/spec/streams/publishing_api/message_adapter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PublishingAPI::MessageAdapter do
   subject { described_class }
 
-  describe '.to_dimension_item' do
+  describe '.new_dimension_items' do
     it 'convert an Event into a Dimensions::Item' do
       payload = GovukSchemas::RandomExample.for_schema(notification_schema: 'detailed_guide') do |result|
         result.merge!(
@@ -20,7 +20,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
       end
 
       event = build(:message, payload: payload, routing_key: 'the-key')
-      dimension_item = subject.to_dimension_items(event)[0]
+      dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(
         content_id: payload.fetch('content_id'),
@@ -57,7 +57,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
       end
 
       event = build(:message, payload: payload, routing_key: 'the-key')
-      dimension_item = subject.to_dimension_items(event)[0]
+      dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(
         primary_organisation_content_id: 'ce91c056-8165-49fe-b318-b71113ab4a30',
@@ -75,13 +75,13 @@ RSpec.describe PublishingAPI::MessageAdapter do
         it "transfom schema: `#{schema_name}` with no errors" do
           event = build(:message, payload: payload, routing_key: 'the-key')
 
-          expect { subject.to_dimension_items(event) }.to_not raise_error
+          expect { subject.new(event).new_dimension_items }.to_not raise_error
         end
       end
     end
   end
 
-  describe '.to_dimension_items' do
+  describe '.new_dimension_items' do
     let(:payload) do
       GovukSchemas::RandomExample.for_schema(notification_schema: 'guide') do |result|
         result.merge!(
@@ -107,14 +107,14 @@ RSpec.describe PublishingAPI::MessageAdapter do
 
     it 'convert an multipart event into a set of Dimensions::Items' do
       event = build(:message, payload: payload, routing_key: 'the-key')
-      result = subject.to_dimension_items(event)
+      result = subject.new(event).new_dimension_items
 
       expect(result.length).to eq(2)
     end
 
     it 'extracts page attributes into the Item' do
       event = build(:message, payload: payload, routing_key: 'the-key')
-      dimension_item = subject.to_dimension_items(event)[0]
+      dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(
         content_id: payload.fetch('content_id'),


### PR DESCRIPTION
This adds support for storing individual parts of multi-part pages (guides and travel advice).

More details in the individual commit messages. There are specs in `spec/integration/streams/process_sub_pages_spec.rb` and I recommend reviewing those first, as there may be edge cases I've missed.

Trello: https://trello.com/c/oDKoKiim/415-5-update-etl-to-handle-sub-pages-for-guides-basepath