### PR TITLE
Speed up boot time in rspec tests

### DIFF
--- a/spec/integration/item/extract_content_all_schemas_spec.rb
+++ b/spec/integration/item/extract_content_all_schemas_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Process parser', type: :integration do
   context 'with a list of content schemas' do
     SchemasIterator.each_schema do |schema_name, schema|
       it "extracts the content for: #{schema_name}" do
-        sample = GovukSchemas::RandomExample.new(schema: schema).payload
-        expect(Etl::Edition::Content::Parser.extract_content(sample)).to be_a(String).or eq(nil)
+        payload = SchemasIterator.payload_for(schema_name, schema)
+        expect(Etl::Edition::Content::Parser.extract_content(payload)).to be_a(String).or eq(nil)
       end
     end
   end

--- a/spec/integration/streams/on_update_message_spec.rb
+++ b/spec/integration/streams/on_update_message_spec.rb
@@ -141,10 +141,8 @@ RSpec.describe PublishingAPI::Consumer do
       allow(GovukError).to receive(:notify)
     end
 
-    schemas = GovukSchemas::Schema.all(schema_type: 'notification')
-    schemas.each_value do |schema|
+    SchemasIterator.each_schema do |schema_name, schema|
       payload = GovukSchemas::RandomExample.new(schema: schema).payload
-      schema_name = payload.dig('schema_name')
       unless %w{travel_advice guide}.include?(schema_name) || schema_name.include?('placeholder')
 
         %w{major minor links republish unpublish}.each do |update_type|

--- a/spec/integration/streams/on_update_message_spec.rb
+++ b/spec/integration/streams/on_update_message_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe PublishingAPI::Consumer do
       unless %w{travel_advice guide}.include?(schema_name) || schema_name.include?('placeholder')
         %w{major minor links republish unpublish}.each do |update_type|
           it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do
-            payload = GovukSchemas::RandomExample.new(schema: schema).payload
+            payload = SchemasIterator.payload_for(schema_name, schema)
             message = build(:message, payload: payload, routing_key: "#{schema_name}.#{update_type}")
 
             subject.process(message)

--- a/spec/integration/streams/on_update_message_spec.rb
+++ b/spec/integration/streams/on_update_message_spec.rb
@@ -142,11 +142,10 @@ RSpec.describe PublishingAPI::Consumer do
     end
 
     SchemasIterator.each_schema do |schema_name, schema|
-      payload = GovukSchemas::RandomExample.new(schema: schema).payload
       unless %w{travel_advice guide}.include?(schema_name) || schema_name.include?('placeholder')
-
         %w{major minor links republish unpublish}.each do |update_type|
           it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do
+            payload = GovukSchemas::RandomExample.new(schema: schema).payload
             message = build(:message, payload: payload, routing_key: "#{schema_name}.#{update_type}")
 
             subject.process(message)

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -330,11 +330,11 @@ RSpec.describe "Process sub-pages for multipart content types" do
     end
 
     SchemasIterator.each_schema do |schema_name, schema|
-      payload = GovukSchemas::RandomExample.new(schema: schema).payload
       if %w{travel_advice guide}.include?(schema_name) && !schema_name.include?('placeholder')
 
         %w{major minor links republish unpublish}.each do |update_type|
           it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do
+            payload = GovukSchemas::RandomExample.new(schema: schema).payload
             message = build(:message, :with_parts, payload: payload, routing_key: "#{schema_name}.#{update_type}")
 
             subject.process(message)

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -329,10 +329,8 @@ RSpec.describe "Process sub-pages for multipart content types" do
       allow(GovukError).to receive(:notify)
     end
 
-    schemas = GovukSchemas::Schema.all(schema_type: 'notification')
-    schemas.each_value do |schema|
+    SchemasIterator.each_schema do |schema_name, schema|
       payload = GovukSchemas::RandomExample.new(schema: schema).payload
-      schema_name = payload.dig('schema_name')
       if %w{travel_advice guide}.include?(schema_name) && !schema_name.include?('placeholder')
 
         %w{major minor links republish unpublish}.each do |update_type|

--- a/spec/integration/streams/process_sub_pages_spec.rb
+++ b/spec/integration/streams/process_sub_pages_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
 
         %w{major minor links republish unpublish}.each do |update_type|
           it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do
-            payload = GovukSchemas::RandomExample.new(schema: schema).payload
+            payload = SchemasIterator.payload_for(schema_name, schema)
             message = build(:message, :with_parts, payload: payload, routing_key: "#{schema_name}.#{update_type}")
 
             subject.process(message)

--- a/spec/support/schemas_iterator.rb
+++ b/spec/support/schemas_iterator.rb
@@ -1,9 +1,12 @@
 module SchemasIterator
   def self.each_schema
-    schemas = GovukSchemas::Schema.all(schema_type: "notification")
-    schemas.each do |schema_name, value|
+    all_schemas.each do |schema_name, value|
       schema_name = schema_name.split('/')[-3]
       yield schema_name, value
     end
+  end
+
+  def self.all_schemas
+    @all_schemas ||= GovukSchemas::Schema.all(schema_type: "notification")
   end
 end

--- a/spec/support/schemas_iterator.rb
+++ b/spec/support/schemas_iterator.rb
@@ -6,6 +6,14 @@ module SchemasIterator
     end
   end
 
+  def self.payload_for(schema_name, schema)
+    all_payloads[schema_name] ||= GovukSchemas::RandomExample.new(schema: schema).payload
+  end
+
+  def self.all_payloads
+    @all_payloads ||= {}
+  end
+
   def self.all_schemas
     @all_schemas ||= GovukSchemas::Schema.all(schema_type: "notification")
   end


### PR DESCRIPTION
We are generating tests samples dynamically based on the list
of schemas that are available. The process to read all the schemas
is really fast, but generating a sample for each schema is time 
consuming, so we need to speed it up.

I have done the following improvements:

1. Cache the list of schemas
2. Cache each sample for each type of schema
3. Lazy creation of the sample: we only generate a sample when the test runs

Achievments:

1. Reduce load time of  **all suite time in 20 seconds**
2. Reduce load time of **individual executions in 9 seconds**.

### All suite

```
Running via Spring preloader in process 26787
Randomized with seed 52091
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1 minute 7.92 seconds (files took 17.97 seconds to load)
756 examples, 0 failures
```

```
Randomized with seed 45120
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1 minute 6.37 seconds (files took 0.82826 seconds to load)
756 examples, 0 failures

Randomized with seed 45120
```

### For individual tests


```
% rspec './spec/integration/streams/on_update_message_spec.rb[1:8:33]' # PublishingAPI::Consumer all schemas handles event for: `organisations_homepage` with no errors for a `links` update                                         
Running via Spring preloader in process 26996
Run options: include {:ids=>{"./spec/integration/streams/on_update_message_spec.rb"=>["1:8:33"]}}

Randomized with seed 15246
.

Finished in 0.85963 seconds (files took 9.27 seconds to load)
1 example, 0 failures
```

to

```
% rspec './spec/integration/streams/on_update_message_spec.rb[1:8:33]' # PublishingAPI::Consumer all schemas handles event for: `organisations_homepage` with no errors for a `links` update                                         
Running via Spring preloader in process 27088
Run options: include {:ids=>{"./spec/integration/streams/on_update_message_spec.rb"=>["1:8:33"]}}

Randomized with seed 3630
.

Finished in 1.64 seconds (files took 0.50254 seconds to load)
1 example, 0 failures
```








