### PR TITLE
Improve the performance of /organisations

### DIFF
--- a/app/domain/queries/find_all_organisations.rb
+++ b/app/domain/queries/find_all_organisations.rb
@@ -5,8 +5,15 @@ class Queries::FindAllOrganisations
 
   def retrieve
     Dimensions::Edition.latest
-      .select(:organisation_id, :primary_organisation_title)
-      .distinct
-      .order(:primary_organisation_title).to_a
+      .where(document_type: 'organisation')
+      .order(:title)
+      .pluck(:content_id, :title)
+      .map(&method(:convert_result))
+  end
+
+private
+
+  def convert_result(arry)
+    { organisation_id: arry[0], title: arry[1] }
   end
 end

--- a/app/views/organisation/index.json.jbuilder
+++ b/app/views/organisation/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.organisations @organisations do |organisation|
-  json.title organisation.primary_organisation_title
-  json.organisation_id organisation.organisation_id
+  json.title organisation[:title]
+  json.organisation_id organisation[:organisation_id]
 end

--- a/spec/domain/queries/find_all_organisations_spec.rb
+++ b/spec/domain/queries/find_all_organisations_spec.rb
@@ -2,17 +2,16 @@ RSpec.describe Queries::FindAllOrganisations do
   context 'when we have data' do
     before do
       create :user
-      create :edition, organisation_id: 'org-1-id', primary_organisation_title: 'z Org'
-      create :edition, organisation_id: 'org-1-id', primary_organisation_title: 'z Org'
-      create :edition, organisation_id: 'org-2-id', primary_organisation_title: 'a Org'
+      create :edition, document_type: 'organisation', content_id: 'org-1-id', title: 'z Org'
+      create :edition, document_type: 'organisation', content_id: 'org-2-id', title: 'a Org'
     end
 
     it 'returns distinct organisations ordered by primary_organisation_title' do
       results = described_class.retrieve
-      expect(results.pluck(:primary_organisation_title, :organisation_id)).to eq([
-                          ['a Org', 'org-2-id'],
-                          ['z Org', 'org-1-id']
-                        ])
+      expect(results).to eq([
+                            { title: 'a Org', organisation_id: 'org-2-id' },
+                            { title: 'z Org', organisation_id: 'org-1-id' }
+                          ])
     end
   end
 

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe '/organisations' do
   before do
     create :user
-    create :edition, organisation_id: 'org-1-id', primary_organisation_title: 'z Org'
-    create :edition, organisation_id: 'org-1-id', primary_organisation_title: 'z Org'
-    create :edition, organisation_id: 'org-2-id', primary_organisation_title: 'a Org'
+    create :edition, document_type: 'organisation', content_id: 'org-1-id', title: 'z Org'
+    create :edition, document_type: 'organisation', content_id: 'org-2-id', title: 'a Org'
   end
 
   it 'returns distinct organisations ordered by title' do


### PR DESCRIPTION
The /organisations endpoint has unacceptable performance.

The performance is getting worse as the database grows.

This commit retrieves organisation by returning documents
with a content_type of `organisation`.