### PR TITLE
Set rubyLintDiff to false

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ library("govuk")
 node("postgresql-9.6") {
   govuk.buildProject(
     postgres96Lint: false,
+    rubyLintDiff: false,
     beforeTest: {
       govuk.setEnvar("TEST_COVERAGE", "true")
     }


### PR DESCRIPTION
To ensure all the code is valid given the current linting rules.