### PR TITLE
Exercise GA::Client in tests

### DIFF
--- a/app/domain/etl/ga/client.rb
+++ b/app/domain/etl/ga/client.rb
@@ -5,6 +5,10 @@ class Etl::GA::Client
   include Google::Apis::AnalyticsreportingV4
   include Google::Auth
 
+  def self.build
+    new.build
+  end
+
   def build(scope: AUTH_ANALYTICS_READONLY)
     @client ||= AnalyticsReportingService.new
     @client.authorization ||= ServiceAccountCredentials.make_creds(scope: scope)

--- a/app/domain/etl/ga/internal_search_service.rb
+++ b/app/domain/etl/ga/internal_search_service.rb
@@ -15,7 +15,7 @@ class Etl::GA::InternalSearchService
   end
 
   def client
-    @client ||= Etl::GA::Client.new.build
+    @client ||= Etl::GA::Client.build
   end
 
 private

--- a/app/domain/etl/ga/user_feedback_service.rb
+++ b/app/domain/etl/ga/user_feedback_service.rb
@@ -17,7 +17,7 @@ class Etl::GA::UserFeedbackService
   end
 
   def client
-    @client ||= GA::Client.new.build
+    @client ||= Etl::GA::Client.build
   end
 
 private

--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -15,7 +15,7 @@ class Etl::GA::ViewsAndNavigationService
   end
 
   def client
-    @client ||= Etl::GA::Client.new.build
+    @client ||= Etl::GA::Client.build
   end
 
 private

--- a/spec/domain/etl/ga/internal_search_service_spec.rb
+++ b/spec/domain/etl/ga/internal_search_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Etl::GA::InternalSearchService do
   subject { Etl::GA::InternalSearchService }
 
   let(:google_client) { double('client') }
-  before { allow_any_instance_of(Etl::GA::Client).to receive(:build).and_return(google_client) }
+  before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do
     let(:date) { Date.new(2018, 2, 20) }

--- a/spec/domain/etl/ga/internal_search_service_spec.rb
+++ b/spec/domain/etl/ga/internal_search_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Etl::GA::InternalSearchService do
 
   subject { Etl::GA::InternalSearchService }
 
-  let(:google_client) { double('client') }
+  let(:google_client) { instance_double(Google::Apis::AnalyticsreportingV4::AnalyticsReportingService) }
   before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do

--- a/spec/domain/etl/ga/user_feedback_service_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Etl::GA::UserFeedbackService do
   subject { Etl::GA::UserFeedbackService }
 
   let(:google_client) { double('client') }
-  before { allow_any_instance_of(Etl::GA::UserFeedbackService).to receive(:client).and_return(google_client) }
+  before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do
     let(:date) { Date.new(2018, 2, 20) }

--- a/spec/domain/etl/ga/user_feedback_service_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Etl::GA::UserFeedbackService do
 
   subject { Etl::GA::UserFeedbackService }
 
-  let(:google_client) { double('client') }
+  let(:google_client) { instance_double(Google::Apis::AnalyticsreportingV4::AnalyticsReportingService) }
   before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do

--- a/spec/domain/etl/ga/views_and_navigation_service_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
   subject { Etl::GA::ViewsAndNavigationService }
 
   let(:google_client) { double('client') }
-  before { allow_any_instance_of(Etl::GA::ViewsAndNavigationService).to receive(:client).and_return(google_client) }
+  before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do
     let(:date) { Date.new(2018, 2, 20) }

--- a/spec/domain/etl/ga/views_and_navigation_service_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
 
   subject { Etl::GA::ViewsAndNavigationService }
 
-  let(:google_client) { double('client') }
+  let(:google_client) { instance_double(Google::Apis::AnalyticsreportingV4::AnalyticsReportingService) }
   before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
 
   describe "#find_in_batches" do


### PR DESCRIPTION
Google Analytics client client was not tested because we were mocking 
at the method level, as a result we were not able to catch production errors 
that were result of name changes.