### PR TITLE
Fix ETL not calculating satisfaction_score

### DIFF
--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -37,16 +37,15 @@ private
     conn = ActiveRecord::Base.connection
     date_to_s = date.strftime("%F")
     conn.execute(load_metrics_query(date_to_s))
+    calculate_and_set_satisfaction_scores(date)
     clean_up_events!
   end
 
   def load_metrics_query(date_to_s)
-    # Using PostgreSQL round() to coax the integers into floats before calculating
     <<~SQL
       UPDATE facts_metrics
       SET is_this_useful_no = s.is_this_useful_no,
-          is_this_useful_yes = s.is_this_useful_yes,
-          satisfaction_score = s.is_this_useful_yes / round((s.is_this_useful_yes + s.is_this_useful_no), 10)
+          is_this_useful_yes = s.is_this_useful_yes
       FROM (
         SELECT is_this_useful_no,
                is_this_useful_yes,
@@ -61,6 +60,13 @@ private
 
   def clean_up_events!
     Events::GA.delete_all
+  end
+
+  def calculate_and_set_satisfaction_scores(date)
+    Facts::Metric.from_day_before_to(date).find_each do |metric|
+      metric.satisfaction_score = Facts::Calculations::SatisfactionScore.apply(metric)
+      metric.save!
+    end
   end
 
   attr_reader :date

--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -41,10 +41,12 @@ private
   end
 
   def load_metrics_query(date_to_s)
+    # Using PostgreSQL round() to coax the integers into floats before calculating
     <<~SQL
       UPDATE facts_metrics
       SET is_this_useful_no = s.is_this_useful_no,
-          is_this_useful_yes = s.is_this_useful_yes
+          is_this_useful_yes = s.is_this_useful_yes,
+          satisfaction_score = s.is_this_useful_yes / round((s.is_this_useful_yes + s.is_this_useful_no), 10)
       FROM (
         SELECT is_this_useful_no,
                is_this_useful_yes,

--- a/app/models/facts/calculations/satisfaction_score.rb
+++ b/app/models/facts/calculations/satisfaction_score.rb
@@ -1,0 +1,13 @@
+class Facts::Calculations::SatisfactionScore
+  def self.apply(metric)
+    metric.satisfaction_score = if metric.is_this_useful_yes.nil? && metric.is_this_useful_no.nil?
+                                  nil
+                                elsif metric.is_this_useful_yes.nil? || metric.is_this_useful_yes.zero?
+                                  0.0
+                                elsif metric.is_this_useful_no.nil? || metric.is_this_useful_no.zero?
+                                  1.0
+                                else
+                                  metric.is_this_useful_yes.to_f / (metric.is_this_useful_yes + metric.is_this_useful_no).to_f
+                                end
+  end
+end

--- a/lib/tasks/temporary/data_migrations.rake
+++ b/lib/tasks/temporary/data_migrations.rake
@@ -1,0 +1,13 @@
+namespace :data_migrations do
+  desc 'Calculate satisfaction score for all existing metrics that have `is this useful?` values'
+  task update_satisfaction: :environment do
+    metrics = Facts::Metric.where.not(is_this_useful_yes: nil).or(Facts::Metric.where.not(is_this_useful_no: nil))
+    puts "Going to update #{metrics.size} metrics"
+
+    metrics.find_each do |metric|
+      Facts::Calculations::SatisfactionScore.apply(metric)
+      metric.save
+      print '.'
+    end
+  end
+end

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -90,23 +90,4 @@ private
       },
     ]
   end
-
-  def ga_response_with_govuk_prefix
-    [
-      {
-        'page_path' => '/https://www.gov.uk/path1',
-        'is_this_useful_no' => 1,
-        'is_this_useful_yes' => 1,
-        'date' => '2018-02-20',
-        'process_name' => 'user_feedback',
-      },
-      {
-        'page_path' => '/path2',
-        'is_this_useful_no' => 5,
-        'is_this_useful_yes' => 10,
-        'date' => '2018-02-20',
-        'process_name' => 'user_feedback',
-      },
-    ]
-  end
 end

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -11,13 +11,20 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
     before { allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it 'update the facts with the GA metrics' do
-      fact1 = create_metric base_path: '/path1', date: '2018-02-20', daily: { is_this_useful_no: 1, is_this_useful_yes: 1 }
-      fact2 = create_metric base_path: '/path2', date: '2018-02-20', daily: { is_this_useful_no: 5, is_this_useful_yes: 10 }
+      fact1 = create_metric base_path: '/path1', date: '2018-02-20', daily: { is_this_useful_no: 1, is_this_useful_yes: 2 }
+      fact2 = create_metric base_path: '/path2', date: '2018-02-20', daily: { is_this_useful_no: 20, is_this_useful_yes: 10 }
+
+      expect(fact1).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 2)
+      expect(fact1.satisfaction_score).to be_within(0.1).of(0.67)
+      expect(fact2).to have_attributes(is_this_useful_no: 20, is_this_useful_yes: 10)
+      expect(fact2.satisfaction_score).to be_within(0.1).of(0.33)
 
       described_class.process(date: date)
 
-      expect(fact1.reload).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 1, satisfaction_score: 0.5)
-      expect(fact2.reload).to have_attributes(is_this_useful_no: 5, is_this_useful_yes: 10, satisfaction_score: 0.666666666666667)
+      expect(fact1.reload).to have_attributes(is_this_useful_no: 1, is_this_useful_yes: 1)
+      expect(fact1.satisfaction_score).to be_within(0.1).of(0.5)
+      expect(fact2.reload).to have_attributes(is_this_useful_no: 5, is_this_useful_yes: 10)
+      expect(fact2.satisfaction_score).to be_within(0.1).of(0.67)
     end
 
     it 'does not update metrics for other days' do

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -70,6 +70,20 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
     end
   end
 
+  context 'the calculation for satisfaction_score in SQL is compared to the calculation in the model' do
+    it 'matches the calculation in the model' do
+      fact = create_metric base_path: '/path1', date: '2018-02-20'
+      allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_yield(ga_response(useful_yes: 1, useful_no: 0))
+      described_class.process(date: date)
+
+      comparison_fact = build :metric
+      comparison_fact.is_this_useful_yes = 1
+      comparison_fact.is_this_useful_no = 0
+
+      expect(fact.reload.satisfaction_score).to eq(comparison_fact.satisfaction_score)
+    end
+  end
+
   context 'When is_this_useful values are received from GA' do
     let!(:fact) { create_metric base_path: '/path1', date: '2018-02-20' }
 

--- a/spec/integration/master/daily_metrics_spec.rb
+++ b/spec/integration/master/daily_metrics_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe 'Master process spec' do
     )
   end
 
+  def validate_satisfaction_score!
+    expect(latest_metric).to have_attributes(
+      is_this_useful_yes: 1,
+      is_this_useful_no: 1,
+      satisfaction_score: 0.5
+    )
+  end
+
   def validate_feedex!
     expect(latest_metric).to have_attributes(feedex_comments: 21)
   end

--- a/spec/models/facts/metric_spec.rb
+++ b/spec/models/facts/metric_spec.rb
@@ -96,4 +96,19 @@ RSpec.describe Facts::Metric, type: :model do
       expect(Facts::Metric.for_yesterday).to match_array([metric1, metric2])
     end
   end
+
+  describe ".from_yesterday" do
+    around do |example|
+      Timecop.freeze(Date.new(2018, 1, 13)) { example.run }
+    end
+
+    it "returns a previous date's metrics" do
+      date = Date.new(2018, 1, 13)
+      metric1 = create_metric base_path: '/path1', date: '2018-01-13'
+      metric2 = create_metric base_path: '/path2', date: '2018-01-12'
+      create_metric base_path: '/path2', date: '2018-01-11'
+
+      expect(Facts::Metric.from_day_before_to(date)).to match_array([metric1, metric2])
+    end
+  end
 end

--- a/spec/tasks/temporary/data_migrations_spec.rb
+++ b/spec/tasks/temporary/data_migrations_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe 'rake data_migrations:update_satisfaction', type: task do
+  it 'calls Facts::Calculations::SatisfactionScore.apply' do
+    create :metric
+
+    calculator = class_double(Facts::Calculations::SatisfactionScore, apply: true).as_stubbed_const
+
+    expect(calculator).to receive(:apply)
+
+    Rake::Task['data_migrations:update_satisfaction'].invoke
+  end
+end


### PR DESCRIPTION
The ETL process was not calculating the satisfaction_score within the
SQL that we execute in order to cope with setting a huge number of
updates. Previously we were only using the the ActiveModel overrides of
the setters for `is_this_useful_yes` and `is_this_useful_no` to then
calculate and set the value of `satisfaction_score` but the SQL bypassed
that mechanism.