### PR TITLE
Restore JSON events from Publishing-API

### DIFF
--- a/app/models/dimensions/item.rb
+++ b/app/models/dimensions/item.rb
@@ -1,8 +1,6 @@
 require 'json'
 
 class Dimensions::Item < ApplicationRecord
-  attr_accessor :raw_json
-
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_item_id
   validates :content_id, presence: true
   validates :base_path, presence: true

--- a/db/migrate/20180924093138_restore_raw_json_to_dimensions_item.rb
+++ b/db/migrate/20180924093138_restore_raw_json_to_dimensions_item.rb
@@ -1,0 +1,5 @@
+class RestoreRawJsonToDimensionsItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dimensions_items, :raw_json, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_31_101255) do
+ActiveRecord::Schema.define(version: 2018_09_24_093138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2018_08_31_101255) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
+    t.json "raw_json"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["latest"], name: "index_dimensions_items_on_latest"


### PR DESCRIPTION
[Trello card](https://trello.com/c/3AS0KShH/697-1-track-events-with-content-changes-in-dw)

Each Content Item is defined by a JSON document that includes all the
metadata, the links and the content details. The links include
information about organisations, policies, taxonomies, and details
including the actual content of the page, the attachments, and other
necessary details like title, description, publishing-app, rendering
app, etc.

In the Data Warehouse, we started storing the Event with the JSON
document, but we decided to remove it because our database was growing
too quickly. Later on, we found out that we had a bug in our code
because we were not filtering Publishing-API events correctly. Some days
we had more than 4 million events, and each one of them implied a new
version of a Content Item with no real changes.

As of today (September 2018), the Content Items dimension is growing
very slowly, as it only tracks changes related to content updates. The
current pace of growth is around 600-800 rows per day, which is very
small for a Data Warehouse.

For this reason we have decided to:

Store the entire JSON document of the Content Items that grow the Items
dimension, which is the same as storing all the information that we
currently have about a Dimension Item.

[See ADR][1]

[1]: https://github.com/alphagov/content-performance-manager/blob/master/doc/arch/adr-013-store-json-from-events-that-carry-content-changes.md