### PR TITLE
Assign default fetch value to message.payload.locale

### DIFF
--- a/app/streams/publishing_api/message_validator.rb
+++ b/app/streams/publishing_api/message_validator.rb
@@ -2,7 +2,7 @@ module PublishingAPI
   class MessageValidator
     def self.is_old_message?(message)
       payload_version = message.payload.fetch('payload_version').to_i
-      locale = message.payload.fetch('locale')
+      locale = message.payload.fetch('locale', nil)
       content_id = message.payload.fetch('content_id')
 
       payload_version <= Dimensions::Item.where(

--- a/spec/integration/streams/on_update_message_spec.rb
+++ b/spec/integration/streams/on_update_message_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe PublishingAPI::Consumer do
 
   let(:subject) { described_class.new }
 
+  it 'does not notify error if message is missing `locale`' do
+    message = build(:message)
+    message.payload.except!('locale')
+
+    expect(GovukError).not_to receive(:notify)
+    subject.process(message)
+  end
+
   it 'grows the dimension with update events' do
     expect {
       subject.process(build(:message))

--- a/spec/streams/publishing_api/message_validator_spec.rb
+++ b/spec/streams/publishing_api/message_validator_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe PublishingAPI::MessageValidator do
+  subject { described_class }
+
+  describe '.is_old_message?' do
+    it 'does not throw an exception when receiving message without locale' do
+      message = build(:message)
+      message.payload.except!('locale')
+
+      expect { subject.is_old_message?(message) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Key error is currently raised if we attempt `message.payload.fetch(locale)` on a
message from the publishing api rabbitmq queue without a locale.

Issue was caused in this pr: https://github.com/alphagov/content-performance-manager/pull/825/files

Add a default value to the fetch calls to avoid raising key errors to sentry.