### PR TITLE
Fix missing `expanded_links` bugs

### DIFF
--- a/app/streams/publishing_api/item_handler.rb
+++ b/app/streams/publishing_api/item_handler.rb
@@ -19,10 +19,14 @@ private
 
   def links_have_changed?
     return true if old_item.nil?
+    return false if new_item.nil?
+
+    old_links = old_item.expanded_links ? old_item.expanded_links : {}
+    new_links = new_item.expanded_links ? new_item.expanded_links : {}
 
     HashDiff::Comparison.new(
-      old_item.expanded_links.deep_sort,
-      new_item.expanded_links.deep_sort
+      old_links.deep_sort,
+      new_links.deep_sort
     ).diff.present?
   end
 

--- a/spec/integration/streams/on_links_update_message_spec.rb
+++ b/spec/integration/streams/on_links_update_message_spec.rb
@@ -20,6 +20,17 @@ RSpec.describe PublishingAPI::Consumer do
       to_return(status: 200, body: response.to_json, headers: { 'Content-Type' => 'application/json' })
   end
 
+  it 'does not notify error if old item is missing `expanded_links`' do
+    item = create(:dimensions_item, expanded_links: nil)
+    message = build(:message, :link_update)
+    message.payload['content_id'] = item.content_id
+    message.payload['publishing_api_payload_version'] = item.publishing_api_payload_version + 1
+    message.payload['base_path'] = item.base_path
+
+    expect(GovukError).not_to receive(:notify)
+    subject.process(message)
+  end
+
   it 'discard the event if no real link changes' do
     expect(GovukError).to_not receive(:notify)
 


### PR DESCRIPTION
NoMethodError is currently being raised when items do not
have expanded_links and we attempt to call .deep_sort on nil.

Fix bug by assigning expanded_links to a variable and ensuring it
can never be nil.