### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gem 'rack-proxy'
 gem 'rails', '~> 5.1'
 gem 'ruby-progressbar'
 gem 'sass-rails'
-gem 'turbolinks'
 gem 'uglifier'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,9 +443,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
-    turbolinks (5.1.1)
-      turbolinks-source (~> 5.1)
-    turbolinks-source (5.1.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -530,7 +527,6 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen
   timecop
-  turbolinks
   uglifier
   unicorn
   web-console

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,8 @@
 
 <% content_for :head do %>
   <%= csrf_meta_tags %>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
 <% end %>
 
 <% content_for :content do %>


### PR DESCRIPTION
There is no need to use turbolinks because the application is mainly an
API that serve JSON requests.