### PR TITLE
Add pagination

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -5,10 +5,9 @@ class ContentController < Api::BaseController
     filter = api_request.to_filter
     content = Queries::FindContent.call(filter: filter)
 
-    render json: {
-      results: content,
+    render json: content.merge(
       organisation_id: params[:organisation_id]
-    }.to_json
+    ).to_json
   end
 
 private

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -5,9 +5,7 @@ class ContentController < Api::BaseController
     filter = api_request.to_filter
     content = Queries::FindContent.call(filter: filter)
 
-    render json: content.merge(
-      organisation_id: params[:organisation_id]
-    ).to_json
+    render json: content.to_json
   end
 
 private

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -18,7 +18,7 @@ private
   end
 
   def permitted_params
-    params.permit(:from, :to, :organisation_id, :document_type, :format)
+    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size)
   end
 
   def validate_params!

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,12 +1,15 @@
 class Api::ContentRequest < Api::BaseRequest
-  attr_reader :organisation_id, :document_type
+  attr_reader :organisation_id, :document_type, :page, :page_size
   validate :valid_organisation_id
+  validates_numericality_of :page, :page_size, allow_nil: true
 
   def initialize(params)
     super(params)
 
     @organisation_id = params[:organisation_id]
     @document_type = params[:document_type]
+    @page = params[:page].try(:to_i)
+    @page_size = params[:page_size].try(:to_i)
   end
 
   def to_filter
@@ -15,6 +18,8 @@ class Api::ContentRequest < Api::BaseRequest
       document_type: document_type,
       from: from,
       to: to,
+      page: page,
+      page_size: page_size
     }
   end
 

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,4 +1,5 @@
 class Queries::FindContent
+  DEFAULT_PAGE_SIZE = 100
   def self.call(filter:)
     filter.assert_valid_keys :from, :to, :organisation_id, :document_type, :page, :page_size
 
@@ -31,7 +32,7 @@ private
     @organisation_id = filter.fetch(:organisation_id)
     @document_type = filter.fetch(:document_type)
     @page = filter[:page] || 1
-    @page_size = filter[:page_size] || 100
+    @page_size = filter[:page_size] || DEFAULT_PAGE_SIZE
   end
 
   def aggregates

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Api::ContentRequest do
         organisation_id: 'the-id',
         from: '2018-01-01',
         to: '2018-01-31',
+        page: '1',
+        page_size: '20',
       )
 
       expect(request.to_filter).to eq(
@@ -13,6 +15,8 @@ RSpec.describe Api::ContentRequest do
         organisation_id: 'the-id',
         from: '2018-01-01',
         to: '2018-01-31',
+        page: 1,
+        page_size: 20,
       )
     end
 
@@ -29,6 +33,8 @@ RSpec.describe Api::ContentRequest do
         organisation_id: nil,
         from: nil,
         to: nil,
+        page: nil,
+        page_size: nil,
       )
     end
   end

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Queries::FindContent do
 
     it 'aggregates the data by content item' do
       results = described_class.call(filter: filter)
-      expect(results).to eq(
+      expect(results[:results]).to eq(
         [
           {
             base_path: '/path/1',
@@ -88,7 +88,7 @@ RSpec.describe Queries::FindContent do
 
     it 'returns aggregated metrics from all versions with metadata from the latest version' do
       results = described_class.call(filter: filter)
-      expect(results).to eq(
+      expect(results[:results]).to eq(
         [{
           base_path: '/new/base/path',
           title: 'new title',
@@ -104,12 +104,12 @@ RSpec.describe Queries::FindContent do
     it 'returns items matching the document_type of the latest version' do
       results = described_class.call(filter: filter.merge(document_type: 'press_release'))
 
-      expect(results.first).to include(document_type: 'press_release')
+      expect(results[:results].first).to include(document_type: 'press_release')
     end
 
     it 'does not return items matching the document_type of older versions' do
       results = described_class.call(filter: filter.merge(document_type: 'news_story'))
-      expect(results.count).to eq(0)
+      expect(results[:results].count).to eq(0)
     end
   end
 
@@ -124,22 +124,34 @@ RSpec.describe Queries::FindContent do
       end
     end
 
-    it 'returns the first page of data' do
+    it 'returns the first page of data with pagination info' do
       results = described_class.call(filter: filter.merge(page: 1, page_size: 2))
-      paths = results.map { |hsh| hsh[:base_path] }
+      paths = results[:results].map { |hsh| hsh[:base_path] }
       expect(paths).to eq(['/path/1', '/path/2'])
+      expect(results).to include(
+        page: 1,
+        total_results: 4,
+                         )
     end
 
     it 'returns the second page of data' do
       results = described_class.call(filter: filter.merge(page: 2, page_size: 2))
-      paths = results.map { |hsh| hsh[:base_path] }
+      paths = results[:results].map { |hsh| hsh[:base_path] }
       expect(paths).to eq(['/path/3', '/path/4'])
+      expect(results).to include(
+        page: 2,
+        total_results: 4,
+                         )
     end
 
     it 'responds to the page_size parameter' do
-      results = described_class.call(filter: filter.merge(page: 1, page_size: 3))
-      paths = results.map { |hsh| hsh[:base_path] }
-      expect(paths).to eq(['/path/1', '/path/2', '/path/3'])
+      results = described_class.call(filter: filter.merge(page: 1, page_size: 5))
+      paths = results[:results].map { |hsh| hsh[:base_path] }
+      expect(paths).to eq(['/path/1', '/path/2', '/path/3', '/path/4'])
+      expect(results).to include(
+        page: 1,
+        total_results: 4,
+                         )
     end
   end
 
@@ -157,7 +169,7 @@ RSpec.describe Queries::FindContent do
 
     it 'returns the nil for the satisfaction' do
       results = described_class.call(filter: filter)
-      expect(results.first).to include(
+      expect(results[:results].first).to include(
         satisfaction: nil,
         satisfaction_score_responses: 0
       )
@@ -169,14 +181,14 @@ RSpec.describe Queries::FindContent do
 
     it 'returns a empty array' do
       results = described_class.call(filter: filter)
-      expect(results).to be_empty
+      expect(results[:results]).to be_empty
     end
   end
 
   context 'when no items exist for the organisation' do
     it 'returns a empty array' do
       results = described_class.call(filter: filter)
-      expect(results).to be_empty
+      expect(results[:results]).to be_empty
     end
   end
 

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -113,6 +113,36 @@ RSpec.describe Queries::FindContent do
     end
   end
 
+  context 'when pagination parameters are provided' do
+    before do
+      (1..4).each do |n|
+        edition = create :edition,
+                         date: '2018-01-01',
+                         base_path: "/path/#{n}",
+                         organisation_id: primary_org_id
+        create :metric, edition: edition, date: '2018-01-01'
+      end
+    end
+
+    it 'returns the first page of data' do
+      results = described_class.call(filter: filter.merge(page: 1, page_size: 2))
+      paths = results.map { |hsh| hsh[:base_path] }
+      expect(paths).to eq(['/path/1', '/path/2'])
+    end
+
+    it 'returns the second page of data' do
+      results = described_class.call(filter: filter.merge(page: 2, page_size: 2))
+      paths = results.map { |hsh| hsh[:base_path] }
+      expect(paths).to eq(['/path/3', '/path/4'])
+    end
+
+    it 'responds to the page_size parameter' do
+      results = described_class.call(filter: filter.merge(page: 1, page_size: 3))
+      paths = results.map { |hsh| hsh[:base_path] }
+      expect(paths).to eq(['/path/1', '/path/2', '/path/3'])
+    end
+  end
+
   context 'when no useful_yes/no.. responses' do
     before do
       edition = create :edition,

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -155,6 +155,27 @@ RSpec.describe Queries::FindContent do
     end
   end
 
+  context 'when no pagination parameters are provided' do
+    before do
+      (1..101).each do |n|
+        edition = create :edition,
+                         date: '2018-01-01',
+                         base_path: "/path/#{n}",
+                         organisation_id: primary_org_id
+        create :metric, edition: edition, date: '2018-01-01'
+      end
+    end
+
+    it 'defaults to page 1 with page size of 100' do
+      results = described_class.call(filter: filter)
+      expect(results[:results].count).to eq(100)
+      expect(results).to include(
+        page: 1,
+        total_results: 101
+                         )
+    end
+  end
+
   context 'when no useful_yes/no.. responses' do
     before do
       edition = create :edition,

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -112,12 +112,36 @@ RSpec.describe '/content' do
         expect(json[:results].first[:base_path]).to eq('/new/base/path')
       end
 
+      it 'returns the first page pagination info' do
+        get '/content', params: { from: '2018-01-01',
+                                  to: '2018-09-01',
+                                  organisation_id: primary_org_id,
+                                  page: 1,
+                                  page_size: 1 }
+        expect(response.status).to eq(200)
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json).to include(
+          page: 1,
+          total_results: 2
+        )
+      end
+
       it 'returns the second page of the data' do
         get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id, page: 2, page_size: 1 }
         expect(response.status).to eq(200)
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:results].count).to eq(1)
         expect(json[:results].first[:base_path]).to eq('/path/2')
+      end
+
+      it 'returns the second page pagination info' do
+        get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id, page: 2, page_size: 1 }
+        expect(response.status).to eq(200)
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json).to include(
+          page: 2,
+          total_results: 2
+        )
       end
     end
   end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe '/content' do
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:results].count).to eq(1)
     end
+
+    context 'when pagination parameters are provided' do
+      it 'returns the first page of the data' do
+        get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id, page: 1, page_size: 1 }
+        expect(response.status).to eq(200)
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:results].count).to eq(1)
+        expect(json[:results].first[:base_path]).to eq('/new/base/path')
+      end
+
+      it 'returns the second page of the data' do
+        get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id, page: 2, page_size: 1 }
+        expect(response.status).to eq(200)
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:results].count).to eq(1)
+        expect(json[:results].first[:base_path]).to eq('/path/2')
+      end
+    end
   end
 
   include_examples 'API response', '/content', from: '2018-01-01', to: '2018-09-01', organisation_id: '17d84dc6-e5b5-4065-a8b5-8783bd934938'

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -90,12 +90,6 @@ RSpec.describe '/content' do
       )
     end
 
-    it 'returns organisation id' do
-      get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id }
-      json = JSON.parse(response.body).deep_symbolize_keys
-      expect(json[:organisation_id]).to eq primary_org_id
-    end
-
     it 'filters by document_type' do
       get '/content', params: { from: '2018-01-01', to: '2018-09-01', organisation_id: primary_org_id, document_type: 'latest_doc_type' }
       expect(response.status).to eq(200)


### PR DESCRIPTION
Add pagination to /content endpoint.

the /content endpoint now accepts `page` and `page_size' parameters.

The default `page_size` is 100.

Also removed the redundant `organisation_id` from the response.

There is a [Related PR in content-data-admin](https://github.com/alphagov/content-data-admin/pull/169)

## Before
![screen shot 2018-10-30 at 11 00 39](https://user-images.githubusercontent.com/511319/47713886-3aa2f100-dc33-11e8-85ac-366fb166ee26.png)

## After
![screen shot 2018-10-30 at 11 00 50](https://user-images.githubusercontent.com/511319/47713901-42fb2c00-dc33-11e8-94fc-3ca5b033c664.png)

Url to test: http://content-performance-manager.dev.gov.uk/content?from=2018-09-26&to=2018-10-26&organisation_id=25aacd68-dc0c-4041-9c3a-df59a5357c23&page=1&page_size=10

