### PR TITLE
Add document types end point

### DIFF
--- a/app/controllers/document_type_controller.rb
+++ b/app/controllers/document_type_controller.rb
@@ -1,0 +1,5 @@
+class DocumentTypeController < Api::BaseController
+  def index
+    @document_types = Queries::FindAllDocumentTypes.retrieve
+  end
+end

--- a/app/domain/queries/find_all_document_types.rb
+++ b/app/domain/queries/find_all_document_types.rb
@@ -1,0 +1,12 @@
+class Queries::FindAllDocumentTypes
+  def self.retrieve
+    new.retrieve
+  end
+
+  def retrieve
+    Dimensions::Edition.latest
+      .select(:document_type)
+      .distinct
+      .order(:document_type).to_a
+  end
+end

--- a/app/views/document_type/index.json.jbuilder
+++ b/app/views/document_type/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.document_types @document_types.map(&:document_type)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   get '/content', to: 'content#show'
   get '/single_page/*base_path', to: 'single_item#show', defaults: { format: :json }
   get '/organisations', to: 'organisation#index', defaults: { format: :json }
+  get '/document_types', to: 'document_type#index', defaults: { format: :json }
 end

--- a/db/migrate/20181015093842_add_index_dimensions_editions_document_type.rb
+++ b/db/migrate/20181015093842_add_index_dimensions_editions_document_type.rb
@@ -1,0 +1,5 @@
+class AddIndexDimensionsEditionsDocumentType < ActiveRecord::Migration[5.2]
+  def change
+    add_index :dimensions_editions, %i[latest document_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_09_133439) do
+ActiveRecord::Schema.define(version: 2018_10_15_093842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2018_10_09_133439) do
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
+    t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
     t.index ["latest"], name: "index_dimensions_editions_on_latest"
     t.index ["organisation_id"], name: "index_dimensions_editions_organisation_id"

--- a/spec/domain/queries/find_all_document_types_spec.rb
+++ b/spec/domain/queries/find_all_document_types_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Queries::FindAllDocumentTypes do
+  context 'when we have data' do
+    before do
+      create :user
+      create :edition, document_type: 'guide', latest: true
+      create :edition, document_type: 'travel_advice', latest: true
+      create :edition, document_type: 'manual', latest: true
+      create :edition, document_type: 'service-manual', latest: false
+    end
+
+    it 'returns distinct document types of latest editions' do
+      results = described_class.retrieve
+      expect(results.pluck(:document_type)).to eq(%w(guide manual travel_advice))
+    end
+
+    it 'does not return document types of editions that are not the latest' do
+      results = described_class.retrieve
+      expect(results.pluck(:document_type)).to_not include('service-manual')
+    end
+  end
+
+  context 'when there is no data' do
+    it 'returns an empty array' do
+      expect(described_class.retrieve).to eq([])
+    end
+  end
+end

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe '/document_types' do
+  before do
+    create :user
+    create :edition, document_type: 'guide'
+    create :edition, document_type: 'manual'
+    create :edition, document_type: 'manual'
+  end
+
+  it 'returns distinct document types ordered by title' do
+    get '/document_types'
+    json = JSON.parse(response.body).deep_symbolize_keys
+    expect(json).to eq(document_types: %w(guide manual))
+  end
+end


### PR DESCRIPTION
### What?
Add an end point to render all unique document types.

[Trello card](https://trello.com/c/7zjqCznt/726-2-index-page-filter-by-document-type)

### Why?
So that we can render a dropdown with all document types in our front end to allow users to filter by document type

<img width="314" alt="screen shot 2018-10-12 at 13 06 30" src="https://user-images.githubusercontent.com/13124899/46868283-bb828000-ce1f-11e8-8fa7-c9cee8d8ce84.png">
