### PR TITLE
Add withdrawn and historical attributes to metadata

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -50,7 +50,9 @@ class Dimensions::Edition < ApplicationRecord
       public_updated_at: public_updated_at,
       publishing_app: publishing_app,
       document_type: document_type,
-      primary_organisation_title: primary_organisation_title
+      primary_organisation_title: primary_organisation_title,
+      withdrawn: withdrawn,
+      historical: historical
     }
   end
 end

--- a/app/streams/publishing_api/handlers/base_handler.rb
+++ b/app/streams/publishing_api/handlers/base_handler.rb
@@ -20,6 +20,8 @@ class PublishingAPI::Handlers::BaseHandler
       analytics_identifier: message.payload.fetch('analytics_identifier', nil),
       update_type: message.payload.fetch('update_type', nil),
       latest: true,
+      withdrawn: message.withdrawn_notice?,
+      historical: message.historically_political?,
       raw_json: message.payload
     }
   end

--- a/app/streams/publishing_api/messages/base_message.rb
+++ b/app/streams/publishing_api/messages/base_message.rb
@@ -20,4 +20,22 @@ class PublishingAPI::Messages::BaseMessage
       locale: locale
     ).maximum('publishing_api_payload_version').to_i
   end
+
+  def withdrawn_notice?
+    @payload.dig('withdrawn_notice', :explanation).present?
+  end
+
+  def historically_political?
+    historical? && political?
+  end
+
+private
+
+  def political?
+    @payload.dig('details', 'political') || false
+  end
+
+  def historical?
+    @payload.dig('details', 'government').present? && !@payload.dig('details', 'government', 'current')
+  end
 end

--- a/db/migrate/20181029112946_add_withdrawn_and_historical.rb
+++ b/db/migrate/20181029112946_add_withdrawn_and_historical.rb
@@ -1,0 +1,6 @@
+class AddWithdrawnAndHistorical < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dimensions_editions, :withdrawn, :boolean
+    add_column :dimensions_editions, :historical, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_15_093842) do
+ActiveRecord::Schema.define(version: 2018_10_29_112946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,8 @@ ActiveRecord::Schema.define(version: 2018_10_15_093842) do
     t.datetime "last_edited_at"
     t.json "raw_json"
     t.string "warehouse_item_id", null: false
+    t.boolean "withdrawn"
+    t.boolean "historical"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"

--- a/spec/domain/queries/find_metadata_spec.rb
+++ b/spec/domain/queries/find_metadata_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe Queries::FindMetadata do
       publishing_app: 'whitehall',
       first_published_at: '2018-07-17T10:35:59.000Z',
       public_updated_at: '2018-07-17T10:35:57.000Z',
-      primary_organisation_title: 'The ministry'
+      primary_organisation_title: 'The ministry',
+      withdrawn: false,
+      historical: false
 
     create :edition,
       latest: false,
@@ -21,7 +23,9 @@ RSpec.describe Queries::FindMetadata do
       publishing_app: 'whitehall',
       first_published_at: '2018-06-17T10:35:59.000Z',
       public_updated_at: '2018-06-17T10:35:57.000Z',
-      primary_organisation_title: 'The ministry'
+      primary_organisation_title: 'The ministry',
+      withdrawn: false,
+      historical: false
   end
 
   it "returns metadata for latest edition" do
@@ -34,7 +38,9 @@ RSpec.describe Queries::FindMetadata do
       publishing_app: 'whitehall',
       first_published_at: '2018-07-17T10:35:59.000Z',
       public_updated_at: '2018-07-17T10:35:57.000Z',
-      primary_organisation_title: 'The ministry'
+      primary_organisation_title: 'The ministry',
+      withdrawn: false,
+      historical: false
     )
   end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -198,7 +198,9 @@ RSpec.describe Dimensions::Edition, type: :model do
         public_updated_at: '2018-05-20',
         publishing_app: 'publisher',
         document_type: 'guide',
-        primary_organisation_title: 'The ministry'
+        primary_organisation_title: 'The ministry',
+        withdrawn: false,
+        historical: false
     end
 
     it 'returns the correct attributes' do
@@ -210,7 +212,9 @@ RSpec.describe Dimensions::Edition, type: :model do
         public_updated_at: Time.new(2018, 5, 20).strftime("%Y-%m-%d"),
         publishing_app: 'publisher',
         document_type: 'guide',
-        primary_organisation_title: 'The ministry'
+        primary_organisation_title: 'The ministry',
+        withdrawn: false,
+        historical: false
       )
     end
   end

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe '/single_page', type: :request do
       first_published_at: '2018-07-17T10:35:59.000Z',
       public_updated_at: '2018-07-17T10:35:57.000Z',
       primary_organisation_title: 'The ministry',
+      withdrawn: false,
+      historical: false,
       facts: {
         'words': 30
       }
@@ -41,10 +43,12 @@ RSpec.describe '/single_page', type: :request do
           "publishing_app" => 'whitehall',
           "first_published_at" => "2018-07-17T10:35:59.000Z",
           "public_updated_at" => '2018-07-17T10:35:57.000Z',
-          "primary_organisation_title" => 'The ministry'
+          "primary_organisation_title" => 'The ministry',
+          "withdrawn" => false,
+          "historical" => false
         }
       }
-      expect(body).to include(expected)
+      expect(body['metadata']).to include(expected['metadata'])
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/streams/publishing_api/messages/multipart_message_spec.rb
+++ b/spec/streams/publishing_api/messages/multipart_message_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe PublishingAPI::Messages::MultipartMessage do
   subject { described_class }
+  include_examples 'BaseMessage#historically_political?'
+  include_examples 'BaseMessage#withdrawn_notice?'
 
   describe ".is_multipart?" do
     it "returns true if message is for multipart item" do

--- a/spec/streams/publishing_api/messages/single_item_message_spec.rb
+++ b/spec/streams/publishing_api/messages/single_item_message_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe PublishingAPI::Messages::SingleItemMessage do
+  subject { described_class }
+  include_examples 'BaseMessage#historically_political?'
+  include_examples 'BaseMessage#withdrawn_notice?'
+end

--- a/spec/support/shared/shared_messages.rb
+++ b/spec/support/shared/shared_messages.rb
@@ -1,0 +1,54 @@
+RSpec.shared_examples 'BaseMessage#historically_political?' do
+  describe '#historically_political?' do
+    let(:payload) { build(:message).payload }
+    let(:message) { described_class.new(payload) }
+    subject { message.historically_political? }
+
+    context 'when payload has current goverment as false and has political as true' do
+      before {
+        payload['details']['political'] = true
+        payload['details']['government']['current'] = false
+      }
+      it { is_expected.to eq true }
+    end
+
+    context 'when payload has no political information' do
+      before { payload['details'].delete('political') }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when payload has political as false' do
+      before { payload['details']['political'] = false }
+      it { is_expected.to eq false }
+    end
+
+    context 'when payload has no goverment information' do
+      before { payload['details'].delete('government') }
+      it { is_expected.to eq false }
+    end
+
+    context 'when payload has current goverment as true' do
+      before { payload['details']['government']['current'] = true }
+      it { is_expected.to eq false }
+    end
+  end
+end
+
+RSpec.shared_examples 'BaseMessage#withdrawn_notice?' do
+  describe '#withdrawn_notice?' do
+    let(:payload) { build(:message).payload }
+    let(:message) { described_class.new(payload) }
+    subject { message.withdrawn_notice? }
+
+    context 'when payload has withdrawn notice with explanation' do
+      before { payload['withdrawn_notice'] = { explanation: 'Not relevant' } }
+      it { is_expected.to eq true }
+    end
+
+    context 'when payload has no withdrawn notice information' do
+      before { payload.delete('withdrawn_notice') }
+      it { is_expected.to eq false }
+    end
+  end
+end


### PR DESCRIPTION
Added `withdrawn` and `historical` boolean attributes to metadata. This is to indicate whether a content item has a withdrawn notice or/and is historically political. 

Changes include: 
- Add `withdrawn` and `historical` columns to edition model
- Add logic to determine if message has a withdrawn notice or is historically political
- Message handlers create editions with correct attributes