### PR TITLE
Fix bug in links_have_changed logic in message_handler

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -30,6 +30,14 @@ class Dimensions::Item < ApplicationRecord
     update(latest: true)
   end
 
+  def expanded_links
+    if raw_json && raw_json['expanded_links']
+      raw_json['expanded_links']
+    else
+      {}
+    end
+  end
+
 protected
 
   def deprecate!

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -32,10 +32,11 @@ private
   end
 
   def links_have_changed?
-    current_links = old_item.raw_json['expanded_links'].deep_sort
-    new_links = new_item.raw_json['expanded_links'].deep_sort
-
-    HashDiff::Comparison.new(current_links, new_links).diff.present?
+    return true if old_item.nil?
+    HashDiff::Comparison.new(
+      old_item.expanded_links.deep_sort,
+      new_item.expanded_links.deep_sort
+    ).diff.present?
   end
 
   def grow_dimension!

--- a/spec/integration/streams/on_links_update_message_spec.rb
+++ b/spec/integration/streams/on_links_update_message_spec.rb
@@ -82,4 +82,31 @@ RSpec.describe PublishingAPI::Consumer do
       subject.process(link_update)
     }.to change(Dimensions::Item, :count).by(0)
   end
+
+  it 'does not raise error if `old_item` does not exist' do
+    expect(GovukError).to_not receive(:notify)
+
+    link_update = build :message, :link_update
+    link_update.payload['payload_version'] = 2
+    link_update.payload['expanded_links'] = nil
+    expect {
+      subject.process(link_update)
+    }.to_not raise_error
+  end
+
+  it 'does not raise error if `expanded_links` field is not present' do
+    expect(GovukError).to_not receive(:notify)
+
+    message = build(:message)
+    message.payload['payload_version'] = 1
+    message.payload['expanded_links'] = nil
+    subject.process(message)
+
+    link_update = build :message, :link_update, payload: message.payload
+    link_update.payload['payload_version'] = 2
+    link_update.payload['expanded_links'] = nil
+    expect {
+      subject.process(link_update)
+    }.to_not raise_error
+  end
 end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -109,4 +109,37 @@ RSpec.describe Dimensions::Item, type: :model do
       expect(old_item.latest).to be false
     end
   end
+
+  describe '#expanded_links' do
+    let(:item) { build :dimensions_item }
+    context 'when item has raw_json' do
+      it 'returns `expanded links` if raw_json has the `expanded_links` field' do
+        raw_json = {
+          'expanded_links' => [
+            {
+              'name' => 'tax-rates',
+              'url' => '/tax_rates'
+            },
+            {
+              'name' => 'vat-rates',
+              'url' => '/vat_rates'
+            }
+          ]
+        }
+        item.update_attributes(raw_json: raw_json)
+        expect(item.expanded_links).to eq raw_json['expanded_links']
+      end
+
+      it 'returns an empty hash if raw json does not have `expanded_links` field' do
+        expect(item.expanded_links).to eq Hash.new
+      end
+    end
+
+    context 'when item does not have raw_json' do
+      it 'returns empty hash' do
+        item.update_attributes(raw_json: nil)
+        expect(item.expanded_links).to eq Hash.new
+      end
+    end
+  end
 end


### PR DESCRIPTION
We are getting a lot of errors when we try to compared links for items in which 'expanded_links' field
is not included in their raw_json field. This PR checks for the presence of `expanded_links` before it
compares the values.