### PR TITLE
Add not NULL constraints to withrawn and historical

### DIFF
--- a/db/migrate/20181030120956_add_withdrawn_and_historical_constraints.rb
+++ b/db/migrate/20181030120956_add_withdrawn_and_historical_constraints.rb
@@ -1,0 +1,13 @@
+class AddWithdrawnAndHistoricalConstraints < ActiveRecord::Migration[5.2]
+  def up
+    Dimensions::Edition.where("withdrawn IS NULL").update_all(withdrawn: false)
+    Dimensions::Edition.where("historical IS NULL").update_all(historical: false)
+    change_column_null :dimensions_editions, :withdrawn, false
+    change_column_null :dimensions_editions, :historical, false
+  end
+
+  def down
+    change_column_null :dimensions_editions, :withdrawn, true
+    change_column_null :dimensions_editions, :historical, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_29_112946) do
+ActiveRecord::Schema.define(version: 2018_10_30_120956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,11 +64,12 @@ ActiveRecord::Schema.define(version: 2018_10_29_112946) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
-    t.string "warehouse_item_id", null: false
     t.json "raw_json"
-    t.boolean "withdrawn"
-    t.boolean "historical"
+    t.string "warehouse_item_id", null: false
+    t.boolean "withdrawn", null: false
+    t.boolean "historical", null: false
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
+    t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -10,6 +10,9 @@ FactoryBot.define do
     schema_name { 'detailed_guide' }
     document_type { 'detailed_guide' }
     warehouse_item_id { "#{content_id}:#{locale}:#{base_path}" }
+    withdrawn { false }
+    historical { false }
+
     transient do
       date { Time.zone.today }
       replaces { nil }


### PR DESCRIPTION
This adds the migrations to apply not NULL constraints for withdrawn and historical columns in Editions table. We are apply this constraint as we should always know the status of a content item.