### PR TITLE
Add Lint Fixes 

### DIFF
--- a/db/migrate/20180926091756_add_default_value_to_feedback_metrics.rb
+++ b/db/migrate/20180926091756_add_default_value_to_feedback_metrics.rb
@@ -14,11 +14,11 @@ class AddDefaultValueToFeedbackMetrics < ActiveRecord::Migration[5.2]
 
     say 'Updating `satisfaction_score` values in `facts_metrics`'
     ActiveRecord::Base.connection.execute(
-        <<~SQL
+      <<~SQL
         UPDATE facts_metrics
         SET satisfaction_score = is_this_useful_yes / (is_this_useful_yes + is_this_useful_no::float)
         WHERE (is_this_useful_yes + is_this_useful_no > 0)
-    SQL
+      SQL
     )
   end
 end

--- a/db/migrate/20180928141301_populate_warehouse_item_id.rb
+++ b/db/migrate/20180928141301_populate_warehouse_item_id.rb
@@ -1,6 +1,6 @@
 class PopulateWarehouseItemId < ActiveRecord::Migration[5.2]
-	class Dimensions::Item < ActiveRecord::Base
-	end
+  class Dimensions::Item < ActiveRecord::Base
+  end
 
   def change
     multipart_types = %w[travel_advice guide]

--- a/db/migrate/20181009133439_add_index_for_organisation_list.rb
+++ b/db/migrate/20181009133439_add_index_for_organisation_list.rb
@@ -1,6 +1,6 @@
 class AddIndexForOrganisationList < ActiveRecord::Migration[5.2]
   def change
-    add_index :dimensions_editions, [:latest, :organisation_id, :primary_organisation_title],
+    add_index :dimensions_editions, %i[latest organisation_id primary_organisation_title],
      name: 'index_dimensions_editions_on_latest_org_id_org_title'
   end
 end


### PR DESCRIPTION
Fixes several lint issues after running:

```
% bundle exec govuk-lint-ruby --format clang -a                                                                                                                                                                                      
```

```
db/migrate/20180928141301_populate_warehouse_item_id.rb:2:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:2:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 3) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:2:1: C: [Corrected] Layout/Tab: Tab detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:3:1: C: [Corrected] Layout/Tab: Tab detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:5:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:5:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:5:2: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:5:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:5:5: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:7:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected. (https://github.com/rubocop-hq/ruby-style-guide#no-trailing-whitespace)
db/migrate/20180928141301_populate_warehouse_item_id.rb:11:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected. (https://github.com/rubocop-hq/ruby-style-guide#no-trailing-whitespace)
db/migrate/20180928141301_populate_warehouse_item_id.rb:15:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected. (https://github.com/rubocop-hq/ruby-style-guide#no-trailing-whitespace)
db/migrate/20180928141301_populate_warehouse_item_id.rb:21:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:21:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:21:2: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:21:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:21:5: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
db/migrate/20180928141301_populate_warehouse_item_id.rb:25:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
```
