### PR TITLE
Retry Quality metrics jobs without raising error ifNet::OpenTimeout

### DIFF
--- a/app/domain/etl/jobs/quality_metrics_job.rb
+++ b/app/domain/etl/jobs/quality_metrics_job.rb
@@ -1,4 +1,5 @@
 class Etl::Jobs::QualityMetricsJob
+  retry_on Net::OpenTimeout, wait: 5.seconds, attempts: 10
   include Sidekiq::Worker
 
   sidekiq_options queue: 'quality_metrics'


### PR DESCRIPTION
In order to minimise errors being raised in sentry this PR will ensure that a Net::OpenTimeout error
does not raise an error in sentry until it has been retried and failed 10 times.