### PR TITLE
Handle base paths with more than 1 segment in path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     get '/v1/metrics/', to: "metrics#index"
-    get '/v1/metrics/:metric/:base_path/', to: "metrics#summary"
-    get '/v1/metrics/:metric/:base_path/time-series', to: "metrics#time_series"
+    get '/v1/metrics/:metric/*base_path/time-series', to: "metrics#time_series"
+    get '/v1/metrics/:metric/*base_path', to: "metrics#summary"
     get '/v1/healthcheck', to: "healthcheck#index"
   end
 

--- a/spec/routing/metrics_routing_spec.rb
+++ b/spec/routing/metrics_routing_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe 'metrics routing' do
+  it 'routes /api/v1/metrics/:metric/long/base/path correctly' do
+    expect(get: '/api/v1/metrics/pageviews/long/base/path').to route_to(
+      controller: 'api/metrics',
+      action: 'summary',
+      format: :json,
+      metric: 'pageviews',
+      base_path: 'long/base/path'
+    )
+  end
+
+  it 'routes /api/v1/metrics/:metric/long/base/path/time-series correctly' do
+    expect(get: '/api/v1/metrics/pageviews/long/base/path/time-series').to route_to(
+      controller: 'api/metrics',
+      action: 'time_series',
+      format: :json,
+      metric: 'pageviews',
+      base_path: 'long/base/path'
+    )
+  end
+end


### PR DESCRIPTION
Currently the api endpoints can only handle a
single segment in the url eg:

GET /api/v1/metrics/pageviews/path > 200
GET /api/v1/metrics/pageviews/long/base/path > 404
GET /api/v1/metrics/pageviews/path/time-series > 200
GET /api/v1/metrics/pageviews/long/base/path/time-series > 404

This commit uses * in these routes so longer base paths
will be handled correctly.