### PR TITLE
Sort time series by date

### DIFF
--- a/app/domain/queries/series.rb
+++ b/app/domain/queries/series.rb
@@ -11,11 +11,12 @@ class Queries::Series
   end
 
   def time_series
-    @all_metrics.map do |metric|
+    time_series = @all_metrics.map do |metric|
       {
         date: metric.dimensions_date_id.to_s,
         value: metric.public_send(metric_name)
       }
     end
+    time_series.sort_by { |point| point[:date] }
   end
 end

--- a/spec/domain/queries/find_series_spec.rb
+++ b/spec/domain/queries/find_series_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe Queries::FindSeries do
       expect(result.first.time_series).to eq([
         { date: "2018-01-12", value: 1 },
         { date: "2018-01-13", value: 1 },
-        { date: "2018-01-14", value: 1 },
         { date: "2018-01-13", value: 2 },
+        { date: "2018-01-14", value: 1 },
         { date: "2018-01-14", value: 2 }
       ])
     end

--- a/spec/domain/queries/series_spec.rb
+++ b/spec/domain/queries/series_spec.rb
@@ -7,26 +7,22 @@ RSpec.describe Queries::Series do
   let!(:edition) { create :edition, date: day1, content_id: content_id, base_path: base_path, locale: 'en' }
 
   before do
+    create :metric, edition: edition, date: day3, pviews: 30
     create :metric, edition: edition, date: day1, pviews: 10
     create :metric, edition: edition, date: day2, pviews: 20
-    create :metric, edition: edition, date: day3, pviews: 30
   end
 
-  it 'return the time series' do
+  it 'return the time series in order' do
     series = Queries::Series.new('pviews', Facts::Metric.all)
-    expect(series.time_series).to eq expected_values
+    expect(series.time_series).to eq([
+      { date: "2018-01-13", value: 10 },
+      { date: "2018-01-14", value: 20 },
+      { date: "2018-01-15", value: 30 }
+    ])
   end
 
   it 'return the total value for time period' do
     series = Queries::Series.new('pviews', Facts::Metric.all)
     expect(series.total).to eq 60
-  end
-
-  def expected_values
-    [
-      { date: "2018-01-13", value: 10 },
-      { date: "2018-01-14", value: 20 },
-      { date: "2018-01-15", value: 30 }
-    ]
   end
 end


### PR DESCRIPTION
The API needs to respond with the time series in chronological order. Previously data was just returned as ordered within thedatabase. We now sort the time series data by date from oldest to latest.