### PR TITLE
Render selected organisation id

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -7,7 +7,8 @@ class ContentController < Api::BaseController
       to: to,
       organisation_id: params[:organisation_id]
     )
-    render json: { results: @content }.to_json
+    @organisation_id = params[:organisation_id]
+    render json: { results: @content, organisation_id: @organisation_id }.to_json
   end
 
   def api_request

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe '/content' do
         ]
       )
     end
+
+    it 'returns organisation id' do
+      get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:organisation_id]).to eq primary_org_id
+    end
   end
 
   describe "an API response" do


### PR DESCRIPTION
### What?

Render the selected organisation id from the content endpoint

### Why?

So that our front end can show end users which organisation's content they are viewing