### PR TITLE
Fix messsage processing job to call monitoring

### DIFF
--- a/app/domain/monitor/messages.rb
+++ b/app/domain/monitor/messages.rb
@@ -1,10 +1,10 @@
 class Monitor::Messages
-  def self.run(message)
-    new.run(message)
+  def self.run(routing_key)
+    new.run(routing_key)
   end
 
-  def run(message)
-    statsd_for_messages!(message)
+  def run(routing_key)
+    statsd_for_messages!(routing_key)
   end
 
   def self.increment_discarded
@@ -13,8 +13,8 @@ class Monitor::Messages
 
 private
 
-  def statsd_for_messages!(message)
-    GovukStatsd.increment(monitoring_code(message.delivery_info['routing_key']))
+  def statsd_for_messages!(routing_key)
+    GovukStatsd.increment(monitoring_code(routing_key))
   end
 
   def monitoring_code(routing_key)

--- a/app/streams/publishing_api/consumer.rb
+++ b/app/streams/publishing_api/consumer.rb
@@ -2,7 +2,7 @@ module PublishingAPI
   class Consumer
     def process(message)
       if valid_routing_key?(message)
-        MessageProcessorJob.perform_later(message.payload)
+        MessageProcessorJob.perform_later(message.payload, message.delivery_info.routing_key)
       else
         Monitor::Messages.increment_discarded
       end

--- a/app/streams/publishing_api/message_processor_job.rb
+++ b/app/streams/publishing_api/message_processor_job.rb
@@ -1,12 +1,14 @@
 module PublishingAPI
   class MessageProcessorJob < ActiveJob::Base
-    def perform(payload)
+    def perform(payload, routing_key)
       message = Messages::Factory.build(payload)
 
       if message.invalid? || message.is_old_message?
         Monitor::Messages.increment_discarded
         return
       end
+
+      Monitor::Messages.run(routing_key)
 
       ActiveRecord::Base.transaction do
         handler = message.handler

--- a/spec/domain/monitor/messages_spec.rb
+++ b/spec/domain/monitor/messages_spec.rb
@@ -4,38 +4,32 @@ RSpec.describe Monitor::Messages do
   end
 
   it 'increments major if routing key ends .major' do
-    message = build(:message, routing_key: 'news_story.major')
     expect(GovukStatsd).to receive(:increment).with("monitor.messages.major")
-    Monitor::Messages.run(message)
+    Monitor::Messages.run('news_story.major')
   end
 
   it 'increments minor if routing key ends .minor' do
-    message = build(:message, routing_key: 'news_story.minor')
     expect(GovukStatsd).to receive(:increment).with("monitor.messages.minor")
-    Monitor::Messages.run(message)
+    Monitor::Messages.run('news_story.minor')
   end
 
   it 'increments links if routing key ends .links' do
-    message = build(:message, routing_key: 'news_story.links')
     expect(GovukStatsd).to receive(:increment).with("monitor.messages.links")
-    Monitor::Messages.run(message)
+    Monitor::Messages.run('news_story.links')
   end
 
   it 'increments republish if routing key ends .republish' do
-    message = build(:message, routing_key: 'news_story.republish')
     expect(GovukStatsd).to receive(:increment).with("monitor.messages.republish")
-    Monitor::Messages.run(message)
+    Monitor::Messages.run('news_story.republish')
   end
 
   it 'increments unpublish if routing key ends .unpublish' do
-    message = build(:message, routing_key: 'news_story.unpublish')
     expect(GovukStatsd).to receive(:increment).with("monitor.messages.unpublish")
-    Monitor::Messages.run(message)
+    Monitor::Messages.run('news_story.unpublish')
   end
 
-  it 'increments discarded if routing key ends .discarded' do
-    message = build(:message, routing_key: 'news_story.discarded')
+  it '.increment_discarded increments discarded' do
     expect(GovukStatsd).to receive(:increment).with("monitor.messages.discarded")
-    Monitor::Messages.run(message)
+    Monitor::Messages.increment_discarded
   end
 end

--- a/spec/streams/publishing_api/message_processor_job_spec.rb
+++ b/spec/streams/publishing_api/message_processor_job_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe PublishingAPI::MessageProcessorJob do
+  it 'increments `monitor.messages.*` ' do
+    message = build(:message, routing_key: 'news_story.major')
+    expect(GovukStatsd).to receive(:increment).with("monitor.messages.major")
+
+    subject.perform(message.payload, message.delivery_info.routing_key)
+  end
+end


### PR DESCRIPTION
We also refactor slightly to accept just the routing key in the monitoring message.

Paired with @KyleMacPherson 