### PR TITLE
Link the dimension_item to the event

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class Dimensions::Item < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_item_id
-  has_one :publishing_api_event
+  belongs_to :publishing_api_event
 
   validates :content_id, presence: true
   validates :base_path, presence: true

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -19,7 +19,7 @@ module PublishingAPI
             base_path: base_path_for_part(part),
             title: title_for_part(part),
             content: Etl::Item::Content::Parser.extract_content(message.payload, subpage: part['slug']),
-            publishing_api_events_id: message.id,
+            publishing_api_event_id: message.id,
             **attributes
           )
         end
@@ -29,7 +29,7 @@ module PublishingAPI
             base_path: base_path,
             title: title,
             content: Etl::Item::Content::Parser.extract_content(message.payload),
-            publishing_api_events_id: message.id,
+            publishing_api_event_id: message.id,
             **attributes
           )
         ]
@@ -56,7 +56,7 @@ module PublishingAPI
         public_updated_at: parse_time('public_updated_at'),
         schema_name: message.payload.fetch('schema_name'),
         raw_json: message.payload,
-        publishing_api_events_id: message.id,
+        publishing_api_event_id: message.id,
         latest: true
       }
     end

--- a/db/migrate/20180711100526_rename_column_dimensions_items_event_id.rb
+++ b/db/migrate/20180711100526_rename_column_dimensions_items_event_id.rb
@@ -1,0 +1,5 @@
+class RenameColumnDimensionsItemsEventId < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :dimensions_items, :publishing_api_events_id, :publishing_api_event_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626085229) do
+ActiveRecord::Schema.define(version: 20180711100526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,12 +58,12 @@ ActiveRecord::Schema.define(version: 20180626085229) do
     t.string "content_purpose_subgroup"
     t.string "schema_name", null: false
     t.text "content"
-    t.bigint "publishing_api_events_id"
+    t.bigint "publishing_api_event_id"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
-    t.index ["publishing_api_events_id"], name: "index_dimensions_items_on_publishing_api_events_id"
+    t.index ["publishing_api_event_id"], name: "index_dimensions_items_on_publishing_api_event_id"
   end
 
   create_table "events_feedexes", force: :cascade do |t|
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 20180626085229) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
-  add_foreign_key "dimensions_items", "publishing_api_events", column: "publishing_api_events_id"
+  add_foreign_key "dimensions_items", "publishing_api_events"
   add_foreign_key "facts_editions", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_editions", "dimensions_items"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"

--- a/spec/factories/dimensions_items.rb
+++ b/spec/factories/dimensions_items.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     schema_name 'detailed_guide'
     document_type 'detailed_guide'
 
+    publishing_api_event
+
     initialize_with { Dimensions::Item.find_or_create_by(base_path: base_path, latest: latest) }
   end
 end

--- a/spec/factories/publishing_api_events.rb
+++ b/spec/factories/publishing_api_events.rb
@@ -7,5 +7,8 @@ FactoryBot.define do
     trait :major_update do
       routing_key 'guides.major'
     end
+
+    sequence(:payload) { |i| "payload - #{i}" }
+    sequence(:routing_key) { |i| "routing_key - #{i}" }
   end
 end

--- a/spec/integration/streams/track_events_spec.rb
+++ b/spec/integration/streams/track_events_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'Track Publishing API events' do
+  include QualityMetricsHelpers
+
+  let(:subject) { PublishingAPI::Consumer.new }
+  let(:message) { build :message }
+
+  before { stub_quality_metrics }
+
+  it 'stores all the events' do
+    expect {
+      subject.process message
+      subject.process message
+    }.to change(PublishingApiEvent, :count).by(2)
+  end
+
+  context 'when the Item has no multiparts' do
+    let(:content_id) { message.payload.fetch('content_id') }
+    let(:dimension_item) { Dimensions::Item.find_by!(content_id: content_id) }
+    let(:event) { PublishingApiEvent.first }
+
+    it 'links the dimension_item to the event' do
+      subject.process message
+
+      expect(dimension_item.publishing_api_event).to eq(event)
+    end
+
+    it 'links the event to the item' do
+      subject.process message
+
+      expect(event.dimensions_items).to match_array(dimension_item)
+    end
+  end
+end

--- a/spec/streams/publishing_api/event_adapter_spec.rb
+++ b/spec/streams/publishing_api/event_adapter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         latest: true,
         content: 'some content',
         raw_json: payload,
-        publishing_api_events_id: event.id,
+        publishing_api_event_id: event.id,
       )
     end
 


### PR DESCRIPTION
This is a [follow on work to PR][1] because the association from the 
dimension_item to the event wasn’t properly done because the name
of the column for the foreign_key was not correct.

I have added an integration test to ensure that we are exercising this
code.



[1]: https://github.com/alphagov/content-performance-manager/pull/780