### PR TITLE
Disable quality metrics job while we fix queue issue

### DIFF
--- a/app/domain/etl/item/processor.rb
+++ b/app/domain/etl/item/processor.rb
@@ -37,6 +37,8 @@ private
       dimensions_date: dimensions_date,
       dimensions_item: new_item
     )
-    Etl::Jobs::QualityMetricsJob.perform_later(new_item.id)
+    # temporarily disable quality metrics job as queues are not properly configured currently
+    # and it is causing problems for 2nd line
+    # Etl::Jobs::QualityMetricsJob.perform_later(new_item.id)
   end
 end

--- a/spec/domain/etl/item/item_processor_spec.rb
+++ b/spec/domain/etl/item/item_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Etl::Item::Processor do
   subject { described_class.new(old_item: old_item, new_item: new_item, date: Date.today) }
 
   before do
-    allow(Etl::Jobs::QualityMetricsJob).to receive(:perform_later)
+    # allow(Etl::Jobs::QualityMetricsJob).to receive(:perform_later)
     allow(Etl::Item::Metadata::NumberOfWordFiles).to receive(:parse).and_return(1)
     allow(Etl::Item::Metadata::NumberOfPdfs).to receive(:parse).and_return(2)
     subject.run
@@ -33,7 +33,7 @@ RSpec.describe Etl::Item::Processor do
       expect(new_item.reload.facts_edition).to be_persisted
     end
 
-    it 'fires a sidekiq job to populate quality metrics for the new edition' do
+    xit 'fires a sidekiq job to populate quality metrics for the new edition' do
       expect(Etl::Jobs::QualityMetricsJob).to have_received(:perform_later).with(new_item.id)
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe Etl::Item::Processor do
       )
     end
 
-    it 'does not fire a sidekiq job to populate quality metrics' do
+    xit 'does not fire a sidekiq job to populate quality metrics' do
       expect(Etl::Jobs::QualityMetricsJob).not_to have_received(:perform_later)
     end
   end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Import edition metrics' do
     end
   end
 
-  it 'stores content item metrics', perform_enqueued: true do
+  xit 'stores content item metrics', perform_enqueued: true do
     message = build(:message, schema_name: 'publication', base_path: '/new-path')
     message.payload['details']['body'] = 'This is good content.'
     message.payload['details']['documents'] = [


### PR DESCRIPTION
Quality metrics job is currently failing repeatedly, potentially due to our sidekiq queues not
yet being configured as necessary. This PR stops the job from being called.

This is necessary because it is causing huge problems to second line support.