### PR TITLE
Endpoint for index page

### DIFF
--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,6 +1,23 @@
-class Api::ContentController < ApplicationController
+class Api::ContentController < Api::BaseController
+  before_action :validate_params!
   def index
     @content = Reports::Content.retrieve(from: params[:from], to: params[:to])
     render json: { results: @content }.to_json
+  end
+
+  def api_request
+    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :format, metrics: []),
+      requires_metrics: false,
+      requires_base_path: false)
+  end
+
+  def validate_params!
+    unless api_request.valid?
+      error_response(
+        "validation-error",
+        title: "One or more parameters is invalid",
+        invalid_params: api_request.errors.to_hash
+      )
+    end
   end
 end

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,0 +1,6 @@
+class Api::ContentController < ApplicationController
+  def index
+    @content = Reports::Content.retrieve(from: params[:from], to: params[:to])
+    render json: { results: @content }.to_json
+  end
+end

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,12 +1,13 @@
 class Api::ContentController < Api::BaseController
   before_action :validate_params!
   def index
-    @content = Reports::Content.retrieve(from: params[:from], to: params[:to])
+    @content = Reports::Content.retrieve(from: params[:from], to: params[:to],
+    organisation: params[:organisation])
     render json: { results: @content }.to_json
   end
 
   def api_request
-    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :format, metrics: []),
+    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :organisation, :format, metrics: []),
       requires_metrics: false,
       requires_base_path: false)
   end

--- a/app/domain/api/request.rb
+++ b/app/domain/api/request.rb
@@ -9,19 +9,23 @@ class Api::Request
 
   validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
   validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
-  validates :base_path, presence: true
+  validates :base_path, presence: true, if: :requires_base_path
   validate :from_before_to, if: :have_a_date_range?
-  validates :metrics, presence: true
-  validate :verify_metrics, if: [Proc.new { metrics.present? }]
+  validates :metrics, presence: true, if: :requires_metrics
+  validate :verify_metrics, if: [Proc.new { metrics.present? }, :requires_metrics]
 
-  def initialize(params)
+  def initialize(params, requires_metrics: true, requires_base_path: true)
     @metrics = params[:metrics]
     @from = params[:from]
     @to = params[:to]
     @base_path = params[:base_path]
+    @requires_metrics = requires_metrics
+    @requires_base_path = requires_base_path
   end
 
 private
+
+  attr_reader :requires_metrics, :requires_base_path
 
   def have_a_date_range?
     from.present? && to.present? && from =~ DATE_REGEX && to =~ DATE_REGEX

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -14,7 +14,7 @@ private
     Metric.edition_metrics.map(&:name).each do |edition_metric|
       path = path_for_edition_metric(edition_metric)
 
-      GovukStatsd.count(path, editions.sum("facts_editions.#{edition_metric}"))
+      GovukStatsd.count(path, sum("facts_editions.#{edition_metric}"))
     end
   end
 
@@ -22,8 +22,12 @@ private
     Metric.daily_metrics.map(&:name).each do |daily_metric|
       path = path_for_daily_metric(daily_metric)
 
-      GovukStatsd.count(path, metrics.sum(daily_metric))
+      GovukStatsd.count(path, sum(daily_metric))
     end
+  end
+
+  def sum(selector)
+    editions.sum(Arel.sql(selector))
   end
 
   def path_for_edition_metric(edition_metric)

--- a/app/domain/reports/content.rb
+++ b/app/domain/reports/content.rb
@@ -21,7 +21,8 @@ class Reports::Content
   end
 
 private
-    def aggregates
+
+  def aggregates
     [
       sum('unique_pageviews'),
       average_satisfaction_score,

--- a/app/domain/reports/content.rb
+++ b/app/domain/reports/content.rb
@@ -1,0 +1,73 @@
+class Reports::Content
+  def self.retrieve(from:, to:)
+    new(from, to).retrieve
+  end
+
+  def initialize(from, to)
+    @from = from
+    @to = to
+  end
+
+  def retrieve
+    Facts::Metric.all
+      .joins(dimensions_item: :facts_edition)
+      .joins(:dimensions_date).merge(slice_dates)
+      .group(group_columns)
+      .limit(100)
+      .pluck(*group_columns, *aggregates)
+      .map(&method(:array_to_hash))
+  end
+
+private
+
+  def aggregates
+    [
+      sum('unique_pageviews'),
+      average_satisfaction_score,
+      satifaction_score_responses,
+      sum('number_of_internal_searches')
+    ]
+  end
+
+  def group_columns
+    %w[base_path title document_type].map { |col| Arel.sql(col) }
+  end
+
+  def sum(column)
+    Arel.sql("SUM(#{column})")
+  end
+
+  def avg(column)
+    Arel.sql("AVG(#{column})")
+  end
+
+  def satifaction_score_responses
+    Arel.sql("SUM(is_this_useful_yes + is_this_useful_no)")
+  end
+
+  def average_satisfaction_score
+    sql = <<-FOO
+        CASE
+          WHEN SUM(is_this_useful_yes + is_this_useful_no) > 0 THEN 1.0 * SUM(is_this_useful_yes) / SUM(is_this_useful_yes + is_this_useful_no)
+          ELSE -1
+          END
+    FOO
+    Arel.sql(sql)
+  end
+
+  def array_to_hash(array)
+    {
+      base_path: array[0],
+      title: array[1],
+      document_type: array[2],
+      unique_pageviews: array[3],
+      satisfaction_score: array[4].negative? ? nil : array[4].to_f,
+      satisfaction_score_responses: array[5],
+      number_of_internal_searches: array[6],
+    }
+  end
+
+  def slice_dates
+    Dimensions::Date.between(@from, @to)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get '/audits', to: redirect(Plek.find('content-audit-tool', status: 302))
 
   namespace :api, defaults: { format: :json } do
+    get '/v1/content', to: "content#index"
     get '/v1/metrics/', to: "metrics#index"
     get '/v1/metrics/*base_path/time-series', to: "metrics#time_series"
     get '/v1/metrics/*base_path', to: "metrics#summary"

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe '/api/v1/content' do
+  include ItemSetupHelpers
+  before do
+    create :user
+  end
+
+  context 'when successful' do
+    before do
+      create_metric(base_path: '/path/1', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 50,
+          is_this_useful_no: 20,
+          number_of_internal_searches: 20,
+        },
+        item: { title: 'the title' },)
+      create_metric(base_path: '/path/1', date: '2018-01-02',
+        daily: {
+          unique_pageviews: 133,
+          is_this_useful_yes: 150,
+          is_this_useful_no: 30,
+          number_of_internal_searches: 200
+        },
+        item: {
+          title: 'the title',
+          document_type: 'news_story',
+          primary_organisation_content_id: primary_org_id,
+        })
+      create_metric(base_path: '/another/path', date: '2018-01-02',
+        daily: {
+          unique_pageviews: 34,
+          is_this_useful_yes: 22,
+          is_this_useful_no: 10,
+          number_of_internal_searches: 15
+        },
+        item: {
+          title: 'another org title',
+          document_type: 'news_story',
+          primary_organisation_content_id: another_org_id,
+        })
+      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id }
+    end
+
+    it 'is successful' do
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns the correct data' do
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:results]).to match_array(
+        [
+          base_path: '/path/1',
+          title: 'the title',
+          unique_pageviews: 233,
+          document_type: 'news_story',
+          satisfaction_score: 0.8,
+          satisfaction_score_responses: 250,
+          number_of_internal_searches: 220
+        ]
+      )
+    end
+  end
+
+  context 'when no is_this_useful.. reponses' do
+    before do
+      create_metric(base_path: '/path/1', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 0,
+          is_this_useful_no: 0,
+        },
+
+        item: { title: 'the title', primary_organisation_content_id: primary_org_id },)
+      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id }
+    end
+
+    it 'returns the nil for the satisfaction_score' do
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:results][0]).to include(
+        satisfaction_score: nil,
+        satisfaction_score_responses: 0
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -82,4 +82,38 @@ RSpec.describe '/api/v1/content' do
       )
     end
   end
+
+  context 'with invalid params' do
+    it 'returns an error for badly formatted dates' do
+      get "/api/v1/content", params: { from: 'today', to: '2018-01-15' }
+
+      expect(response.status).to eq(400)
+
+      json = JSON.parse(response.body)
+
+      expected_error_response = {
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
+        "title" => "One or more parameters is invalid",
+        "invalid_params" => { "from" => ["Dates should use the format YYYY-MM-DD"] }
+      }
+
+      expect(json).to eq(expected_error_response)
+    end
+
+    it 'returns an error for bad date ranges' do
+      get "/api/v1/content/", params: { from: '2018-01-16', to: '2018-01-15' }
+
+      expect(response.status).to eq(400)
+
+      json = JSON.parse(response.body)
+
+      expected_error_response = {
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
+        "title" => "One or more parameters is invalid",
+        "invalid_params" => { "from,to" => ["`from` parameter can't be after the `to` parameter"] }
+      }
+
+      expect(json).to eq(expected_error_response)
+    end
+  end
 end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe '/api/v1/content' do
     create :user
   end
 
+  let(:primary_org_id) { '6667cce2-e809-4e21-ae09-cb0bdc1ddda3' }
+  let(:another_org_id) { '05e9c04d-534b-4ff0-ae8f-35c1bf9e510f' }
+
   context 'when successful' do
     before do
       create_metric(base_path: '/path/1', date: '2018-01-01',
@@ -13,7 +16,12 @@ RSpec.describe '/api/v1/content' do
           is_this_useful_no: 20,
           number_of_internal_searches: 20,
         },
-        item: { title: 'the title' },)
+        item: {
+          title: 'the title',
+          document_type: 'news_story',
+          primary_organisation_content_id: primary_org_id,
+        })
+
       create_metric(base_path: '/path/1', date: '2018-01-02',
         daily: {
           unique_pageviews: 133,
@@ -61,7 +69,7 @@ RSpec.describe '/api/v1/content' do
     end
   end
 
-  context 'when no is_this_useful.. reponses' do
+  context 'when no is_this_useful.. responses' do
     before do
       create_metric(base_path: '/path/1', date: '2018-01-01',
         daily: {
@@ -69,9 +77,15 @@ RSpec.describe '/api/v1/content' do
           is_this_useful_yes: 0,
           is_this_useful_no: 0,
         },
+<<<<<<< HEAD
 
         item: { title: 'the title', primary_organisation_content_id: primary_org_id },)
       get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id }
+=======
+        item: { title: 'the title', primary_organisation_content_id: primary_org_id },)
+      get "//api/v1/content", params: {from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id}
+
+>>>>>>> b24efb0... Add filter for organisation
     end
 
     it 'returns the nil for the satisfaction_score' do

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -77,15 +77,8 @@ RSpec.describe '/api/v1/content' do
           is_this_useful_yes: 0,
           is_this_useful_no: 0,
         },
-<<<<<<< HEAD
-
-        item: { title: 'the title', primary_organisation_content_id: primary_org_id },)
+        item: { title: 'the title', primary_organisation_content_id: primary_org_id })
       get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id }
-=======
-        item: { title: 'the title', primary_organisation_content_id: primary_org_id },)
-      get "//api/v1/content", params: {from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id}
-
->>>>>>> b24efb0... Add filter for organisation
     end
 
     it 'returns the nil for the satisfaction_score' do


### PR DESCRIPTION
This is an interim PR to allow work to continue on the index page.

Adds a /api/v1/content endpoint to retrieve a summary of all content items.

Url: http://content-performance-manager.dev.gov.uk/api/v1/content?from=2018-08-19&organisation=6667cce2-e809-4e21-ae09-cb0bdc1ddda3&to=2018-09-18

## Still to do

* validate parameters
* add test for cache headers
* Remove the group_by and retrieve the item's metadata from the latest item.

There is a [relate PR in content-data-admin](https://github.com/alphagov/content-data-admin/pull/59)