### PR TITLE
Add metrics raw bounce and time on page

### DIFF
--- a/app/domain/etl/ga/views_and_navigation_processor.rb
+++ b/app/domain/etl/ga/views_and_navigation_processor.rb
@@ -49,7 +49,9 @@ private
           entrances = s.entrances,
           exits = s.exits,
           bounce_rate = s.bounce_rate,
-          avg_time_on_page = s.avg_time_on_page
+          avg_time_on_page = s.avg_time_on_page,
+          bounces = s.bounces,
+          time_on_page = s.time_on_page
       FROM (
         SELECT pageviews,
                unique_pageviews,
@@ -57,6 +59,8 @@ private
                exits,
                bounce_rate,
                avg_time_on_page,
+               bounces,
+               time_on_page,
                dimensions_items.id
         FROM events_gas, dimensions_items
         WHERE page_path = base_path

--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -21,7 +21,7 @@ class Etl::GA::ViewsAndNavigationService
 private
 
   def append_data_labels(values)
-    page_path, pageviews, unique_pageviews, entrances, exits, bounce_rate, avg_time_on_page = *values
+    page_path, pageviews, unique_pageviews, entrances, exits, bounce_rate, avg_time_on_page, bounces, time_on_page = *values
 
     {
       'page_path' => page_path,
@@ -31,7 +31,9 @@ private
       'entrances' => entrances,
       'exits' => exits,
       'bounce_rate' => bounce_rate,
-      'avg_time_on_page' => avg_time_on_page
+      'avg_time_on_page' => avg_time_on_page,
+      'bounces' => bounces,
+      'time_on_page' => time_on_page
     }
   end
 
@@ -78,6 +80,8 @@ private
         { expression: 'ga:exits' },
         { expression: 'ga:bounceRate' },
         { expression: 'ga:avgTimeOnPage' },
+        { expression: 'ga:bounces' },
+        { expression: 'ga:timeOnPage' },
       ],
       page_size: 10_000,
       view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],

--- a/db/migrate/20180801075913_add_bounces_and_time_on_page_to_events_gas_and_facts_metrics.rb
+++ b/db/migrate/20180801075913_add_bounces_and_time_on_page_to_events_gas_and_facts_metrics.rb
@@ -1,0 +1,8 @@
+class AddBouncesAndTimeOnPageToEventsGasAndFactsMetrics < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events_gas, :bounces, :integer, default: 0
+    add_column :events_gas, :time_on_page, :integer, default: 0
+    add_column :facts_metrics, :bounces, :integer, default: 0
+    add_column :facts_metrics, :time_on_page, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180725104938) do
+ActiveRecord::Schema.define(version: 20180801075913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,8 @@ ActiveRecord::Schema.define(version: 20180725104938) do
     t.integer "entrances", default: 0
     t.integer "bounce_rate", default: 0
     t.integer "avg_time_on_page", default: 0
+    t.integer "bounces", default: 0
+    t.integer "time_on_page", default: 0
     t.index ["page_path", "date"], name: "index_events_gas_on_page_path_and_date"
     t.index ["process_name", "date", "page_path"], name: "index_events_gas_on_process_name_and_date_and_page_path", unique: true
   end
@@ -135,6 +137,8 @@ ActiveRecord::Schema.define(version: 20180725104938) do
     t.integer "entrances", default: 0
     t.integer "bounce_rate", default: 0
     t.integer "avg_time_on_page", default: 0
+    t.integer "bounces", default: 0
+    t.integer "time_on_page", default: 0
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "metrics_item_id_date_id", unique: true
   end
 

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
 
       described_class.process(date: date)
 
-      expect(fact1.reload).to have_attributes(pageviews: 1, unique_pageviews: 1, entrances: 10, exits: 5, bounce_rate: 50, avg_time_on_page: 60)
-      expect(fact2.reload).to have_attributes(pageviews: 2, unique_pageviews: 2, entrances: 20, exits: 10, bounce_rate: 100, avg_time_on_page: 30)
+      expect(fact1.reload).to have_attributes(pageviews: 1, unique_pageviews: 1, entrances: 10, exits: 5, bounce_rate: 50, avg_time_on_page: 60, bounces: 31, time_on_page: 20)
+      expect(fact2.reload).to have_attributes(pageviews: 2, unique_pageviews: 2, entrances: 20, exits: 10, bounce_rate: 100, avg_time_on_page: 30, bounces: 50, time_on_page: 23)
     end
 
     it 'does not update metrics for other days' do
@@ -79,6 +79,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
         'exits' => 5,
         'bounce_rate' => 50,
         'avg_time_on_page' => 60,
+        'bounces' => 31,
+        'time_on_page' => 20,
       },
       {
         'page_path' => '/path2',
@@ -90,6 +92,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
         'exits' => 10,
         'bounce_rate' => 100,
         'avg_time_on_page' => 30,
+        'bounces' => 50,
+        'time_on_page' => 23,
       },
     ]
   end
@@ -106,6 +110,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
         'exits' => 5,
         'bounce_rate' => 50,
         'avg_time_on_page' => 60,
+        'bounces' => 66,
+        'time_on_page' => 86,
       },
       {
         'page_path' => '/path2',
@@ -117,6 +123,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
         'exits' => 10,
         'bounce_rate' => 100,
         'avg_time_on_page' => 30,
+        'bounces' => 15,
+        'time_on_page' => 63,
       },
     ]
   end

--- a/spec/domain/etl/ga/views_and_navigation_service_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_service_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
       allow(google_client).to receive(:fetch_all) do
         [
           build_report_data(
-            build_report_row(dimensions: %w(/foo), metrics: %w(1 1 1 1 1 1))
+            build_report_row(dimensions: %w(/foo), metrics: %w(1 1 1 1 1 1 1 1))
           ),
           build_report_data(
-            build_report_row(dimensions: %w(/bar), metrics: %w(2 2 2 2 2 2))
+            build_report_row(dimensions: %w(/bar), metrics: %w(2 2 2 2 2 2 2 2))
           ),
           build_report_data(
-            build_report_row(dimensions: %w(/cool), metrics: %w(3 3 3 3 3 3))
+            build_report_row(dimensions: %w(/cool), metrics: %w(3 3 3 3 3 3 3 3))
           ),
         ]
       end
@@ -38,6 +38,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             'exits' => 1,
             'bounce_rate' => 1,
             'avg_time_on_page' => 1,
+            'bounces' => 1,
+            'time_on_page' => 1,
             'date' => '2018-02-20',
           ),
           a_hash_including(
@@ -48,6 +50,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             'exits' => 2,
             'bounce_rate' => 2,
             'avg_time_on_page' => 2,
+            'bounces' => 2,
+            'time_on_page' => 2,
             'date' => '2018-02-20',
           )
         ]
@@ -60,6 +64,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             'exits' => 3,
             'bounce_rate' => 3,
             'avg_time_on_page' => 3,
+            'bounces' => 3,
+            'time_on_page' => 3,
             'date' => '2018-02-20',
           )
         ]


### PR DESCRIPTION
[Trello: Add raw bounces and time on page metrics from Google Analytics to the data warehouse](https://trello.com/c/AnV8O5Yx/507-3-add-raw-bounces-and-time-on-page-metrics-from-google-analytics-to-the-data-warehouse)

This PR gets 'bounces' and 'time-on-page' metrics from Google Analytics. 

Although we have the metrics for  'bounce-rate' and 'avg-time-on-page', these are pre-calculated metrics from Google Analytics. They are accurate for individual days, but are misleading when aggregated over a longer date range or multiple content items. 

Getting the 'bounces' and 'time-on-page' metrics will enable us to create the calculated metrics ourselves after aggregation.