### PR TITLE
Handle the GdsApi::TimedOutException when calling support-api

### DIFF
--- a/app/domain/etl/feedex/processor.rb
+++ b/app/domain/etl/feedex/processor.rb
@@ -27,6 +27,11 @@ private
       Events::Feedex.import(events, batch_size: BATCH_SIZE)
       batch += 1
     end
+  rescue GdsApi::TimedOutException,
+         GdsApi::HTTPNotFound,
+         GdsApi::EndpointNotFound,
+         GdsApi::InvalidUrl => e
+    GovukError.notify(e)
   end
 
   def load_metrics

--- a/app/domain/etl/feedex/service.rb
+++ b/app/domain/etl/feedex/service.rb
@@ -3,10 +3,10 @@ require 'gds_api/support_api'
 class Etl::Feedex::Service
   attr_reader :date, :batch_size, :support_api
 
-  def initialize(date, batch_size, support_api = GdsApi::SupportApi.new(Plek.new.find('support-api')))
+  def initialize(date, batch_size, support_api = nil)
     @date = date
     @batch_size = batch_size
-    @support_api = support_api
+    @support_api = support_api || support_api_with_long_timeout
   end
 
   def find_in_batches
@@ -21,6 +21,12 @@ class Etl::Feedex::Service
   end
 
 private
+
+  def support_api_with_long_timeout
+    GdsApi::SupportApi.new(Plek.new.find('support-api')).tap do |client|
+      client.options[:timeout] = 15
+    end
+  end
 
   def convert_results(results)
     results.map do |result|

--- a/spec/domain/etl/feedex/processor_spec.rb
+++ b/spec/domain/etl/feedex/processor_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Etl::Feedex::Processor do
 
   let(:date) { Date.new(2018, 2, 20) }
 
-  before { allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_yield(feedex_response) }
 
   context 'When the base_path matches the feedex path' do
+    before { allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_yield(feedex_response) }
     it 'update the facts with the feedex metrics' do
       fact1 = create_metric base_path: '/path1', date: '2018-02-20'
       fact2 = create_metric base_path: '/path2', date: '2018-02-20'
@@ -45,6 +45,7 @@ RSpec.describe Etl::Feedex::Processor do
 
   context 'when there are events from other days' do
     before do
+      allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_yield(feedex_response)
       create(:feedex, date: date - 1, page_path: '/path1')
       create(:feedex, date: date - 2, page_path: '/path1')
     end
@@ -63,6 +64,40 @@ RSpec.describe Etl::Feedex::Processor do
       described_class.process(date: date)
 
       expect(Events::Feedex.count).to eq(3)
+    end
+  end
+
+  context 'when the support-api throws' do
+    before do
+      allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_raise(error)
+      allow(GovukError).to receive(:notify)
+      described_class.process(date: date)
+    end
+
+    shared_examples 'all errors' do
+      it 'traps the error and notifies Sentry' do
+        expect(GovukError).to have_received(:notify).with(error)
+      end
+    end
+
+    context 'a GdsApi::TimedOutException' do
+      let(:error) { GdsApi::TimedOutException.new 'test message' }
+      it_behaves_like 'all errors'
+    end
+
+    context 'a GdsApi::InvalidUrl' do
+      let(:error) { GdsApi::InvalidUrl.new 'test message' }
+      it_behaves_like 'all errors'
+    end
+
+    context 'a GdsApi::EndpointNotFound' do
+      let(:error) { GdsApi::EndpointNotFound.new 'test message' }
+      it_behaves_like 'all errors'
+    end
+
+    context 'any other GdsApi::HTTPErrorResponse' do
+      let(:error) { GdsApi::HTTPNotFound.new 'test message' }
+      it_behaves_like 'all errors'
     end
   end
 


### PR DESCRIPTION
We have been getting a GdsApi::TimedOutException when
retrieving feedex comments from the support API.

The default timeout for gds-api-adapters is 4 seconds.

This PR overrides the default to allow a 15 second timeout.

It also traps any GdsApi:: errors and sends the error to sentry

Trello: https://trello.com/c/hzJF3BrN/599-2-fix-timeouterror-in-feedex