### PR TITLE
Ensure a link update don't deprecate all items

### DIFF
--- a/app/streams/publishing_api/message_handler.rb
+++ b/app/streams/publishing_api/message_handler.rb
@@ -39,7 +39,9 @@ private
       )
     end
 
-    old_items.each(&:deprecate!)
+    if new_items.length < old_items.length
+      old_items.each(&:deprecate!)
+    end
 
     result
   end

--- a/spec/integration/streams/on_links_update_message_spec.rb
+++ b/spec/integration/streams/on_links_update_message_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe PublishingAPI::Consumer do
     expect {
       subject.process(link_update)
     }.to change(Dimensions::Item, :count).by(0)
+    expect(Dimensions::Item.first).to have_attributes(latest: true)
   end
 
   it 'grows the dimension with when links change' do


### PR DESCRIPTION
When we receive a link update and the update contains no changes then we
deprecate all the content items which implies that we won't be storing
the latest version of that content item.

The way we currently process messages is not very reasy to read and side
effects can happen without a clear representation of the cause in the
codebase. This is something that we will deal with very soon. In the
meantime, I have covered this logic with an integration test.