### PR TITLE
Revert sidekiq config changes

### DIFF
--- a/app/domain/etl/item/processor.rb
+++ b/app/domain/etl/item/processor.rb
@@ -37,8 +37,6 @@ private
       dimensions_date: dimensions_date,
       dimensions_item: new_item
     )
-    # temporarily disable quality metrics job as queues are not properly configured currently
-    # and it is causing problems for 2nd line
-    # Etl::Jobs::QualityMetricsJob.perform_later(new_item.id)
+    Etl::Jobs::QualityMetricsJob.perform_async(new_item.id)
   end
 end

--- a/app/domain/etl/jobs/quality_metrics_job.rb
+++ b/app/domain/etl/jobs/quality_metrics_job.rb
@@ -1,6 +1,6 @@
-class Etl::Jobs::QualityMetricsJob < ActiveJob::Base
-  retry_on Net::OpenTimeout, wait: 5.seconds, attempts: 10
-  queue_as :quality_metrics
+class Etl::Jobs::QualityMetricsJob
+  include Sidekiq::Worker
+  sidekiq_options queue: 'quality_metrics'
 
   def perform(item_id, _ = {})
     item = Dimensions::Item.find(item_id)

--- a/spec/domain/etl/item/item_processor_spec.rb
+++ b/spec/domain/etl/item/item_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Etl::Item::Processor do
   subject { described_class.new(old_item: old_item, new_item: new_item, date: Date.today) }
 
   before do
-    # allow(Etl::Jobs::QualityMetricsJob).to receive(:perform_later)
+    allow(Etl::Jobs::QualityMetricsJob).to receive(:perform_async)
     allow(Etl::Item::Metadata::NumberOfWordFiles).to receive(:parse).and_return(1)
     allow(Etl::Item::Metadata::NumberOfPdfs).to receive(:parse).and_return(2)
     subject.run
@@ -33,8 +33,8 @@ RSpec.describe Etl::Item::Processor do
       expect(new_item.reload.facts_edition).to be_persisted
     end
 
-    xit 'fires a sidekiq job to populate quality metrics for the new edition' do
-      expect(Etl::Jobs::QualityMetricsJob).to have_received(:perform_later).with(new_item.id)
+    it 'fires a sidekiq job to populate quality metrics for the new edition' do
+      expect(Etl::Jobs::QualityMetricsJob).to have_received(:perform_async).with(new_item.id)
     end
   end
 
@@ -53,8 +53,8 @@ RSpec.describe Etl::Item::Processor do
       )
     end
 
-    xit 'does not fire a sidekiq job to populate quality metrics' do
-      expect(Etl::Jobs::QualityMetricsJob).not_to have_received(:perform_later)
+    it 'does not fire a sidekiq job to populate quality metrics' do
+      expect(Etl::Jobs::QualityMetricsJob).not_to have_received(:perform_async)
     end
   end
 end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -2,7 +2,6 @@ require 'sidekiq/testing'
 RSpec.describe 'Import edition metrics' do
   include QualityMetricsHelpers
   include ItemSetupHelpers
-  include ActiveJob::TestHelper
 
   subject { PublishingAPI::MessageHandler }
 
@@ -12,7 +11,7 @@ RSpec.describe 'Import edition metrics' do
     end
   end
 
-  xit 'stores content item metrics', perform_enqueued: true do
+  it 'stores content item metrics' do
     message = build(:message, schema_name: 'publication', base_path: '/new-path')
     message.payload['details']['body'] = 'This is good content.'
     message.payload['details']['documents'] = [

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,11 +46,6 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
-
-  config.before :example, perform_enqueued: true do
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
-  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Reverts this PR https://github.com/alphagov/content-performance-manager/pull/810

Turn back on the quality metrics job in a separate PR.