### PR TITLE
Cut down the parts of Rails that are loaded

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require polyfills/bind
-//= require cable
 
 // --- Analytics ---
 

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,13 +1,9 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the rails generate channel command.
 //
-//= require action_cable
 //= require_self
 //= require_tree ./channels
 
 (function() {
   this.App || (this.App = {});
-
-  App.cable = ActionCable.createConsumer();
-
 }).call(this);

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,12 @@
 require_relative 'boot'
 
-require 'rails/all'
+require 'rails'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'active_job/railtie'
+require 'active_model/railtie'
+require 'active_record/railtie'
+require 'sprockets/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,9 +27,9 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "content_performance_manager_#{Rails.env}"
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,12 +27,12 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
Some parts of Rails loaded by default are not being used, and probably
won't ever be, like actionmailer for example. So just require the
parts that are used.

The motivation behind this change is to remove activestorage from
being required, as it requires secrets when precompiling assets, which
breaks it in the GOV.UK Mini Environment Admin.