### PR TITLE
Move ContentController out of API

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,7 +1,7 @@
-class Api::ContentController < Api::BaseController
+class ContentController < Api::BaseController
   before_action :validate_params!
 
-  def index
+  def show
     @content = Reports::Content.retrieve(
       from: params[:from],
       to: params[:to],

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/update
+++ b/bin/update
@@ -4,7 +4,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,11 @@ Rails.application.routes.draw do
   get '/audits', to: redirect(Plek.find('content-audit-tool', status: 302))
 
   namespace :api, defaults: { format: :json } do
-    get '/v1/content', to: "content#index"
     get '/v1/metrics/', to: "metrics#index"
     get '/v1/metrics/*base_path/time-series', to: "time_series#show"
     get '/v1/metrics/*base_path', to: "aggregations#show"
     get '/v1/healthcheck', to: "healthcheck#index"
   end
+
+  get '/content', to: 'content#show'
 end

--- a/db/migrate/20170824145426_drop_organisations.rb
+++ b/db/migrate/20170824145426_drop_organisations.rb
@@ -6,7 +6,7 @@ class DropOrganisations < ActiveRecord::Migration[5.1]
       t.datetime "updated_at", null: false
       t.string "title"
       t.string "content_id"
-      t.index ["slug"], name: "index_organisations_on_slug", unique: true
+      t.index %w[slug], name: "index_organisations_on_slug", unique: true
     end
   end
 end

--- a/db/migrate/20170912052917_drop_subthemes.rb
+++ b/db/migrate/20170912052917_drop_subthemes.rb
@@ -6,7 +6,7 @@ class DropSubthemes < ActiveRecord::Migration[5.1]
       t.timestamps
 
       t.index %w[theme_id name], name: "index_subthemes_on_theme_id_and_name", unique: true
-      t.index ["theme_id"], name: "index_subthemes_on_theme_id"
+      t.index %w[theme_id], name: "index_subthemes_on_theme_id"
     end
   end
 end

--- a/db/migrate/20170912052927_drop_themes.rb
+++ b/db/migrate/20170912052927_drop_themes.rb
@@ -4,7 +4,7 @@ class DropThemes < ActiveRecord::Migration[5.1]
       t.string "name", null: false
       t.timestamps
 
-      t.index ["name"], name: "index_themes_on_name", unique: true
+      t.index %w[name], name: "index_themes_on_name", unique: true
     end
   end
 end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe '/api/v1/content' do
+RSpec.describe '/content' do
   include ItemSetupHelpers
   before do
     create :user
@@ -46,7 +46,7 @@ RSpec.describe '/api/v1/content' do
           document_type: 'news_story',
           primary_organisation_content_id: another_org_id,
         })
-      get "/api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+      get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
     end
 
     it 'is successful' do
@@ -72,7 +72,7 @@ RSpec.describe '/api/v1/content' do
   describe "an API response" do
     it "should be cacheable until the end of the day" do
       Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
-        get "/api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+        get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
 
         expect(response.headers['ETag']).to be_present
         expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
@@ -81,7 +81,7 @@ RSpec.describe '/api/v1/content' do
 
     it "expires at 1am" do
       Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        get "/api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+        get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
 
         expect(response.headers['ETag']).to be_present
         expect(response.headers['Cache-Control']).to eq "max-age=0, public"
@@ -90,7 +90,7 @@ RSpec.describe '/api/v1/content' do
 
     it "can be cached for up to a day" do
       Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
-        get "/api/v1/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+        get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
 
         expect(response.headers['ETag']).to be_present
         expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
@@ -102,7 +102,7 @@ RSpec.describe '/api/v1/content' do
 
   context 'with invalid params' do
     it 'returns an error for badly formatted dates' do
-      get "/api/v1/content", params: { from: 'today', to: '2018-01-15', organisation_id: '386ea723-d8fc-4581-8e53-bb8ee9aa8c03' }
+      get "/content", params: { from: 'today', to: '2018-01-15', organisation_id: '386ea723-d8fc-4581-8e53-bb8ee9aa8c03' }
 
       expect(response.status).to eq(400)
 
@@ -118,7 +118,7 @@ RSpec.describe '/api/v1/content' do
     end
 
     it 'returns an error for bad date ranges' do
-      get "/api/v1/content/", params: { from: '2018-01-16', to: '2018-01-15', organisation_id: '1182a3ed-a9a3-482c-81e1-0a9ecfb847d0' }
+      get "/content/", params: { from: '2018-01-16', to: '2018-01-15', organisation_id: '1182a3ed-a9a3-482c-81e1-0a9ecfb847d0' }
 
       expect(response.status).to eq(400)
 
@@ -134,7 +134,7 @@ RSpec.describe '/api/v1/content' do
     end
 
     it 'returns an error for invalid organisation_id' do
-      get "/api/v1/content/", params: { from: '2018-01-16', to: '2018-01-17', organisation_id: 'blah' }
+      get "/content/", params: { from: '2018-01-16', to: '2018-01-17', organisation_id: 'blah' }
 
       expect(response.status).to eq(400)
 


### PR DESCRIPTION
It is better not to have the ContentController as part of the API as
it is evolving on a daily basis. This way we don’t have to keep the
documentation up to date.