### PR TITLE
Fix to handle race conditions in Dimensions::Date

### DIFF
--- a/app/domain/etl/edition/processor.rb
+++ b/app/domain/etl/edition/processor.rb
@@ -4,7 +4,7 @@ class Etl::Edition::Processor
   end
 
   def initialize(old_item, new_item, date = Date.today)
-    @dimensions_date = Dimensions::Date.for(date)
+    @dimensions_date = Dimensions::Date.find_or_create(date)
     @old_item = old_item
     @new_item = new_item
   end

--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -23,7 +23,7 @@ module Etl
 
       def create_metrics
         log process: :metrics, message: 'about to get the Dimensions::Date'
-        dimensions_date = Dimensions::Date.for(date)
+        dimensions_date = Dimensions::Date.find_or_create(date)
         log process: :metrics, message: 'got the Dimensions::Date'
         Dimensions::Item.latest.find_in_batches(batch_size: 50000)
           .with_index do |batch, index|

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -36,7 +36,7 @@ private
 
   def statsd_for_yesterday_editions!
     path = path_for('daily_editions')
-    count = Facts::Edition.where(dimensions_date: Dimensions::Date.for(Date.yesterday)).count
+    count = Facts::Edition.where(dimensions_date: Dimensions::Date.find_or_create(Date.yesterday)).count
 
     GovukStatsd.count(path, count)
   end

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -33,6 +33,8 @@ class Dimensions::Date < ApplicationRecord
   def self.for(date)
     begin
       find_by(date: date) || create_with(date)
+    rescue ActiveRecord::RecordNotUnique
+      find_by(date: date)
     rescue StandardError => e
       GovukError.notify(e)
     end

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -35,8 +35,6 @@ class Dimensions::Date < ApplicationRecord
       find_by(date: date) || create_with(date)
     rescue ActiveRecord::RecordNotUnique
       find_by(date: date)
-    rescue StandardError => e
-      GovukError.notify(e)
     end
   end
 

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -24,11 +24,17 @@ class Dimensions::Date < ApplicationRecord
       )
   end
 
+  def self.create_with(date)
+    date_dimension = build(date)
+    date_dimension.save
+    date_dimension
+  end
+
   def self.for(date)
-    where(date: date).first || begin
-      date_dimension = build(date)
-      date_dimension.save
-      date_dimension
+    begin
+      find_by(date: date) || create_with(date)
+    rescue StandardError => e
+      GovukError.notify(e)
     end
   end
 

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -30,7 +30,7 @@ class Dimensions::Date < ApplicationRecord
     date_dimension
   end
 
-  def self.for(date)
+  def self.find_or_create(date)
     begin
       find_by(date: date) || create_with(date)
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -21,7 +21,7 @@ class Facts::Metric < ApplicationRecord
     self.satisfaction_score = calculate_satisfaction_score
   end
 
-  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.for(Date.yesterday)) }
+  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.find_or_create(Date.yesterday)) }
 
   def self.csv_fields
     %i[

--- a/spec/domain/etl/master/metrics_spec.rb
+++ b/spec/domain/etl/master/metrics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Etl::Master::MetricsProcessor do
 
     expect(Facts::Metric.count).to eq(2)
     expect(Facts::Metric.find_by(dimensions_item: item)).to have_attributes(
-      dimensions_date: Dimensions::Date.for(Date.new(2018, 3, 15)),
+      dimensions_date: Dimensions::Date.find_or_create(Date.new(2018, 3, 15)),
       dimensions_item: item,
     )
   end

--- a/spec/domain/reports/find_series_spec.rb
+++ b/spec/domain/reports/find_series_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Reports::FindSeries do
     it 'ignores parameters when blank' do
       item = create(:dimensions_item)
       metric = create(:metric, dimensions_item: item)
-      today = Dimensions::Date.for(Date.today)
+      today = Dimensions::Date.find_or_create(Date.today)
       create(:facts_edition, dimensions_item: item,
         dimensions_date: today)
 
@@ -90,7 +90,7 @@ RSpec.describe Reports::FindSeries do
     it 'ignores parameters when blank' do
       item = create(:dimensions_item)
       metric = create(:metric, dimensions_item: item)
-      today = Dimensions::Date.for(Date.today)
+      today = Dimensions::Date.find_or_create(Date.today)
       create(:facts_edition, dimensions_item: item,
         dimensions_date: today)
 

--- a/spec/factories/dimensions_date.rb
+++ b/spec/factories/dimensions_date.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :dimensions_date, class: Dimensions::Date do
     sequence(:date) { |i| i.days.ago.to_date }
 
-    initialize_with { Dimensions::Date.for(date) }
+    initialize_with { Dimensions::Date.find_or_create(date) }
   end
 end

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Dimensions::Date, type: :model do
     end
   end
 
-  describe '.for' do
+  describe '.find_or_create' do
     let(:date) { ::Date.new(2017, 12, 21) }
 
     context 'when a dimension exists for the given date' do
@@ -119,13 +119,13 @@ RSpec.describe Dimensions::Date, type: :model do
         dimension_date = create(:dimensions_date, date: date)
         dimension_date.save!
 
-        expect(Dimensions::Date.for(date)).to eq(dimension_date)
+        expect(Dimensions::Date.find_or_create(date)).to eq(dimension_date)
       end
     end
 
     context 'when a dimension does not exist for the given date' do
       it 'should return the newly created dimension' do
-        dimension_date = Dimensions::Date.for(date)
+        dimension_date = Dimensions::Date.find_or_create(date)
 
         expect(Dimensions::Date.count).to eq(1)
         expect(dimension_date.date).to eq(date)
@@ -139,7 +139,7 @@ RSpec.describe Dimensions::Date, type: :model do
           dimension_date.save
           raise ActiveRecord::RecordNotUnique
         }
-        expect(Dimensions::Date.for(date)).to eq(dimension_date)
+        expect(Dimensions::Date.find_or_create(date)).to eq(dimension_date)
       end
     end
   end

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe Dimensions::Date, type: :model do
         expect(dimension_date.date).to eq(date)
       end
     end
+
+    context 'when a dimension created under losing race conditions' do
+      it 'should return the existing dimension' do
+        dimension_date = Dimensions::Date.build(date)
+        allow(Dimensions::Date).to receive(:create) {
+          dimension_date.save
+          raise ActiveRecord::RecordNotUnique
+        }
+        expect(Dimensions::Date.for(date)).to eq(dimension_date)
+      end
+    end
   end
 
   describe '.exists?' do

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe Dimensions::Date, type: :model do
     end
   end
 
+  describe '.create_with' do
+    it 'builds and saves a new date dimension' do
+      dimension_date = Dimensions::Date.create_with(date)
+      expect(Dimensions::Date.count).to eq(1)
+      expect(Dimensions::Date.first).to eq(dimension_date)
+    end
+  end
+
   describe '.for' do
     let(:date) { ::Date.new(2017, 12, 21) }
 


### PR DESCRIPTION
This PR addresses the UniqueRecord exception thrown by the `Dimensions::Date::for` method. This is due to race conditions when one process beats another in creating record. The method now retries finding the newly created record when the exception is enccountered. The method has been renamed from `for` to `find_or_create` to clarify its purpose. 