### PR TITLE
Include content_id in Dimensions::Edition metadata

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -45,6 +45,7 @@ class Dimensions::Edition < ApplicationRecord
     {
       title: title,
       base_path: base_path,
+      content_id: content_id,
       first_published_at: first_published_at,
       public_updated_at: public_updated_at,
       publishing_app: publishing_app,

--- a/spec/domain/queries/find_metadata_spec.rb
+++ b/spec/domain/queries/find_metadata_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Queries::FindMetadata do
       latest: true,
       title: 'the title',
       base_path: base_path,
+      content_id: 'content_id - 1',
       document_type: 'guide',
       publishing_app: 'whitehall',
       first_published_at: '2018-07-17T10:35:59.000Z',
@@ -28,6 +29,7 @@ RSpec.describe Queries::FindMetadata do
     expect(metadata).to eq(
       title: 'the title',
       base_path: base_path,
+      content_id: 'content_id - 1',
       document_type: 'guide',
       publishing_app: 'whitehall',
       first_published_at: '2018-07-17T10:35:59.000Z',

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       create :edition,
         title: 'The Title',
         base_path: '/the/base/path',
+        content_id: 'the-content-id',
         first_published_at: '2018-01-01',
         public_updated_at: '2018-05-20',
         publishing_app: 'publisher',
@@ -203,6 +204,7 @@ RSpec.describe Dimensions::Edition, type: :model do
     it 'returns the correct attributes' do
       expect(edition.reload.metadata).to eq(
         base_path: '/the/base/path',
+        content_id: 'the-content-id',
         title: 'The Title',
         first_published_at: Time.new(2018, 1, 1).strftime("%Y-%m-%d"),
         public_updated_at: Time.new(2018, 5, 20).strftime("%Y-%m-%d"),

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe '/single_page', type: :request do
       latest: true,
       title: 'the title',
       base_path: base_path,
+      content_id: 'the-content-id',
       document_type: 'guide',
       publishing_app: 'whitehall',
       first_published_at: '2018-07-17T10:35:59.000Z',
@@ -35,6 +36,7 @@ RSpec.describe '/single_page', type: :request do
         'metadata' => {
           "title" => 'the title',
           "base_path" => base_path,
+          "content_id" => 'the-content-id',
           "document_type" => 'guide',
           "publishing_app" => 'whitehall',
           "first_published_at" => "2018-07-17T10:35:59.000Z",


### PR DESCRIPTION
This is needed in the Content Data Admin to generate links to
publishing applications to edit the content (for example Whitehall
Publisher).

https://trello.com/c/pamIZVPi/716-2-page-data-add-link-to-correct-page-in-publishing-tool