### PR TITLE
Do not publish StatsD data for historic measures

### DIFF
--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -21,7 +21,7 @@ class Etl::Master::MasterProcessor
     end
 
     time(process: :monitor) do
-      Monitor::Etl.run
+      Monitor::Etl.run unless historic_data?
     end
   end
 
@@ -32,6 +32,10 @@ class Etl::Master::MasterProcessor
 private
 
   attr_reader :date
+
+  def historic_data?
+    date != Date.yesterday
+  end
 
   class DuplicateDateError < StandardError;
   end

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -51,10 +51,18 @@ RSpec.describe Etl::Master::MasterProcessor do
     subject.process
   end
 
-  it 'monitors ETL processes' do
-    expect(Monitor::Etl).to receive(:run)
+  describe 'Monitoring' do
+    it 'monitors ETL processes' do
+      expect(Monitor::Etl).to receive(:run)
 
-    subject.process
+      subject.process
+    end
+
+    it 'does not add ETL stats if not the day before' do
+      expect(Monitor::Etl).to_not receive(:run)
+
+      subject.process(date: Date.today)
+    end
   end
 
   it 'can run the process for other days' do


### PR DESCRIPTION
We shouldn’t send old data for StatsD as it will just mess up with 
the previous day. We need to investigate further how to publish
information for previous days but for the time being it is good
enough to just not publish stats for historic data.