### PR TITLE
Move content quality call into Sidekiq

### DIFF
--- a/app/domain/etl/item/processor.rb
+++ b/app/domain/etl/item/processor.rb
@@ -31,15 +31,12 @@ private
   end
 
   def create_new_edition
-    Facts::Edition.create!({
+    Facts::Edition.create!(
       number_of_pdfs: Etl::Item::Metadata::NumberOfPdfs.parse(new_item.raw_json),
       number_of_word_files: Etl::Item::Metadata::NumberOfWordFiles.parse(new_item.raw_json),
       dimensions_date: dimensions_date,
       dimensions_item: new_item
-    }.merge(quality_metrics))
-  end
-
-  def quality_metrics
-    Etl::Item::Quality::Service.new.run(new_item.document_text)
+    )
+    Etl::Jobs::QualityMetricsJob.perform_async(new_item.id)
   end
 end

--- a/app/domain/etl/item/quality/service.rb
+++ b/app/domain/etl/item/quality/service.rb
@@ -33,7 +33,7 @@ private
     repeated_words_count
     simplify_count
     spell_count
-]
+    ]
     result = Odyssey.flesch_kincaid_re(content, true)
     response.slice(*result_fields).symbolize_keys.merge(
       readability_score: result.fetch('score'),

--- a/app/domain/etl/item/quality/service.rb
+++ b/app/domain/etl/item/quality/service.rb
@@ -3,12 +3,15 @@ require 'odyssey'
 class Etl::Item::Quality::Service
   def run(content)
     return {} if content.blank?
-
-    parsed_response = fetch(content)
+    parsed_response = fetch(space_between_sentences(content))
     convert_results(parsed_response, content)
   end
 
 private
+
+  def space_between_sentences(content)
+    content.gsub(/\./, '. ')
+  end
 
   URL = 'https://govuk-content-quality-metrics.cloudapps.digital/metrics'.freeze
 

--- a/app/domain/etl/jobs/quality_metrics_job.rb
+++ b/app/domain/etl/jobs/quality_metrics_job.rb
@@ -1,0 +1,16 @@
+class Etl::Jobs::QualityMetricsJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'quality_metrics'
+
+  def perform(item_id, _ = {})
+    item = Dimensions::Item.find(item_id)
+    item.facts_edition.update!(quality_metrics(item.document_text))
+  end
+
+private
+
+  def quality_metrics(content)
+    Etl::Item::Quality::Service.new.run(content)
+  end
+end

--- a/spec/domain/etl/item/item_processor_spec.rb
+++ b/spec/domain/etl/item/item_processor_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe Etl::Item::Processor do
+  include ItemSetupHelpers
+  let(:old_item) do
+    create_edition(
+      base_path: '/base-path',
+      date: Date.today,
+      item: {
+        document_text: 'existing content',
+        latest: false
+      },
+      edition: {
+        contractions_count: 2,
+        equality_count: 3,
+        indefinite_article_count: 4,
+      }
+).dimensions_item
+  end
+  subject { described_class.new(old_item: old_item, new_item: new_item, date: Date.today) }
+
+  before do
+    allow(Etl::Jobs::QualityMetricsJob).to receive(:perform_async)
+    allow(Etl::Item::Metadata::NumberOfWordFiles).to receive(:parse).and_return(1)
+    allow(Etl::Item::Metadata::NumberOfPdfs).to receive(:parse).and_return(2)
+    subject.run
+  end
+
+  context 'when the content has changed' do
+    let(:new_item) do
+      create(:dimensions_item, base_path: '/base-path', document_text: 'new content')
+    end
+
+    it 'creates a new edition' do
+      expect(new_item.reload.facts_edition).to be_persisted
+    end
+
+    it 'fires a sidekiq job to populate quality metrics for the new edition' do
+      expect(Etl::Jobs::QualityMetricsJob).to have_received(:perform_async).with(new_item.id)
+    end
+  end
+
+  context 'when the content has not changed' do
+    let(:new_item) do
+      build(:dimensions_item, base_path: '/base-path', document_text: 'existing content')
+    end
+
+    it 'clones the existing edition' do
+      updated_item = new_item.reload
+      expect(updated_item.facts_edition).to be_persisted
+      expect(updated_item.facts_edition).to have_attributes(
+        contractions_count: 2,
+        equality_count: 3,
+        indefinite_article_count: 4,
+      )
+    end
+
+    it 'does not fire a sidekiq job to populate quality metrics' do
+      expect(Etl::Jobs::QualityMetricsJob).not_to have_received(:perform_async)
+    end
+  end
+end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -1,8 +1,15 @@
+require 'sidekiq/testing'
 RSpec.describe 'Import edition metrics' do
   include QualityMetricsHelpers
   include ItemSetupHelpers
 
   subject { PublishingAPI::MessageHandler }
+
+  around do |example|
+    Sidekiq::Testing.inline! do
+      example.run
+    end
+  end
 
   it 'stores content item metrics' do
     message = build(:message, schema_name: 'publication', base_path: '/new-path')

--- a/spec/support/item_setup_helpers.rb
+++ b/spec/support/item_setup_helpers.rb
@@ -9,7 +9,7 @@ module ItemSetupHelpers
     )
   end
 
-  def create_edition(base_path:, date:, edition:, item:)
+  def create_edition(base_path:, date:, edition: {}, item: {})
     ensure_edition_exists(dimensions_item(item.merge(base_path: base_path)), dimensions_date(date), edition)
   end
 


### PR DESCRIPTION
We have been filling up the disk space on
RabbitMQ because the call to the quality metric service
takes a long time (6-25 seconds).

This commit moves the call to the metrics service into
a Sidekiq job to allow the RabbitMQ messages to be
processed faster.

Trello: [Create Sidekiq job to make processing Quality Metrics more reliable](https://trello.com/c/ONjimA9e/525-5-create-sidekiq-job-to-make-processing-quality-metrics-more-reliable)

There is a related [PR in govuk-content-quality-metrics](https://github.com/alphagov/govuk-content-quality-metrics/pull/8)