### PR TITLE
Add useful totals to single page api endpoint

### DIFF
--- a/app/controllers/single_item_controller.rb
+++ b/app/controllers/single_item_controller.rb
@@ -27,6 +27,8 @@ private
         pviews
         feedex
         satisfaction
+        useful_yes
+        useful_no
         searches
       ))
       .run

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
 RSpec.describe '/single_page', type: :request do
-  let!(:expected_time_series_metrics) { %w[upviews pviews feedex searches satisfaction] }
+  let!(:expected_time_series_metrics) { %w[upviews pviews feedex searches satisfaction useful_yes useful_no] }
   let!(:expected_edition_metrics) { %w[words pdf_count] }
   let!(:base_path) { '/base_path' }
   let!(:item) do


### PR DESCRIPTION
This is for calculating the total number of respondents on the front end.