### PR TITLE
Store list of attributes from events into the dimensions_items table

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -27,14 +27,6 @@ class Dimensions::Item < ApplicationRecord
     update!(latest: true)
   end
 
-  def expanded_links
-    if raw_json && raw_json['expanded_links']
-      raw_json['expanded_links']
-    else
-      {}
-    end
-  end
-
   def deprecate!
     update!(latest: false)
   end

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -63,6 +63,12 @@ module PublishingAPI
         public_updated_at: parse_time('public_updated_at'),
         schema_name: message.payload.fetch('schema_name'),
         raw_json: message.payload,
+        phase: message.payload.fetch('phase', nil),
+        publishing_app: message.payload.fetch('publishing_app', nil),
+        rendering_app: message.payload.fetch('rendering_app', nil),
+        analytics_identifier: message.payload.fetch('analytics_identifier', nil),
+        update_type: message.payload.fetch('update_type', nil),
+        links: message.payload.fetch('links', nil),
         latest: true
       }
     end

--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -68,7 +68,7 @@ module PublishingAPI
         rendering_app: message.payload.fetch('rendering_app', nil),
         analytics_identifier: message.payload.fetch('analytics_identifier', nil),
         update_type: message.payload.fetch('update_type', nil),
-        links: message.payload.fetch('links', nil),
+        expanded_links: message.payload.fetch('expanded_links', nil),
         latest: true
       }
     end

--- a/db/migrate/20180719133916_add_columns_to_dimensions_items.rb
+++ b/db/migrate/20180719133916_add_columns_to_dimensions_items.rb
@@ -1,0 +1,12 @@
+class AddColumnsToDimensionsItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions_items, :publishing_app, :string
+    add_column :dimensions_items, :rendering_app, :string
+    add_column :dimensions_items, :analytics_identifier, :string
+    add_column :dimensions_items, :phase, :string
+    add_column :dimensions_items, :previous_version, :string
+    add_column :dimensions_items, :update_type, :string
+    add_column :dimensions_items, :last_edited_at, :datetime
+    add_column :dimensions_items, :links, :json
+  end
+end

--- a/db/migrate/20180725102859_rename_dimensions_items_links_column.rb
+++ b/db/migrate/20180725102859_rename_dimensions_items_links_column.rb
@@ -1,0 +1,5 @@
+class RenameDimensionsItemsLinksColumn < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :dimensions_items, :links, :expanded_links
+  end
+end

--- a/db/migrate/20180725103453_add_default_to_dimensions_items_expanded_links.rb
+++ b/db/migrate/20180725103453_add_default_to_dimensions_items_expanded_links.rb
@@ -1,0 +1,5 @@
+class AddDefaultToDimensionsItemsExpandedLinks < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :dimensions_items, :expanded_links, {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180725103453) do
+ActiveRecord::Schema.define(version: 20180725104938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 20180725103453) do
     t.string "update_type"
     t.datetime "last_edited_at"
     t.json "expanded_links", default: {}
-    t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180725104938) do
+ActiveRecord::Schema.define(version: 20180719133916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,15 @@ ActiveRecord::Schema.define(version: 20180725104938) do
     t.string "content_purpose_subgroup"
     t.string "schema_name", null: false
     t.text "document_text"
+    t.string "publishing_app"
+    t.string "rendering_app"
+    t.string "analytics_identifier"
+    t.string "phase"
+    t.string "previous_version"
+    t.string "update_type"
+    t.datetime "last_edited_at"
+    t.json "links"
+    t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180719133916) do
+ActiveRecord::Schema.define(version: 20180725103453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20180719133916) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
-    t.json "links"
+    t.json "expanded_links", default: {}
     t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"

--- a/spec/integration/streams/on_links_update_message_spec.rb
+++ b/spec/integration/streams/on_links_update_message_spec.rb
@@ -94,17 +94,17 @@ RSpec.describe PublishingAPI::Consumer do
     }.to_not raise_error
   end
 
-  it 'does not raise error if `expanded_links` field is not present' do
+  it 'does not raise error if `expanded_links` field is empty' do
     expect(GovukError).to_not receive(:notify)
 
     message = build(:message)
     message.payload['payload_version'] = 1
-    message.payload['expanded_links'] = nil
+    message.payload['expanded_links'] = {}
     subject.process(message)
 
     link_update = build :message, :link_update, payload: message.payload
     link_update.payload['payload_version'] = 2
-    link_update.payload['expanded_links'] = nil
+    link_update.payload['expanded_links'] = {}
     expect {
       subject.process(link_update)
     }.to_not raise_error

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -177,23 +177,6 @@ RSpec.describe Dimensions::Item, type: :model do
   describe '#expanded_links' do
     let(:item) { build :dimensions_item }
     context 'when item has raw_json' do
-      it 'returns `expanded links` if raw_json has the `expanded_links` field' do
-        raw_json = {
-          'expanded_links' => [
-            {
-              'name' => 'tax-rates',
-              'url' => '/tax_rates'
-            },
-            {
-              'name' => 'vat-rates',
-              'url' => '/vat_rates'
-            }
-          ]
-        }
-        item.update_attributes(raw_json: raw_json)
-        expect(item.expanded_links).to eq raw_json['expanded_links']
-      end
-
       it 'returns an empty hash if raw json does not have `expanded_links` field' do
         expect(item.expanded_links).to eq Hash.new
       end

--- a/spec/streams/publishing_api/message_adapter_spec.rb
+++ b/spec/streams/publishing_api/message_adapter_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe PublishingAPI::MessageAdapter do
           'content_purpose_subgroup' => 'the-subgroup',
           'first_published_at' => '2018-04-19T12:00:40+01:00',
           'public_updated_at' => '2018-04-20T12:00:40+01:00',
+          'phase' => 'live',
+          'publishing_app' => 'calendars',
+          'rendering_app' => 'calendars',
+          'analytics_identifier' => 'analytics_identifier',
+          'update_type' => 'major',
+          'links' => { 'policy_areas' => ['f50bb933-d558-49e1-934d-ccd1e68405fb',
+                                          '132c48c6-e274-4c46-838a-36916f6dfa8f',
+                                          'dbe221f3-43c4-4dae-9958-b87cde95c966',
+                                          '1e3e32e2-d616-4cba-a449-22f5a0219468'] },
         )
         result['details']['body'] = 'some content'
         result
@@ -37,7 +46,16 @@ RSpec.describe PublishingAPI::MessageAdapter do
         schema_name: 'detailed_guide',
         latest: true,
         document_text: 'some content',
-        raw_json: payload
+        phase: 'live',
+        publishing_app: 'calendars',
+        rendering_app: 'calendars',
+        analytics_identifier: 'analytics_identifier',
+        update_type: 'major',
+        links: { "policy_areas" => ["f50bb933-d558-49e1-934d-ccd1e68405fb",
+                                    "132c48c6-e274-4c46-838a-36916f6dfa8f",
+                                    "dbe221f3-43c4-4dae-9958-b87cde95c966",
+                                    "1e3e32e2-d616-4cba-a449-22f5a0219468"] },
+        raw_json: payload,
       )
     end
 

--- a/spec/streams/publishing_api/message_adapter_spec.rb
+++ b/spec/streams/publishing_api/message_adapter_spec.rb
@@ -19,10 +19,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
           'rendering_app' => 'calendars',
           'analytics_identifier' => 'analytics_identifier',
           'update_type' => 'major',
-          'links' => { 'policy_areas' => ['f50bb933-d558-49e1-934d-ccd1e68405fb',
-                                          '132c48c6-e274-4c46-838a-36916f6dfa8f',
-                                          'dbe221f3-43c4-4dae-9958-b87cde95c966',
-                                          '1e3e32e2-d616-4cba-a449-22f5a0219468'] },
+          'expanded_links' => { 'policy_areas' => [] },
         )
         result['details']['body'] = 'some content'
         result
@@ -51,10 +48,7 @@ RSpec.describe PublishingAPI::MessageAdapter do
         rendering_app: 'calendars',
         analytics_identifier: 'analytics_identifier',
         update_type: 'major',
-        links: { "policy_areas" => ["f50bb933-d558-49e1-934d-ccd1e68405fb",
-                                    "132c48c6-e274-4c46-838a-36916f6dfa8f",
-                                    "dbe221f3-43c4-4dae-9958-b87cde95c966",
-                                    "1e3e32e2-d616-4cba-a449-22f5a0219468"] },
+        expanded_links: { 'policy_areas' => [] },
         raw_json: payload,
       )
     end


### PR DESCRIPTION
[Trello: Store list of event attributes](https://trello.com/c/6L9Rejah/530-3-store-list-of-attributes-from-the-events-into-the-dimensionsitem-depends-on-474)

We are storing a number of event attributes so that we do not have to re-populate data backwards over time. Because we can't store all the events, we need to store in advance as much information as possible so we can satisfy the user needs for the long run.