### PR TITLE
Quality metrics service uses simpler response

### DIFF
--- a/app/domain/etl/item/quality/service.rb
+++ b/app/domain/etl/item/quality/service.rb
@@ -21,28 +21,30 @@ private
   end
 
   def convert_results(response, content)
+    result_fields = %w[
+    contractions_count
+    equality_count
+    indefinite_article_count
+    passive_count
+    profanities_count
+    redundant_acronyms_count
+    repeated_words_count
+    simplify_count
+    spell_count
+]
     result = Odyssey.flesch_kincaid_re(content, true)
-    {
+    response.slice(*result_fields).symbolize_keys.merge(
       readability_score: result.fetch('score'),
       string_length: result.fetch('string_length'),
       sentence_count: result.fetch('sentence_count'),
       word_count: result.fetch('word_count'),
-    }.tap do |results|
-      results[:contractions_count] = count_metric(response, 'contractions')
-      results[:equality_count] = count_metric(response, 'equality')
-      results[:indefinite_article_count] = count_metric(response, 'indefinite_article')
-      results[:passive_count] = count_metric(response, 'passive')
-      results[:profanities_count] = count_metric(response, 'profanities')
-      results[:redundant_acronyms_count] = count_metric(response, 'redundant_acronyms')
-      results[:repeated_words_count] = count_metric(response, 'repeated_words')
-      results[:simplify_count] = count_metric(response, 'simplify')
-      results[:spell_count] = count_metric(response, 'spell')
-    end
+    )
   end
 
   def count_metric(response, metric_name)
-    response.dig(metric_name, 'count') || 0
+    response.dig(metric_name) || 0
   end
 
-  class QualityMetricsError < StandardError; end
+  class QualityMetricsError < StandardError;
+  end
 end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -37,16 +37,16 @@ RSpec.describe 'Import edition metrics' do
 
   def stub_quality_metrics_request
     stub_quality_metrics(
-      readability: { 'count' => 1 },
-      contractions: { 'count' => 2 },
-      equality: { 'count' => 3 },
-      indefinite_article: { 'count' => 4 },
-      passive: { 'count' => 5 },
-      profanities: { 'count' => 6 },
-      redundant_acronyms: { 'count' => 7 },
-      repeated_words: { 'count' => 8 },
-      simplify: { 'count' => 9 },
-      spell: { 'count' => 10 }
+      readability_count: 1,
+      contractions_count: 2,
+      equality_count: 3,
+      indefinite_article_count: 4,
+      passive_count: 5,
+      profanities_count: 6,
+      redundant_acronyms_count: 7,
+      repeated_words_count: 8,
+      simplify_count: 9,
+      spell_count: 10
     )
   end
 end

--- a/spec/support/quality_metrics_helpers.rb
+++ b/spec/support/quality_metrics_helpers.rb
@@ -1,16 +1,16 @@
 module QualityMetricsHelpers
   def stub_quality_metrics(options = {})
     response = {
-      readability: { 'count' => 1 },
-      contractions: { 'count' => 2 },
-      equality: { 'count' => 3 },
-      indefinite_article: { 'count' => 4 },
-      passive: { 'count' => 5 },
-      profanities: { 'count' => 6 },
-      redundant_acronyms: { 'count' => 7 },
-      repeated_words: { 'count' => 8 },
-      simplify: { 'count' => 9 },
-      spell: { 'count' => 10 }
+      readability_count: 1,
+      contractions_count: 2,
+      equality_count: 3,
+      indefinite_article_count: 4,
+      passive_count: 5,
+      profanities_count: 6,
+      redundant_acronyms_count: 7,
+      repeated_words_count: 8,
+      simplify_count: 9,
+      spell_count: 1
     }.merge!(options)
 
     stub_request(:post, 'https://govuk-content-quality-metrics.cloudapps.digital/metrics').


### PR DESCRIPTION
The quality metrics (node) service has been experiencing
a 'Payload Too Large' error when sending a large block of text.

This is due to the service returning the details of every error
found.

The service has now been refactored to return the following format:
{
  readability_count: 1,
  contractions_count: 2,
  equality_count: 3,
}

without any of the detail.

This commit changes the local client of this service to use the
new response format.

Trello: [Quality Service: Payload too large error](https://trello.com/c/yjkmaISV/459-quality-service-payload-too-large-error)

There is a [related PR in govuk-content-quality-metrics](https://github.com/alphagov/govuk-content-quality-metrics/pull/7)