### PR TITLE
Return only totals for summary

### DIFF
--- a/app/views/api/metrics/summary.json.jbuilder
+++ b/app/views/api/metrics/summary.json.jbuilder
@@ -1,6 +1,3 @@
 @series.each do |series|
-  json.set! series.metric_name do
-    json.total series.total
-    json.latest series.latest
-  end
+  json.set! series.metric_name, series.total
 end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -110,11 +110,11 @@ RSpec.describe '/api/v1/metrics/', type: :request do
 
   describe 'Daily metrics' do
     before do
-      create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30, is_this_useful_yes: 10, is_this_useful_no: 20
-      create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40, is_this_useful_yes: 10, is_this_useful_no: 20
+      create :metric, dimensions_item: item, dimensions_date: day1, pageviews: 10, feedex_comments: 10, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item_fr, dimensions_date: day2, pageviews: 100, feedex_comments: 200, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item, dimensions_date: day2, pageviews: 20, feedex_comments: 20, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item, dimensions_date: day3, pageviews: 30, feedex_comments: 30, is_this_useful_yes: 10, is_this_useful_no: 30
+      create :metric, dimensions_item: item, dimensions_date: day4, pageviews: 40, feedex_comments: 40, is_this_useful_yes: 10, is_this_useful_no: 30
       create :facts_edition, dimensions_item: item, dimensions_date: day1
     end
 
@@ -130,16 +130,16 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       satisfaction_score = {
         satisfaction_score: [
           {
-              date: "2018-01-13",
-              value: 0.333333333333333
+            date: "2018-01-13",
+            value: 0.25
           },
           {
-              date: "2018-01-14",
-              value: 0.333333333333333
+            date: "2018-01-14",
+            value: 0.25
           },
           {
-              date: "2018-01-15",
-              value: 0.333333333333333
+            date: "2018-01-15",
+            value: 0.25
           }
         ]
       }

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -162,10 +162,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
         json = JSON.parse(response.body)
 
         expected_response = {
-          feedex_comments: {
-            total: 60,
-            latest: 30
-          }
+          feedex_comments: 60
         }
         expect(json.deep_symbolize_keys).to eq(expected_response)
       end


### PR DESCRIPTION
Currently the /v1/metrics/*base_path endpoint returns results
with the format:
```
{
  "metric_name": {
    "total": 100,
    "latest": 50
  }
}
```

This commit refactors the output to be in this format:

```
{ "metric_name": 100 }
```

Returning only the total.