### PR TITLE
Allow filter by document type

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,11 +2,7 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @content = Queries::FindContent.retrieve(
-      from: from,
-      to: to,
-      organisation_id: params[:organisation_id]
-    )
+    @content = Queries::FindContent.retrieve(api_request: api_request)
     @organisation_id = params[:organisation_id]
     render json: { results: @content, organisation_id: @organisation_id }.to_json
   end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,7 +2,7 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @content = Queries::FindContent.retrieve(api_request: api_request)
+    @content = Queries::FindContent.retrieve(content_filters: api_request)
     @organisation_id = params[:organisation_id]
     render json: { results: @content, organisation_id: @organisation_id }.to_json
   end
@@ -14,7 +14,7 @@ class ContentController < Api::BaseController
 private
 
   def permitted_params
-    params.permit(:from, :to, :organisation_id, :format)
+    params.permit(:from, :to, :organisation_id, :document_type, :format)
   end
 
   def validate_params!

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,7 +2,7 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @content = Queries::FindContent.retrieve(filter: api_request.to_filter)
+    @content = Queries::FindContent.call(filter: api_request.to_filter)
     @organisation_id = params[:organisation_id]
 
     render json: { results: @content, organisation_id: @organisation_id }.to_json

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,17 +2,20 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    content = Queries::FindContent.call(filter: api_request.to_filter)
-    organisation_id = params[:organisation_id]
+    filter = api_request.to_filter
+    content = Queries::FindContent.call(filter: filter)
 
-    render json: { results: content, organisation_id: organisation_id }.to_json
+    render json: {
+      results: content,
+      organisation_id: params[:organisation_id]
+    }.to_json
   end
+
+private
 
   def api_request
     @api_request ||= Api::ContentRequest.new(permitted_params)
   end
-
-private
 
   def permitted_params
     params.permit(:from, :to, :organisation_id, :document_type, :format)

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,8 +2,9 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @content = Queries::FindContent.retrieve(filter: api_request)
+    @content = Queries::FindContent.retrieve(filter: api_request.to_filter)
     @organisation_id = params[:organisation_id]
+
     render json: { results: @content, organisation_id: @organisation_id }.to_json
   end
 

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,7 +2,7 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @content = Queries::FindContent.retrieve(content_filters: api_request)
+    @content = Queries::FindContent.retrieve(filter: api_request)
     @organisation_id = params[:organisation_id]
     render json: { results: @content, organisation_id: @organisation_id }.to_json
   end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,10 +2,10 @@ class ContentController < Api::BaseController
   before_action :validate_params!
 
   def show
-    @content = Queries::FindContent.call(filter: api_request.to_filter)
-    @organisation_id = params[:organisation_id]
+    content = Queries::FindContent.call(filter: api_request.to_filter)
+    organisation_id = params[:organisation_id]
 
-    render json: { results: @content, organisation_id: @organisation_id }.to_json
+    render json: { results: content, organisation_id: organisation_id }.to_json
   end
 
   def api_request

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -4,8 +4,18 @@ class Api::ContentRequest < Api::BaseRequest
 
   def initialize(params)
     super(params)
+
     @organisation_id = params[:organisation_id]
     @document_type = params[:document_type]
+  end
+
+  def to_filter
+    {
+      organisation_id: organisation_id,
+      document_type: document_type,
+      from: from,
+      to: to,
+    }
   end
 
 private

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,10 +1,11 @@
 class Api::ContentRequest < Api::BaseRequest
-  attr_reader :organisation_id
+  attr_reader :organisation_id, :document_type
   validate :valid_organisation_id
 
   def initialize(params)
     super(params)
     @organisation_id = params[:organisation_id]
+    @document_type = params[:document_type]
   end
 
 private

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,10 +1,10 @@
 class Queries::FindContent
-  def self.retrieve(api_request:)
-    new(api_request).retrieve
+  def self.retrieve(content_filters:)
+    new(content_filters).retrieve
   end
 
-  def initialize(api_request)
-    @api_request = api_request
+  def initialize(content_filters)
+    @content_filters = content_filters
   end
 
   def retrieve
@@ -60,10 +60,12 @@ private
   end
 
   def slice_editions
-    Dimensions::Edition.by_organisation_id(@api_request.organisation_id)
+    editions = Dimensions::Edition.by_organisation_id(@content_filters.organisation_id)
+    editions = editions.where('latest.document_type = ?', @content_filters.document_type) if @content_filters.document_type
+    editions
   end
 
   def slice_dates
-    Dimensions::Date.between(@api_request.from, @api_request.to)
+    Dimensions::Date.between(@content_filters.from, @content_filters.to)
   end
 end

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -67,7 +67,8 @@ private
   end
 
   def slice_editions
-    editions = Dimensions::Edition.by_organisation_id(organisation_id)
+    editions = Dimensions::Edition.all
+    editions = editions.where('latest.organisation_id = ?', organisation_id)
     editions = editions.where('latest.document_type = ?', document_type) if document_type
     editions
   end

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,5 +1,7 @@
 class Queries::FindContent
   def self.call(filter:)
+    filter.assert_valid_keys :from, :to, :organisation_id, :document_type
+
     new(filter).call
   end
 

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,6 +1,6 @@
 class Queries::FindContent
-  def self.retrieve(filter:)
-    new(filter).retrieve
+  def self.call(filter:)
+    new(filter).call
   end
 
   def initialize(filter)
@@ -10,7 +10,7 @@ class Queries::FindContent
     @document_type = filter.fetch(:document_type)
   end
 
-  def retrieve
+  def call
     Facts::Metric.all
       .joins(:dimensions_date).merge(slice_dates)
       .joins(:dimensions_edition).merge(slice_editions)

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,12 +1,10 @@
 class Queries::FindContent
-  def self.retrieve(from:, to:, organisation_id:)
-    new(from, to, organisation_id).retrieve
+  def self.retrieve(api_request:)
+    new(api_request).retrieve
   end
 
-  def initialize(from, to, organisation_id)
-    @from = from
-    @to = to
-    @organsation_id = organisation_id
+  def initialize(api_request)
+    @api_request = api_request
   end
 
   def retrieve
@@ -62,10 +60,10 @@ private
   end
 
   def slice_editions
-    Dimensions::Edition.by_organisation_id(@organsation_id)
+    Dimensions::Edition.by_organisation_id(@api_request.organisation_id)
   end
 
   def slice_dates
-    Dimensions::Date.between(@from, @to)
+    Dimensions::Date.between(@api_request.from, @api_request.to)
   end
 end

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -3,13 +3,6 @@ class Queries::FindContent
     new(filter).call
   end
 
-  def initialize(filter)
-    @from = filter.fetch(:from)
-    @to = filter.fetch(:to)
-    @organisation_id = filter.fetch(:organisation_id)
-    @document_type = filter.fetch(:document_type)
-  end
-
   def call
     Facts::Metric.all
       .joins(:dimensions_date).merge(slice_dates)
@@ -25,6 +18,13 @@ class Queries::FindContent
 private
 
   attr_reader :from, :to, :organisation_id, :document_type
+
+  def initialize(filter)
+    @from = filter.fetch(:from)
+    @to = filter.fetch(:to)
+    @organisation_id = filter.fetch(:organisation_id)
+    @document_type = filter.fetch(:document_type)
+  end
 
   def aggregates
     [

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -4,7 +4,10 @@ class Queries::FindContent
   end
 
   def initialize(filter)
-    @filter = filter
+    @from = filter.fetch(:from)
+    @to = filter.fetch(:to)
+    @organisation_id = filter.fetch(:organisation_id)
+    @document_type = filter.fetch(:document_type)
   end
 
   def retrieve
@@ -20,6 +23,8 @@ class Queries::FindContent
   end
 
 private
+
+  attr_reader :from, :to, :organisation_id, :document_type
 
   def aggregates
     [
@@ -60,12 +65,12 @@ private
   end
 
   def slice_editions
-    editions = Dimensions::Edition.by_organisation_id(@filter.organisation_id)
-    editions = editions.where('latest.document_type = ?', @filter.document_type) if @filter.document_type
+    editions = Dimensions::Edition.by_organisation_id(organisation_id)
+    editions = editions.where('latest.document_type = ?', document_type) if document_type
     editions
   end
 
   def slice_dates
-    Dimensions::Date.between(@filter.from, @filter.to)
+    Dimensions::Date.between(from, to)
   end
 end

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,10 +1,10 @@
 class Queries::FindContent
-  def self.retrieve(content_filters:)
-    new(content_filters).retrieve
+  def self.retrieve(filter:)
+    new(filter).retrieve
   end
 
-  def initialize(content_filters)
-    @content_filters = content_filters
+  def initialize(filter)
+    @filter = filter
   end
 
   def retrieve
@@ -60,12 +60,12 @@ private
   end
 
   def slice_editions
-    editions = Dimensions::Edition.by_organisation_id(@content_filters.organisation_id)
-    editions = editions.where('latest.document_type = ?', @content_filters.document_type) if @content_filters.document_type
+    editions = Dimensions::Edition.by_organisation_id(@filter.organisation_id)
+    editions = editions.where('latest.document_type = ?', @filter.document_type) if @filter.document_type
     editions
   end
 
   def slice_dates
-    Dimensions::Date.between(@content_filters.from, @content_filters.to)
+    Dimensions::Date.between(@filter.from, @filter.to)
   end
 end

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -1,17 +1,35 @@
 RSpec.describe Api::ContentRequest do
-  it '#to_filter' do
-    request = Api::ContentRequest.new(
-      document_type: 'guide',
-      organisation_id: 'the-id',
-      from: '2018-01-01',
-      to: '2018-01-31'
-    )
+  describe '#to_filter' do
+    it 'returns a hash with the parameters' do
+      request = Api::ContentRequest.new(
+        document_type: 'guide',
+        organisation_id: 'the-id',
+        from: '2018-01-01',
+        to: '2018-01-31',
+      )
 
-    expect(request.to_filter).to eq(
-      document_type: 'guide',
-      organisation_id: 'the-id',
-      from: '2018-01-01',
-      to: '2018-01-31'
-    )
+      expect(request.to_filter).to eq(
+        document_type: 'guide',
+        organisation_id: 'the-id',
+        from: '2018-01-01',
+        to: '2018-01-31',
+      )
+    end
+
+    it 'includes missing parameters' do
+      request = Api::ContentRequest.new(
+        document_type: nil,
+        organisation_id: nil,
+        from: nil,
+        to: nil,
+      )
+
+      expect(request.to_filter).to eq(
+        document_type: nil,
+        organisation_id: nil,
+        from: nil,
+        to: nil,
+      )
+    end
   end
 end

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Api::ContentRequest do
+  it '#to_filter' do
+    request = Api::ContentRequest.new(
+      document_type: 'guide',
+      organisation_id: 'the-id',
+      from: '2018-01-01',
+      to: '2018-01-31'
+    )
+
+    expect(request.to_filter).to eq(
+      document_type: 'guide',
+      organisation_id: 'the-id',
+      from: '2018-01-01',
+      to: '2018-01-31'
+    )
+  end
+end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -155,4 +155,31 @@ RSpec.describe Queries::FindContent do
       expect(results).to be_empty
     end
   end
+
+  context 'when invalid filter' do
+    it 'raises an error if no `organisation_id` attribute' do
+      filter.delete :organisation_id
+
+      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
+    end
+
+    it 'raises an error if no `document_type` attribute' do
+      filter.delete :document_type
+
+      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
+    end
+
+    it 'raises an error if no `to` attribute' do
+      filter.delete :to
+
+      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
+    end
+
+    it 'raises an error if no `from` attribute' do
+      filter.delete :from
+
+      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
+    end
+
+  end
 end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Queries::FindContent do
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
   let(:warehouse_item_id) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
   let(:another_warehouse_item_id) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
+  let(:api_request) { Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id) }
 
   before do
     create :user
@@ -55,7 +56,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'aggregates the data by content item' do
-      results = described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)
+      results = described_class.retrieve(api_request: api_request)
       expect(results).to eq(
         [
           {
@@ -115,7 +116,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns aggregated metrics from all versions with metadata from the latest version' do
-      results = described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)
+      results = described_class.retrieve(api_request: api_request)
       expect(results.count).to eq(1)
       expect(results.first).to eq(
         base_path: '/new/base/path',
@@ -142,7 +143,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns the nil for the satisfaction' do
-      results = described_class.retrieve(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id)
+      results = described_class.retrieve(api_request: api_request)
       expect(results.first).to include(
         satisfaction: nil,
         satisfaction_score_responses: 0
@@ -156,14 +157,14 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns a empty array' do
-      results = described_class.retrieve(from: '2018-02-01', to: '2018-02-02', organisation_id: primary_org_id)
+      results = described_class.retrieve(api_request: api_request)
       expect(results).to be_empty
     end
   end
 
   context 'when no items exist for the organisation' do
     it 'returns a empty array' do
-      results = described_class.retrieve(from: '2018-02-01', to: '2018-02-02', organisation_id: primary_org_id)
+      results = described_class.retrieve(api_request: api_request)
       expect(results).to be_empty
     end
   end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'aggregates the data by content item' do
-      results = described_class.retrieve(filter: filter)
+      results = described_class.call(filter: filter)
       expect(results).to eq(
         [
           {
@@ -117,7 +117,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns aggregated metrics from all versions with metadata from the latest version' do
-      results = described_class.retrieve(filter: filter)
+      results = described_class.call(filter: filter)
       expect(results.count).to eq(1)
       expect(results.first).to eq(
         base_path: '/new/base/path',
@@ -132,7 +132,7 @@ RSpec.describe Queries::FindContent do
 
     it 'returns items matching the document_type of the latest version' do
       by_document_type = { from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'press_release' }
-      results = described_class.retrieve(filter: by_document_type)
+      results = described_class.call(filter: by_document_type)
       expect(results.count).to eq(1)
       expect(results.first).to eq(
         base_path: '/new/base/path',
@@ -147,7 +147,7 @@ RSpec.describe Queries::FindContent do
 
     it 'does not return items matching the document_type of older versions' do
       by_document_type = { from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'news_story' }
-      results = described_class.retrieve(filter: by_document_type)
+      results = described_class.call(filter: by_document_type)
       expect(results.count).to eq(0)
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns the nil for the satisfaction' do
-      results = described_class.retrieve(filter: filter)
+      results = described_class.call(filter: filter)
       expect(results.first).to include(
         satisfaction: nil,
         satisfaction_score_responses: 0
@@ -179,14 +179,14 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns a empty array' do
-      results = described_class.retrieve(filter: filter)
+      results = described_class.call(filter: filter)
       expect(results).to be_empty
     end
   end
 
   context 'when no items exist for the organisation' do
     it 'returns a empty array' do
-      results = described_class.retrieve(filter: filter)
+      results = described_class.call(filter: filter)
       expect(results).to be_empty
     end
   end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -103,15 +103,8 @@ RSpec.describe Queries::FindContent do
 
     it 'returns items matching the document_type of the latest version' do
       results = described_class.call(filter: filter.merge(document_type: 'press_release'))
-      expect(results).to eq([{
-        base_path: '/new/base/path',
-        title: 'new title',
-        upviews: 200,
-        document_type: 'press_release',
-        satisfaction: 0.5,
-        satisfaction_score_responses: 120,
-        searches: 20,
-      }])
+
+      expect(results.first).to include(document_type: 'press_release')
     end
 
     it 'does not return items matching the document_type of older versions' do

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe Queries::FindContent do
 
     it 'returns aggregated metrics from all versions with metadata from the latest version' do
       results = described_class.call(filter: filter)
-      expect(results).to eq([
-        {
+      expect(results).to eq(
+        [{
           base_path: '/new/base/path',
           title: 'new title',
           upviews: 200,
@@ -97,7 +97,8 @@ RSpec.describe Queries::FindContent do
           satisfaction: 0.5,
           satisfaction_score_responses: 120,
           searches: 20,
-        }])
+        }]
+      )
     end
 
     it 'returns items matching the document_type of the latest version' do
@@ -180,6 +181,5 @@ RSpec.describe Queries::FindContent do
 
       expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
     end
-
   end
 end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Queries::FindContent do
     before do
       old_edition = create :edition,
         date: '2018-01-01',
-        organisation_id: primary_org_id,
+        organisation_id: 'another-primary-org-id',
         latest: false,
         warehouse_item_id: warehouse_item_id
       create :metric, edition: old_edition, date: '2018-01-02', upviews: 100, useful_yes: 10, useful_no: 10, searches: 15

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe Queries::FindContent do
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
   let(:warehouse_item_id) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
   let(:another_warehouse_item_id) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
-  let(:filter) { Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id) }
+
+  let(:filter) { { from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: nil } }
 
   before do
     create :user
@@ -130,7 +131,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns items matching the document_type of the latest version' do
-      by_document_type = Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'press_release')
+      by_document_type = { from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'press_release' }
       results = described_class.retrieve(filter: by_document_type)
       expect(results.count).to eq(1)
       expect(results.first).to eq(
@@ -145,7 +146,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'does not return items matching the document_type of older versions' do
-      by_document_type = Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'news_story')
+      by_document_type = { from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'news_story' }
       results = described_class.retrieve(filter: by_document_type)
       expect(results.count).to eq(0)
     end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Queries::FindContent do
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
   let(:warehouse_item_id) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
   let(:another_warehouse_item_id) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
-  let(:content_filters) { Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id) }
+  let(:filter) { Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id) }
 
   before do
     create :user
@@ -56,7 +56,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'aggregates the data by content item' do
-      results = described_class.retrieve(content_filters: content_filters)
+      results = described_class.retrieve(filter: filter)
       expect(results).to eq(
         [
           {
@@ -116,7 +116,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns aggregated metrics from all versions with metadata from the latest version' do
-      results = described_class.retrieve(content_filters: content_filters)
+      results = described_class.retrieve(filter: filter)
       expect(results.count).to eq(1)
       expect(results.first).to eq(
         base_path: '/new/base/path',
@@ -131,7 +131,7 @@ RSpec.describe Queries::FindContent do
 
     it 'returns items matching the document_type of the latest version' do
       by_document_type = Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'press_release')
-      results = described_class.retrieve(content_filters: by_document_type)
+      results = described_class.retrieve(filter: by_document_type)
       expect(results.count).to eq(1)
       expect(results.first).to eq(
         base_path: '/new/base/path',
@@ -146,7 +146,7 @@ RSpec.describe Queries::FindContent do
 
     it 'does not return items matching the document_type of older versions' do
       by_document_type = Api::ContentRequest.new(from: '2018-01-01', to: '2018-02-01', organisation_id: primary_org_id, document_type: 'news_story')
-      results = described_class.retrieve(content_filters: by_document_type)
+      results = described_class.retrieve(filter: by_document_type)
       expect(results.count).to eq(0)
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns the nil for the satisfaction' do
-      results = described_class.retrieve(content_filters: content_filters)
+      results = described_class.retrieve(filter: filter)
       expect(results.first).to include(
         satisfaction: nil,
         satisfaction_score_responses: 0
@@ -178,14 +178,14 @@ RSpec.describe Queries::FindContent do
     end
 
     it 'returns a empty array' do
-      results = described_class.retrieve(content_filters: content_filters)
+      results = described_class.retrieve(filter: filter)
       expect(results).to be_empty
     end
   end
 
   context 'when no items exist for the organisation' do
     it 'returns a empty array' do
-      results = described_class.retrieve(content_filters: content_filters)
+      results = described_class.retrieve(filter: filter)
       expect(results).to be_empty
     end
   end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe '/content' do
     create :user
   end
 
-  let(:primary_org_id) { SecureRandom.uuid }
+  let(:primary_org_id) { '17d84dc6-e5b5-4065-a8b5-8783bd934938' }
   let(:another_org_id) { SecureRandom.uuid }
   let(:warehouse_item_id) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
   let(:another_warehouse_item_id) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
@@ -104,35 +104,7 @@ RSpec.describe '/content' do
     end
   end
 
-  describe "an API response" do
-    it "should be cacheable until the end of the day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
-        get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
-      end
-    end
-
-    it "expires at 1am" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=0, public"
-      end
-    end
-
-    it "can be cached for up to a day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
-        get "/content", params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
-      end
-    end
-  end
-
+  include_examples 'API response', '/content', from: '2018-01-01', to: '2018-09-01', organisation_id: '17d84dc6-e5b5-4065-a8b5-8783bd934938'
 
   context 'with invalid params' do
     it 'returns an error for badly formatted dates' do

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe '/content' do
         base_path: '/path/1',
         date: '2018-01-01',
         title: 'old-title',
+        document_type: 'old_doc_type',
         organisation_id: primary_org_id
       create :metric,
         date: '2018-01-01',
@@ -59,14 +60,11 @@ RSpec.describe '/content' do
       create :metric,
         edition: another_org_edition,
         upviews: 34
-      get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
-    end
-
-    it 'is successful' do
-      expect(response.status).to eq(200)
     end
 
     it 'returns aggregated metrics from all versions with metadata from the latest version' do
+      get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
+      expect(response.status).to eq(200)
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:results]).to eq(
         [
@@ -96,6 +94,13 @@ RSpec.describe '/content' do
       get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:organisation_id]).to eq primary_org_id
+    end
+
+    it 'filters by document_type' do
+      get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id, document_type: 'latest_doc_type' }
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:results].count).to eq(1)
     end
   end
 

--- a/spec/requests/api/v1/metrics_spec.rb
+++ b/spec/requests/api/v1/metrics_spec.rb
@@ -25,34 +25,7 @@ RSpec.describe '/api/v1/metrics/', type: :request do
   end
   let!(:edition_fr) { create :edition, content_id: content_id, locale: 'de' }
 
-  describe "an API response" do
-    it "should be cacheable until the end of the day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
-        get "/api/v1/metrics/"
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
-      end
-    end
-
-    it "expires at 1am" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        get "/api/v1/metrics/"
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=0, public"
-      end
-    end
-
-    it "can be cached for up to a day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
-        get "/api/v1/metrics/"
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
-      end
-    end
-  end
+  include_examples 'API response', '/api/v1/metrics'
 
   describe "invalid requests" do
     it 'returns an error for metrics not on the whitelist' do

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -11,4 +11,33 @@ RSpec.describe '/document_types' do
     json = JSON.parse(response.body).deep_symbolize_keys
     expect(json).to eq(document_types: %w(guide manual))
   end
+
+  describe "an API response" do
+    it "should be cacheable until the end of the day" do
+      Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
+        get "/document_types"
+
+        expect(response.headers['ETag']).to be_present
+        expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
+      end
+    end
+
+    it "expires at 1am" do
+      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
+        get '/document_types'
+
+        expect(response.headers['ETag']).to be_present
+        expect(response.headers['Cache-Control']).to eq "max-age=0, public"
+      end
+    end
+
+    it "can be cached for up to a day" do
+      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
+        get '/document_types'
+
+        expect(response.headers['ETag']).to be_present
+        expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
+      end
+    end
+  end
 end

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -12,32 +12,5 @@ RSpec.describe '/document_types' do
     expect(json).to eq(document_types: %w(guide manual))
   end
 
-  describe "an API response" do
-    it "should be cacheable until the end of the day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
-        get "/document_types"
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
-      end
-    end
-
-    it "expires at 1am" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        get '/document_types'
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=0, public"
-      end
-    end
-
-    it "can be cached for up to a day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
-        get '/document_types'
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
-      end
-    end
-  end
+  include_examples 'API response', '/document_types'
 end

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -16,4 +16,33 @@ RSpec.describe '/organisations' do
       ]
     )
   end
+
+  describe "an API response" do
+    it "should be cacheable until the end of the day" do
+      Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
+        get '/organisations'
+
+        expect(response.headers['ETag']).to be_present
+        expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
+      end
+    end
+
+    it "expires at 1am" do
+      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
+        get '/organisations'
+
+        expect(response.headers['ETag']).to be_present
+        expect(response.headers['Cache-Control']).to eq "max-age=0, public"
+      end
+    end
+
+    it "can be cached for up to a day" do
+      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
+        get '/organisations'
+
+        expect(response.headers['ETag']).to be_present
+        expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
+      end
+    end
+  end
 end

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -17,32 +17,5 @@ RSpec.describe '/organisations' do
     )
   end
 
-  describe "an API response" do
-    it "should be cacheable until the end of the day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
-        get '/organisations'
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=3600, public"
-      end
-    end
-
-    it "expires at 1am" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        get '/organisations'
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=0, public"
-      end
-    end
-
-    it "can be cached for up to a day" do
-      Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
-        get '/organisations'
-
-        expect(response.headers['ETag']).to be_present
-        expect(response.headers['Cache-Control']).to eq "max-age=86399, public"
-      end
-    end
-  end
+  include_examples 'API response', '/organisations'
 end

--- a/spec/support/shared/shared_api_response.rb
+++ b/spec/support/shared/shared_api_response.rb
@@ -1,0 +1,28 @@
+RSpec.shared_examples 'API response' do |path, params = {}|
+  it 'should be cacheable until the end of the day' do
+    Timecop.freeze(Time.zone.local(2020, 1, 1, 0, 0, 0)) do
+      get path, params: params
+
+      expect(response.headers['ETag']).to be_present
+      expect(response.headers['Cache-Control']).to eq 'max-age=3600, public'
+    end
+  end
+
+  it 'expires at 1am' do
+    Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
+      get path, params: params
+
+      expect(response.headers['ETag']).to be_present
+      expect(response.headers['Cache-Control']).to eq 'max-age=0, public'
+    end
+  end
+
+  it 'can be cached for up to a day' do
+    Timecop.freeze(Time.zone.local(2020, 1, 1, 1, 0, 1)) do
+      get path, params: params
+
+      expect(response.headers['ETag']).to be_present
+      expect(response.headers['Cache-Control']).to eq 'max-age=86399, public'
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the `document_type` optional parameter to the /content endpoint

When the `document_type` parameter is supplied, the endpoint only returns data where
the latest edition of a content item has that `document_type`

Url to test: http://content-performance-manager.dev.gov.uk/content?document_type=corporate_report&from=2018-09-19&organisation_id=b8a6a8f2-d04f-4346-90c1-d28898565866&to=2018-10-19