### PR TITLE
Fix migrations since model rename

### DIFF
--- a/db/migrate/20180928141301_populate_warehouse_item_id.rb
+++ b/db/migrate/20180928141301_populate_warehouse_item_id.rb
@@ -1,4 +1,7 @@
 class PopulateWarehouseItemId < ActiveRecord::Migration[5.2]
+	class Dimensions::Item < ActiveRecord::Base
+	end
+
   def change
     multipart_types = %w[travel_advice guide]
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,8 +64,8 @@ ActiveRecord::Schema.define(version: 2018_10_04_120457) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
-    t.string "warehouse_item_id", null: false
     t.json "raw_json"
+    t.string "warehouse_item_id", null: false
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest"], name: "index_dimensions_editions_on_latest"


### PR DESCRIPTION
Since we renamed Dimensions::Item to Dimensions::Edition,
a migration that relied on the model is broken. Adding to the
migration a Data Model fixes a failure to run db:migrate.