### PR TITLE
Add error documentation

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -31,13 +31,13 @@ private
     # Type is an arbitrary URI identifying the error type
     # https://tools.ietf.org/html/rfc7807#section-3.1 recommends using
     # human-readable documentation for this, so point to our API docs.
-    error_hash[:type] = "https://content-performance-api.publishing.service.gov.uk/errors/##{type}"
+    error_hash[:type] = "https://content-performance-api.publishing.service.gov.uk/errors.html##{type}"
     render json: error_hash, status: :bad_request, content_type: "application/problem+json"
   end
 
   def not_found_response
     response_hash = {
-      type: "https://content-performance-api.publishing.service.gov.uk/errors/#base-path-not-found",
+      type: "https://content-performance-api.publishing.service.gov.uk/errors.html#base-path-not-found",
       title: 'The base path you are looking for cannot be found',
       invalid_params: %w[base_path]
     }

--- a/doc/api/config/tech-docs.yml
+++ b/doc/api/config/tech-docs.yml
@@ -12,6 +12,7 @@ phase: Alpha
 header_links:
   About: /
   Reference: /reference.html
+  Errors: /errors.html
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 #ga_tracking_id: UA-26179049-13

--- a/doc/api/source/errors.html.md.erb
+++ b/doc/api/source/errors.html.md.erb
@@ -1,0 +1,44 @@
+---
+title: Errors
+---
+
+# GOV.UK Content Performance API
+
+<div class="phase-tag">
+  <p>
+    <strong class="phase-banner"><%= config[:tech_docs][:phase] %></strong>
+    <span>
+      This is a trial service. <a href="#version">Find out what
+      this means</a>.
+    </span>
+  </p>
+</div>
+
+## Validation Error
+
+## Unknown Parameter
+
+## Base Path Not Found
+
+## Support
+
+If you experience any issues or have questions regarding GOV.UK Content Performance API
+please:
+
+- **if you are a government department:** Raise a ticket with [GOV.UK Support][]
+- **otherwise:** [Contact GOV.UK][] with your query
+
+
+[getting started section]: /#getting-started
+[Contact support]: http://dev.gov.uk:4567/#support
+[authentication]: /#authentication-and-authorisation
+[GOV.UK Signon]: https://signon.publishing.service.gov.uk/
+[GOV.UK Slack]: https://govuk.slack.com
+[GOV.UK Content API]: https://content-api.publishing.service.gov.uk
+[government HTTPS security guidelines]: https://www.ncsc.gov.uk/guidance/tls-external-facing-services
+[Contact GOV.UK]: https://www.gov.uk/contact/govuk
+[contact the team]: http://dev.gov.uk:4567/#Support
+[GOV.UK Support]: http://dev.gov.uk:4567/#Support
+[Zendesk]: https://www.zendesk.co.uk/
+[GOV.UK Content Performance API]: https://content-performance-api.publishing.service.gov.uk/#gov-uk-content-performance-api
+[reference documentation]: https://content-performance-api.publishing.service.gov.uk/reference.html#gov-uk-content-performance-api-v1-0-0

--- a/doc/api/source/errors.html.md.erb
+++ b/doc/api/source/errors.html.md.erb
@@ -2,23 +2,19 @@
 title: Errors
 ---
 
-# GOV.UK Content Performance API
-
-<div class="phase-tag">
-  <p>
-    <strong class="phase-banner"><%= config[:tech_docs][:phase] %></strong>
-    <span>
-      This is a trial service. <a href="#version">Find out what
-      this means</a>.
-    </span>
-  </p>
-</div>
+# Errors
 
 ## Validation Error
 
+Value supplied for parameter is invalid. Check parameter values.
+
 ## Unknown Parameter
 
+An unknown parameter supplied in the request. Check parameter names match the available parameters for that request.
+
 ## Base Path Not Found
+
+The base path supplied with the request does not match a known content item. Check that the base path matches an existing content item on GOV.UK.
 
 ## Support
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -270,7 +270,7 @@ components:
             - can't be blank
             - Dates should use the format YYYY-MM-DD
         type: >-
-          https://content-performance-api.publishing.service.gov.uk/errors/#validation-error
+          https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error
     MetricsExample:
       summary: An list of available metrics.
       value:

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
         "title" => "One or more parameters is invalid",
         "invalid_params" => { "metric" => ["is not included in the list"] }
       }
@@ -78,7 +78,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
         "title" => "One or more parameters is invalid",
         "invalid_params" => { "from" => ["Dates should use the format YYYY-MM-DD"] }
       }
@@ -94,7 +94,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
         "title" => "One or more parameters is invalid",
         "invalid_params" => { "from,to" => ["`from` parameter can't be after the `to` parameter"] }
       }
@@ -110,7 +110,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#validation-error",
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
         "title" => "One or more parameters is invalid",
         "invalid_params" => { "metrics" => ["can't be blank"] }
       }
@@ -126,7 +126,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#unknown-parameter",
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#unknown-parameter",
         "title" => "One or more parameter names are invalid",
         "invalid_params" => %w[extra]
       }
@@ -232,7 +232,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
         json = JSON.parse(response.body)
 
         expected_error_response = {
-          "type" => "https://content-performance-api.publishing.service.gov.uk/errors/#base-path-not-found",
+          "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#base-path-not-found",
           "title" => "The base path you are looking for cannot be found",
           "invalid_params" => %w[base_path]
         }


### PR DESCRIPTION
This PR adds the initial documentation page for errors presented to user of the API. All existing errors should be listed. Links supplied by error messages to documenation is also fixed, as was missing the `.html` extension.