### PR TITLE
Trap errors in Etl::Master::MetricsProcessor

### DIFF
--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -34,6 +34,8 @@ module Etl
           end
           Facts::Metric.import(values, validate: false)
         end
+      rescue StandardError => e
+        GovukError.notify(e)
       end
     end
   end


### PR DESCRIPTION
We have a problem in this class.

We are not seeing any errors anywhere.
We should now see errors in Sentry.