### PR TITLE
Return a 404 error when not latest item exists

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,3 +1,6 @@
+class Api::NotFoundError < StandardError
+end
+
 class Api::BaseController < ApplicationController
   before_action :set_cache_headers
 
@@ -7,6 +10,10 @@ class Api::BaseController < ApplicationController
       title: "One or more parameter names are invalid",
       invalid_params: pme.params
     )
+  end
+
+  rescue_from(Api::NotFoundError) do
+    not_found_response
   end
 
 private
@@ -26,5 +33,14 @@ private
     # human-readable documentation for this, so point to our API docs.
     error_hash[:type] = "https://content-performance-api.publishing.service.gov.uk/errors/##{type}"
     render json: error_hash, status: :bad_request, content_type: "application/problem+json"
+  end
+
+  def not_found_response
+    response_hash = {
+      type: "https://content-performance-api.publishing.service.gov.uk/errors/#base-path-not-found",
+      title: 'The base path you are looking for cannot be found',
+      invalid_params: %w[base_path]
+    }
+    render json: response_hash, status: 404, content_type: "application/problem+json"
   end
 end

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -33,7 +33,9 @@ private
   end
 
   def metadata
-    Dimensions::Item.latest_by_base_path(format_base_path_param).first.metadata
+    latest_item = Dimensions::Item.latest_by_base_path(format_base_path_param).first
+    raise Api::NotFoundError.new("#{@api_request.base_path} not found") if latest_item.nil?
+    latest_item.metadata
   end
 
   delegate :from, :to, :base_path, :metrics, to: :api_request


### PR DESCRIPTION
Current we are getting a 500 error when
we try to get the metadata for a non-existent
base path.

This commit checks for the existence of the Dimensions::Item
and returns a 404 if it does not exist.