### PR TITLE
Rename Dimensions::Item content to document_text

### DIFF
--- a/app/domain/etl/item/processor.rb
+++ b/app/domain/etl/item/processor.rb
@@ -18,8 +18,8 @@ class Etl::Item::Processor
       dimensions_item: item,
     )
 
-    if item.content.present?
-      edition.update(Etl::Item::Quality::Service.new.run(item.content))
+    if item.document_text.present?
+      edition.update(Etl::Item::Quality::Service.new.run(item.document_text))
     end
   end
 end

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -18,7 +18,7 @@ module PublishingAPI
           Dimensions::Item.new(
             base_path: base_path_for_part(part),
             title: title_for_part(part),
-            content: Etl::Item::Content::Parser.extract_content(message.payload, subpage: part['slug']),
+            document_text: Etl::Item::Content::Parser.extract_content(message.payload, subpage: part['slug']),
             publishing_api_event_id: message.id,
             **attributes
           )
@@ -28,7 +28,7 @@ module PublishingAPI
           Dimensions::Item.new(
             base_path: base_path,
             title: title,
-            content: Etl::Item::Content::Parser.extract_content(message.payload),
+            document_text: Etl::Item::Content::Parser.extract_content(message.payload),
             publishing_api_event_id: message.id,
             **attributes
           )

--- a/db/migrate/20180712115111_rename_dimensions_item_content_to_document_text.rb
+++ b/db/migrate/20180712115111_rename_dimensions_item_content_to_document_text.rb
@@ -1,0 +1,5 @@
+class RenameDimensionsItemContentToDocumentText < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :dimensions_items, :content, :document_text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180711100526) do
+ActiveRecord::Schema.define(version: 20180712115111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20180711100526) do
     t.string "content_purpose_supergroup"
     t.string "content_purpose_subgroup"
     t.string "schema_name", null: false
-    t.text "content"
+    t.text "document_text"
     t.bigint "publishing_api_event_id"
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"

--- a/spec/streams/publishing_api/event_adapter_spec.rb
+++ b/spec/streams/publishing_api/event_adapter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         public_updated_at: Time.zone.parse('2018-04-20T12:00:40+01:00'),
         schema_name: 'detailed_guide',
         latest: true,
-        content: 'some content',
+        document_text: 'some content',
         raw_json: payload,
         publishing_api_event_id: event.id,
       )
@@ -121,7 +121,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         content_id: payload.fetch('content_id'),
         base_path: '/root/part1',
         title: 'part 1',
-        content: 'part 1 content',
+        document_text: 'part 1 content',
       )
     end
   end


### PR DESCRIPTION
ActiveRecord seems to be assuming the content_id and content
attributes are related - they are not.

This commit renames to content column to document_text
so that ActiveRecord will not get confused.

Possibly this is a bug in ActiveRecord.

I need it for the trello card [Do not get quality metrics if content has not changed](https://trello.com/c/cuXkXicW/457-5-do-not-get-quality-metrics-if-content-has-not-changed)