### PR TITLE
Fix: Invalid namespace when populating metrics

### DIFF
--- a/app/domain/etl/ga/internal_search_service.rb
+++ b/app/domain/etl/ga/internal_search_service.rb
@@ -15,7 +15,7 @@ class Etl::GA::InternalSearchService
   end
 
   def client
-    @client ||= GA::Client.new.build
+    @client ||= Etl::GA::Client.new.build
   end
 
 private

--- a/spec/domain/etl/ga/internal_search_service_spec.rb
+++ b/spec/domain/etl/ga/internal_search_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Etl::GA::InternalSearchService do
   subject { Etl::GA::InternalSearchService }
 
   let(:google_client) { double('client') }
-  before { allow_any_instance_of(Etl::GA::InternalSearchService).to receive(:client).and_return(google_client) }
+  before { allow_any_instance_of(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do
     let(:date) { Date.new(2018, 2, 20) }


### PR DESCRIPTION
There was an error in the etl::master process.

The error was not caught by tests because the method with the error
was stubbed out in the tests.

The test is now stubbed out at a lower level, and the bug is caught.

Code fixed and should not be able to happen again.

The trello card is [Invalid namespace when populating daily metrics](https://trello.com/c/b0f38wET/461-invalid-namespace-when-populating-daily-metrics)