### PR TITLE
Store events received in the PublishingAPI

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -2,6 +2,8 @@ require 'json'
 
 class Dimensions::Item < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_item_id
+  has_one :publishing_api_event
+
   validates :content_id, presence: true
   validates :base_path, presence: true
   validates :schema_name, presence: true

--- a/app/models/publishing_api_event.rb
+++ b/app/models/publishing_api_event.rb
@@ -3,4 +3,8 @@ class PublishingApiEvent < ApplicationRecord
 
   validates :payload, presence: true
   validates :routing_key, presence: true
+
+  def is_links_update?
+    routing_key.ends_with?('.links')
+  end
 end

--- a/app/models/publishing_api_event.rb
+++ b/app/models/publishing_api_event.rb
@@ -1,0 +1,6 @@
+class PublishingApiEvent < ApplicationRecord
+  has_many :dimensions_items, class_name: 'Dimensions::Item'
+
+  validates :payload, presence: true
+  validates :routing_key, presence: true
+end

--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -6,14 +6,14 @@ module PublishingAPI
       if is_invalid_message?(message)
         message.discard
       else
-        do_process(message)
+        do_process(event, message)
       end
     end
 
   private
 
-    def do_process(message)
-      PublishingAPI::MessageHandler.process(message)
+    def do_process(event, message)
+      PublishingAPI::MessageHandler.process(event)
 
       message.ack
     rescue StandardError => e

--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -1,6 +1,8 @@
 module PublishingAPI
   class Consumer
     def process(message)
+      event = track_event(message)
+
       if is_invalid_message?(message)
         message.discard
       else
@@ -19,9 +21,16 @@ module PublishingAPI
       message.discard
     end
 
-    def is_invalid_message?(message)
-      mandatory_fields = message.payload.values_at('base_path', 'schema_name')
+    def is_invalid_message?(event)
+      mandatory_fields = event.payload.values_at('base_path', 'schema_name')
       mandatory_fields.any?(&:nil?)
+    end
+
+    def track_event(event)
+      PublishingApiEvent.create!(
+        payload: event.payload,
+        routing_key: event.delivery_info.routing_key,
+      )
     end
   end
 end

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -19,6 +19,7 @@ module PublishingAPI
             base_path: base_path_for_part(part),
             title: title_for_part(part),
             content: Etl::Item::Content::Parser.extract_content(message.payload, subpage: part['slug']),
+            publishing_api_events_id: message.id,
             **attributes
           )
         end
@@ -28,6 +29,7 @@ module PublishingAPI
             base_path: base_path,
             title: title,
             content: Etl::Item::Content::Parser.extract_content(message.payload),
+            publishing_api_events_id: message.id,
             **attributes
           )
         ]
@@ -54,6 +56,7 @@ module PublishingAPI
         public_updated_at: parse_time('public_updated_at'),
         schema_name: message.payload.fetch('schema_name'),
         raw_json: message.payload,
+        publishing_api_events_id: message.id,
         latest: true
       }
     end

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -8,7 +8,7 @@ class PublishingAPI::MessageHandler
   end
 
   def process
-    if is_links_update?
+    if publishing_api_event.is_links_update?
       item_handlers.each(&:process_links!)
     else
       item_handlers.each(&:process!)
@@ -40,10 +40,5 @@ private
     old_items.each(&:deprecate!)
 
     result
-  end
-
-  def is_links_update?
-    routing_key = publishing_api_event.routing_key
-    routing_key.ends_with?('.links')
   end
 end

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -3,8 +3,8 @@ class PublishingAPI::MessageHandler
     new(*args).process
   end
 
-  def initialize(message)
-    @message = message
+  def initialize(publishing_api_event)
+    @publishing_api_event = publishing_api_event
   end
 
   def process
@@ -17,10 +17,10 @@ class PublishingAPI::MessageHandler
 
 private
 
-  attr_reader :message
+  attr_reader :publishing_api_event
 
   def item_handlers
-    adapter = PublishingAPI::MessageAdapter.new(message)
+    adapter = PublishingAPI::MessageAdapter.new(publishing_api_event)
     new_items = adapter.new_dimension_items
 
     old_items = Dimensions::Item.existing_latest_items(
@@ -43,7 +43,7 @@ private
   end
 
   def is_links_update?
-    routing_key = message.delivery_info.routing_key
+    routing_key = publishing_api_event.routing_key
     routing_key.ends_with?('.links')
   end
 end

--- a/db/migrate/20180626085042_create_publishing_api_events.rb
+++ b/db/migrate/20180626085042_create_publishing_api_events.rb
@@ -1,0 +1,10 @@
+class CreatePublishingApiEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :publishing_api_events do |t|
+      t.string :routing_key
+      t.jsonb :payload
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180626085229_add_reference_to_events_from_dimensions_items.rb
+++ b/db/migrate/20180626085229_add_reference_to_events_from_dimensions_items.rb
@@ -1,0 +1,5 @@
+class AddReferenceToEventsFromDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :dimensions_items, :publishing_api_events, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180625120718) do
+ActiveRecord::Schema.define(version: 20180626085229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,10 +58,12 @@ ActiveRecord::Schema.define(version: 20180625120718) do
     t.string "content_purpose_subgroup"
     t.string "schema_name", null: false
     t.text "content"
+    t.bigint "publishing_api_events_id"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
+    t.index ["publishing_api_events_id"], name: "index_dimensions_items_on_publishing_api_events_id"
   end
 
   create_table "events_feedexes", force: :cascade do |t|
@@ -131,6 +133,13 @@ ActiveRecord::Schema.define(version: 20180625120718) do
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "metrics_item_id_date_id", unique: true
   end
 
+  create_table "publishing_api_events", force: :cascade do |t|
+    t.string "routing_key"
+    t.jsonb "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -145,6 +154,7 @@ ActiveRecord::Schema.define(version: 20180625120718) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "dimensions_items", "publishing_api_events", column: "publishing_api_events_id"
   add_foreign_key "facts_editions", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_editions", "dimensions_items"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"

--- a/spec/factories/publishing_api_events.rb
+++ b/spec/factories/publishing_api_events.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :publishing_api_event do
+    trait :link_update do
+      routing_key 'something.links'
+    end
+
+    trait :major_update do
+      routing_key 'guides.major'
+    end
+  end
+end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Import edition metrics' do
   include QualityMetricsHelpers
 
-  subject { PublishingAPI::MessageHandler }
+  subject { PublishingAPI::Consumer.new }
 
   it 'stores content item metrics' do
     message = build(:message, schema_name: 'publication', base_path: '/base-path')

--- a/spec/integration/streams/on_links_update_message_spec.rb
+++ b/spec/integration/streams/on_links_update_message_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe PublishingAPI::Consumer do
     }.to change(Dimensions::Item, :count).by(0)
   end
 
+  it 'tracks the message' do
+    expect {
+      subject.process(build(:message))
+    }.to change(PublishingApiEvent, :count).by(1)
+  end
+
   it 'grows the dimension with when links change' do
     expect(GovukError).to_not receive(:notify)
 

--- a/spec/models/publishing_api_event_spec.rb
+++ b/spec/models/publishing_api_event_spec.rb
@@ -3,4 +3,18 @@ require 'rails_helper'
 RSpec.describe PublishingApiEvent, type: :model do
   it { is_expected.to validate_presence_of(:payload) }
   it { is_expected.to validate_presence_of(:routing_key) }
+
+  describe 'is_link_update?' do
+    it 'returns true if ends with `.links`' do
+      event = build :publishing_api_event, :link_update
+
+      expect(event.is_links_update?).to be true
+    end
+
+    it 'returns false otherwise' do
+      event = build :publishing_api_event, :major_update
+
+      expect(event.is_links_update?).to be false
+    end
+  end
 end

--- a/spec/models/publishing_api_event_spec.rb
+++ b/spec/models/publishing_api_event_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe PublishingApiEvent, type: :model do
+  it { is_expected.to validate_presence_of(:payload) }
+  it { is_expected.to validate_presence_of(:routing_key) }
+end

--- a/spec/models/streams/message_spec.rb
+++ b/spec/models/streams/message_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe PublishingApiEvent, type: :model do
+  it { is_expected.to validate_presence_of(:payload) }
+  it { is_expected.to validate_presence_of(:routing_key) }
+end

--- a/spec/streams/publishing_api/consumer_spec.rb
+++ b/spec/streams/publishing_api/consumer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe PublishingAPI::Consumer do
+  describe '#process' do
+    describe 'event tracking coming from PublishingAPI' do
+      before { allow(PublishingAPI::MessageHandler).to receive(:process) }
+
+      it 'stores all the events' do
+        expect {
+          subject.process(build(:message))
+          subject.process(build(:message))
+        }.to change(PublishingApiEvent, :count).by(2)
+      end
+
+      it 'does not check for duplicities' do
+        expect {
+          message = build :message
+
+          subject.process(message)
+          subject.process(message)
+        }.to change(PublishingApiEvent, :count).by(2)
+      end
+    end
+  end
+end

--- a/spec/streams/publishing_api/event_adapter_spec.rb
+++ b/spec/streams/publishing_api/event_adapter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         result
       end
 
-      event = build(:message, payload: payload, routing_key: 'the-key')
+      event = create(:publishing_api_event, payload: payload, routing_key: 'the-key')
       dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(
@@ -37,7 +37,8 @@ RSpec.describe PublishingAPI::MessageAdapter do
         schema_name: 'detailed_guide',
         latest: true,
         content: 'some content',
-        raw_json: payload
+        raw_json: payload,
+        publishing_api_events_id: event.id,
       )
     end
 
@@ -56,7 +57,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         result
       end
 
-      event = build(:message, payload: payload, routing_key: 'the-key')
+      event = create(:publishing_api_event, payload: payload, routing_key: 'the-key')
       dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(
@@ -73,7 +74,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         schema_name = payload.dig('schema_name')
 
         it "transfom schema: `#{schema_name}` with no errors" do
-          event = build(:message, payload: payload, routing_key: 'the-key')
+          event = create(:publishing_api_event, payload: payload, routing_key: 'the-key')
 
           expect { subject.new(event).new_dimension_items }.to_not raise_error
         end
@@ -106,14 +107,14 @@ RSpec.describe PublishingAPI::MessageAdapter do
     end
 
     it 'convert an multipart event into a set of Dimensions::Items' do
-      event = build(:message, payload: payload, routing_key: 'the-key')
+      event = create(:publishing_api_event, payload: payload, routing_key: 'the-key')
       result = subject.new(event).new_dimension_items
 
       expect(result.length).to eq(2)
     end
 
     it 'extracts page attributes into the Item' do
-      event = build(:message, payload: payload, routing_key: 'the-key')
+      event = create(:publishing_api_event, payload: payload, routing_key: 'the-key')
       dimension_item = subject.new(event).new_dimension_items[0]
 
       expect(dimension_item).to have_attributes(


### PR DESCRIPTION
[Trello card](https://trello.com/c/WCKDsjZH/419-5-extract-events-into-their-own-table)

We currently receive events via RabbitMQ with each update in Publishing API.
To be able to recreate the changes through time (should any bug appears), 
we need to track the events so they could be replied if needed

### What

Stores the events in its own table and link with the Dimension::Item

### Why

It will increase the robustness of the CPM, and will also make it more efficient as the queries about metrics don't need to carry the raw_json.

