### PR TITLE
Revert "Inline or branch in list of attributes"

### DIFF
--- a/spec/integration/streams/on_update_message_spec.rb
+++ b/spec/integration/streams/on_update_message_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe PublishingAPI::Consumer do
     schemas.each_value do |schema|
       payload = GovukSchemas::RandomExample.new(schema: schema).payload
       schema_name = payload.dig('schema_name')
-      unless %w{travel_advice guide placeholder}.include?(schema_name)
+      unless %w{travel_advice guide}.include?(schema_name) || schema_name.include?('placeholder')
 
         %w{major minor links republish unpublish}.each do |update_type|
           it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/LcUD6IAW/634-5-refactor-simplify-code-that-process-incoming-events-from-publishingapi)


This reverts commit 5b8e221d19d352b332a37af980258e9c59b8721d.

The branch is checking for the inclusion of text in the string, not in
the collection.

We were having the following errors:

```
rspec './spec/integration/streams/on_update_message_spec.rb[1:9:252]' # PublishingAPI::Consumer all schemas handles event for: `placeholder_egestas.` with no errors for a `minor` update
rspec './spec/integration/streams/on_update_message_spec.rb[1:9:251]' # PublishingAPI::Consumer all schemas handles event for: `placeholder_egestas.` with no errors for a `major` update
rspec './spec/integration/streams/on_update_message_spec.rb[1:9:253]' # PublishingAPI::Consumer all schemas handles event for: `placeholder_egestas.` with no errors for a `links` update
rspec './spec/integration/streams/on_update_message_spec.rb[1:9:254]' # PublishingAPI::Consumer all schemas handles event for: `placeholder_egestas.` with no errors for a `republish` update
rspec './spec/integration/streams/on_update_message_spec.rb[1:9:255]' # PublishingAPI::Consumer all schemas handles event for: `placeholder_egestas.` with no errors for a `unpublish` update
```