### PR TITLE
Fix parts bug

### DIFF
--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -14,9 +14,9 @@ module PublishingAPI
 
     def new_dimension_items
       if has_multiple_parts?
-        parts.map do |part|
+        parts.each_with_index.map do |part, index|
           Dimensions::Item.new(
-            base_path: base_path_for_part(part),
+            base_path: base_path_for_part(part, index),
             title: title_for_part(part),
             content: Item::Content::Parser.extract_content(message.payload, subpage: part['slug']),
             **attributes
@@ -75,9 +75,9 @@ module PublishingAPI
       message.payload['title']
     end
 
-    def base_path_for_part(part)
+    def base_path_for_part(part, index)
       slug = part.fetch('slug')
-      base_path + '/' + slug
+      index.zero? ? base_path : base_path + '/' + slug
     end
 
     def title_for_part(part)

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     parts = Dimensions::Item.pluck(:base_path, :title).to_set
 
     expect(parts).to eq Set[
-      ["/base-path/part1", "Part 1"],
+      ["/base-path", "Part 1"],
       ["/base-path/part2", "Part 2"],
       ["/base-path/part3", "Part 3"],
       ["/base-path/part4", "Part 4"]

--- a/spec/streams/publishing_api/message_adapter_spec.rb
+++ b/spec/streams/publishing_api/message_adapter_spec.rb
@@ -114,11 +114,23 @@ RSpec.describe PublishingAPI::MessageAdapter do
 
     it 'extracts page attributes into the Item' do
       event = build(:message, payload: payload, routing_key: 'the-key')
+      dimension_item = subject.new(event).new_dimension_items[1]
+
+      expect(dimension_item).to have_attributes(
+        content_id: payload.fetch('content_id'),
+        base_path: '/root/part2',
+        title: 'part 2',
+        content: 'part 2 content',
+      )
+    end
+
+    it 'the first page of multipart pages do not have a slug in the url' do
+      event = build(:message, payload: payload, routing_key: 'the-key')
       dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(
         content_id: payload.fetch('content_id'),
-        base_path: '/root/part1',
+        base_path: '/root',
         title: 'part 1',
         content: 'part 1 content',
       )


### PR DESCRIPTION
The first part of multipart content items should not have the slug appended to the base path.
This PR fixes this issue.