### PR TITLE
Increase pool size to 12 connections

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: 12
 
 development:
   <<: *default


### PR DESCRIPTION
Increases the pool size to 12 conections as it is the [It is the default way for all 
GOV.UK applications][1], and we are having [intermittent issues in Staging with 
our PostgreSQL database connections][2]

[1]: https://github.com/alphagov/govuk-developer-docs/blob/5623c8bba3855a1e711dc03abf7471709ed0e4f2/source/manual/setting-up-new-rails-app.html.md
[2]: https://sentry.io/govuk/app-content-performance-manager/issues/669964377/?query=is:unresolved%20environment:staging