### PR TITLE
Discard messages right after checking that their payload number is old

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -16,12 +16,6 @@ class Dimensions::Item < ApplicationRecord
   scope :latest_by_base_path, ->(base_paths) { where(base_path: base_paths, latest: true) }
   scope :existing_latest_items, ->(content_id, locale, base_paths) { latest_by_content_id(content_id, locale).or(latest_by_base_path(base_paths)) }
 
-  def newer_than?(other)
-    return true unless other
-
-    self.publishing_api_payload_version > other.publishing_api_payload_version
-  end
-
   def promote!(old_item)
     old_item.deprecate! if old_item
     update!(latest: true)

--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -5,21 +5,17 @@ class PublishingAPI::ItemHandler
   end
 
   def process!
-    grow_dimension! if new_version?
+    grow_dimension!
   end
 
   def process_links!
-    grow_dimension! if new_version? && links_have_changed?
+    grow_dimension! if links_have_changed?
   end
 
 private
 
   attr_reader :old_item
   attr_reader :new_item
-
-  def new_version?
-    new_item && new_item.newer_than?(old_item)
-  end
 
   def links_have_changed?
     return true if old_item.nil?

--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -8,6 +8,8 @@ class PublishingAPI::MessageHandler
   end
 
   def process
+    return if PublishingAPI::MessageValidator.is_old_message?(message)
+
     if is_links_update?
       item_handlers.each(&:process_links!)
     else

--- a/app/streams/publishing_api/message_validator.rb
+++ b/app/streams/publishing_api/message_validator.rb
@@ -1,0 +1,14 @@
+module PublishingAPI
+  class MessageValidator
+    def self.is_old_message?(message)
+      payload_version = message.payload.fetch('payload_version').to_i
+      locale = message.payload.fetch('locale')
+      content_id = message.payload.fetch('content_id')
+
+      payload_version <= Dimensions::Item.where(
+        content_id: content_id,
+        locale: locale
+      ).maximum('publishing_api_payload_version').to_i
+    end
+  end
+end

--- a/spec/integration/streams/on_update_message_spec.rb
+++ b/spec/integration/streams/on_update_message_spec.rb
@@ -24,7 +24,13 @@ RSpec.describe PublishingAPI::Consumer do
 
   it 'ignores old events' do
     message = build :message, base_path: '/base-path', attributes: { 'payload_version' => 2 }
-    message2 = build :message, base_path: '/base-path', attributes: { 'payload_version' => 1 }
+    message2 = build :message,
+      base_path: '/base-path',
+      attributes: {
+        'payload_version' => 1,
+        'locale' => message.payload['locale'],
+        'content_id' => message.payload['content_id'],
+      }
 
     expect {
       subject.process(message)
@@ -32,11 +38,16 @@ RSpec.describe PublishingAPI::Consumer do
     }.to change(Dimensions::Item, :count).by(1)
 
     expect(Dimensions::Item.first).to have_attributes(publishing_api_payload_version: 2)
+    expect(Dimensions::Item.first).to have_attributes(latest: true)
   end
 
   it 'deprecates old items' do
     message = build :message, base_path: '/base-path', attributes: { 'payload_version' => 2 }
-    message2 = build :message, base_path: '/base-path', attributes: { 'payload_version' => 4 }
+    message2 = build :message, base_path: '/base-path', attributes: {
+      'payload_version' => 4,
+      'locale' => message.payload['locale'],
+      'content_id' => message.payload['content_id'],
+    }
 
     expect {
       subject.process(message)

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -128,28 +128,6 @@ RSpec.describe Dimensions::Item, type: :model do
     end
   end
 
-  describe '#newer_than?' do
-    let(:dimension_item) { build :dimensions_item, publishing_api_payload_version: 10 }
-
-    it 'returns true when compared with `nil`' do
-      other = nil
-
-      expect(dimension_item.newer_than?(other)).to be true
-    end
-
-    it 'returns true if the payload version is bigger' do
-      other = build :dimensions_item, publishing_api_payload_version: 9
-
-      expect(dimension_item.newer_than?(other)).to be true
-    end
-
-    it 'returns false if the payload version is smaller' do
-      other = build :dimensions_item, publishing_api_payload_version: 11
-
-      expect(dimension_item.newer_than?(other)).to be false
-    end
-  end
-
   it 'stores/read a Hash with the item JSON' do
     item = create :dimensions_item, raw_json: { a: :b }
     item.reload


### PR DESCRIPTION
We need to discard the messages when they are old because we can’t take
any action based on old data.

We were having issues because old messages were deprecating all our
content items, which is something not exposed in our tests; I have added
an integration test so this situation don’t happen again.

### Pending

- [ ] Add a unit test for `PublishingAPI::MessageValidator`
- [ ] DRY-up fixtures to create old messages