### PR TITLE
Rename, and remove unused, sidekiq configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,4 @@
-publishing-api-worker: bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
-google-analytics-worker: bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
+default-worker: bundle exec sidekiq -C ./config/sidekiq/default.yml
 publishing-api-consumer: bundle exec rake publishing_api:consumer
 bulk-import-publishing-api-consumer: bundle exec rake publishing_api:bulk_import_consumer
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/config/sidekiq/default.yml
+++ b/config/sidekiq/default.yml
@@ -1,5 +1,4 @@
 ---
 :concurrency:  3
 :queues:
-  - publishing_api
   - quality_metrics

--- a/config/sidekiq/google_analytics.yml
+++ b/config/sidekiq/google_analytics.yml
@@ -1,4 +1,0 @@
----
-:concurrency:  1
-:queues:
-  - google_analytics


### PR DESCRIPTION
Remove sidekiq workers/queues so we are left with only a default worker and a quality metrics queue

(DO NOT MERGE: May need to deploy at the same time as changes to govuk_app_deploy and puppet?)