### PR TITLE
Improve content endpoint code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'ruby-progressbar'
 gem 'sass-rails'
 gem 'uglifier'
 gem 'unicorn'
+gem 'uuid'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
+    macaddr (1.7.1)
+      systemu (~> 2.6.2)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     marcel (0.3.2)
@@ -441,6 +443,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
+    systemu (2.6.5)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -457,6 +460,8 @@ GEM
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
     warden (1.2.7)
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
@@ -531,6 +536,7 @@ DEPENDENCIES
   timecop
   uglifier
   unicorn
+  uuid
   web-console
   webmock
 

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,8 +1,12 @@
 class Api::ContentController < Api::BaseController
   before_action :validate_params!
+
   def index
-    @content = Reports::Content.retrieve(from: params[:from], to: params[:to],
-    organisation: params[:organisation_id])
+    @content = Reports::Content.retrieve(
+      from: params[:from],
+      to: params[:to],
+      organisation_id: params[:organisation_id]
+    )
     render json: { results: @content }.to_json
   end
 

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -7,7 +7,13 @@ class Api::ContentController < Api::BaseController
   end
 
   def api_request
-    @api_request ||= Api::ContentRequest.new(params.permit(:from, :to, :organisation_id, :format))
+    @api_request ||= Api::ContentRequest.new(permitted_params)
+  end
+
+private
+
+  def permitted_params
+    params.permit(:from, :to, :organisation_id, :format)
   end
 
   def validate_params!

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -2,14 +2,12 @@ class Api::ContentController < Api::BaseController
   before_action :validate_params!
   def index
     @content = Reports::Content.retrieve(from: params[:from], to: params[:to],
-    organisation: params[:organisation])
+    organisation: params[:organisation_id])
     render json: { results: @content }.to_json
   end
 
   def api_request
-    @api_request ||= Api::MetricsRequest.new(params.permit(:from, :to, :metric, :base_path, :organisation, :format, metrics: []),
-      requires_metrics: false,
-      requires_base_path: false)
+    @api_request ||= Api::ContentRequest.new(params.permit(:from, :to, :organisation_id, :format))
   end
 
   def validate_params!

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -7,7 +7,7 @@ class Api::ContentController < Api::BaseController
   end
 
   def api_request
-    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :organisation, :format, metrics: []),
+    @api_request ||= Api::MetricsRequest.new(params.permit(:from, :to, :metric, :base_path, :organisation, :format, metrics: []),
       requires_metrics: false,
       requires_base_path: false)
   end

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -41,7 +41,11 @@ private
   delegate :from, :to, :base_path, :metrics, to: :api_request
 
   def api_request
-    @api_request ||= Api::MetricsRequest.new(params.permit(:from, :to, :metric, :base_path, :format, metrics: []))
+    @api_request ||= Api::MetricsRequest.new(permitted_params)
+  end
+
+  def permitted_params
+    params.permit(:from, :to, :base_path, :format, metrics: [])
   end
 
   def validate_params!

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -41,7 +41,7 @@ private
   delegate :from, :to, :base_path, :metrics, to: :api_request
 
   def api_request
-    @api_request ||= Api::Request.new(params.permit(:from, :to, :metric, :base_path, :format, metrics: []))
+    @api_request ||= Api::MetricsRequest.new(params.permit(:from, :to, :metric, :base_path, :format, metrics: []))
   end
 
   def validate_params!

--- a/app/domain/api/base_request.rb
+++ b/app/domain/api/base_request.rb
@@ -1,0 +1,31 @@
+class Api::BaseRequest
+  DATE_REGEX = /\A\d\d\d\d-\d\d-\d\d\Z/
+
+  private_constant :DATE_REGEX
+
+  include ActiveModel::Validations
+
+  attr_reader :from, :to
+
+  validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
+  validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
+  validate :from_before_to, if: :have_a_date_range?
+
+  def initialize(params)
+    @from = params[:from]
+    @to = params[:to]
+  end
+
+private
+
+  def have_a_date_range?
+    from.present? && to.present? && from =~ DATE_REGEX && to =~ DATE_REGEX
+  end
+
+  def from_before_to
+    # This is a string comparison, but the sort order is the same as for dates.
+    if from > to
+      errors.add("from,to", "`from` parameter can't be after the `to` parameter")
+    end
+  end
+end

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,0 +1,16 @@
+class Api::ContentRequest < Api::BaseRequest
+  attr_reader :organisation_id
+  validate :valid_organisation_id
+
+  def initialize(params)
+    super(params)
+    @organisation_id = params[:organisation_id]
+  end
+
+private
+
+  def valid_organisation_id
+    return true if UUID.validate organisation_id
+    errors.add('organisation_id', 'this is not a valid organisation id')
+  end
+end

--- a/app/domain/api/metrics_request.rb
+++ b/app/domain/api/metrics_request.rb
@@ -1,42 +1,17 @@
-class Api::MetricsRequest
-  DATE_REGEX = /\A\d\d\d\d-\d\d-\d\d\Z/
+class Api::MetricsRequest < Api::BaseRequest
+  attr_reader :metrics, :base_path
 
-  private_constant :DATE_REGEX
+  validates :base_path, presence: true
+  validates :metrics, presence: true
+  validate :verify_metrics, if: [Proc.new { metrics.present? }]
 
-  include ActiveModel::Validations
-
-  attr_reader :metrics, :from, :to, :base_path
-
-  validates :from, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
-  validates :to, presence: true, format: { with: DATE_REGEX, message: "Dates should use the format YYYY-MM-DD" }
-  validates :base_path, presence: true, if: :requires_base_path
-  validate :from_before_to, if: :have_a_date_range?
-  validates :metrics, presence: true, if: :requires_metrics
-  validate :verify_metrics, if: [Proc.new { metrics.present? }, :requires_metrics]
-
-  def initialize(params, requires_metrics: true, requires_base_path: true)
+  def initialize(params)
+    super(params)
     @metrics = params[:metrics]
-    @from = params[:from]
-    @to = params[:to]
     @base_path = params[:base_path]
-    @requires_metrics = requires_metrics
-    @requires_base_path = requires_base_path
   end
 
 private
-
-  attr_reader :requires_metrics, :requires_base_path
-
-  def have_a_date_range?
-    from.present? && to.present? && from =~ DATE_REGEX && to =~ DATE_REGEX
-  end
-
-  def from_before_to
-    # This is a string comparison, but the sort order is the same as for dates.
-    if from > to
-      errors.add("from,to", "`from` parameter can't be after the `to` parameter")
-    end
-  end
 
   def verify_metrics
     if metrics.blank?

--- a/app/domain/api/metrics_request.rb
+++ b/app/domain/api/metrics_request.rb
@@ -1,4 +1,4 @@
-class Api::Request
+class Api::MetricsRequest
   DATE_REGEX = /\A\d\d\d\d-\d\d-\d\d\Z/
 
   private_constant :DATE_REGEX

--- a/app/domain/reports/content.rb
+++ b/app/domain/reports/content.rb
@@ -1,12 +1,12 @@
 class Reports::Content
-  def self.retrieve(from:, to:, organisation:)
-    new(from, to, organisation).retrieve
+  def self.retrieve(from:, to:, organisation_id:)
+    new(from, to, organisation_id).retrieve
   end
 
-  def initialize(from, to, organisation)
+  def initialize(from, to, organisation_id)
     @from = from
     @to = to
-    @organsation = organisation
+    @organsation_id = organisation_id
   end
 
   def retrieve
@@ -74,7 +74,7 @@ private
   end
 
   def slice_items
-    Dimensions::Item.by_organisation_id(@organsation)
+    Dimensions::Item.by_organisation_id(@organsation_id)
   end
 
   def slice_dates

--- a/spec/domain/reports/content_spec.rb
+++ b/spec/domain/reports/content_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe Reports::Content do
+  include ItemSetupHelpers
+
+  let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
+
+  before do
+    create :user
+  end
+
+  context 'when successful' do
+    before do
+      create_metric(base_path: '/path/1', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 50,
+          is_this_useful_no: 20,
+          number_of_internal_searches: 20,
+        },
+        item: {
+          title: 'the title',
+          document_type: 'news_story',
+          primary_organisation_content_id: primary_org_id,
+        })
+
+      create_metric(base_path: '/path/1', date: '2018-01-02',
+        daily: {
+          unique_pageviews: 133,
+          is_this_useful_yes: 150,
+          is_this_useful_no: 30,
+          number_of_internal_searches: 200
+        },
+        item: {
+          title: 'the title',
+          document_type: 'news_story',
+          primary_organisation_content_id: primary_org_id,
+        })
+    end
+
+    it 'returns the correct data' do
+      expect(described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)).to match_array(
+        [
+          base_path: '/path/1',
+          title: 'the title',
+          unique_pageviews: 233,
+          document_type: 'news_story',
+          satisfaction_score: 0.8,
+          satisfaction_score_responses: 250,
+          number_of_internal_searches: 220
+        ]
+      )
+    end
+  end
+
+  context 'when no is_this_useful.. responses' do
+    before do
+      create_metric(base_path: '/path/1', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 0,
+          is_this_useful_no: 0,
+        },
+        item: { title: 'the title', primary_organisation_content_id: primary_org_id })
+    end
+
+    it 'returns the nil for the satisfaction_score' do
+      results = described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)
+      expect(results.first).to include(
+        satisfaction_score: nil,
+        satisfaction_score_responses: 0
+      )
+    end
+  end
+
+  context 'when no metrics in the date range' do
+    before do
+      create_metric(base_path: '/path/1', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 0,
+          is_this_useful_no: 0,
+        },
+        item: { title: 'the title', primary_organisation_content_id: primary_org_id })
+    end
+
+    it 'returns a empty array' do
+      results = described_class.retrieve(from: '2018-02-01', to: '2018-02-02', organisation_id: primary_org_id)
+      expect(results).to be_empty
+    end
+  end
+
+  context 'when no items exist for the organisation' do
+    it 'returns a empty array' do
+      results = described_class.retrieve(from: '2018-02-01', to: '2018-02-02', organisation_id: primary_org_id)
+      expect(results).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe '/api/v1/content' do
           document_type: 'news_story',
           primary_organisation_content_id: another_org_id,
         })
-      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+      get "/api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
     end
 
     it 'is successful' do
@@ -65,27 +65,6 @@ RSpec.describe '/api/v1/content' do
           satisfaction_score_responses: 250,
           number_of_internal_searches: 220
         ]
-      )
-    end
-  end
-
-  context 'when no is_this_useful.. responses' do
-    before do
-      create_metric(base_path: '/path/1', date: '2018-01-01',
-        daily: {
-          unique_pageviews: 100,
-          is_this_useful_yes: 0,
-          is_this_useful_no: 0,
-        },
-        item: { title: 'the title', primary_organisation_content_id: primary_org_id })
-      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
-    end
-
-    it 'returns the nil for the satisfaction_score' do
-      json = JSON.parse(response.body).deep_symbolize_keys
-      expect(json[:results][0]).to include(
-        satisfaction_score: nil,
-        satisfaction_score_responses: 0
       )
     end
   end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe '/api/v1/content' do
           document_type: 'news_story',
           primary_organisation_content_id: another_org_id,
         })
-      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id }
+      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
     end
 
     it 'is successful' do
@@ -78,7 +78,7 @@ RSpec.describe '/api/v1/content' do
           is_this_useful_no: 0,
         },
         item: { title: 'the title', primary_organisation_content_id: primary_org_id })
-      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation: primary_org_id }
+      get "//api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
     end
 
     it 'returns the nil for the satisfaction_score' do
@@ -92,7 +92,7 @@ RSpec.describe '/api/v1/content' do
 
   context 'with invalid params' do
     it 'returns an error for badly formatted dates' do
-      get "/api/v1/content", params: { from: 'today', to: '2018-01-15' }
+      get "/api/v1/content", params: { from: 'today', to: '2018-01-15', organisation_id: '386ea723-d8fc-4581-8e53-bb8ee9aa8c03' }
 
       expect(response.status).to eq(400)
 
@@ -108,7 +108,7 @@ RSpec.describe '/api/v1/content' do
     end
 
     it 'returns an error for bad date ranges' do
-      get "/api/v1/content/", params: { from: '2018-01-16', to: '2018-01-15' }
+      get "/api/v1/content/", params: { from: '2018-01-16', to: '2018-01-15', organisation_id: '1182a3ed-a9a3-482c-81e1-0a9ecfb847d0' }
 
       expect(response.status).to eq(400)
 
@@ -118,6 +118,22 @@ RSpec.describe '/api/v1/content' do
         "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
         "title" => "One or more parameters is invalid",
         "invalid_params" => { "from,to" => ["`from` parameter can't be after the `to` parameter"] }
+      }
+
+      expect(json).to eq(expected_error_response)
+    end
+
+    it 'returns an error for invalid organisation_id' do
+      get "/api/v1/content/", params: { from: '2018-01-16', to: '2018-01-17', organisation_id: 'blah' }
+
+      expect(response.status).to eq(400)
+
+      json = JSON.parse(response.body)
+
+      expected_error_response = {
+        "type" => "https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error",
+        "title" => "One or more parameters is invalid",
+        "invalid_params" => { "organisation_id" => ["this is not a valid organisation id"] }
       }
 
       expect(json).to eq(expected_error_response)


### PR DESCRIPTION
This PR Addresses some code quality issues from the [previous PR](https://github.com/alphagov/content-performance-manager/pull/919)

This includes:

* Splitting Api:Request into 2 classes
* Move some of the /content endpoint specs into a new Unit test for Reports:Content.
* Added a spec for cache headers on the /content endpoint.