### PR TITLE
Remove database connection check in API healthcheck

### DIFF
--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -3,15 +3,6 @@ class Api::HealthcheckController < Api::BaseController
   skip_before_action :set_cache_headers
 
   def index
-    database = ActiveRecord::Base.establish_connection ? :ok : :critical
-
-    healthcheck = {
-      checks: {
-        database: { status: database }
-      },
-      status: :ok
-    }
-
-    render json: healthcheck
+    render json: { status: 'ok' }
   end
 end

--- a/spec/requests/api/v1/healthcheck_spec.rb
+++ b/spec/requests/api/v1/healthcheck_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe '/api/v1/healthcheck/', type: :request do
   it "is not cacheable" do
     get "/api/v1/healthcheck/"


### PR DESCRIPTION
[Trello card](https://trello.com/c/jOTrrdNP/605-investigate-threads-issue-when-upgrading-to-rails-521)

There is no need to validate for a database connection when checking the
status of the API. This and other health checks are being validated by
the health check ‘/healthcheck’ that triggers alarms in 2ndline.

We also need to disable it to test the threads issues with Rails 5.2.1
