### PR TITLE
Add StatsD for all metrics when the master ETL process is finished

### DIFF
--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -19,6 +19,10 @@ class Etl::Master::MasterProcessor
       Etl::GA::InternalSearchProcessor.process(date: date)
       Etl::Feedex::Processor.process(date: date)
     end
+
+    time(process: :monitor) do
+      Monitor::Etl.run
+    end
   end
 
   def already_run?

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -1,4 +1,8 @@
 class Monitor::Etl
+  def self.run(*args)
+    new(*args).run
+  end
+
   def run
     count_metrics!
     count_daily_metrics!

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -1,4 +1,4 @@
-class Monitor::ETL
+class Monitor::Etl
   def run
     count_metrics!
     count_daily_metrics!
@@ -9,18 +9,32 @@ private
 
   def count_edition_metrics!
     Metric.edition_metrics.map(&:name).each do |edition_metric|
-      GovukStatsd.count("monitor.etl.#{edition_metric}", editions.sum("facts_editions.#{edition_metric}"))
+      path = path_for_edition_metric(edition_metric)
+
+      GovukStatsd.count(path, editions.sum("facts_editions.#{edition_metric}"))
     end
   end
 
   def count_daily_metrics!
     Metric.daily_metrics.map(&:name).each do |daily_metric|
-      GovukStatsd.count("monitor.etl.#{daily_metric}", metrics.sum(daily_metric))
+      path = path_for_daily_metric(daily_metric)
+
+      GovukStatsd.count(path, metrics.sum(daily_metric))
     end
   end
 
   def count_metrics!
-    GovukStatsd.count("monitor.etl.facts_metrics", metrics.count)
+    path = "monitor.etl.facts_metrics"
+
+    GovukStatsd.count(path, metrics.count)
+  end
+
+  def path_for_edition_metric(edition_metric)
+    "monitor.etl.edition.#{edition_metric}"
+  end
+
+  def path_for_daily_metric(daily_metric)
+    "monitor.etl.daily.#{daily_metric}"
   end
 
   def metrics

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -1,0 +1,33 @@
+class Monitor::ETL
+  def run
+    count_metrics!
+    count_daily_metrics!
+    count_edition_metrics!
+  end
+
+private
+
+  def count_edition_metrics!
+    Metric.edition_metrics.map(&:name).each do |edition_metric|
+      GovukStatsd.count("monitor.etl.#{edition_metric}", editions.sum("facts_editions.#{edition_metric}"))
+    end
+  end
+
+  def count_daily_metrics!
+    Metric.daily_metrics.map(&:name).each do |daily_metric|
+      GovukStatsd.count("monitor.etl.#{daily_metric}", metrics.sum(daily_metric))
+    end
+  end
+
+  def count_metrics!
+    GovukStatsd.count("monitor.etl.facts_metrics", metrics.count)
+  end
+
+  def metrics
+    @metrics ||= Facts::Metric.for_yesterday
+  end
+
+  def editions
+    @editions = metrics.joins(dimensions_item: :facts_edition)
+  end
+end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -44,13 +44,10 @@ class Facts::Metric < ApplicationRecord
       number_of_pdfs
       number_of_word_files
       readability_score
-      spell_count
       is_this_useful_yes
       is_this_useful_no
       number_of_internal_searches
       word_count
-      passive_count
-      simplify_count
       string_length
       sentence_count
       entrances

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -21,6 +21,8 @@ class Facts::Metric < ApplicationRecord
     self.satisfaction_score = calculate_satisfaction_score
   end
 
+  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.for(Date.yesterday)) }
+
   def self.csv_fields
     %i[
       date

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -55,42 +55,6 @@ edition:
   - name: 'readability_score'
     description: "Flesch-Kincaid Reading Ease score"
 
-  - name: 'contractions_count'
-    description: "Count of improper apostrophe use in contractions."
-    source: 'retext'
-
-  - name: 'equality_count'
-    description: "Number of times potentially insensitive language is used"
-    source: 'retext'
-
-  - name: 'indefinite_article_count'
-    description: "Number of times the indefinite articles (a, an) are used incorrectly"
-    source: 'retext'
-
-  - name: 'passive_count'
-    description: "Number of times the passive voice is used"
-    source: 'retext'
-
-  - name: 'profanities_count'
-    description: "Number of times profanities are used"
-    source: 'retext'
-
-  - name: 'redundant_acronyms_count'
-    description: "Number of times redundant acronyms are used (like ATM machine instead of ATM)"
-    source: 'retext'
-
-  - name: 'repeated_words_count'
-    description: 'Number of times a word is repeated (like "for for")'
-    source: 'retext'
-
-  - name: 'simplify_count'
-    description: "Count of complicated words that have a simpler alternative"
-    source: 'retext'
-
-  - name: 'spell_count'
-    description: "Number of spelling errors"
-    source: 'retext'
-
   - name: 'string_length'
     description: "Total number of characters used in the text"
     source: 'custom'

--- a/db/migrate/20180824105759_delete_old_edition_metrics.rb
+++ b/db/migrate/20180824105759_delete_old_edition_metrics.rb
@@ -1,0 +1,13 @@
+class DeleteOldEditionMetrics < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :facts_editions, :contractions_count
+    remove_column :facts_editions, :equality_count
+    remove_column :facts_editions, :indefinite_article_count
+    remove_column :facts_editions, :passive_count
+    remove_column :facts_editions, :profanities_count
+    remove_column :facts_editions, :redundant_acronyms_count
+    remove_column :facts_editions, :repeated_words_count
+    remove_column :facts_editions, :simplify_count
+    remove_column :facts_editions, :spell_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_22_144907) do
+ActiveRecord::Schema.define(version: 2018_08_24_105759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,15 +104,6 @@ ActiveRecord::Schema.define(version: 2018_08_22_144907) do
     t.integer "number_of_pdfs"
     t.integer "number_of_word_files"
     t.integer "readability_score"
-    t.integer "contractions_count"
-    t.integer "equality_count"
-    t.integer "indefinite_article_count"
-    t.integer "passive_count"
-    t.integer "profanities_count"
-    t.integer "redundant_acronyms_count"
-    t.integer "repeated_words_count"
-    t.integer "simplify_count"
-    t.integer "spell_count"
     t.integer "string_length"
     t.integer "sentence_count"
     t.integer "word_count"

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Etl::Master::MasterProcessor do
     allow(Etl::GA::InternalSearchProcessor).to receive(:process)
     allow(Etl::Feedex::Processor).to receive(:process)
     allow(Etl::Master::MetricsProcessor).to receive(:process)
+    allow(Monitor::Etl).to receive(:run)
   end
 
   describe 'runs only once per day' do
@@ -46,6 +47,12 @@ RSpec.describe Etl::Master::MasterProcessor do
 
   it 'update Feedex metrics in the Facts table' do
     expect(Etl::Feedex::Processor).to receive(:process).with(date: Date.new(2018, 2, 19))
+
+    subject.process
+  end
+
+  it 'monitors ETL processes' do
+    expect(Monitor::Etl).to receive(:run)
 
     subject.process
   end

--- a/spec/domain/monitor/etl_spec.rb
+++ b/spec/domain/monitor/etl_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Monitor::ETL do
+  include ItemSetupHelpers
+
+  around do |example|
+    Timecop.freeze(Date.new(2018, 1, 15)) { example.run }
+  end
+
+  let(:yesterday) { '2018-01-14' }
+
+  before { allow(GovukStatsd).to receive(:count) }
+
+  it 'sends StatsD counter for facts_metrics for previous day' do
+    expect(GovukStatsd).to receive(:count).with("monitor.etl.facts_metrics", 1)
+
+    create_metric date: yesterday
+    subject.run
+  end
+
+  Metric.daily_metrics.map(&:name).each do |metric_name|
+    it "sends StatsD counter for daily metric: `#{metric_name}` for previous day" do
+      expect(GovukStatsd).to receive(:count).with("monitor.etl.#{metric_name}", 10)
+
+      create_metric date: yesterday, daily: { metric_name => 10 }
+      subject.run
+    end
+  end
+
+  Metric.edition_metrics.map(&:name).each do |metric_name|
+    it "sends StatsD counter for edition metric `#{metric_name}` for previous day" do
+      expect(GovukStatsd).to receive(:count).with("monitor.etl.#{metric_name}", 10)
+
+      create_metric date: yesterday, edition: { metric_name => 10 }
+      subject.run
+    end
+  end
+end

--- a/spec/domain/monitor/etl_spec.rb
+++ b/spec/domain/monitor/etl_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Monitor::ETL do
+RSpec.describe Monitor::Etl do
   include ItemSetupHelpers
 
   around do |example|
@@ -18,7 +18,7 @@ RSpec.describe Monitor::ETL do
 
   Metric.daily_metrics.map(&:name).each do |metric_name|
     it "sends StatsD counter for daily metric: `#{metric_name}` for previous day" do
-      expect(GovukStatsd).to receive(:count).with("monitor.etl.#{metric_name}", 10)
+      expect(GovukStatsd).to receive(:count).with("monitor.etl.daily.#{metric_name}", 10)
 
       create_metric date: yesterday, daily: { metric_name => 10 }
       subject.run
@@ -27,7 +27,7 @@ RSpec.describe Monitor::ETL do
 
   Metric.edition_metrics.map(&:name).each do |metric_name|
     it "sends StatsD counter for edition metric `#{metric_name}` for previous day" do
-      expect(GovukStatsd).to receive(:count).with("monitor.etl.#{metric_name}", 10)
+      expect(GovukStatsd).to receive(:count).with("monitor.etl.edition.#{metric_name}", 10)
 
       create_metric date: yesterday, edition: { metric_name => 10 }
       subject.run

--- a/spec/features/sandbox/download_csv_spec.rb
+++ b/spec/features/sandbox/download_csv_spec.rb
@@ -31,10 +31,6 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
 
     edition = create :facts_edition, dimensions_item: item, dimensions_date: day0
     edition.readability_score = 9
-    edition.spell_count = 10
-    edition.word_count = 14
-    edition.passive_count = 15
-    edition.simplify_count = 16
     edition.string_length = 17
     edition.sentence_count = 18
     edition.number_of_pdfs = 22
@@ -63,10 +59,10 @@ RSpec.feature 'Show aggregated metrics', type: :feature do
     expect(page.response_headers['Content-Type']).to eq "text/csv"
     expect(page.response_headers['Content-disposition']).to eq 'attachment; filename="download.csv"'
 
-    header = 'date,content_id,base_path,locale,title,description,document_type,schema_name,content_purpose_document_supertype,content_purpose_supergroup,content_purpose_subgroup,first_published_at,public_updated_at,pageviews,primary_organisation_title,primary_organisation_content_id,unique_pageviews,feedex_comments,number_of_pdfs,number_of_word_files,readability_score,spell_count,is_this_useful_yes,is_this_useful_no,number_of_internal_searches,word_count,passive_count,simplify_count,string_length,sentence_count,entrances,exits,bounce_rate,avg_time_on_page'
+    header = 'date,content_id,base_path,locale,title,description,document_type,schema_name,content_purpose_document_supertype,content_purpose_supergroup,content_purpose_subgroup,first_published_at,public_updated_at,pageviews,primary_organisation_title,primary_organisation_content_id,unique_pageviews,feedex_comments,number_of_pdfs,number_of_word_files,readability_score,is_this_useful_yes,is_this_useful_no,number_of_internal_searches,word_count,string_length,sentence_count,entrances,exits,bounce_rate,avg_time_on_page'
     expect(page.body).to include(header)
 
-    row = "2018-01-12,content-id,/base-path,en,This is the title,This is the description,Guide,Guide,Super Guide,Guide,guidance,2018-02-03 00:00:00 UTC,2018-03-03 00:00:00 UTC,19,HMRC,the-organisation-id,20,21,22,23,9,10,11,12,13,14,15,16,17,18,30,31,32,33"
+    row = "2018-01-12,content-id,/base-path,en,This is the title,This is the description,Guide,Guide,Super Guide,Guide,guidance,2018-02-03 00:00:00 UTC,2018-03-03 00:00:00 UTC,19,HMRC,the-organisation-id,20,21,22,23,9,11,12,13,,17,18,30,31,32,33"
     expect(page.body).to include(row)
   end
 end

--- a/spec/features/sandbox/quality_metrics_spec.rb
+++ b/spec/features/sandbox/quality_metrics_spec.rb
@@ -10,19 +10,10 @@ RSpec.feature 'Quality metrics', type: :feature do
 
   context 'Content metrics' do
     metrics = %w(
-      contractions_count
-      equality_count
-      indefinite_article_count
       number_of_pdfs
       number_of_word_files
-      passive_count
-      profanities_count
       readability_score
-      redundant_acronyms_count
-      repeated_words_count
       sentence_count
-      simplify_count
-      spell_count
       string_length
       word_count
     )

--- a/spec/integration/master/daily_metrics_spec.rb
+++ b/spec/integration/master/daily_metrics_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe 'Master process spec' do
     stub_google_analytics_user_feedback_response
     stub_google_analytics_internal_search_response
     stub_feedex_response
+    stub_monitoring
 
     Etl::Master::MasterProcessor.process
 
     validate_facts_metrics!
     validate_google_analytics!
     validate_feedex!
+    validate_monitoring!
   end
 
   def latest_version
@@ -49,6 +51,10 @@ RSpec.describe 'Master process spec' do
 
   def validate_feedex!
     expect(latest_metric).to have_attributes(feedex_comments: 21)
+  end
+
+  def validate_monitoring!
+    expect(GovukStatsd).to have_received(:count).at_least(1).times
   end
 
   def stub_google_analytics_response
@@ -110,6 +116,10 @@ RSpec.describe 'Master process spec' do
         },
       ]
     )
+  end
+
+  def stub_monitoring
+    allow(GovukStatsd).to receive(:count)
   end
 
   def stub_feedex_response

--- a/spec/models/facts/edition_spec.rb
+++ b/spec/models/facts/edition_spec.rb
@@ -11,15 +11,6 @@ RSpec.describe Facts::Edition do
       string_length: 21,
       sentence_count: 1,
       word_count: 4,
-      contractions_count: 2,
-      equality_count: 3,
-      indefinite_article_count: 4,
-      passive_count: 5,
-      profanities_count: 6,
-      redundant_acronyms_count: 7,
-      repeated_words_count: 8,
-      simplify_count: 9,
-      spell_count: 10,
     }
   end
 

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -1,5 +1,6 @@
-
 RSpec.describe Facts::Metric, type: :model do
+  include ItemSetupHelpers
+
   it { is_expected.to validate_presence_of(:dimensions_date) }
   it { is_expected.to validate_presence_of(:dimensions_item) }
 
@@ -79,6 +80,20 @@ RSpec.describe Facts::Metric, type: :model do
 
       metric.is_this_useful_yes = 1
       expect(metric.satisfaction_score).to eq(0.5)
+    end
+  end
+
+  describe ".for_yesterday" do
+    around do |example|
+      Timecop.freeze(Date.new(2018, 1, 15)) { example.run }
+    end
+
+    it "returns yesterday's metrics" do
+      metric1 = create_metric base_path: '/path1', date: '2018-01-14'
+      metric2 = create_metric base_path: '/path2', date: '2018-01-14'
+      create_metric base_path: '/path2', date: '2018-01-13'
+
+      expect(Facts::Metric.for_yesterday).to match_array([metric1, metric2])
     end
   end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1,19 +1,10 @@
 RSpec.describe Metric do
   EDITION_METRICS =
     %w(
-      contractions_count
-      equality_count
-      indefinite_article_count
       number_of_pdfs
       number_of_word_files
-      passive_count
-      profanities_count
       readability_score
-      redundant_acronyms_count
-      repeated_words_count
       sentence_count
-      simplify_count
-      spell_count
       string_length
       word_count
     ).freeze
@@ -36,7 +27,7 @@ RSpec.describe Metric do
     it "returns a list of all metrics" do
       metrics = Metric.find_all
 
-      expect(metrics.length).to eq(26)
+      expect(metrics.length).to eq(17)
       a_metric = metrics.first
       expect(a_metric).to be_an_instance_of(Metric)
     end

--- a/spec/support/item_setup_helpers.rb
+++ b/spec/support/item_setup_helpers.rb
@@ -1,5 +1,5 @@
 module ItemSetupHelpers
-  def create_metric(base_path:, date:, edition: {}, daily: {}, item: {})
+  def create_metric(base_path: '/base-path', date:, edition: {}, daily: {}, item: {})
     dimensions_item = dimensions_item(item.merge(base_path: base_path))
     dimensions_date = dimensions_date(date)
     ensure_edition_exists(dimensions_item, dimensions_date, edition)


### PR DESCRIPTION
[Trello card](https://trello.com/c/XSVkcFvP/616-etl-monitor-add-data-about-acquisition-metrics)

Related to https://github.com/alphagov/govuk-puppet/pull/8043

On a daily basis, when the master process finish, we send to
Grafana via StatsD the aggregation of each metric.

We aim to have patters in the metrics that enable the team to 
detect issues in our ETL processes. If a new metric is being published
or removed we don't have to modify our process, it will continue
publishing all available metrics.