### PR TITLE
Add unique constraints for editions (warehouse_item_id and base_path)

### DIFF
--- a/app/streams/publishing_api/handlers/multipart_handler.rb
+++ b/app/streams/publishing_api/handlers/multipart_handler.rb
@@ -38,6 +38,7 @@ private
       warehouse_item_id: "#{content_id}:#{locale}:#{base_path}",
       **all_attributes
     )
+    new_edition.latest = false
     new_edition.assign_attributes(facts_edition: Etl::Edition::Processor.process(old_edition, new_edition))
     new_edition.promote!(old_edition)
   end

--- a/app/streams/publishing_api/handlers/single_item_handler.rb
+++ b/app/streams/publishing_api/handlers/single_item_handler.rb
@@ -26,6 +26,7 @@ private
       warehouse_item_id: "#{content_id}:#{locale}",
       **all_attributes
     )
+    new_edition.latest = false
     new_edition.assign_attributes(facts_edition: Etl::Edition::Processor.process(old_edition, new_edition))
     new_edition
   end

--- a/db/migrate/20181025132726_add_index_to_facts_metrics_on_edition_id.rb
+++ b/db/migrate/20181025132726_add_index_to_facts_metrics_on_edition_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToFactsMetricsOnEditionId < ActiveRecord::Migration[5.2]
+  def change
+    add_index :facts_metrics, :dimensions_edition_id
+  end
+end

--- a/db/migrate/20181025133812_remove_duplicated_warehouse_item_ids_in_metrics.rb
+++ b/db/migrate/20181025133812_remove_duplicated_warehouse_item_ids_in_metrics.rb
@@ -1,0 +1,30 @@
+class RemoveDuplicatedWarehouseItemIdsInMetrics < ActiveRecord::Migration[5.2]
+  def up
+    loop do
+      say "------> Deleting batch of duplications"
+      total = clean_up_duplicated_metrics!
+      break if total.zero?
+    end
+  end
+
+private
+
+  def clean_up_duplicated_metrics!
+    edition_ids = Dimensions::Edition.
+      select('warehouse_item_id, count(id), max(id) as id').
+      where(latest: true).
+      group(:warehouse_item_id).
+      having('count(id) > 1').
+      map(&:id)
+
+    total = edition_ids.count
+    edition_ids.each_with_index do |edition_id, index|
+      say "#{index + 1} / #{total} : Deleting metrics for Edition: #{edition_id}"
+      Facts::Metric.where(dimensions_edition_id: edition_id).delete_all
+      Dimensions::Edition.find(edition_id).facts_edition.destroy
+      Dimensions::Edition.find(edition_id).destroy
+    end
+
+    total
+  end
+end

--- a/db/migrate/20181025134740_add_unique_index_warehouse_id_latest.rb
+++ b/db/migrate/20181025134740_add_unique_index_warehouse_id_latest.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexWarehouseIdLatest < ActiveRecord::Migration[5.2]
+  def change
+    add_index :dimensions_editions, %i(latest warehouse_item_id), unique: true, where: "latest = 'true'"
+  end
+end

--- a/db/migrate/20181025135539_remove_duplicated_base_paths_metrics.rb
+++ b/db/migrate/20181025135539_remove_duplicated_base_paths_metrics.rb
@@ -1,0 +1,30 @@
+class RemoveDuplicatedBasePathsMetrics < ActiveRecord::Migration[5.2]
+  def up
+    loop do
+      say "------> Deleting batch of duplications"
+      total = clean_up_duplicated_metrics!
+      break if total.zero?
+    end
+  end
+
+private
+
+  def clean_up_duplicated_metrics!
+    edition_ids = Dimensions::Edition.
+      select('base_path, count(id), max(id) as id').
+      where(latest: true).
+      group(:base_path).
+      having('count(id) > 1').
+      map(&:id)
+
+    total = edition_ids.count
+    edition_ids.each_with_index do |edition_id, index|
+      say "#{index + 1} / #{total} : Deleting metrics for Edition: #{edition_id}"
+      Facts::Metric.where(dimensions_edition_id: edition_id).delete_all
+      Dimensions::Edition.find(edition_id).facts_edition.destroy
+      Dimensions::Edition.find(edition_id).destroy
+    end
+
+    total
+  end
+end

--- a/db/migrate/20181025135947_add_unique_index_on_latest_basepath.rb
+++ b/db/migrate/20181025135947_add_unique_index_on_latest_basepath.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnLatestBasepath < ActiveRecord::Migration[5.2]
+  def change
+    add_index :dimensions_editions, %i(latest base_path), unique: true, where: "latest = 'true'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_133812) do
+ActiveRecord::Schema.define(version: 2018_10_25_134740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2018_10_25_133812) do
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
+    t.index ["latest", "warehouse_item_id"], name: "index_dimensions_editions_on_latest_and_warehouse_item_id", unique: true, where: "(latest = true)"
     t.index ["latest"], name: "index_dimensions_editions_on_latest"
     t.index ["organisation_id"], name: "index_dimensions_editions_organisation_id"
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 2018_10_25_132726) do
     t.boolean "historical"
     t.json "raw_json"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
-    t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_134740) do
+ActiveRecord::Schema.define(version: 2018_10_25_135539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_135539) do
+ActiveRecord::Schema.define(version: 2018_10_29_112946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,11 +65,12 @@ ActiveRecord::Schema.define(version: 2018_10_25_135539) do
     t.string "update_type"
     t.datetime "last_edited_at"
     t.string "warehouse_item_id", null: false
+    t.json "raw_json"
     t.boolean "withdrawn"
     t.boolean "historical"
-    t.json "raw_json"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
+    t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
     t.index ["latest", "warehouse_item_id"], name: "index_dimensions_editions_on_latest_and_warehouse_item_id", unique: true, where: "(latest = true)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_132726) do
+ActiveRecord::Schema.define(version: 2018_10_25_133812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_29_112946) do
+ActiveRecord::Schema.define(version: 2018_10_25_132726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2018_10_29_112946) do
     t.integer "page_time", default: 0
     t.float "satisfaction", default: 0.0, null: false
     t.index ["dimensions_date_id", "dimensions_edition_id"], name: "metrics_edition_id_date_id", unique: true
+    t.index ["dimensions_edition_id"], name: "index_facts_metrics_on_dimensions_edition_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,10 +64,10 @@ ActiveRecord::Schema.define(version: 2018_10_25_132726) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
-    t.json "raw_json"
     t.string "warehouse_item_id", null: false
     t.boolean "withdrawn"
     t.boolean "historical"
+    t.json "raw_json"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -4,18 +4,18 @@ require 'traceable'
 RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
   subject { described_class }
 
-  let!(:edition1) { create :edition, base_path: '/path1', latest: true }
-  let!(:edition2) { create :edition, base_path: '/path2', latest: true }
+  let!(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
+  let!(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
 
   let(:date) { Date.new(2018, 2, 20) }
 
 
   context 'When the base_path matches the GA path' do
     before { allow(Etl::GA::ViewsAndNavigationService).to receive(:find_in_batches).and_yield(ga_response) }
+
     it 'update the facts with the GA metrics' do
-      edition1 = create :edition, base_path: '/path1', date: '2018-02-20'
-      edition2 = create :edition, base_path: '/path2', date: '2018-02-20'
-      fact1 = create :metric, edition: edition1, date: '2018-02-20'
+      fact1 = create :metric, edition: edition1,
+        date: '2018-02-20'
       fact2 = create :metric, edition: edition2, date: '2018-02-20'
 
       described_class.process(date: date)
@@ -25,8 +25,7 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
     end
 
     it 'does not update metrics for other days' do
-      edition = create :edition, date: '2018-02-20', base_path: '/path1'
-      fact1 = create :metric, edition: edition, date: '2018-02-20', pviews: 20, upviews: 10
+      fact1 = create :metric, edition: edition1, date: '2018-02-20', pviews: 20, upviews: 10
 
       day_before = date - 1
       described_class.process(date: day_before)
@@ -58,8 +57,7 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
       end
 
       it 'only updates metrics for the current day' do
-        edition = create :edition, date: '2018-02-20', base_path: '/path1'
-        fact1 = create :metric, edition: edition, date: '2018-02-20'
+        fact1 = create :metric, edition: edition1, date: '2018-02-20'
 
         described_class.process(date: date)
 

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     sequence(:publishing_api_payload_version)
     schema_name { 'detailed_guide' }
     document_type { 'detailed_guide' }
-    warehouse_item_id { "#{content_id}:#{locale}" }
+    warehouse_item_id { "#{content_id}:#{locale}:#{base_path}" }
     transient do
       date { Time.zone.today }
       replaces { nil }

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -218,4 +218,32 @@ RSpec.describe Dimensions::Edition, type: :model do
       )
     end
   end
+
+  describe 'Unique constraint on `warehouse_item_id` and `latest`' do
+    it 'prevent duplicating `warehouse_item_id` for latest items' do
+      create :edition, warehouse_item_id: 'value', latest: true
+
+      expect(-> { create :edition, warehouse_item_id: 'value', latest: true }).to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'does not prevent duplicating `warehouse_item_id` for old items' do
+      create :edition, warehouse_item_id: 'value', latest: true
+
+      expect(-> { create :edition, warehouse_item_id: 'value', latest: false }).to_not raise_error
+    end
+  end
+
+  describe 'Unique constraint on `base_path` and `latest`' do
+    it 'prevent duplicating `base_path` for latest items' do
+      create :edition, base_path: 'value', latest: true
+
+      expect(-> { create :edition, base_path: 'value', latest: true }).to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'does not prevent duplicating `base_path` for old items' do
+      create :edition, base_path: 'value', latest: true
+
+      expect(-> { create :edition, base_path: 'value', latest: false }).to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/pnDONJDx/773-5-prevent-duplicated-entries-in-editions-dimension)

## What

Prevent multiple latest editions for the same content Item.

## Why

We are currently storing multiple editions in their latest version for  the same `base_path` 
and `warehous_item_id`. For this reason, on a daily basis, we are duplicating the number
of daily metrics for each one of those editions.

I have decided to solve this problem by adding database constraints that ensure that 
we can't have multiple editions (in the latest version) sharing the same `warehouse_item_id`
or `base_path`.

To be able to add the migrations, I have also added two migrations to delete the duplicated
entries in the daily Metrics table, and in the editions table. On the same go, I have also updated
the test so they are consistent with the new constraints.

Finally, I have added two tests to ensure that the constraints are not deleted accidentally.

## Note

If an error is being raised because of a constraint issue, then we will log the error in Sentry. I would
rather know how many time it happen, before silencing these errors. This is something to be 
addressed in future PRs.
