### PR TITLE
Return metadata from api endpoint

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -19,20 +19,11 @@ class Api::MetricsController < Api::BaseController
 private
 
   def query_series
-    series = Reports::FindSeries.new
-               .between(from: from, to: to)
-               .by_base_path(format_base_path_param)
-               .run
-    if Metric.is_edition_metric?(metrics.first)
-      series
-        .with_edition_metrics
-        .order('dimensions_dates.date asc')
-        .pluck(:date, "facts_editions.#{metrics.first}").to_h
-    else
-      series
-        .order('dimensions_dates.date asc')
-        .pluck(:date, metrics.first).to_h
-    end
+    Reports::FindSeries.new
+       .between(from: from, to: to)
+       .by_base_path(format_base_path_param)
+       .by_metrics(params[:metrics])
+       .run
   end
 
   def format_base_path_param
@@ -40,10 +31,10 @@ private
     "/#{base_path}"
   end
 
-  delegate :from, :to, :metrics, :base_path, to: :api_request
+  delegate :from, :to, :base_path, :metrics, to: :api_request
 
   def api_request
-    @api_request ||= Api::Request.new(params.permit(:from, :to, :base_path, :format, metrics: []))
+    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :format, metrics: []))
   end
 
   def validate_params!

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -19,7 +19,7 @@ class Api::MetricsController < Api::BaseController
 private
 
   def query_series
-    series = Reports::Series.new
+    series = Reports::FindSeries.new
                .between(from: from, to: to)
                .by_base_path(format_base_path_param)
                .run

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -23,15 +23,15 @@ private
                .between(from: from, to: to)
                .by_base_path(format_base_path_param)
                .run
-    if Metric.is_edition_metric?(metric)
+    if Metric.is_edition_metric?(metrics.first)
       series
         .with_edition_metrics
         .order('dimensions_dates.date asc')
-        .pluck(:date, "facts_editions.#{metric}").to_h
+        .pluck(:date, "facts_editions.#{metrics.first}").to_h
     else
       series
         .order('dimensions_dates.date asc')
-        .pluck(:date, metric).to_h
+        .pluck(:date, metrics.first).to_h
     end
   end
 
@@ -40,10 +40,10 @@ private
     "/#{base_path}"
   end
 
-  delegate :from, :to, :metric, :base_path, to: :api_request
+  delegate :from, :to, :metrics, :base_path, to: :api_request
 
   def api_request
-    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :format))
+    @api_request ||= Api::Request.new(params.permit(:from, :to, :base_path, :format, metrics: []))
   end
 
   def validate_params!

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -9,6 +9,7 @@ class Api::MetricsController < Api::BaseController
   def summary
     @series = query_series
     @api_request = api_request
+    @metadata = metadata
   end
 
   def index
@@ -29,6 +30,10 @@ private
   def format_base_path_param
     #  add '/' as param is received without leading forward slash which is needed to query by base_path.
     "/#{base_path}"
+  end
+
+  def metadata
+    Dimensions::Item.latest_by_base_path(format_base_path_param).first.metadata
   end
 
   delegate :from, :to, :base_path, :metrics, to: :api_request

--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -20,7 +20,7 @@ class SandboxController < ApplicationController
 private
 
   def build_series_report
-    Reports::Series.new
+    Reports::FindSeries.new
       .between(from: from, to: to)
       .by_base_path(base_path)
       .by_organisation_id(organisation)

--- a/app/domain/api/request.rb
+++ b/app/domain/api/request.rb
@@ -38,5 +38,4 @@ private
       errors.add("metric", "is not included in the list") unless Metric.find_all.map(&:name).include?(metric)
     end
   end
-
 end

--- a/app/domain/api/request.rb
+++ b/app/domain/api/request.rb
@@ -5,16 +5,16 @@ class Api::Request
 
   include ActiveModel::Validations
 
-  attr_reader :metric, :from, :to, :base_path
+  attr_reader :metrics, :from, :to, :base_path
 
-  validates :metric, presence: true, inclusion: { in: Metric.find_all.map(&:name) }
   validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
   validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
   validates :base_path, presence: true
   validate :from_before_to, if: :have_a_date_range?
+  validate :verify_metrics
 
   def initialize(params)
-    @metric = params[:metric]
+    @metrics = params[:metrics]
     @from = params[:from]
     @to = params[:to]
     @base_path = params[:base_path]
@@ -32,4 +32,11 @@ private
       errors.add("from,to", "`from` parameter can't be after the `to` parameter")
     end
   end
+
+  def verify_metrics
+    metrics.each do |metric|
+      errors.add("metric", "is not included in the list") unless Metric.find_all.map(&:name).include?(metric)
+    end
+  end
+
 end

--- a/app/domain/reports/find_series.rb
+++ b/app/domain/reports/find_series.rb
@@ -1,4 +1,4 @@
-class Reports::Series
+class Reports::FindSeries
   def between(from:, to:)
     @from = from
     @to = to

--- a/app/domain/reports/find_series.rb
+++ b/app/domain/reports/find_series.rb
@@ -24,6 +24,12 @@ class Reports::FindSeries
     self
   end
 
+  def by_metrics(metrics)
+    @metric_names = metrics
+
+    self
+  end
+
   def content_items
     slice_content_items
   end
@@ -32,10 +38,16 @@ class Reports::FindSeries
     dates = slice_dates
     items = slice_content_items
 
-    metrics = Facts::Metric.all.with_edition_metrics
-    metrics
-      .joins(:dimensions_item).merge(items)
+    metrics = Facts::Metric.all
+    metrics = metrics
+      .joins(dimensions_item: :facts_edition).merge(items)
       .joins(:dimensions_date).merge(dates)
+
+    if @metric_names
+      @metric_names.map { |metric_name| Reports::Series.new(metric_name, metrics) }
+    else
+      metrics
+    end
   end
 
 private

--- a/app/domain/reports/series.rb
+++ b/app/domain/reports/series.rb
@@ -1,0 +1,25 @@
+class Reports::Series
+  attr_reader :metric_name, :all_metrics, :values_by_date
+
+  def initialize(metric_name, all_metrics)
+    @metric_name = metric_name
+    @all_metrics = all_metrics
+    @values_by_date = set_values
+  end
+
+  def set_values
+    all_metrics.map do |metric|
+      key = metric.dimensions_date_id.to_s
+      value = Metric.is_edition_metric?(metric_name) ? metric.facts_edition.send(metric_name) : metric.send(metric_name)
+      { key => value }
+    end
+  end
+
+  def total
+    values_by_date.reduce(0) { |memo, value_by_date| memo + value_by_date.values.first }
+  end
+
+  def latest
+    values_by_date.last.values.first
+  end
+end

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -37,4 +37,15 @@ class Dimensions::Item < ApplicationRecord
     reload
     dirty
   end
+
+  def metadata
+    {
+      title: title,
+      base_path: base_path,
+      first_published_at: first_published_at,
+      public_updated_at: public_updated_at,
+      publishing_app: publishing_app,
+      document_type: document_type
+    }
+  end
 end

--- a/app/views/api/metrics/summary.json.jbuilder
+++ b/app/views/api/metrics/summary.json.jbuilder
@@ -1,4 +1,6 @@
-json.set! @api_request.metrics.first do
-  json.total @series.values.sum
-  json.latest @series.values.last
+@series.each do |series|
+  json.set! series.metric_name do
+    json.total series.total
+    json.latest series.latest
+  end
 end

--- a/app/views/api/metrics/summary.json.jbuilder
+++ b/app/views/api/metrics/summary.json.jbuilder
@@ -1,3 +1,4 @@
 @series.each do |series|
   json.set! series.metric_name, series.total
+  json.merge! @metadata
 end

--- a/app/views/api/metrics/summary.json.jbuilder
+++ b/app/views/api/metrics/summary.json.jbuilder
@@ -1,4 +1,4 @@
-json.set! @api_request.metric do
+json.set! @api_request.metrics.first do
   json.total @series.values.sum
   json.latest @series.values.last
 end

--- a/app/views/api/metrics/summary.json.jbuilder
+++ b/app/views/api/metrics/summary.json.jbuilder
@@ -1,6 +1,3 @@
 @series.each do |series|
-  json.set! series.metric_name do
-    json.total series.total
-    json.latest series.latest
-  end
+  json.set! series.metric_name, series.total
 end

--- a/app/views/api/metrics/time_series.json.jbuilder
+++ b/app/views/api/metrics/time_series.json.jbuilder
@@ -1,4 +1,4 @@
-json.set! @api_request.metric do
+json.set! @api_request.metrics.first do
   json.array! @series do |date, value|
     json.date date
     json.value value

--- a/app/views/api/metrics/time_series.json.jbuilder
+++ b/app/views/api/metrics/time_series.json.jbuilder
@@ -1,6 +1,8 @@
-json.set! @api_request.metrics.first do
-  json.array! @series do |date, value|
-    json.date date
-    json.value value
+@series.each do |series|
+  json.set! series.metric_name do
+    json.array! series.values_by_date do |value|
+      json.date value.keys.first
+      json.value value.values.first
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     get '/v1/metrics/', to: "metrics#index"
-    get '/v1/metrics/:metric/*base_path/time-series', to: "metrics#time_series"
-    get '/v1/metrics/:metric/*base_path', to: "metrics#summary"
+    get '/v1/metrics/*base_path/time-series', to: "metrics#time_series"
+    get '/v1/metrics/*base_path', to: "metrics#summary"
     get '/v1/healthcheck', to: "healthcheck#index"
   end
 

--- a/spec/domain/reports/find_series_spec.rb
+++ b/spec/domain/reports/find_series_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::Series do
+RSpec.describe Reports::FindSeries do
   include ItemSetupHelpers
   context "all" do
     it "returns a series of all metrics" do

--- a/spec/domain/reports/series_spec.rb
+++ b/spec/domain/reports/series_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Reports::Series do
+  let!(:day1) { create :dimensions_date, date: Date.new(2018, 1, 13) }
+  let!(:day2) { create :dimensions_date, date: Date.new(2018, 1, 14) }
+  let!(:day3) { create :dimensions_date, date: Date.new(2018, 1, 15) }
+  let!(:content_id) { SecureRandom.uuid }
+  let!(:base_path) { '/base_path' }
+  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, locale: 'en' }
+
+  before do
+    create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10
+    create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20
+    create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30
+    create :facts_edition, dimensions_item: item, dimensions_date: day1
+  end
+
+  it 'presents the values_by_date' do
+    series = Reports::Series.new('pageviews', Facts::Metric.all)
+    expect(series.values_by_date).to eq expected_values
+  end
+
+  it 'presents the total' do
+    series = Reports::Series.new('pageviews', Facts::Metric.all)
+    expect(series.total).to eq 60
+  end
+
+  it 'presents the latest' do
+    series = Reports::Series.new('pageviews', Facts::Metric.all)
+    expect(series.latest).to eq 30
+  end
+
+  def expected_values
+    [
+      { "2018-01-13" => 10 },
+      { "2018-01-14" => 20 },
+      { "2018-01-15" => 30 }
+    ]
+  end
+end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -182,4 +182,27 @@ RSpec.describe Dimensions::Item, type: :model do
       expect(item.change_from?(attrs.merge(raw_json: '{}'))).to eq(false)
     end
   end
+
+  describe '#metadata' do
+    let(:item) do
+      create :dimensions_item,
+        title: 'The Title',
+        base_path: '/the/base/path',
+        first_published_at: '2018-01-01',
+        public_updated_at: '2018-05-20',
+        publishing_app: 'publisher',
+        document_type: 'guide'
+    end
+
+    it 'returns the correct attributes' do
+      expect(item.reload.metadata).to eq(
+        base_path: '/the/base/path',
+        title: 'The Title',
+        first_published_at: Time.new(2018, 1, 1),
+        public_updated_at: Time.new(2018, 5, 20),
+        publishing_app: 'publisher',
+        document_type: 'guide'
+      )
+    end
+  end
 end

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -22,21 +22,21 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   end
 
   it 'returns the `number of pdfs` between two dates' do
-    get "/api/v1/metrics/number_of_pdfs/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['number_of_pdfs'] }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_pdfs'))
   end
 
   it 'returns the `number of word documents` between two dates' do
-    get "/api/v1/metrics/number_of_word_files/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['number_of_word_files'] }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
   end
 
   it 'returns the `readability score` between two dates' do
-    get "/api/v1/metrics/readability_score/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['readability_score'] }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(

--- a/spec/requests/api/v1/daily_editions_metrics_spec.rb
+++ b/spec/requests/api/v1/daily_editions_metrics_spec.rb
@@ -22,21 +22,21 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   end
 
   it 'returns the `number of pdfs` between two dates' do
-    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['number_of_pdfs'] }
+    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[number_of_pdfs] }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_pdfs'))
   end
 
   it 'returns the `number of word documents` between two dates' do
-    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['number_of_word_files'] }
+    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[number_of_word_files] }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(api_reponse('number_of_word_files'))
   end
 
   it 'returns the `readability score` between two dates' do
-    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['readability_score'] }
+    get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[readability_score] }
 
     json = JSON.parse(response.body)
     expect(json.deep_symbolize_keys).to eq(

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -156,16 +156,13 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     describe "Summary information" do
-      it 'returns sums and latest values' do
+      it 'returns sums for each metric' do
         get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
 
         json = JSON.parse(response.body)
 
         expected_response = {
-          feedex_comments: {
-            total: 60,
-            latest: 30
-          }
+          feedex_comments: 60
         }
         expect(json.deep_symbolize_keys).to eq(expected_response)
       end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -10,7 +10,17 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   let!(:content_id) { SecureRandom.uuid }
   let!(:base_path) { '/base_path' }
 
-  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, locale: 'en' }
+  let!(:item) do
+    create :dimensions_item,
+      content_id: content_id,
+      title: 'the title',
+      base_path: base_path,
+      document_type: 'guide',
+      locale: 'en',
+      publishing_app: 'whitehall',
+      first_published_at: '2018-02-01',
+      public_updated_at: '2018-04-25'
+  end
   let!(:item_fr) { create :dimensions_item, content_id: content_id, locale: 'de' }
 
   describe "an API response" do
@@ -156,15 +166,29 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     describe "Summary information" do
-      it 'returns sums for each metric' do
+      it 'returns the sum of feedex comments' do
         get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
 
         json = JSON.parse(response.body)
 
-        expected_response = {
+        expect(json.deep_symbolize_keys).to include(
           feedex_comments: 60
-        }
-        expect(json.deep_symbolize_keys).to eq(expected_response)
+        )
+      end
+
+      it 'returns the metadata from the latest item' do
+        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
+
+        json = JSON.parse(response.body)
+
+        expect(json.deep_symbolize_keys).to include(
+          title: 'the title',
+          base_path: base_path,
+          document_type: 'guide',
+          publishing_app: 'whitehall',
+          first_published_at: '2018-02-01T00:00:00.000Z',
+          public_updated_at: '2018-04-25T00:00:00.000Z'
+        )
       end
     end
 

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -110,11 +110,11 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
   describe 'Daily metrics' do
     before do
-      create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40, is_this_useful_yes: 10, is_this_useful_no: 20
+      create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40, is_this_useful_yes: 10, is_this_useful_no: 30
       create :facts_edition, dimensions_item: item, dimensions_date: day1
     end
 
@@ -130,16 +130,16 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       satisfaction_score = {
         satisfaction_score: [
           {
-              date: "2018-01-13",
-              value: 0.333333333333333
+            date: "2018-01-13",
+            value: 0.25
           },
           {
-              date: "2018-01-14",
-              value: 0.333333333333333
+            date: "2018-01-14",
+            value: 0.25
           },
           {
-              date: "2018-01-15",
-              value: 0.333333333333333
+            date: "2018-01-15",
+            value: 0.25
           }
         ]
       }

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
   describe "invalid requests" do
     it 'returns an error for metrics not on the whitelist' do
-      get "/api/v1/metrics/number_of_puns/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['number_of_puns'] }
 
       expect(response.status).to eq(400)
 
@@ -60,7 +60,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for badly formatted dates' do
-      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: 'today', to: '2018-01-15' }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: 'today', to: '2018-01-15', metrics: ['pageviews'] }
 
       expect(response.status).to eq(400)
 
@@ -76,7 +76,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for bad date ranges' do
-      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: '2018-01-16', to: '2018-01-15' }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-16', to: '2018-01-15', metrics: ['pageviews'] }
 
       expect(response.status).to eq(400)
 
@@ -92,7 +92,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for unknown parameters' do
-      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: '2018-01-14', to: '2018-01-15', extra: "bla" }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-14', to: '2018-01-15', extra: "bla", metrics: ['pageviews'] }
 
       expect(response.status).to eq(400)
 
@@ -119,14 +119,14 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns `pageviews` values between two dates' do
-      get "/api/v1/metrics/pageviews/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['pageviews'] }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json).to eq(build_time_series_response('pageviews'))
     end
 
     it 'returns `satisfaction_score` values between two dates' do
-      get "/api/v1/metrics/satisfaction_score/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['satisfaction_score'] }
       satisfaction_score = {
         satisfaction_score: [
           {
@@ -149,7 +149,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns `feedex issues` between two dates' do
-      get "/api/v1/metrics/feedex_comments/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15' }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(build_time_series_response('feedex_comments'))
@@ -157,7 +157,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
     describe "Summary information" do
       it 'returns sums and latest values' do
-        get "//api/v1/metrics/feedex_comments/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15' }
+        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
 
         json = JSON.parse(response.body)
 

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
   describe "invalid requests" do
     it 'returns an error for metrics not on the whitelist' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['number_of_puns'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[number_of_puns] }
 
       expect(response.status).to eq(400)
 
@@ -70,7 +70,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for badly formatted dates' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: 'today', to: '2018-01-15', metrics: ['pageviews'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: 'today', to: '2018-01-15', metrics: %w[pageviews] }
 
       expect(response.status).to eq(400)
 
@@ -86,7 +86,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for bad date ranges' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-16', to: '2018-01-15', metrics: ['pageviews'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-16', to: '2018-01-15', metrics: %w[pageviews] }
 
       expect(response.status).to eq(400)
 
@@ -102,7 +102,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns an error for unknown parameters' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-14', to: '2018-01-15', extra: "bla", metrics: ['pageviews'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-14', to: '2018-01-15', extra: "bla", metrics: %w[pageviews] }
 
       expect(response.status).to eq(400)
 
@@ -129,14 +129,14 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns `pageviews` values between two dates' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['pageviews'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[pageviews] }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json).to eq(build_time_series_response('pageviews'))
     end
 
     it 'returns `satisfaction_score` values between two dates' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['satisfaction_score'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[satisfaction_score] }
       satisfaction_score = {
         satisfaction_score: [
           {
@@ -159,7 +159,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     it 'returns `feedex issues` between two dates' do
-      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
+      get "/api/v1/metrics/#{base_path}/time-series", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[feedex_comments] }
 
       json = JSON.parse(response.body)
       expect(json.deep_symbolize_keys).to eq(build_time_series_response('feedex_comments'))
@@ -167,7 +167,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
     describe "Summary information" do
       it 'returns the sum of feedex comments' do
-        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
+        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[feedex_comments] }
 
         json = JSON.parse(response.body)
 
@@ -177,7 +177,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       end
 
       it 'returns the metadata from the latest item' do
-        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: ['feedex_comments'] }
+        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[feedex_comments] }
 
         json = JSON.parse(response.body)
 

--- a/spec/routing/metrics_routing_spec.rb
+++ b/spec/routing/metrics_routing_spec.rb
@@ -1,20 +1,18 @@
 RSpec.describe 'metrics routing' do
   it 'routes /api/v1/metrics/:metric/long/base/path correctly' do
-    expect(get: '/api/v1/metrics/pageviews/long/base/path').to route_to(
+    expect(get: '/api/v1/metrics/long/base/path').to route_to(
       controller: 'api/metrics',
       action: 'summary',
       format: :json,
-      metric: 'pageviews',
       base_path: 'long/base/path'
     )
   end
 
   it 'routes /api/v1/metrics/:metric/long/base/path/time-series correctly' do
-    expect(get: '/api/v1/metrics/pageviews/long/base/path/time-series').to route_to(
+    expect(get: '/api/v1/metrics/long/base/path/time-series').to route_to(
       controller: 'api/metrics',
       action: 'time_series',
       format: :json,
-      metric: 'pageviews',
       base_path: 'long/base/path'
     )
   end


### PR DESCRIPTION
The /metrics/*base_path endpoint now returns
metadata from the latest version of the page.

The follwing attributes are returned:

* title
* base_path
* first_published_at
* public_updated_at
* publishing_app
* document_type