### PR TITLE
Remove FactoryBot deprecation warnings.

### DIFF
--- a/spec/factories/dimensions_items.rb
+++ b/spec/factories/dimensions_items.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :dimensions_item, class: Dimensions::Item do
-    latest true
-    locale 'en'
+    latest { true }
+    locale { 'en' }
     sequence(:content_id) { |i| "content_id - #{i}" }
     sequence(:title) { |i| "title - #{i}" }
     sequence(:base_path) { |i| "link - #{i}" }
     sequence(:description) { |i| "description - #{i}" }
     sequence(:raw_json) { |i| "json - #{i}" }
     sequence(:publishing_api_payload_version)
-    schema_name 'detailed_guide'
-    document_type 'detailed_guide'
+    schema_name { 'detailed_guide' }
+    document_type { 'detailed_guide' }
 
     initialize_with { Dimensions::Item.find_or_create_by(base_path: base_path, latest: latest) }
   end

--- a/spec/factories/facts_editions.rb
+++ b/spec/factories/facts_editions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :facts_edition, class: Facts::Edition do
     dimensions_date
-    number_of_pdfs 0
+    number_of_pdfs { 0 }
   end
 end

--- a/spec/factories/feedexes.rb
+++ b/spec/factories/feedexes.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :feedex, class: Events::Feedex do
     sequence(:page_path) { |i| "/path/#{i}" }
     sequence(:date) { |i| i.days.ago.to_date }
-    feedex_comments 1
+    feedex_comments { 1 }
   end
 end

--- a/spec/factories/ga_events.rb
+++ b/spec/factories/ga_events.rb
@@ -1,20 +1,20 @@
 FactoryBot.define do
   factory :ga_event, class: Events::GA do
     trait :with_views do
-      pageviews 10
-      unique_pageviews 5
-      process_name 'views'
+      pageviews { 10 }
+      unique_pageviews { 5 }
+      process_name { 'views' }
     end
 
     trait :with_user_feedback do
-      is_this_useful_yes 3
-      is_this_useful_no 6
-      process_name 'user_feedback'
+      is_this_useful_yes { 3 }
+      is_this_useful_no { 6 }
+      process_name { 'user_feedback' }
     end
 
     trait :with_number_of_internal_searches do
-      number_of_internal_searches 100
-      process_name 'number_of_internal_searches'
+      number_of_internal_searches { 100 }
+      process_name { 'number_of_internal_searches' }
     end
 
     sequence(:page_path) { |i| "/path/#{i}" }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -4,15 +4,15 @@ FactoryBot.define do
   factory :message, class: GovukMessageQueueConsumer::MockMessage do
     transient do
       sequence(:payload_version) { |i| 10 + i }
-      schema_name 'detailed_guide'
-      document_type 'detailed_guide'
-      base_path '/base-path'
-      routing_key 'news_story.major'
+      schema_name { 'detailed_guide' }
+      document_type { 'detailed_guide' }
+      base_path { '/base-path' }
+      routing_key { 'news_story.major' }
       attributes { {} }
     end
 
     trait :link_update do
-      routing_key 'schema.links'
+      routing_key { 'schema.links' }
     end
 
     delivery_info { OpenStruct.new(routing_key: routing_key) }
@@ -26,8 +26,8 @@ FactoryBot.define do
     end
 
     trait :with_parts do
-      schema_name 'guide'
-      document_type 'guide'
+      schema_name { 'guide' }
+      document_type { 'guide' }
       payload do
         GovukSchemas::RandomExample.for_schema(notification_schema: schema_name) do |result|
           result['base_path'] = base_path
@@ -101,8 +101,8 @@ FactoryBot.define do
     end
 
     trait :travel_advice do
-      schema_name 'travel_advice'
-      document_type 'travel_advice'
+      schema_name { 'travel_advice' }
+      document_type { 'travel_advice' }
       payload do
         GovukSchemas::RandomExample.for_schema(notification_schema: schema_name) do |result|
           result['base_path'] = base_path

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :metric, class: Facts::Metric do
     dimensions_date
     dimensions_item
-    pageviews 10
-    unique_pageviews 5
+    pageviews { 10 }
+    unique_pageviews { 5 }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :user do
     transient do
-      organisation nil
+      organisation { nil }
     end
 
     sequence(:uid) { |i| "user-#{i}" }
     sequence(:name) { |i| "Test User #{i}" }
-    email 'user@example.com'
+    email { 'user@example.com' }
     permissions { ['signin'] }
-    organisation_slug "government-digital-service"
+    organisation_slug { "government-digital-service" }
   end
 end


### PR DESCRIPTION
FactoryBot now requires static attributes to be specified
in a block rather than by passing raw values.

This commit removes the deprecation warnings by using a
block for static attributes.

Discovered these warnings while implementing trello: https://trello.com/c/6L4Q4gjd/598-2-remove-rawjson-column-from-dimensionsitem-etl