### PR TITLE
Use content UUID for content query [WIP][DO NOT MERGE]

### DIFF
--- a/app/domain/reports/content.rb
+++ b/app/domain/reports/content.rb
@@ -12,7 +12,7 @@ class Reports::Content
   def retrieve
     Facts::Metric.all
       .joins(:dimensions_date).merge(slice_dates)
-      .joins(dimensions_item: :facts_edition).merge(slice_items)
+      .joins(:dimensions_item).merge(slice_items)
       .joins(latest_join)
       .group('latest.content_uuid', *group_columns)
       .order(order_by)
@@ -26,8 +26,8 @@ private
   def aggregates
     [
       sum('unique_pageviews'),
-      average_satisfaction_score,
-      satifaction_score_responses,
+      sum('is_this_useful_yes'),
+      sum('is_this_useful_no'),
       sum('number_of_internal_searches')
     ]
   end
@@ -37,43 +37,26 @@ private
   end
 
   def order_by
-    Arel.sql('SUM(unique_pageviews) DESC')
+    Arel.sql('latest.content_uuid')
   end
 
   def sum(column)
     Arel.sql("SUM(#{column})")
   end
 
-  def avg(column)
-    Arel.sql("AVG(#{column})")
-  end
-
-  def satifaction_score_responses
-    Arel.sql("SUM(is_this_useful_yes + is_this_useful_no)")
-  end
-
   def latest_join
     "INNER JOIN dimensions_items latest ON latest.content_uuid = dimensions_items.content_uuid AND latest.latest = true"
   end
 
-  def average_satisfaction_score
-    sql = <<-FOO
-        CASE
-          WHEN SUM(is_this_useful_yes + is_this_useful_no) > 0 THEN 1.0 * SUM(is_this_useful_yes) / SUM(is_this_useful_yes + is_this_useful_no)
-          ELSE -1
-          END
-    FOO
-    Arel.sql(sql)
-  end
-
   def array_to_hash(array)
+    satisfaction_responses = array[4] + array[5]
     {
       base_path: array[0],
       title: array[1],
       document_type: array[2],
       unique_pageviews: array[3],
-      satisfaction_score: array[4].negative? ? nil : array[4].to_f,
-      satisfaction_score_responses: array[5],
+      satisfaction_score: satisfaction_responses.zero? ? nil : array[4].to_f / satisfaction_responses,
+      satisfaction_score_responses: satisfaction_responses,
       number_of_internal_searches: array[6],
     }
   end

--- a/db/migrate/20180920150009_add_content_uuid_to_dimensions_item.rb
+++ b/db/migrate/20180920150009_add_content_uuid_to_dimensions_item.rb
@@ -1,0 +1,5 @@
+class AddContentUuidToDimensionsItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dimensions_items, :content_uuid, :string
+  end
+end

--- a/db/migrate/20180921122451_add_index_dimensions_items_content_uuid.rb
+++ b/db/migrate/20180921122451_add_index_dimensions_items_content_uuid.rb
@@ -1,0 +1,6 @@
+class AddIndexDimensionsItemsContentUuid < ActiveRecord::Migration[5.2]
+  def change
+    add_index :dimensions_items, :content_uuid, name: 'index_dimensions_items_content_uuid'
+    add_index :dimensions_items, %i[content_uuid latest], name: 'index_dimensions_items_content_uuid_latest'
+  end
+end

--- a/db/migrate/20180921155800_add_index_for_content_list.rb
+++ b/db/migrate/20180921155800_add_index_for_content_list.rb
@@ -1,0 +1,7 @@
+class AddIndexForContentList < ActiveRecord::Migration[5.2]
+  def change
+    # This index is required for the query we run to get the data
+    # for the /content endpoint. We GROUP_BY these columns.
+    add_index :dimensions_items, %i[content_uuid base_path title document_type], name: 'index_for_content_query'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_20_150009) do
-
+ActiveRecord::Schema.define(version: 2018_09_21_155800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +67,9 @@ ActiveRecord::Schema.define(version: 2018_09_20_150009) do
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
     t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
+    t.index ["content_uuid", "base_path", "title", "document_type"], name: "index_for_content_query"
+    t.index ["content_uuid", "latest"], name: "index_dimensions_items_content_uuid_latest"
+    t.index ["content_uuid"], name: "index_dimensions_items_content_uuid"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_31_101255) do
+ActiveRecord::Schema.define(version: 2018_09_20_150009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,9 @@ ActiveRecord::Schema.define(version: 2018_08_31_101255) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
+    t.string "content_uuid"
     t.index ["base_path"], name: "index_dimensions_items_on_base_path"
+    t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_items_on_content_id_and_latest"
     t.index ["latest"], name: "index_dimensions_items_on_latest"
     t.index ["primary_organisation_content_id"], name: "index_dimensions_items_primary_organisation_content_id"

--- a/spec/domain/reports/content_spec.rb
+++ b/spec/domain/reports/content_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Reports::Content do
   include ItemSetupHelpers
 
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
-  let(:content_uuid) { SecureRandom.uuid }
-  let(:another_content_uuid) { SecureRandom.uuid }
+  let(:content_uuid) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
+  let(:another_content_uuid) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
 
   before do
     create :user

--- a/spec/domain/reports/content_spec.rb
+++ b/spec/domain/reports/content_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Reports::Content do
   include ItemSetupHelpers
 
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
+  let(:content_uuid) { SecureRandom.uuid }
+  let(:another_content_uuid) { SecureRandom.uuid }
 
   before do
     create :user
@@ -20,6 +22,8 @@ RSpec.describe Reports::Content do
           title: 'the title',
           document_type: 'news_story',
           primary_organisation_content_id: primary_org_id,
+          latest: false,
+          content_uuid: content_uuid,
         })
 
       create_metric(base_path: '/path/1', date: '2018-01-02',
@@ -33,20 +37,97 @@ RSpec.describe Reports::Content do
           title: 'the title',
           document_type: 'news_story',
           primary_organisation_content_id: primary_org_id,
+          latest: true,
+          content_uuid: content_uuid,
+        })
+
+      create_metric(base_path: '/path/2', date: '2018-01-02',
+        daily: {
+          unique_pageviews: 20,
+          is_this_useful_yes: 10,
+          is_this_useful_no: 10,
+          number_of_internal_searches: 7
+        },
+        item: {
+          title: 'title 2',
+          document_type: 'press_release',
+          primary_organisation_content_id: primary_org_id,
+          latest: true,
+          content_uuid: another_content_uuid,
         })
     end
 
     it 'returns the correct data' do
-      expect(described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)).to match_array(
+      results = described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)
+      expect(results).to eq(
         [
-          base_path: '/path/1',
-          title: 'the title',
-          unique_pageviews: 233,
-          document_type: 'news_story',
-          satisfaction_score: 0.8,
-          satisfaction_score_responses: 250,
-          number_of_internal_searches: 220
+          {
+            base_path: '/path/1',
+            title: 'the title',
+            unique_pageviews: 233,
+            document_type: 'news_story',
+            satisfaction_score: 0.8,
+            satisfaction_score_responses: 250,
+            number_of_internal_searches: 220
+          },
+          {
+            base_path: '/path/2',
+            title: 'title 2',
+            unique_pageviews: 20,
+            document_type: 'press_release',
+            satisfaction_score: 0.5,
+            satisfaction_score_responses: 20,
+            number_of_internal_searches: 7
+          }
         ]
+      )
+    end
+  end
+
+
+  context 'the attributes we are displaying have changed over time' do
+    before do
+      create_metric(base_path: '/old/base/path', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 10,
+          is_this_useful_no: 10,
+          number_of_internal_searches: 15,
+        },
+        item: {
+          title: 'old title',
+          document_type: 'news_story',
+          primary_organisation_content_id: primary_org_id,
+          latest: false,
+          content_uuid: content_uuid,
+        })
+      create_metric(base_path: '/new/base/path', date: '2018-01-01',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 50,
+          is_this_useful_no: 50,
+          number_of_internal_searches: 5,
+        },
+        item: {
+          title: 'new title',
+          document_type: 'press_release',
+          primary_organisation_content_id: primary_org_id,
+          latest: true,
+          content_uuid: content_uuid,
+        })
+    end
+
+    it 'returns metrics from all versions with metadata from the latest version' do
+      results = described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)
+      expect(results.count).to eq(1)
+      expect(results.first).to eq(
+        base_path: '/new/base/path',
+        title: 'new title',
+        unique_pageviews: 200,
+        document_type: 'press_release',
+        satisfaction_score: 0.5,
+        satisfaction_score_responses: 120,
+        number_of_internal_searches: 20
       )
     end
   end
@@ -59,7 +140,11 @@ RSpec.describe Reports::Content do
           is_this_useful_yes: 0,
           is_this_useful_no: 0,
         },
-        item: { title: 'the title', primary_organisation_content_id: primary_org_id })
+        item: {
+          title: 'the title',
+          primary_organisation_content_id: primary_org_id,
+          content_uuid: content_uuid,
+        })
     end
 
     it 'returns the nil for the satisfaction_score' do
@@ -79,7 +164,9 @@ RSpec.describe Reports::Content do
           is_this_useful_yes: 0,
           is_this_useful_no: 0,
         },
-        item: { title: 'the title', primary_organisation_content_id: primary_org_id })
+        item: { title: 'the title',
+          primary_organisation_content_id: primary_org_id,
+          content_uuid: content_uuid, })
     end
 
     it 'returns a empty array' do

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe '/api/v1/content' do
     create :user
   end
 
-  let(:primary_org_id) { '6667cce2-e809-4e21-ae09-cb0bdc1ddda3' }
-  let(:another_org_id) { '05e9c04d-534b-4ff0-ae8f-35c1bf9e510f' }
+  let(:primary_org_id) { SecureRandom.uuid }
+  let(:another_org_id) { SecureRandom.uuid }
+  let(:content_uuid) { SecureRandom.uuid }
+  let(:another_content_uuid) { SecureRandom.uuid }
 
   context 'when successful' do
     before do
@@ -17,12 +19,14 @@ RSpec.describe '/api/v1/content' do
           number_of_internal_searches: 20,
         },
         item: {
-          title: 'the title',
+          title: 'old title',
           document_type: 'news_story',
           primary_organisation_content_id: primary_org_id,
+          latest: false,
+          content_uuid: content_uuid,
         })
 
-      create_metric(base_path: '/path/1', date: '2018-01-02',
+      create_metric(base_path: '/new/base/path', date: '2018-01-02',
         daily: {
           unique_pageviews: 133,
           is_this_useful_yes: 150,
@@ -30,11 +34,26 @@ RSpec.describe '/api/v1/content' do
           number_of_internal_searches: 200
         },
         item: {
-          title: 'the title',
-          document_type: 'news_story',
+          title: 'latest title',
+          document_type: 'latest_doc_type',
           primary_organisation_content_id: primary_org_id,
+          latest: true,
+          content_uuid: content_uuid,
         })
-      create_metric(base_path: '/another/path', date: '2018-01-02',
+      create_metric(base_path: '/path/2', date: '2018-01-02',
+        daily: {
+          unique_pageviews: 100,
+          is_this_useful_yes: 10,
+          is_this_useful_no: 10,
+          number_of_internal_searches: 1
+        },
+        item: {
+          title: 'another title',
+          document_type: 'organisation',
+          primary_organisation_content_id: primary_org_id,
+          content_uuid: another_content_uuid,
+        })
+      create_metric(base_path: '/another/org/path', date: '2018-01-02',
         daily: {
           unique_pageviews: 34,
           is_this_useful_yes: 22,
@@ -53,17 +72,28 @@ RSpec.describe '/api/v1/content' do
       expect(response.status).to eq(200)
     end
 
-    it 'returns the correct data' do
+    it 'returns the data summarized with metadata from latest item' do
       json = JSON.parse(response.body).deep_symbolize_keys
-      expect(json[:results]).to match_array(
+      expect(json[:results]).to eq(
         [
-          base_path: '/path/1',
-          title: 'the title',
-          unique_pageviews: 233,
-          document_type: 'news_story',
-          satisfaction_score: 0.8,
-          satisfaction_score_responses: 250,
-          number_of_internal_searches: 220
+          {
+            base_path: '/new/base/path',
+            title: 'latest title',
+            unique_pageviews: 233,
+            document_type: 'latest_doc_type',
+            satisfaction_score: 0.8,
+            satisfaction_score_responses: 250,
+            number_of_internal_searches: 220
+          },
+          {
+            base_path: '/path/2',
+            title: 'another title',
+            unique_pageviews: 100,
+            document_type: 'organisation',
+            satisfaction_score: 0.5,
+            satisfaction_score_responses: 20,
+            number_of_internal_searches: 1
+          }
         ]
       )
     end
@@ -97,7 +127,6 @@ RSpec.describe '/api/v1/content' do
       end
     end
   end
-
 
 
   context 'with invalid params' do

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe '/api/v1/content' do
 
   let(:primary_org_id) { SecureRandom.uuid }
   let(:another_org_id) { SecureRandom.uuid }
-  let(:content_uuid) { SecureRandom.uuid }
-  let(:another_content_uuid) { SecureRandom.uuid }
+  let(:content_uuid) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
+  let(:another_content_uuid) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
 
   context 'when successful' do
     before do


### PR DESCRIPTION
The query that returns data for the /content
endpoint now uses the content_uuid column
to join the latest Dimensions::Item to all
previous editions/metrics for those editions.

This means we will get metrics for all editions
even if the base_path, title, document_type have
changed.

This is implementing [the associated ADR](https://github.com/alphagov/content-performance-manager/pull/924)