### PR TITLE
Add ActiveRecord transaction to message processing

### DIFF
--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -4,7 +4,9 @@ module PublishingAPI
       if is_invalid_message?(message)
         message.discard
       else
-        do_process(message)
+        ActiveRecord::Base.transaction do
+          do_process(message)
+        end
       end
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/ttXpPPdY/534-add-transaction-scope-to-message-processing)

Processing events from PublishingAPI involve a number of steps, each one
of them changes the state of some rows of the Database. If in the middle
of processing a message an exception is thrown we should rollback all
the changes so we don't leave inconsistencies in the Database.