### PR TITLE
Introduce helper to remove noise from tests

### DIFF
--- a/spec/etl/ga/internal_search_processor_spec.rb
+++ b/spec/etl/ga/internal_search_processor_spec.rb
@@ -1,20 +1,18 @@
 require "gds-api-adapters"
+require 'traceable'
 
 RSpec.describe GA::InternalSearchProcessor do
+  include MetricsHelpers
   subject { described_class }
 
-  let!(:item1) { create :dimensions_item, base_path: "/path1", latest: true }
-  let!(:item2) { create :dimensions_item, base_path: "/path2", latest: true }
-
   let(:date) { Date.new(2018, 2, 20) }
-  let(:dimensions_date) { Dimensions::Date.for(date) }
 
   context "When the base_path matches the GA path" do
     before { allow(GA::InternalSearchService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it "updates the facts with GA metrics" do
-      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
-      fact2 = create :metric, dimensions_item: item2, dimensions_date: dimensions_date
+      fact1 = create_metric base_path: "/path1", date: '2018-02-20'
+      fact2 = create_metric base_path: "/path2", date: '2018-02-20'
 
       described_class.process(date: date)
 
@@ -23,7 +21,7 @@ RSpec.describe GA::InternalSearchProcessor do
     end
 
     it "does not update metrics for other days" do
-      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date, number_of_internal_searches: 20
+      fact1 = create_metric base_path: "/path1", date: '2018-02-20', daily: { number_of_internal_searches: 20 }
 
       day_before = date - 1
       described_class.process(date: day_before)
@@ -32,8 +30,7 @@ RSpec.describe GA::InternalSearchProcessor do
     end
 
     it "does not update metrics for other items" do
-      item = create :dimensions_item, base_path: "/non-matching-path", latest: true
-      fact = create :metric, dimensions_item: item, dimensions_date: dimensions_date, number_of_internal_searches: 99
+      fact = create_metric base_path: "/non-matching-path", date: '2018-02-20', daily: { number_of_internal_searches: 99 }
 
       described_class.process(date: date)
 
@@ -55,7 +52,7 @@ RSpec.describe GA::InternalSearchProcessor do
       end
 
       it "only updates metrics for the current day" do
-        fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+        fact1 = create_metric base_path: '/path1', date: '2018-02-20'
 
         described_class.process(date: date)
 

--- a/spec/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/etl/ga/views_and_navigation_processor_spec.rb
@@ -1,21 +1,22 @@
 require 'gds-api-adapters'
+require 'traceable'
 
 RSpec.describe GA::ViewsAndNavigationProcessor do
+  include MetricsHelpers
   subject { described_class }
 
   let!(:item1) { create :dimensions_item, base_path: '/path1', latest: true }
   let!(:item2) { create :dimensions_item, base_path: '/path2', latest: true }
 
   let(:date) { Date.new(2018, 2, 20) }
-  let(:dimensions_date) { Dimensions::Date.for(date) }
 
 
   context 'When the base_path matches the GA path' do
     before { allow(GA::ViewsAndNavigationService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it 'update the facts with the GA metrics' do
-      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
-      fact2 = create :metric, dimensions_item: item2, dimensions_date: dimensions_date
+      fact1 = create_metric base_path: '/path1', date: '2018-02-20'
+      fact2 = create_metric base_path: '/path2', date: '2018-02-20'
 
       described_class.process(date: date)
 
@@ -24,7 +25,7 @@ RSpec.describe GA::ViewsAndNavigationProcessor do
     end
 
     it 'does not update metrics for other days' do
-      fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date, pageviews: 20, unique_pageviews: 10
+      fact1 = create_metric base_path: '/path1', date: '2018-02-20', daily: { pageviews: 20, unique_pageviews: 10 }
 
       day_before = date - 1
       described_class.process(date: day_before)
@@ -33,8 +34,7 @@ RSpec.describe GA::ViewsAndNavigationProcessor do
     end
 
     it 'does not update metrics for other items' do
-      item = create :dimensions_item, base_path: '/non-matching-path', latest: true
-      fact = create :metric, dimensions_item: item, dimensions_date: dimensions_date, pageviews: 99, unique_pageviews: 90
+      fact = create_metric base_path: '/non-matching-path', date: '2018-02-20', daily: { pageviews: 99, unique_pageviews: 90 }
 
       described_class.process(date: date)
 
@@ -56,7 +56,7 @@ RSpec.describe GA::ViewsAndNavigationProcessor do
       end
 
       it 'only updates metrics for the current day' do
-        fact1 = create :metric, dimensions_item: item1, dimensions_date: dimensions_date
+        fact1 = create_metric base_path: '/path1', date: '2018-02-20'
 
         described_class.process(date: date)
 

--- a/spec/factories/dimensions_date.rb
+++ b/spec/factories/dimensions_date.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :dimensions_date, class: Dimensions::Date do
     sequence(:date) { |i| i.days.ago.to_date }
 
-    initialize_with { Dimensions::Date.build(date) }
+    initialize_with { Dimensions::Date.for(date) }
   end
 end

--- a/spec/factories/dimensions_items.rb
+++ b/spec/factories/dimensions_items.rb
@@ -10,5 +10,7 @@ FactoryBot.define do
     sequence(:publishing_api_payload_version)
     schema_name 'detailed_guide'
     document_type 'detailed_guide'
+
+    initialize_with { Dimensions::Item.find_or_create_by(base_path: base_path, latest: latest) }
   end
 end

--- a/spec/features/sandbox/performance_metrics_spec.rb
+++ b/spec/features/sandbox/performance_metrics_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature 'Performance metrics', type: :feature do
+  include MetricsHelpers
   before do
     create(:user)
   end
@@ -7,16 +8,10 @@ RSpec.feature 'Performance metrics', type: :feature do
     Timecop.freeze(Date.new(2018, 1, 15)) { example.run }
   end
 
-  let(:day0) { create :dimensions_date, date: Date.new(2018, 1, 12) }
-  let(:day1) { create :dimensions_date, date: Date.new(2018, 1, 13) }
-
   scenario 'Show total of content items' do
-    item1 = create :dimensions_item
-    item2 = create :dimensions_item
-
-    create :metric, dimensions_item: item1, dimensions_date: day0
-    create :metric, dimensions_item: item1, dimensions_date: day1
-    create :metric, dimensions_item: item2, dimensions_date: day1
+    create_metric base_path: '/path/1', date: '2018-01-12'
+    create_metric base_path: '/path/1', date: '2018-01-13'
+    create_metric base_path: '/path/2', date: '2018-01-13'
 
     visit '/sandbox'
 
@@ -28,9 +23,6 @@ RSpec.feature 'Performance metrics', type: :feature do
   end
 
   context 'Performance metrics' do
-    let(:item1) { create :dimensions_item }
-    let(:item2) { create :dimensions_item }
-
     metrics = %w(
        pageviews
        unique_pageviews
@@ -46,10 +38,8 @@ RSpec.feature 'Performance metrics', type: :feature do
 
     metrics.each do |metric_name|
       scenario "Show Stats for #{metric_name}" do
-        create :metric, dimensions_item: item1, dimensions_date: day0, metric_name => 10
-        create :metric, dimensions_item: item2, dimensions_date: day1, metric_name => 10
-        create :facts_edition, dimensions_item: item1, dimensions_date: day0
-        create :facts_edition, dimensions_item: item2, dimensions_date: day0
+        create_metric base_path: '/path/1', date: '2018-01-12', daily: { metric_name => 10 }
+        create_metric base_path: '/path/2', date: '2018-01-13', daily: { metric_name => 10 }
 
         visit '/sandbox'
 

--- a/spec/features/sandbox/quality_metrics_spec.rb
+++ b/spec/features/sandbox/quality_metrics_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature 'Quality metrics', type: :feature do
+  include MetricsHelpers
   before do
     create(:user)
   end
@@ -6,9 +7,6 @@ RSpec.feature 'Quality metrics', type: :feature do
   around do |example|
     Timecop.freeze(Date.new(2018, 1, 15)) { example.run }
   end
-
-  let(:day0) { create :dimensions_date, date: Date.new(2018, 1, 12) }
-  let(:day1) { create :dimensions_date, date: Date.new(2018, 1, 13) }
 
   context 'Content metrics' do
     metrics = %w(
@@ -31,14 +29,8 @@ RSpec.feature 'Quality metrics', type: :feature do
 
     metrics.each do |metric_name|
       scenario "Show Stats for #{metric_name}" do
-        item1 = create :dimensions_item
-        item2 = create :dimensions_item
-
-        create :metric, dimensions_item: item1, dimensions_date: day0
-        create :metric, dimensions_item: item2, dimensions_date: day1
-
-        create :facts_edition, dimensions_item: item1, dimensions_date: day0, metric_name => 10
-        create :facts_edition, dimensions_item: item2, dimensions_date: day1, metric_name => 10
+        create_metric base_path: '/path/1', date: '2018-01-12', edition: { metric_name => 10 }
+        create_metric base_path: '/path/2', date: '2018-01-13', edition: { metric_name => 10 }
 
         visit '/sandbox'
 

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -1,28 +1,24 @@
 require 'securerandom'
 
 RSpec.describe '/api/v1/metrics/', type: :request do
+  include MetricsHelpers
   before { create(:user) }
 
-  let!(:day1) { create :dimensions_date, date: Date.new(2018, 1, 13) }
-  let!(:day2) { create :dimensions_date, date: Date.new(2018, 1, 14) }
-  let!(:day3) { create :dimensions_date, date: Date.new(2018, 1, 15) }
-  let!(:day4) { create :dimensions_date, date: Date.new(2018, 1, 16) }
-  let!(:content_id) { SecureRandom.uuid }
   let!(:base_path) { '/base_path' }
 
   before do
-    item_day1 = create :dimensions_item, base_path: base_path, locale: 'en', latest: false
-    item_day2 = create :dimensions_item, base_path: base_path, locale: 'en', latest: true
-
-    create :facts_edition, dimensions_item: item_day1, dimensions_date: day1, number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123
-    create :facts_edition, dimensions_item: item_day2, dimensions_date: day2, number_of_pdfs: 20, number_of_word_files: 20, readability_score: 5
-
-    create :dimensions_item, content_id: content_id, locale: 'en'
-
-    create :metric, dimensions_item: item_day1, dimensions_date: day1
-    create :metric, dimensions_item: item_day2, dimensions_date: day2
-    create :metric, dimensions_item: item_day2, dimensions_date: day3
-    create :metric, dimensions_item: item_day2, dimensions_date: day4
+    create_metric(base_path: base_path, date: '2018-01-13',
+      edition: {
+        number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123
+      },
+      item: { latest: false })
+    create_metric(base_path: base_path, date: '2018-01-14',
+      edition: {
+        number_of_pdfs: 20, number_of_word_files: 20, readability_score: 5
+      },
+      item: { latest: true })
+    create_metric base_path: base_path, date: '2018-01-15'
+    create_metric base_path: base_path, date: '2018-01-16'
   end
 
   it 'returns the `number of pdfs` between two dates' do

--- a/spec/support/metrics_helpers.rb
+++ b/spec/support/metrics_helpers.rb
@@ -1,0 +1,32 @@
+module MetricsHelpers
+  def create_metric(base_path:, date:, edition: {}, daily: {}, item: {})
+    dimensions_item = dimensions_item(item.merge(base_path: base_path))
+    dimensions_date = dimensions_date(date)
+    ensure_edition_exists(dimensions_item, dimensions_date, edition)
+    create :metric, daily.merge(
+      dimensions_date: dimensions_date,
+      dimensions_item: dimensions_item
+    )
+  end
+
+private
+
+  def ensure_edition_exists(dimensions_item, dimensions_date, edition_attrs)
+    if Facts::Edition.find_by(dimensions_item: dimensions_item).nil?
+      create(:facts_edition, edition_attrs.merge(dimensions_item: dimensions_item, dimensions_date: dimensions_date))
+    end
+  end
+
+  def dimensions_item(attrs)
+    create(:dimensions_item, attrs)
+  end
+
+  def dimensions_date(date)
+    create(:dimensions_date, date: get_date(date))
+  end
+
+  def get_date(date_or_str)
+    return Date.parse(date_or_str) if date_or_str.class == String
+    date_or_str
+  end
+end


### PR DESCRIPTION
Introduced MetricsHelpers to allow a simple way to
create metrics in tests and refactored tests to use them.

You can now create a metric with code like:

create_metric base_path: base_path, latest: false, date: '2018-01-13',
      edition: {
        number_of_pdfs: 30, number_of_word_files: 30, readability_score: 123
      },
      daily: {
        pageviews: 20, unique_pageviews: 10
      }