### PR TITLE
Remove unique index on base_path and latest

### DIFF
--- a/db/migrate/20180725104938_remove_index_base_path_latest.rb
+++ b/db/migrate/20180725104938_remove_index_base_path_latest.rb
@@ -1,0 +1,5 @@
+class RemoveIndexBasePathLatest < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :dimensions_items, name: 'index_dimensions_items_on_base_path_and_latest'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180718161302) do
+ActiveRecord::Schema.define(version: 20180725104938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,6 @@ ActiveRecord::Schema.define(version: 20180718161302) do
     t.string "content_purpose_subgroup"
     t.string "schema_name", null: false
     t.text "document_text"
-    t.index ["base_path", "latest"], name: "index_dimensions_items_on_base_path_and_latest", unique: true, where: "(latest = true)"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"


### PR DESCRIPTION
We are having many errors and unexpected behaviours and we are not sure
if this constraint is preventing the normal flow of our ETL processes.

We plan to restore it with an AR validation, but for the time being we
prefer to delete it so we can be more confident about the root cause of
our problems.