### PR TITLE
Return TimeSeries objects in Finder 

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -31,6 +31,14 @@ class Api::BaseController < ApplicationController
     "/#{base_path}"
   end
 
+  def from
+    params[:from]
+  end
+
+  def to
+    params[:to]
+  end
+
 private
 
   def set_cache_headers

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -3,8 +3,8 @@ class ContentController < Api::BaseController
 
   def show
     @content = Queries::FindContent.retrieve(
-      from: params[:from],
-      to: params[:to],
+      from: from,
+      to: to,
       organisation_id: params[:organisation_id]
     )
     render json: { results: @content }.to_json

--- a/app/controllers/single_item_controller.rb
+++ b/app/controllers/single_item_controller.rb
@@ -2,8 +2,6 @@ class SingleItemController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @to = params[:to]
-    @from = params[:from]
     @base_path = format_base_path_param
     @metadata = find_metadata
     @time_series_metrics = find_time_series
@@ -20,7 +18,7 @@ private
 
   def find_time_series
     Queries::FindSeries.new
-      .between(from: @from, to: @to)
+      .between(from: from, to: to)
       .by_base_path(@base_path)
       .by_metrics(%i(
         upviews

--- a/app/controllers/single_item_controller.rb
+++ b/app/controllers/single_item_controller.rb
@@ -5,20 +5,20 @@ class SingleItemController < Api::BaseController
     @to = params[:to]
     @from = params[:from]
     @base_path = format_base_path_param
-    @metadata = metadata
-    @time_series_metrics = query_time_series_metrics
-    @edition_metrics = query_edition_metrics
+    @metadata = find_metadata
+    @time_series_metrics = find_time_series
+    @edition_metrics = find_editions
   end
 
 private
 
-  def metadata
+  def find_metadata
     metadata = Queries::FindMetadata.run(@base_path)
     raise Api::NotFoundError.new("#{api_request.base_path} not found") if metadata.nil?
     metadata
   end
 
-  def query_time_series_metrics
+  def find_time_series
     Queries::FindSeries.new
       .between(from: @from, to: @to)
       .by_base_path(@base_path)
@@ -34,7 +34,7 @@ private
       .run
   end
 
-  def query_edition_metrics
+  def find_editions
     Queries::FindEditionMetrics.run(@base_path, %w[words pdf_count])
   end
 

--- a/app/controllers/single_item_controller.rb
+++ b/app/controllers/single_item_controller.rb
@@ -2,6 +2,8 @@ class SingleItemController < Api::BaseController
   before_action :validate_params!
 
   def show
+    @from = from
+    @to = to
     @base_path = format_base_path_param
     @metadata = find_metadata
     @time_series_metrics = find_time_series

--- a/app/controllers/single_item_controller.rb
+++ b/app/controllers/single_item_controller.rb
@@ -49,14 +49,4 @@ private
   def base_path
     params[:base_path]
   end
-
-  def validate_params!
-    unless api_request.valid?
-      error_response(
-        "validation-error",
-          title: "One or more parameters is invalid",
-          invalid_params: api_request.errors.to_hash
-      )
-    end
-  end
 end

--- a/app/domain/api/metrics_request.rb
+++ b/app/domain/api/metrics_request.rb
@@ -20,7 +20,7 @@ private
     end
 
     metrics.each do |metric|
-      errors.add("metric", "is not included in the list") unless Metric.find_all.map(&:name).include?(metric)
+      errors.add("metric", "is not included in the list") unless Metric.find_all_names.include?(metric)
     end
   end
 end

--- a/app/domain/queries/find_series.rb
+++ b/app/domain/queries/find_series.rb
@@ -45,7 +45,7 @@ class Queries::FindSeries
     if @metric_names
       @metric_names.map { |metric_name| Queries::Series.new(metric_name, metrics) }
     else
-      metrics
+      Metric.find_all.map(&:name).map { |metric_name| Queries::Series.new(metric_name, metrics) }
     end
   end
 

--- a/app/domain/queries/find_series.rb
+++ b/app/domain/queries/find_series.rb
@@ -42,11 +42,9 @@ class Queries::FindSeries
     metrics = metrics
       .joins(dimensions_edition: :facts_edition).merge(editions)
       .joins(:dimensions_date).merge(dates)
-    if @metric_names
-      @metric_names.map { |metric_name| Queries::Series.new(metric_name, metrics) }
-    else
-      Metric.find_all.map(&:name).map { |metric_name| Queries::Series.new(metric_name, metrics) }
-    end
+
+    metric_names = @metric_names || Metric.find_all_names
+    metric_names.map { |metric_name| Queries::Series.new(metric_name, metrics) }
   end
 
 private

--- a/app/domain/queries/series.rb
+++ b/app/domain/queries/series.rb
@@ -1,23 +1,24 @@
 class Queries::Series
-  attr_reader :metric_name, :all_metrics, :time_series
+  attr_reader :metric_name
 
   def initialize(metric_name, all_metrics)
     @metric_name = metric_name
     @all_metrics = all_metrics
-    @time_series = format_time_series
   end
 
   def total
     time_series.reduce(0) { |total, time_point| total + time_point[:value] }
   end
 
-private
-
-  def format_time_series
-    all_metrics.map do |metric|
-      key = metric.dimensions_date_id.to_s
-      value = Metric.is_edition_metric?(metric_name) ? metric.facts_edition.send(metric_name) : metric.send(metric_name)
-      { date: key, value: value }
+  def time_series
+    @all_metrics.map do |metric|
+      date = metric.dimensions_date_id.to_s
+      value = if Metric.is_edition_metric?(metric_name)
+                metric.facts_edition.send(metric_name)
+              else
+                metric.send(metric_name)
+              end
+      { date: date, value: value }
     end
   end
 end

--- a/app/domain/queries/series.rb
+++ b/app/domain/queries/series.rb
@@ -12,9 +12,10 @@ class Queries::Series
 
   def time_series
     @all_metrics.map do |metric|
-      date = metric.dimensions_date_id.to_s
-      value = metric.send(metric_name)
-      { date: date, value: value }
+      {
+        date: metric.dimensions_date_id.to_s,
+        value: metric.public_send(metric_name)
+      }
     end
   end
 end

--- a/app/domain/queries/series.rb
+++ b/app/domain/queries/series.rb
@@ -13,11 +13,7 @@ class Queries::Series
   def time_series
     @all_metrics.map do |metric|
       date = metric.dimensions_date_id.to_s
-      value = if Metric.is_edition_metric?(metric_name)
-                metric.facts_edition.send(metric_name)
-              else
-                metric.send(metric_name)
-              end
+      value = metric.send(metric_name)
       { date: date, value: value }
     end
   end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -7,10 +7,6 @@ class Facts::Metric < ApplicationRecord
   validates :dimensions_date, presence: true
   validates :dimensions_edition, presence: true
 
-  scope :with_edition_metrics, -> do
-    joins(dimensions_edition: :facts_edition)
-  end
-
   scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.find_or_create(Date.yesterday)) }
   scope :from_day_before_to, ->(date) { where(dimensions_date: Dimensions::Date.between(date - 1, date)) }
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -4,6 +4,13 @@ class Facts::Metric < ApplicationRecord
 
   has_one :facts_edition, through: :dimensions_edition
 
+  delegate :pdf_count,
+    :doc_count,
+    :readability,
+    :chars,
+    :sentences,
+    :words, to: :facts_edition
+
   validates :dimensions_date, presence: true
   validates :dimensions_edition, presence: true
 

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -13,40 +13,4 @@ class Facts::Metric < ApplicationRecord
 
   scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.find_or_create(Date.yesterday)) }
   scope :from_day_before_to, ->(date) { where(dimensions_date: Dimensions::Date.between(date - 1, date)) }
-
-  def self.csv_fields
-    %i[
-      date
-      content_id
-      base_path
-      locale
-      title
-      description
-      document_type
-      schema_name
-      content_purpose_document_supertype
-      content_purpose_supergroup
-      content_purpose_subgroup
-      first_published_at
-      public_updated_at
-      pviews
-      primary_organisation_title
-      primary_organisation_content_id
-      upviews
-      feedex
-      pdf_count
-      doc_count
-      readability
-      useful_yes
-      useful_no
-      searches
-      words
-      chars
-      sentences
-      entrances
-      exits
-      bounce_rate
-      avg_page_time
-    ]
-  end
 end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -7,6 +7,10 @@ class Metric
     @find_all ||= (daily_metrics + edition_metrics).sort
   end
 
+  def self.find_all_names
+    find_all.map(&:name)
+  end
+
   def self.is_edition_metric?(metric_name)
     edition_metrics.map(&:name).include?(metric_name)
   end

--- a/spec/domain/queries/find_series_spec.rb
+++ b/spec/domain/queries/find_series_spec.rb
@@ -76,20 +76,22 @@ RSpec.describe Queries::FindSeries do
 
   describe '#editions' do
     it 'return the content items included in the report' do
-      edition1 = create :edition, base_path: '/path1', date: '2018-1-12'
-      edition2 = create :edition, base_path: '/path2', date: '2018-1-12'
+      edition1 = create :edition, base_path: '/path1', date: '2018-1-12', facts: { words: 1 }
+      edition2 = create :edition, base_path: '/path2', date: '2018-1-12', facts: { words: 2 }
 
-      create :metric, edition: edition1, date: '2018-1-12', pviews: 1
-      create :metric, edition: edition1, date: '2018-1-13', pviews: 2
-      create :metric, edition: edition1, date: '2018-1-14', pviews: 4
-      create :metric, edition: edition2, date: '2018-1-13', pviews: 5
-      create :metric, edition: edition2, date: '2018-1-14', pviews: 6
+      create :metric, edition: edition1, date: '2018-1-12'
+      create :metric, edition: edition1, date: '2018-1-13'
+      create :metric, edition: edition1, date: '2018-1-14'
+      create :metric, edition: edition2, date: '2018-1-13'
+      create :metric, edition: edition2, date: '2018-1-14'
 
-      result = described_class.new.by_metrics(%w(pviews)).by_base_path('/path1').run
+      result = described_class.new.by_metrics(%w(words)).run
       expect(result.first.time_series).to eq([
         { date: "2018-01-12", value: 1 },
+        { date: "2018-01-13", value: 1 },
+        { date: "2018-01-14", value: 1 },
         { date: "2018-01-13", value: 2 },
-        { date: "2018-01-14", value: 4 },
+        { date: "2018-01-14", value: 2 }
       ])
     end
   end

--- a/spec/domain/queries/find_series_spec.rb
+++ b/spec/domain/queries/find_series_spec.rb
@@ -3,38 +3,31 @@ RSpec.describe Queries::FindSeries do
     it "returns a series of all metrics" do
       create :metric, date: Date.today
 
-      expect(described_class.new.run.one?).to eq(true)
+      expect(described_class.new.run.length).to eq(17)
     end
   end
 
   context "between" do
     it "returns metrics for a given date range" do
       edition = create :edition, base_path: '/the/path', date: '2018-5-13'
-      metric1 = create :metric, edition: edition, date: '2018-5-13'
-      metric2 = create :metric, edition: edition, date: '2018-5-14'
+      create :metric, edition: edition, date: '2018-5-13'
+      create :metric, edition: edition, date: '2018-5-14'
       create :metric, edition: edition, date: '2018-5-24'
       series = described_class.new.between(from: '2018-5-13', to: '2018-5-14').run
 
-      expect(series).to_not be_nil
-      expect(series.size).to eq(2)
-      expect(series).to match_array([metric1, metric2])
+      expect(series.first.time_series.length).to eq(2)
+      expect(series.first.time_series).to eq([
+        { date: '2018-05-13', value: 0 },
+        { date: '2018-05-14', value: 0 },
+      ])
     end
   end
 
   context "by_metric" do
     it "returns a series of metrics filtered by the passed in metric" do
-      today = Date.today
-      tomorrow = today + 1
+      create :metric, date: Date.today
 
-      edition1 = create :edition, base_path: '/path/1', date: today, facts: { words: 10_000 }
-      metric1 = create :metric, date: today, edition: edition1
-      edition2 = create :edition, base_path: '/path/2', date: tomorrow, facts: { words: 20_000 }
-      metric2 = create :metric, date: tomorrow, edition: edition2
-      metric3 = create :metric, date: tomorrow
-
-      series = described_class.new.run
-
-      expect(series).to match_array([metric1, metric2, metric3])
+      expect(described_class.new.by_metrics(%w[pviews]).run.length).to eq(1)
     end
   end
 
@@ -46,19 +39,16 @@ RSpec.describe Queries::FindSeries do
       edition1 = create :edition, date: day0, organisation_id: 'org-1'
       edition2 = create :edition, date: day1, organisation_id: 'org-2'
 
-      metric1 = create(:metric, edition: edition1, date: day0)
-      metric2 = create(:metric, edition: edition1, date: day1)
+      create(:metric, edition: edition1, date: day0)
+      create(:metric, edition: edition1, date: day1)
       create(:metric, edition: edition2, date: day2)
 
       series = described_class.new.by_organisation_id('org-1').run
 
-      expect(series).to match_array([metric1, metric2])
-    end
-
-    it 'ignores parameters when blank' do
-      metric = create(:metric, date: Date.today)
-
-      expect(described_class.new.by_organisation_id('').run).to match_array([metric])
+      expect(series.first.time_series).to eq([
+        { date: '2018-01-12', value: 0 },
+        { date: '2018-01-13', value: 0 },
+      ])
     end
   end
 
@@ -70,21 +60,19 @@ RSpec.describe Queries::FindSeries do
       edition1 = create(:edition, date: day0, base_path: '/path1')
       edition2 = create(:edition, date: day0, base_path: '/path2')
 
-      metric1 = create :metric, edition: edition1, date: day0
-      metric2 = create :metric, edition: edition1, date: day1
-      metric3 = create :metric, edition: edition1, date: day2
+      create :metric, edition: edition1, date: day0
+      create :metric, edition: edition1, date: day1
+      create :metric, edition: edition1, date: day2
       create :metric, edition: edition2, date: day1
       create :metric, edition: edition2, date: day2
 
-      results = described_class.new.by_base_path('/path1').run
+      result = described_class.new.by_base_path('/path1').run
 
-      expect(results).to match_array([metric1, metric2, metric3])
-    end
-
-    it 'ignores parameters when blank' do
-      metric = create(:metric, date: Date.today)
-
-      expect(described_class.new.by_base_path('').run).to match_array([metric])
+      expect(result.first.time_series).to eq([
+        { date: "2018-01-12", value: 0 },
+        { date: "2018-01-13", value: 0 },
+        { date: "2018-01-14", value: 0 },
+      ])
     end
   end
 
@@ -102,7 +90,12 @@ RSpec.describe Queries::FindSeries do
       create(:metric, edition: edition2, date: day1)
       create(:metric, edition: edition2, date: day2)
 
-      expect(described_class.new.editions).to match_array([edition1, edition2])
+      result = described_class.new.by_base_path('/path1').run
+      expect(result.first.time_series).to eq([
+        { date: "2018-01-12", value: 0 },
+        { date: "2018-01-13", value: 0 },
+        { date: "2018-01-14", value: 0 },
+      ])
     end
   end
 end

--- a/spec/domain/queries/find_series_spec.rb
+++ b/spec/domain/queries/find_series_spec.rb
@@ -26,9 +26,12 @@ RSpec.describe Queries::FindSeries do
 
   context "by_metric" do
     it "returns a series of metrics filtered by the passed in metric" do
-      create :metric, date: Date.today, pviews: 1
+      create :metric, date: '2018-05-13', pviews: 1
 
-      expect(described_class.new.by_metrics(%w(pviews)).run.length).to eq(1)
+      series = described_class.new.by_metrics(%w(pviews)).run
+      expect(series.first.time_series).to eq([
+        { date: '2018-05-13', value: 1 },
+      ])
     end
   end
 

--- a/spec/domain/queries/find_series_spec.rb
+++ b/spec/domain/queries/find_series_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Queries::FindSeries do
   context "all" do
     it "returns a series of all metrics" do
-      create :metric, date: Date.today
+      create :metric, date: Date.today, pviews: 1
 
       expect(described_class.new.run.length).to eq(17)
     end
@@ -10,24 +10,25 @@ RSpec.describe Queries::FindSeries do
   context "between" do
     it "returns metrics for a given date range" do
       edition = create :edition, base_path: '/the/path', date: '2018-5-13'
-      create :metric, edition: edition, date: '2018-5-13'
-      create :metric, edition: edition, date: '2018-5-14'
-      create :metric, edition: edition, date: '2018-5-24'
-      series = described_class.new.between(from: '2018-5-13', to: '2018-5-14').run
+      create :metric, edition: edition, date: '2018-5-13', pviews: 1
+      create :metric, edition: edition, date: '2018-5-14', pviews: 2
+      create :metric, edition: edition, date: '2018-5-24', pviews: 3
+
+      series = described_class.new.by_metrics(%w(pviews)).between(from: '2018-5-13', to: '2018-5-14').run
 
       expect(series.first.time_series.length).to eq(2)
       expect(series.first.time_series).to eq([
-        { date: '2018-05-13', value: 0 },
-        { date: '2018-05-14', value: 0 },
+        { date: '2018-05-13', value: 1 },
+        { date: '2018-05-14', value: 2 },
       ])
     end
   end
 
   context "by_metric" do
     it "returns a series of metrics filtered by the passed in metric" do
-      create :metric, date: Date.today
+      create :metric, date: Date.today, pviews: 1
 
-      expect(described_class.new.by_metrics(%w[pviews]).run.length).to eq(1)
+      expect(described_class.new.by_metrics(%w(pviews)).run.length).to eq(1)
     end
   end
 
@@ -36,56 +37,56 @@ RSpec.describe Queries::FindSeries do
       edition1 = create :edition, date: '2018-1-12', organisation_id: 'org-1'
       edition2 = create :edition, date: '2018-1-13', organisation_id: 'org-2'
 
-      create(:metric, edition: edition1, date: '2018-1-12')
-      create(:metric, edition: edition1, date: '2018-1-13')
-      create(:metric, edition: edition2, date: '2018-1-14')
+      create :metric, edition: edition1, date: '2018-1-12', pviews: 1
+      create :metric, edition: edition1, date: '2018-1-13', pviews: 2
+      create :metric, edition: edition2, date: '2018-1-14', pviews: 1
 
-      series = described_class.new.by_organisation_id('org-1').run
+      series = described_class.new.by_metrics(%w(pviews)).by_organisation_id('org-1').run
 
       expect(series.first.time_series).to eq([
-        { date: '2018-01-12', value: 0 },
-        { date: '2018-01-13', value: 0 },
+        { date: '2018-01-12', value: 1 },
+        { date: '2018-01-13', value: 2 },
       ])
     end
   end
 
   context "by_base_path" do
     it "returns a series of metrics for a base path" do
-      edition1 = create(:edition, date: '2018-1-12', base_path: '/path1')
-      edition2 = create(:edition, date: '2018-1-12', base_path: '/path2')
+      edition1 = create :edition, date: '2018-1-12', base_path: '/path1'
+      edition2 = create :edition, date: '2018-1-12', base_path: '/path2'
 
-      create :metric, edition: edition1, date: '2018-1-12'
-      create :metric, edition: edition1, date: '2018-1-13'
-      create :metric, edition: edition1, date: '2018-1-14'
-      create :metric, edition: edition2, date: '2018-1-13'
-      create :metric, edition: edition2, date: '2018-1-14'
+      create :metric, edition: edition1, date: '2018-1-12', pviews: 1
+      create :metric, edition: edition1, date: '2018-1-13', pviews: 2
+      create :metric, edition: edition1, date: '2018-1-14', pviews: 3
+      create :metric, edition: edition2, date: '2018-1-13', pviews: 4
+      create :metric, edition: edition2, date: '2018-1-14', pviews: 5
 
-      result = described_class.new.by_base_path('/path1').run
+      result = described_class.new.by_metrics(%w(pviews)).by_base_path('/path1').run
 
       expect(result.first.time_series).to eq([
-        { date: "2018-01-12", value: 0 },
-        { date: "2018-01-13", value: 0 },
-        { date: "2018-01-14", value: 0 },
+        { date: "2018-01-12", value: 1 },
+        { date: "2018-01-13", value: 2 },
+        { date: "2018-01-14", value: 3 },
       ])
     end
   end
 
   describe '#editions' do
     it 'return the content items included in the report' do
-      edition1 = create(:edition, base_path: '/path1', date: '2018-1-12')
-      edition2 = create(:edition, base_path: '/path2', date: '2018-1-12')
+      edition1 = create :edition, base_path: '/path1', date: '2018-1-12'
+      edition2 = create :edition, base_path: '/path2', date: '2018-1-12'
 
-      create(:metric, edition: edition1, date: '2018-1-12')
-      create(:metric, edition: edition1, date: '2018-1-13')
-      create(:metric, edition: edition1, date: '2018-1-14')
-      create(:metric, edition: edition2, date: '2018-1-13')
-      create(:metric, edition: edition2, date: '2018-1-14')
+      create :metric, edition: edition1, date: '2018-1-12', pviews: 1
+      create :metric, edition: edition1, date: '2018-1-13', pviews: 2
+      create :metric, edition: edition1, date: '2018-1-14', pviews: 4
+      create :metric, edition: edition2, date: '2018-1-13', pviews: 5
+      create :metric, edition: edition2, date: '2018-1-14', pviews: 6
 
-      result = described_class.new.by_base_path('/path1').run
+      result = described_class.new.by_metrics(%w(pviews)).by_base_path('/path1').run
       expect(result.first.time_series).to eq([
-        { date: "2018-01-12", value: 0 },
-        { date: "2018-01-13", value: 0 },
-        { date: "2018-01-14", value: 0 },
+        { date: "2018-01-12", value: 1 },
+        { date: "2018-01-13", value: 2 },
+        { date: "2018-01-14", value: 4 },
       ])
     end
   end

--- a/spec/domain/queries/find_series_spec.rb
+++ b/spec/domain/queries/find_series_spec.rb
@@ -33,15 +33,12 @@ RSpec.describe Queries::FindSeries do
 
   context "by_organisation" do
     it "returns a series of metrics filtered by organisation" do
-      day0 = Date.new(2018, 1, 12)
-      day1 = Date.new(2018, 1, 13)
-      day2 = Date.new(2018, 1, 14)
-      edition1 = create :edition, date: day0, organisation_id: 'org-1'
-      edition2 = create :edition, date: day1, organisation_id: 'org-2'
+      edition1 = create :edition, date: '2018-1-12', organisation_id: 'org-1'
+      edition2 = create :edition, date: '2018-1-13', organisation_id: 'org-2'
 
-      create(:metric, edition: edition1, date: day0)
-      create(:metric, edition: edition1, date: day1)
-      create(:metric, edition: edition2, date: day2)
+      create(:metric, edition: edition1, date: '2018-1-12')
+      create(:metric, edition: edition1, date: '2018-1-13')
+      create(:metric, edition: edition2, date: '2018-1-14')
 
       series = described_class.new.by_organisation_id('org-1').run
 
@@ -54,17 +51,14 @@ RSpec.describe Queries::FindSeries do
 
   context "by_base_path" do
     it "returns a series of metrics for a base path" do
-      day0 = Date.new(2018, 1, 12)
-      day1 = Date.new(2018, 1, 13)
-      day2 = Date.new(2018, 1, 14)
-      edition1 = create(:edition, date: day0, base_path: '/path1')
-      edition2 = create(:edition, date: day0, base_path: '/path2')
+      edition1 = create(:edition, date: '2018-1-12', base_path: '/path1')
+      edition2 = create(:edition, date: '2018-1-12', base_path: '/path2')
 
-      create :metric, edition: edition1, date: day0
-      create :metric, edition: edition1, date: day1
-      create :metric, edition: edition1, date: day2
-      create :metric, edition: edition2, date: day1
-      create :metric, edition: edition2, date: day2
+      create :metric, edition: edition1, date: '2018-1-12'
+      create :metric, edition: edition1, date: '2018-1-13'
+      create :metric, edition: edition1, date: '2018-1-14'
+      create :metric, edition: edition2, date: '2018-1-13'
+      create :metric, edition: edition2, date: '2018-1-14'
 
       result = described_class.new.by_base_path('/path1').run
 
@@ -78,17 +72,14 @@ RSpec.describe Queries::FindSeries do
 
   describe '#editions' do
     it 'return the content items included in the report' do
-      day0 = Date.new(2018, 1, 12)
-      day1 = Date.new(2018, 1, 13)
-      day2 = Date.new(2018, 1, 14)
-      edition1 = create(:edition, base_path: '/path1', date: day0)
-      edition2 = create(:edition, base_path: '/path2', date: day0)
+      edition1 = create(:edition, base_path: '/path1', date: '2018-1-12')
+      edition2 = create(:edition, base_path: '/path2', date: '2018-1-12')
 
-      create(:metric, edition: edition1, date: day0)
-      create(:metric, edition: edition1, date: day1)
-      create(:metric, edition: edition1, date: day2)
-      create(:metric, edition: edition2, date: day1)
-      create(:metric, edition: edition2, date: day2)
+      create(:metric, edition: edition1, date: '2018-1-12')
+      create(:metric, edition: edition1, date: '2018-1-13')
+      create(:metric, edition: edition1, date: '2018-1-14')
+      create(:metric, edition: edition2, date: '2018-1-13')
+      create(:metric, edition: edition2, date: '2018-1-14')
 
       result = described_class.new.by_base_path('/path1').run
       expect(result.first.time_series).to eq([

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Metric do
     end
   end
 
+  describe '.find_all_names' do
+    it "returns a list of all metrics" do
+      metric_names = Metric.find_all_names
+
+      expect(metric_names.length).to eq(17)
+      a_metric = metric_names.first
+      expect(a_metric).to eq('avg_page_time')
+    end
+  end
+
   describe '.is_edition_metric?' do
     EDITION_METRICS.each do |metric|
       it "returns true for #{metric}" do


### PR DESCRIPTION
The finder that returns time series returned different types based
on the filter parameters. This should never happen, so I have refactored
it to always return the same type.

On the same go, I have also cleaned up and increase coverage of the 
RSpec test for FindSeries.