### PR TITLE
Remove progress bar from RSpec output

### DIFF
--- a/lib/tasks/one_off/001_migrate_dimension-items_content.rake
+++ b/lib/tasks/one_off/001_migrate_dimension-items_content.rake
@@ -1,3 +1,5 @@
+require 'ruby-progressbar/outputs/null'
+
 namespace :etl do
   desc 'Populate document_text property for items which have no content'
   task populate_content: :environment do
@@ -6,7 +8,11 @@ namespace :etl do
 
   def process
     scope = Dimensions::Item.where(document_text: nil)
-    progress_bar = ProgressBar.create(total: scope.count)
+
+    options = { total: scope.count }
+    options[:output] = ProgressBar::Outputs::Null if Rails.env.test?
+
+    progress_bar = ProgressBar.create(options)
     scope.find_each do |item|
       item.update document_text: Etl::Item::Content::Parser.extract_content(item.raw_json)
       progress_bar.increment


### PR DESCRIPTION
[Trello card](https://trello.com/c/2PdGbHUF/536-remove-progress-bar-output-from-rspec-tests)

It is better not to have debug output in the RSpec tests, so I have
decided to exclude it in the test environment.

To do it I have decided to just use a null output [as per the documentation][1]

[1]: https://github.com/jfelchner/ruby-progressbar/wiki/Null-(Blackhole)-Output