### PR TITLE
Don't return nil from quality service

### DIFF
--- a/app/etl/item/quality/service.rb
+++ b/app/etl/item/quality/service.rb
@@ -4,8 +4,6 @@ class Item::Quality::Service
   def run(content)
     parsed_response = fetch(content)
     convert_results(parsed_response, content)
-  rescue StandardError => e
-    GovukError.notify(e, extra: { content: content, message: e.message })
   end
 
 private
@@ -18,7 +16,7 @@ private
       body: { content: content }.to_json,
       headers: { 'Content-Type' => 'application/json' }
     )
-    raise QualityMetricsError("response body: #{response.body}") unless response.code == 200
+    raise QualityMetricsError.new("response body: #{response.body}") unless response.code == 200
     response.parsed_response
   end
 


### PR DESCRIPTION
If there is an error in the quality service, just let it fail.
At the moment, we catch the error, raise a notification, but
then return nil. The caller then throws another exception.

This also fixes a bug in the code that throws the QualityMetricsError
exception.