### PR TITLE
Assign default values to fetch calls

### DIFF
--- a/app/streams/publishing_api/message_adapter.rb
+++ b/app/streams/publishing_api/message_adapter.rb
@@ -68,7 +68,7 @@ module PublishingAPI
         rendering_app: message.payload.fetch('rendering_app', nil),
         analytics_identifier: message.payload.fetch('analytics_identifier', nil),
         update_type: message.payload.fetch('update_type', nil),
-        expanded_links: message.payload.fetch('expanded_links', nil),
+        expanded_links: message.payload.fetch('expanded_links', {}),
         latest: true
       }
     end

--- a/app/streams/publishing_api/message_validator.rb
+++ b/app/streams/publishing_api/message_validator.rb
@@ -2,7 +2,7 @@ module PublishingAPI
   class MessageValidator
     def self.is_old_message?(message)
       payload_version = message.payload.fetch('payload_version').to_i
-      locale = message.payload.fetch('locale')
+      locale = message.payload.fetch('locale', 'en')
       content_id = message.payload.fetch('content_id')
 
       payload_version <= Dimensions::Item.where(


### PR DESCRIPTION
Temporary fix to stop using up sentry resources

We are currently getting thousands of errors a day in Sentry due to expanded links or locale being nil in the messages. This should stop the errors in Sentry to avoid using all sentry resources.

It seems that the changes in [this PR](https://github.com/alphagov/content-performance-manager/pull/825/files) are causing issues.

In the newly created `app/streams/publishing_api/message_validator.rb` fetching `locale` without a default value causes problems as `locale` does not seem to be a mandatory field based on `app/streams/publishing_api/consumer.rb line 24`.  This PR adds a default value of ‘en’ to this fetch to avoid `KeyError: key not found: "locale"` which is raising [here](https://sentry.io/govuk/app-content-performance-manager/issues/620993164/?query=is:unresolved) in sentry.

[This](https://sentry.io/govuk/app-content-performance-manager/issues/625225540/?query=is:unresolved) error seems to be caused by message.payload.fetch('expanded_links') defaulting to nil while not being a mandatory field. This PR adds `{}` as a default value as a temporary fix. Further investigation needs to be done to discover why messages appear to have begun to come in with unexpected values 