### PR TITLE
[do not merge] Use govuk-app-config healthcheck support

### DIFF
--- a/app/domain/healthchecks/daily_metrics_check.rb
+++ b/app/domain/healthchecks/daily_metrics_check.rb
@@ -1,0 +1,21 @@
+module Healthchecks
+  class DailyMetricsCheck
+    def name
+      :daily_metrics
+    end
+
+    def status
+      metrics.any? ? :ok : :critical
+    end
+
+    def message
+      "There are #{metrics.count} metrics for #{Date.yesterday}"
+    end
+
+  private
+
+    def metrics
+      @metrics ||= Facts::Metric.where(dimensions_date_id: Date.yesterday)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,8 @@ Rails.application.routes.draw do
   end
 
   get '/sandbox', to: 'sandbox#index'
+
+  get '/healthcheck', to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+  )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get '/sandbox', to: 'sandbox#index'
 
   get '/healthcheck', to: GovukHealthcheck.rack_response(
+    Healthchecks::DailyMetricsCheck,
     GovukHealthcheck::ActiveRecord,
   )
 end

--- a/spec/domain/healthchecks/daily_metrics_check_spec.rb
+++ b/spec/domain/healthchecks/daily_metrics_check_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Healthchecks::DailyMetricsCheck do
+  let(:today) { Date.new(2018, 1, 15) }
+
+  around do |example|
+    Timecop.freeze(today) { example.run }
+  end
+
+  context 'When there are metric' do
+    before { create :metric, dimensions_date: Dimensions::Date.for(Date.yesterday) }
+
+    it 'returns status :ok' do
+      expect(subject.status).to eq(:ok)
+    end
+
+    it 'returns a detailed message' do
+      expect(subject.message).to eq('There are 1 metrics for 2018-01-14')
+    end
+  end
+
+  context 'When there are no metrics' do
+    it 'returns status :critical' do
+      expect(subject.status).to eq(:critical)
+    end
+
+    it 'returns a detailed message' do
+      expect(subject.message).to eq('There are 0 metrics for 2018-01-14')
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/jOTrrdNP/605-investigate-threads-issue-when-upgrading-to-rails-521)

We have implemented our own way of supporting healthchecks, which is ok
but we should be [using the gem that GOV.UK has created for all the
applications](https://github.com/alphagov/govuk_app_config).

This update is also related to an incidence when the existing
implementation of the healthcheck was causing issues with a memory leak
with Rails 5.2.1

In any case, we should use the gem support.

I am also adding a check to ensure that we collected daily metrics.