### PR TITLE
Revert govuk_app_config from 1.7.0 to 1.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (1.7.0)
+    govuk_app_config (1.6.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)


### PR DESCRIPTION
Upgrading govuk_app_config to 1.7.0 caused all our CI builds to fail. In order to unblock
our PR queue downgrade to 1.6.0 while investigating root cause.