### PR TITLE
Reduce number of quality metrics

### DIFF
--- a/spec/domain/etl/item/item_processor_spec.rb
+++ b/spec/domain/etl/item/item_processor_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe Etl::Item::Processor do
         latest: false
       },
       edition: {
-        contractions_count: 2,
-        equality_count: 3,
-        indefinite_article_count: 4,
+        word_count: 2,
       }
 ).dimensions_item
   end
@@ -26,15 +24,15 @@ RSpec.describe Etl::Item::Processor do
 
   context 'when the content has changed' do
     let(:new_item) do
-      create(:dimensions_item, base_path: '/base-path', document_text: 'new content')
+      create(:dimensions_item, base_path: '/base-path', document_text: 'fresh new content')
     end
 
     it 'creates a new edition' do
       expect(new_item.reload.facts_edition).to be_persisted
     end
 
-    it 'fires a sidekiq job to populate quality metrics for the new edition' do
-      expect(Etl::Jobs::QualityMetricsJob).to have_received(:perform_async).with(new_item.id)
+    it 'populates word count for the new edition' do
+      expect(new_item.reload.facts_edition.word_count).to eq 3
     end
   end
 
@@ -47,14 +45,8 @@ RSpec.describe Etl::Item::Processor do
       updated_item = new_item.reload
       expect(updated_item.facts_edition).to be_persisted
       expect(updated_item.facts_edition).to have_attributes(
-        contractions_count: 2,
-        equality_count: 3,
-        indefinite_article_count: 4,
+        word_count: 2
       )
-    end
-
-    it 'does not fire a sidekiq job to populate quality metrics' do
-      expect(Etl::Jobs::QualityMetricsJob).not_to have_received(:perform_async)
     end
   end
 end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -30,26 +30,13 @@ RSpec.describe 'Import edition metrics' do
       readability_score: 97,
       string_length: 21,
       sentence_count: 1,
-      word_count: 4,
-      contractions_count: 2,
-      equality_count: 3,
-      indefinite_article_count: 4,
-      passive_count: 5,
-      profanities_count: 6,
-      redundant_acronyms_count: 7,
-      repeated_words_count: 8,
-      simplify_count: 9,
-      spell_count: 10,
+      word_count: 4
     )
   end
 
   let(:existing_quality_metrics) do
     {
-      repeated_words_count: 1,
       word_count: 3,
-      equality_count: 2,
-      indefinite_article_count: 2,
-      passive_count: 6
     }
   end
 


### PR DESCRIPTION
Our team will only use word_count in the first iteration of this app which means
that we have no need to make calls to the govuk-content-quality-service.

In this PR we disable requests to the above service and calculate the only
quality metric we currently require for our mvp, word count, within our own codebase.

We continue to calculate the other metrics that we can get without making a
call to the quality metrics service as they basically come for free.

Note: Performing the population of quality metrics requires us to validate that
new_items have document_text. This was not previously needed as only the
job concerned with the item with no document text would fail when run async.