### PR TITLE
Remove route to sandbox

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,4 @@ Rails.application.routes.draw do
     get '/v1/metrics/*base_path', to: "metrics#summary"
     get '/v1/healthcheck', to: "healthcheck#index"
   end
-
-  get '/sandbox', to: 'sandbox#index'
 end


### PR DESCRIPTION
This route is no longer needed as sandbox functionality was previously removed in https://github.com/alphagov/content-performance-manager/pull/900 .