### PR TITLE
Return the metadata for the page.

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -9,6 +9,7 @@ class Api::MetricsController < Api::BaseController
   def summary
     @series = query_series
     @api_request = api_request
+    @metadata = metadata
   end
 
   def index
@@ -29,6 +30,10 @@ private
   def format_base_path_param
     #  add '/' as param is received without leading forward slash which is needed to query by base_path.
     "/#{base_path}"
+  end
+
+  def metadata
+    Dimensions::Item.latest_by_base_path(format_base_path_param).first.metadata
   end
 
   delegate :from, :to, :base_path, :metrics, to: :api_request

--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -37,4 +37,16 @@ class Dimensions::Item < ApplicationRecord
     reload
     dirty
   end
+
+  def metadata
+    {
+      title: title,
+      base_path: base_path,
+      first_published_at: first_published_at,
+      public_updated_at: public_updated_at,
+      publishing_app: publishing_app,
+      document_type: document_type,
+      primary_organisation_title: primary_organisation_title
+    }
+  end
 end

--- a/app/views/api/metrics/summary.json.jbuilder
+++ b/app/views/api/metrics/summary.json.jbuilder
@@ -1,3 +1,4 @@
 @series.each do |series|
   json.set! series.metric_name, series.total
+  json.merge! @metadata
 end

--- a/spec/models/dimensions/item_spec.rb
+++ b/spec/models/dimensions/item_spec.rb
@@ -182,4 +182,29 @@ RSpec.describe Dimensions::Item, type: :model do
       expect(item.change_from?(attrs.merge(raw_json: '{}'))).to eq(false)
     end
   end
+
+  describe '#metadata' do
+    let(:item) do
+      create :dimensions_item,
+        title: 'The Title',
+        base_path: '/the/base/path',
+        first_published_at: '2018-01-01',
+        public_updated_at: '2018-05-20',
+        publishing_app: 'publisher',
+        document_type: 'guide',
+        primary_organisation_title: 'The ministry'
+    end
+
+    it 'returns the correct attributes' do
+      expect(item.reload.metadata).to eq(
+        base_path: '/the/base/path',
+        title: 'The Title',
+        first_published_at: Time.new(2018, 1, 1),
+        public_updated_at: Time.new(2018, 5, 20),
+        publishing_app: 'publisher',
+        document_type: 'guide',
+        primary_organisation_title: 'The ministry'
+      )
+    end
+  end
 end

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -10,7 +10,18 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   let!(:content_id) { SecureRandom.uuid }
   let!(:base_path) { '/base_path' }
 
-  let!(:item) { create :dimensions_item, content_id: content_id, base_path: base_path, locale: 'en' }
+  let!(:item) do
+    create :dimensions_item,
+      content_id: content_id,
+      title: 'the title',
+      base_path: base_path,
+      document_type: 'guide',
+      locale: 'en',
+      publishing_app: 'whitehall',
+      first_published_at: '2018-02-01',
+      public_updated_at: '2018-04-25',
+      primary_organisation_title: 'The ministry'
+  end
   let!(:item_fr) { create :dimensions_item, content_id: content_id, locale: 'de' }
 
   describe "an API response" do
@@ -156,15 +167,30 @@ RSpec.describe '/api/v1/metrics/', type: :request do
     end
 
     describe "Summary information" do
-      it 'returns sums and latest values' do
+      it 'returns the sum of feedex comments' do
         get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[feedex_comments] }
 
         json = JSON.parse(response.body)
 
-        expected_response = {
+        expect(json.deep_symbolize_keys).to include(
           feedex_comments: 60
-        }
-        expect(json.deep_symbolize_keys).to eq(expected_response)
+        )
+      end
+
+      it 'returns the metadata from the latest item' do
+        get "//api/v1/metrics/#{base_path}", params: { from: '2018-01-13', to: '2018-01-15', metrics: %w[feedex_comments] }
+
+        json = JSON.parse(response.body)
+
+        expect(json.deep_symbolize_keys).to include(
+          title: 'the title',
+          base_path: base_path,
+          document_type: 'guide',
+          publishing_app: 'whitehall',
+          first_published_at: '2018-02-01T00:00:00.000Z',
+          public_updated_at: '2018-04-25T00:00:00.000Z',
+          primary_organisation_title: 'The ministry'
+        )
       end
     end
 


### PR DESCRIPTION
The /metrics/*base_path endpoint now returns
metadata from the latest version of the page.

The follwing attributes are returned:

* title
* base_path
* first_published_at
* public_updated_at
* publishing_app
* document_type
* primary_organisation_title

There is a related [PR in content-data-admin](https://github.com/alphagov/content-data-admin/pull/45)

Trello: https://trello.com/c/hjj6IJXH/621-3-show-metadata-information-in-the-single-performance-page-epic-2