### PR TITLE
Add satisfaction score to API

### DIFF
--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -60,7 +60,7 @@ class Facts::Metric < ApplicationRecord
     ]
   end
 
-  private
+private
 
   def calculate_satisfaction_score
     return nil if is_this_useful_yes.nil? && is_this_useful_no.nil?

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -11,6 +11,16 @@ class Facts::Metric < ApplicationRecord
     joins(dimensions_item: :facts_edition)
   end
 
+  def is_this_useful_yes=(value)
+    super(value)
+    self.satisfaction_score = calculate_satisfaction_score
+  end
+
+  def is_this_useful_no=(value)
+    super(value)
+    self.satisfaction_score = calculate_satisfaction_score
+  end
+
   def self.csv_fields
     %i[
       date
@@ -48,5 +58,15 @@ class Facts::Metric < ApplicationRecord
       bounce_rate
       avg_time_on_page
     ]
+  end
+
+  private
+
+  def calculate_satisfaction_score
+    return nil if is_this_useful_yes.nil? && is_this_useful_no.nil?
+    return 0 if is_this_useful_yes.nil? || is_this_useful_yes.zero?
+    return 1 if is_this_useful_no.nil? || is_this_useful_no.zero?
+
+    is_this_useful_yes.to_f / (is_this_useful_yes + is_this_useful_no).to_f
   end
 end

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -19,6 +19,10 @@ daily:
     description: "Total number of people who found the page helpful"
     source: 'Google Analytics'
 
+  - name: 'satisfaction_score'
+    description: "Calculated percentage score based on `is_this_useful_yes` and `is_this_useful_no` values."
+    source: 'custom'
+
   - name: 'number_of_internal_searches'
     description: "Number of times a user searches for something else on GOV.UK from the page"
     source: 'Google Analytics'

--- a/db/migrate/20180822144907_add_satisfaction_score_to_facts_metric.rb
+++ b/db/migrate/20180822144907_add_satisfaction_score_to_facts_metric.rb
@@ -1,0 +1,5 @@
+class AddSatisfactionScoreToFactsMetric < ActiveRecord::Migration[5.2]
+  def change
+    add_column :facts_metrics, :satisfaction_score, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180820115550) do
+ActiveRecord::Schema.define(version: 2018_08_22_144907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define(version: 20180820115550) do
     t.integer "avg_time_on_page", default: 0
     t.integer "bounces", default: 0
     t.integer "time_on_page", default: 0
+    t.float "satisfaction_score"
     t.index ["dimensions_date_id", "dimensions_item_id"], name: "metrics_item_id_date_id", unique: true
   end
 

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
     before { allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it 'update the facts with the GA metrics' do
-      fact1 = create_metric base_path: '/path1', date: '2018-02-20'
-      fact2 = create_metric base_path: '/path2', date: '2018-02-20'
+      fact1 = create_metric base_path: '/path1', date: '2018-02-20', daily: { is_this_useful_no: 1, is_this_useful_yes: 1 }
+      fact2 = create_metric base_path: '/path2', date: '2018-02-20', daily: { is_this_useful_no: 5, is_this_useful_yes: 10 }
 
       described_class.process(date: date)
 
-      expect(fact1.reload).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 1)
-      expect(fact2.reload).to have_attributes(is_this_useful_no: 5, is_this_useful_yes: 10)
+      expect(fact1.reload).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 1, satisfaction_score: 0.5)
+      expect(fact2.reload).to have_attributes(is_this_useful_no: 5, is_this_useful_yes: 10, satisfaction_score: 0.666666666666667)
     end
 
     it 'does not update metrics for other days' do

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -2,4 +2,83 @@
 RSpec.describe Facts::Metric, type: :model do
   it { is_expected.to validate_presence_of(:dimensions_date) }
   it { is_expected.to validate_presence_of(:dimensions_item) }
+
+  describe '.satisfaction_score' do
+    it 'calculates and sets satisfaction_score with yes and no values' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: 10, is_this_useful_no: 2
+
+      expect(metric.satisfaction_score).to eq(10.to_f / (10 + 2).to_f)
+      expect(metric.satisfaction_score.round(2)).to eq(0.83)
+    end
+
+    it 'sets satisfaction_score to `nil` with `no` values' do
+      metric = FactoryBot.build :metric
+
+      expect(metric.satisfaction_score).to be_nil
+    end
+
+    it 'sets satisfaction_score to `nil` with explicit `nil` values' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: nil, is_this_useful_no: nil
+
+      expect(metric.satisfaction_score).to be_nil
+    end
+
+    it 'sets satisfaction_score 100% with only `yes` values and no `no` values' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: 1
+
+      expect(metric.satisfaction_score).to eq(1)
+    end
+
+    it 'sets satisfaction_score 100% with a `yes` value and `no` value explicitly set to `0`' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: 1, is_this_useful_no: 0
+
+      expect(metric.satisfaction_score).to eq(1)
+    end
+
+    it 'sets satisfaction_score 100% with a `yes` value and `no` value explicitly set to `nil`' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: 1, is_this_useful_no: nil
+
+      expect(metric.satisfaction_score).to eq(1)
+    end
+
+    it 'sets satisfaction_score to 0% with only `no` values' do
+      metric = FactoryBot.build :metric, is_this_useful_no: 1
+
+      expect(metric.satisfaction_score).to eq(0)
+    end
+
+    it 'sets satisfaction_score to 0% with a `no` value and `yes` value explicitly set to `0`' do
+      metric = FactoryBot.build :metric, is_this_useful_no: 1, is_this_useful_yes: 0
+
+      expect(metric.satisfaction_score).to eq(0)
+    end
+
+    it 'sets satisfaction_score to 0% with no `no` value and `yes` value explicitly set to `0`' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: 0
+
+      expect(metric.satisfaction_score).to eq(0)
+    end
+
+    it 'sets satisfaction_score to 0% with only no values and yes explicitly set to nil' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: nil, is_this_useful_no: 1
+
+      expect(metric.satisfaction_score).to eq(0)
+    end
+
+    it 'recalculates satisfaction_score when `no` is updated' do
+      metric = FactoryBot.build :metric, is_this_useful_yes: 1
+      expect(metric.satisfaction_score).to eq(1)
+
+      metric.is_this_useful_no = 1
+      expect(metric.satisfaction_score).to eq(0.5)
+    end
+
+    it 'recalculates satisfaction_score when `yes` is updated' do
+      metric = FactoryBot.build :metric, is_this_useful_no: 1
+      expect(metric.satisfaction_score).to eq(0)
+
+      metric.is_this_useful_yes = 1
+      expect(metric.satisfaction_score).to eq(0.5)
+    end
+  end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Metric do
     it "returns a list of all metrics" do
       metrics = Metric.find_all
 
-      expect(metrics.length).to eq(25)
+      expect(metrics.length).to eq(26)
       a_metric = metrics.first
       expect(a_metric).to be_an_instance_of(Metric)
     end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -110,11 +110,11 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
   describe 'Daily metrics' do
     before do
-      create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10
-      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200
-      create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20
-      create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30
-      create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40
+      create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10, is_this_useful_yes: 10, is_this_useful_no: 20
+      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200, is_this_useful_yes: 10, is_this_useful_no: 20
+      create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20, is_this_useful_yes: 10, is_this_useful_no: 20
+      create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30, is_this_useful_yes: 10, is_this_useful_no: 20
+      create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40, is_this_useful_yes: 10, is_this_useful_no: 20
       create :facts_edition, dimensions_item: item, dimensions_date: day1
     end
 
@@ -123,6 +123,29 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json).to eq(build_time_series_response('pageviews'))
+    end
+
+    it 'returns `satisfaction_score` values between two dates' do
+      get "/api/v1/metrics/satisfaction_score/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      satisfaction_score = {
+        satisfaction_score: [
+          {
+              date: "2018-01-13",
+              value: 0.333333333333333
+          },
+          {
+              date: "2018-01-14",
+              value: 0.333333333333333
+          },
+          {
+              date: "2018-01-15",
+              value: 0.333333333333333
+          }
+        ]
+      }
+
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json).to eq(satisfaction_score)
     end
 
     it 'returns `feedex issues` between two dates' do


### PR DESCRIPTION
we want to know `satisfaction_score` based on the values of:

- `is_this_useful_yes`
- `is_this_useful_no`

but we don't want to have to calculate this every time we want to make
use of it, such as filtering or ordering by this value. So we store this value when either of the other yes/no values are set.