### PR TITLE
Add `latest` index to Dimensions::Items

### DIFF
--- a/db/migrate/20180831101255_add_index_to_dimensions_items_on_latest.rb
+++ b/db/migrate/20180831101255_add_index_to_dimensions_items_on_latest.rb
@@ -1,0 +1,5 @@
+class AddIndexToDimensionsItemsOnLatest < ActiveRecord::Migration[5.2]
+  def change
+    add_index :dimensions_items, :latest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_24_105759) do
+ActiveRecord::Schema.define(version: 2018_08_31_101255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2018_08_24_105759) do
     t.json "expanded_links", default: {}
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
+    t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
   end
 


### PR DESCRIPTION
The master process is doing a full scan of the database when querying
for all the latest items. This is slowing down the daily process which
could result in having a less reliable service.