### PR TITLE
Add StatsD for Facts, Editions and Dimensions

### DIFF
--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -24,6 +24,7 @@ class Etl::Master::MasterProcessor
       unless historic_data?
         Monitor::Etl.run
         Monitor::Dimensions.run
+        Monitor::Facts.run
       end
     end
   end

--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -21,7 +21,10 @@ class Etl::Master::MasterProcessor
     end
 
     time(process: :monitor) do
-      Monitor::Etl.run unless historic_data?
+      unless historic_data?
+        Monitor::Etl.run
+        Monitor::Dimensions.run
+      end
     end
   end
 

--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -25,7 +25,7 @@ module Etl
         log process: :metrics, message: 'about to get the Dimensions::Date'
         dimensions_date = Dimensions::Date.for(date)
         log process: :metrics, message: 'got the Dimensions::Date'
-        Dimensions::Item.where(latest: true).find_in_batches(batch_size: 50000)
+        Dimensions::Item.latest.find_in_batches(batch_size: 50000)
           .with_index do |batch, index|
           log process: :metrics, message: "processing #{batch.length} items in batch #{index}"
           values = batch.pluck(:id).map do |value|

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -15,7 +15,7 @@ private
 
   def count_latest_base_paths!
     path = path_for('latest_base_path')
-    count = Dimensions::Item.where(latest: true).count
+    count = Dimensions::Item.latest.count
 
     GovukStatsd.count(path, count)
   end
@@ -29,7 +29,7 @@ private
 
   def count_latest_content_items!
     path = path_for('latest_content_items')
-    count = Dimensions::Item.where(latest: true).count('distinct content_id')
+    count = Dimensions::Item.latest.count('distinct content_id')
 
     GovukStatsd.count(path, count)
   end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -6,5 +6,6 @@ class Monitor::Dimensions
   def run
     GovukStatsd.count('monitor.dimensions.base_path', Dimensions::Item.count)
     GovukStatsd.count('monitor.dimensions.latest_base_path', Dimensions::Item.where(latest: true).count)
+    GovukStatsd.count('monitor.dimensions.content_items', Dimensions::Item.count('distinct content_id'))
   end
 end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -1,0 +1,9 @@
+class Monitor::Dimensions
+  def self.run(*args)
+    new(*args).run
+  end
+
+  def run
+    GovukStatsd.count('monitor.dimensions.base_path', Dimensions::Item.count)
+  end
+end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -7,5 +7,6 @@ class Monitor::Dimensions
     GovukStatsd.count('monitor.dimensions.base_path', Dimensions::Item.count)
     GovukStatsd.count('monitor.dimensions.latest_base_path', Dimensions::Item.where(latest: true).count)
     GovukStatsd.count('monitor.dimensions.content_items', Dimensions::Item.count('distinct content_id'))
+    GovukStatsd.count('monitor.dimensions.latest_content_items', Dimensions::Item.where(latest: true).count('distinct content_id'))
   end
 end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -4,9 +4,44 @@ class Monitor::Dimensions
   end
 
   def run
-    GovukStatsd.count('monitor.dimensions.base_path', Dimensions::Item.count)
-    GovukStatsd.count('monitor.dimensions.latest_base_path', Dimensions::Item.where(latest: true).count)
-    GovukStatsd.count('monitor.dimensions.content_items', Dimensions::Item.count('distinct content_id'))
-    GovukStatsd.count('monitor.dimensions.latest_content_items', Dimensions::Item.where(latest: true).count('distinct content_id'))
+    count_base_paths!
+    count_latest_base_paths!
+
+    count_content_items
+    count_latest_content_items!
+  end
+
+private
+
+  def count_latest_base_paths!
+    path = path_for('latest_base_path')
+    count = Dimensions::Item.where(latest: true).count
+
+    GovukStatsd.count(path, count)
+  end
+
+  def count_base_paths!
+    path = path_for('base_path')
+    count = Dimensions::Item.count
+
+    GovukStatsd.count(path, count)
+  end
+
+  def count_latest_content_items!
+    path = path_for('latest_content_items')
+    count = Dimensions::Item.where(latest: true).count('distinct content_id')
+
+    GovukStatsd.count(path, count)
+  end
+
+  def count_content_items
+    path = path_for('content_items')
+    count = Dimensions::Item.count('distinct content_id')
+
+    GovukStatsd.count(path, count)
+  end
+
+  def path_for(item)
+    "monitor.dimensions.#{item}"
   end
 end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -14,14 +14,14 @@ class Monitor::Dimensions
 private
 
   def statsd_for_latest_base_paths!
-    path = path_for('latest_base_path')
+    path = path_for('latest_base_paths')
     count = Dimensions::Item.latest.count
 
     GovukStatsd.count(path, count)
   end
 
   def statsd_for_all_base_paths!
-    path = path_for('base_path')
+    path = path_for('base_paths')
     count = Dimensions::Item.count
 
     GovukStatsd.count(path, count)

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -5,5 +5,6 @@ class Monitor::Dimensions
 
   def run
     GovukStatsd.count('monitor.dimensions.base_path', Dimensions::Item.count)
+    GovukStatsd.count('monitor.dimensions.latest_base_path', Dimensions::Item.where(latest: true).count)
   end
 end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -4,37 +4,37 @@ class Monitor::Dimensions
   end
 
   def run
-    count_base_paths!
-    count_latest_base_paths!
+    statsd_for_all_base_paths!
+    statsd_for_latest_base_paths!
 
-    count_content_items
-    count_latest_content_items!
+    statsd_for_all_content_items!
+    statsd_for_latest_content_items!
   end
 
 private
 
-  def count_latest_base_paths!
+  def statsd_for_latest_base_paths!
     path = path_for('latest_base_path')
     count = Dimensions::Item.latest.count
 
     GovukStatsd.count(path, count)
   end
 
-  def count_base_paths!
+  def statsd_for_all_base_paths!
     path = path_for('base_path')
     count = Dimensions::Item.count
 
     GovukStatsd.count(path, count)
   end
 
-  def count_latest_content_items!
+  def statsd_for_latest_content_items!
     path = path_for('latest_content_items')
     count = Dimensions::Item.latest.count('distinct content_id')
 
     GovukStatsd.count(path, count)
   end
 
-  def count_content_items
+  def statsd_for_all_content_items!
     path = path_for('content_items')
     count = Dimensions::Item.count('distinct content_id')
 

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -4,13 +4,13 @@ class Monitor::Etl
   end
 
   def run
-    count_daily_metrics!
-    count_edition_metrics!
+    statsd_for_performance_metrics!
+    statsd_for_edition_metrics!
   end
 
 private
 
-  def count_edition_metrics!
+  def statsd_for_edition_metrics!
     Metric.edition_metrics.map(&:name).each do |edition_metric|
       path = path_for_edition_metric(edition_metric)
 
@@ -18,7 +18,7 @@ private
     end
   end
 
-  def count_daily_metrics!
+  def statsd_for_performance_metrics!
     Metric.daily_metrics.map(&:name).each do |daily_metric|
       path = path_for_daily_metric(daily_metric)
 

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -4,7 +4,6 @@ class Monitor::Etl
   end
 
   def run
-    count_metrics!
     count_daily_metrics!
     count_edition_metrics!
   end
@@ -25,12 +24,6 @@ private
 
       GovukStatsd.count(path, metrics.sum(daily_metric))
     end
-  end
-
-  def count_metrics!
-    path = "monitor.etl.facts_metrics"
-
-    GovukStatsd.count(path, metrics.count)
   end
 
   def path_for_edition_metric(edition_metric)

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -7,6 +7,8 @@ class Monitor::Facts
   def run
     count_facts_metrics!
     count_facts_daily_metrics!
+
+    count_facts_editions!
   end
 
 private
@@ -21,6 +23,13 @@ private
   def count_facts_daily_metrics!
     path = path_for('daily_metrics')
     count = Facts::Metric.for_yesterday.count
+
+    GovukStatsd.count(path, count)
+  end
+
+  def count_facts_editions!
+    path = path_for('all_editions')
+    count = Facts::Edition.count
 
     GovukStatsd.count(path, count)
   end

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -4,37 +4,37 @@ class Monitor::Facts
   end
 
   def run
-    count_facts_metrics!
-    count_facts_daily_metrics!
+    statsd_for_all_metrics!
+    statsd_for_yesterday_metrics!
 
-    count_facts_editions!
-    count_daily_facts_editions!
+    statsd_for_total_editions!
+    statsd_for_yesterday_editions!
   end
 
 private
 
-  def count_facts_metrics!
+  def statsd_for_all_metrics!
     path = path_for('all_metrics')
     count = Facts::Metric.count
 
     GovukStatsd.count(path, count)
   end
 
-  def count_facts_daily_metrics!
+  def statsd_for_yesterday_metrics!
     path = path_for('daily_metrics')
     count = Facts::Metric.for_yesterday.count
 
     GovukStatsd.count(path, count)
   end
 
-  def count_facts_editions!
+  def statsd_for_total_editions!
     path = path_for('all_editions')
     count = Facts::Edition.count
 
     GovukStatsd.count(path, count)
   end
 
-  def count_daily_facts_editions!
+  def statsd_for_yesterday_editions!
     path = path_for('daily_editions')
     count = Facts::Edition.where(dimensions_date: Dimensions::Date.for(Date.yesterday)).count
 

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -1,5 +1,4 @@
 class Monitor::Facts
- 
   def self.run(*args)
     new(*args).run
   end
@@ -9,6 +8,7 @@ class Monitor::Facts
     count_facts_daily_metrics!
 
     count_facts_editions!
+    count_daily_facts_editions!
   end
 
 private
@@ -34,6 +34,12 @@ private
     GovukStatsd.count(path, count)
   end
 
+  def count_daily_facts_editions!
+    path = path_for('daily_editions')
+    count = Facts::Edition.where(dimensions_date: Dimensions::Date.for(Date.yesterday)).count
+
+    GovukStatsd.count(path, count)
+  end
 
   def path_for(item)
     "monitor.facts.#{item}"

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -1,0 +1,24 @@
+class Monitor::Facts
+ 
+  def self.run(*args)
+    new(*args).run
+  end
+
+  def run
+    count_facts_metrics!
+  end
+
+private
+
+  def count_facts_metrics!
+    path = path_for('all_metrics')
+    count = Facts::Metric.count
+
+    GovukStatsd.count(path, count)
+  end
+
+
+  def path_for(item)
+    "monitor.facts.#{item}"
+  end
+end

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -6,6 +6,7 @@ class Monitor::Facts
 
   def run
     count_facts_metrics!
+    count_facts_daily_metrics!
   end
 
 private
@@ -13,6 +14,13 @@ private
   def count_facts_metrics!
     path = path_for('all_metrics')
     count = Facts::Metric.count
+
+    GovukStatsd.count(path, count)
+  end
+
+  def count_facts_daily_metrics!
+    path = path_for('daily_metrics')
+    count = Facts::Metric.for_yesterday.count
 
     GovukStatsd.count(path, count)
   end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -14,6 +14,7 @@ class Dimensions::Item < ApplicationRecord
   scope :by_organisation_id, ->(organisation_id) { where(primary_organisation_content_id: organisation_id) }
   scope :by_document_type, ->(document_type) { where('document_type like (?)', document_type) }
   scope :by_locale, ->(locale) { where(locale: locale) }
+  scope :latest, -> { where(latest: true) }
   scope :latest_by_content_id, ->(content_id, locale) { where(content_id: content_id, locale: locale, latest: true) }
   scope :latest_by_base_path, ->(base_paths) { where(base_path: base_paths, latest: true) }
   scope :existing_latest_items, ->(content_id, locale, base_paths) { latest_by_content_id(content_id, locale).or(latest_by_base_path(base_paths)) }

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -52,16 +52,32 @@ RSpec.describe Etl::Master::MasterProcessor do
   end
 
   describe 'Monitoring' do
-    it 'monitors ETL processes' do
-      expect(Monitor::Etl).to receive(:run)
+    context 'the day before' do
+      it 'monitors ETL processes' do
+        expect(Monitor::Etl).to receive(:run)
 
-      subject.process
+        subject.process
+      end
+
+      it 'monitor Item Dimensions' do
+        expect(Monitor::Dimensions).to receive(:run)
+
+        subject.process
+      end
     end
 
-    it 'does not add ETL stats if not the day before' do
-      expect(Monitor::Etl).to_not receive(:run)
+    context 'not the day before' do
+      it 'does not add ETL stats if not the day before' do
+        expect(Monitor::Etl).to_not receive(:run)
 
-      subject.process(date: Date.today)
+        subject.process(date: Date.today)
+      end
+
+      it 'does not add Dimension stats if not the day before' do
+        expect(Monitor::Dimensions).to_not receive(:run)
+
+        subject.process(date: Date.today)
+      end
     end
   end
 

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe Etl::Master::MasterProcessor do
 
         subject.process
       end
+
+      it 'monitor Facts' do
+        expect(Monitor::Facts).to receive(:run)
+
+        subject.process
+      end
     end
 
     context 'not the day before' do
@@ -75,6 +81,12 @@ RSpec.describe Etl::Master::MasterProcessor do
 
       it 'does not add Dimension stats if not the day before' do
         expect(Monitor::Dimensions).to_not receive(:run)
+
+        subject.process(date: Date.today)
+      end
+
+      it 'does not add Facts stats if not the day before' do
+        expect(Monitor::Facts).to_not receive(:run)
 
         subject.process(date: Date.today)
       end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe Monitor::Dimensions do
 
     subject.run
   end
+
+  it 'sends the total number of content_items' do
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.content_items", 1)
+
+    create :dimensions_item, content_id: 'id1', base_path: '/foo'
+    create :dimensions_item, content_id: 'id1', base_path: '/bar'
+
+    subject.run
+  end
 end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -34,4 +34,15 @@ RSpec.describe Monitor::Dimensions do
 
     subject.run
   end
+
+  it 'sends the total number of `latest` content_items' do
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_content_items", 1)
+
+    create :dimensions_item, content_id: 'id1', base_path: '/foo', latest: true
+    create :dimensions_item, content_id: 'id1', base_path: '/bar', latest: true
+    create :dimensions_item, content_id: 'id1', base_path: '/other', latest: false
+    subject.run
+  end
+
+
 end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -43,6 +43,4 @@ RSpec.describe Monitor::Dimensions do
     create :dimensions_item, content_id: 'id1', base_path: '/other', latest: false
     subject.run
   end
-
-
 end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Monitor::Dimensions do
+  include ItemSetupHelpers
+
+  around do |example|
+    Timecop.freeze(Date.new(2018, 1, 15)) { example.run }
+  end
+
+  let(:yesterday) { '2018-01-14' }
+
+  before { allow(GovukStatsd).to receive(:count) }
+
+  it 'sends the total number of base_paths' do
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.base_path", 2)
+
+    create_list :dimensions_item, 2
+
+    subject.run
+  end
+end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Monitor::Dimensions do
   before { allow(GovukStatsd).to receive(:count) }
 
   it 'sends StatsD counter of base_paths' do
-    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.base_path", 2)
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.base_paths", 2)
 
     create_list :dimensions_item, 2
 
@@ -18,7 +18,7 @@ RSpec.describe Monitor::Dimensions do
   end
 
   it 'sends StatsD counter of `latest` base_paths' do
-    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_base_path", 1)
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_base_paths", 1)
 
     create :dimensions_item, base_path: '/foo', latest: true
     create :dimensions_item, base_path: '/bar', latest: false

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Monitor::Dimensions do
 
   before { allow(GovukStatsd).to receive(:count) }
 
-  it 'sends the total number of base_paths' do
+  it 'sends StatsD counter of base_paths' do
     expect(GovukStatsd).to receive(:count).with("monitor.dimensions.base_path", 2)
 
     create_list :dimensions_item, 2
@@ -17,7 +17,7 @@ RSpec.describe Monitor::Dimensions do
     subject.run
   end
 
-  it 'sends the total number of `latest` base_paths' do
+  it 'sends StatsD counter of `latest` base_paths' do
     expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_base_path", 1)
 
     create :dimensions_item, base_path: '/foo', latest: true
@@ -26,7 +26,7 @@ RSpec.describe Monitor::Dimensions do
     subject.run
   end
 
-  it 'sends the total number of content_items' do
+  it 'sends StatsD counter of content_items' do
     expect(GovukStatsd).to receive(:count).with("monitor.dimensions.content_items", 1)
 
     create :dimensions_item, content_id: 'id1', base_path: '/foo'
@@ -35,7 +35,7 @@ RSpec.describe Monitor::Dimensions do
     subject.run
   end
 
-  it 'sends the total number of `latest` content_items' do
+  it 'sends StatsD counter of `latest` content_items' do
     expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_content_items", 1)
 
     create :dimensions_item, content_id: 'id1', base_path: '/foo', latest: true

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -16,4 +16,13 @@ RSpec.describe Monitor::Dimensions do
 
     subject.run
   end
+
+  it 'sends the total number of `latest` base_paths' do
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_base_path", 1)
+
+    create :dimensions_item, base_path: '/foo', latest: true
+    create :dimensions_item, base_path: '/bar', latest: false
+
+    subject.run
+  end
 end

--- a/spec/domain/monitor/etl_spec.rb
+++ b/spec/domain/monitor/etl_spec.rb
@@ -9,13 +9,6 @@ RSpec.describe Monitor::Etl do
 
   before { allow(GovukStatsd).to receive(:count) }
 
-  it 'sends StatsD counter for facts_metrics for previous day' do
-    expect(GovukStatsd).to receive(:count).with("monitor.etl.facts_metrics", 1)
-
-    create_metric date: yesterday
-    subject.run
-  end
-
   Metric.daily_metrics.map(&:name).each do |metric_name|
     it "sends StatsD counter for daily metric: `#{metric_name}` for previous day" do
       expect(GovukStatsd).to receive(:count).with("monitor.etl.daily.#{metric_name}", 10)

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Monitor::Facts do
+  include ItemSetupHelpers
+
+  around do |example|
+    Timecop.freeze(Date.new(2018, 1, 15)) { example.run }
+  end
+
+  let(:yesterday) { '2018-01-14' }
+
+  before { allow(GovukStatsd).to receive(:count) }
+
+  it 'sends the total number of facts metrics' do
+    expect(GovukStatsd).to receive(:count).with("monitor.facts.all_metrics", 2)
+
+    create_list :metric, 2
+
+    subject.run
+  end
+
+end

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Monitor::Facts do
 
   before { allow(GovukStatsd).to receive(:count) }
 
-  it 'sends the total number of facts metrics' do
+  it 'sends StatsD counter for facts metrics' do
     expect(GovukStatsd).to receive(:count).with("monitor.facts.all_metrics", 2)
 
     create_list :metric, 2
@@ -17,7 +17,7 @@ RSpec.describe Monitor::Facts do
     subject.run
   end
 
-  it 'sends the total number of `daily` metrics' do
+  it 'sends StatsD counter for `daily` metrics' do
     expect(GovukStatsd).to receive(:count).with("monitor.facts.daily_metrics", 1)
 
     create_metric date: Date.yesterday
@@ -26,7 +26,7 @@ RSpec.describe Monitor::Facts do
     subject.run
   end
 
-  it 'sends the total number of facts editions' do
+  it 'sends StatsD counter for facts editions' do
     expect(GovukStatsd).to receive(:count).with("monitor.facts.all_editions", 2)
 
     create_metric date: Date.yesterday, base_path: '/foo'
@@ -35,7 +35,7 @@ RSpec.describe Monitor::Facts do
     subject.run
   end
 
-  it 'sends the total number of `daily` editions' do
+  it 'sends StatsD counter for `daily` editions' do
     expect(GovukStatsd).to receive(:count).with("monitor.facts.daily_editions", 1)
 
     create_metric date: Date.yesterday, base_path: '/foo'

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe Monitor::Facts do
 
     subject.run
   end
+
+  it 'sends the total number of facts editions' do
+    expect(GovukStatsd).to receive(:count).with("monitor.facts.all_editions", 2)
+
+    create_metric date: Date.yesterday, base_path: '/foo'
+    create_metric date: Date.today, base_path: '/bar'
+
+    subject.run
+  end
 end

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -17,4 +17,12 @@ RSpec.describe Monitor::Facts do
     subject.run
   end
 
+  it 'sends the total number of `daily` metrics' do
+    expect(GovukStatsd).to receive(:count).with("monitor.facts.daily_metrics", 1)
+
+    create_metric date: Date.yesterday
+    create_metric date: Date.today
+
+    subject.run
+  end
 end

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -34,4 +34,13 @@ RSpec.describe Monitor::Facts do
 
     subject.run
   end
+
+  it 'sends the total number of `daily` editions' do
+    expect(GovukStatsd).to receive(:count).with("monitor.facts.daily_editions", 1)
+
+    create_metric date: Date.yesterday, base_path: '/foo'
+    create_metric date: Date.today, base_path: '/bar'
+
+    subject.run
+  end
 end

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Item.count).to eq(5)
-    expect(Dimensions::Item.where(latest: true).count).to eq(4)
+    expect(Dimensions::Item.latest.count).to eq(4)
   end
 
   it "increases the number of latest items when a subpage is added" do
@@ -77,7 +77,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Item.count).to eq(5)
-    expect(Dimensions::Item.where(latest: true).count).to eq(5)
+    expect(Dimensions::Item.latest.count).to eq(5)
   end
 
   it "decreases the number of latest items when a subpage is removed" do
@@ -90,7 +90,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Item.count).to eq(4)
-    expect(Dimensions::Item.where(latest: true).count).to eq(3)
+    expect(Dimensions::Item.latest.count).to eq(3)
   end
 
   it "still grows the dimension if parts are renamed" do
@@ -103,7 +103,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Item.count).to eq(5)
-    expect(Dimensions::Item.where(latest: true).count).to eq(4)
+    expect(Dimensions::Item.latest.count).to eq(4)
   end
 
   context "when base paths in the message already belong to items with a different content id" do
@@ -119,7 +119,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
       subject.process(another_message)
 
       expect(Dimensions::Item.count).to eq(8)
-      expect(Dimensions::Item.where(latest: true).count).to eq(4)
+      expect(Dimensions::Item.latest.count).to eq(4)
     end
   end
 

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe Dimensions::Item, type: :model do
       expect(results).to match_array([item1])
     end
 
+    it '.latest' do
+      item1 = create :dimensions_item, latest: true
+      _item2 = create :dimensions_item, latest: false
+
+      expect(subject.latest).to match_array([item1])
+    end
+
     describe '.existing_latest_items' do
       let(:content_id_1) { 'd5348817-0c34-4942-9111-2331e12cb1c5' }
       let(:content_id_2) { 'aaaaaaaa-0c34-4942-9111-2331e12cb1c5' }


### PR DESCRIPTION
[Trello card](https://trello.com/c/85P5zbF2/623-3-etl-monitor-add-data-about-dimensions)

Related to PR: https://github.com/alphagov/govuk-puppet/pull/8062

Continuation to work developed in #871. It adds StatsD support for the Dimensions and Facts. 
This is  useful because it will provide us with context about how the processing of events in PublishingAPI impacts in the different version of items that we are storing.

We are publishing to Grafana via StatsD the following metrics:

- Total number of base paths.
- Total number of `latest` base paths.
- Total number of content items.
- Total number of `latest` content items.

- Total number of metrics
- Total number of metrics for yesterday
- Total number of editions
- Total number of editions for yesterday
