### PR TITLE
Add aggregations by month to the Facts::Metrics table

### DIFF
--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -8,6 +8,7 @@ class Etl::Aggregations::Monthly
   end
 
   def process
+    ::Aggregations::MonthlyMetric.where(dimensions_month_id: month).delete_all
     ActiveRecord::Base.connection.execute(query)
   end
 

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -1,0 +1,48 @@
+class Etl::Aggregations::Monthly
+  def self.process(*args)
+    new(*args).process
+  end
+
+  def initialize(date: Date.yesterday)
+    @date = date
+  end
+
+  def process
+    ActiveRecord::Base.connection.execute(query)
+  end
+
+private
+
+  attr_reader :date
+
+  def from
+    date.beginning_of_month
+  end
+
+  def to
+    date.end_of_month
+  end
+
+  def month
+    Dimensions::Month.build(from)
+  end
+
+  def query
+    <<~SQL
+      INSERT INTO aggregations_monthly_metrics (
+        dimensions_month_id,
+        dimensions_edition_id,
+        pviews,
+        upviews,
+        updated_at,
+        created_at
+      )
+      SELECT '#{month.id}', max(dimensions_edition_id), sum(pviews), sum(upviews), now(), now()
+      FROM facts_metrics
+      INNER JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+      INNER JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+      WHERE dimensions_date_id >= '#{from}' AND dimensions_date_id <= '#{to}'
+      GROUP BY warehouse_item_id
+    SQL
+  end
+end

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -1,4 +1,6 @@
 class Etl::Aggregations::Monthly
+  include Concerns::Traceable
+
   def self.process(*args)
     new(*args).process
   end

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -17,7 +17,7 @@ private
   attr_reader :date
 
   def delete_month
-    Aggregations::MonthlyMetric.where(dimensions_month_id: month).delete_all
+    ::Aggregations::MonthlyMetric.where(dimensions_month_id: month).delete_all
   end
 
   def aggregate_month

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -35,10 +35,33 @@ private
         dimensions_edition_id,
         pviews,
         upviews,
+        entrances,
+        searches,
+        bounce_rate,
+        feedex,
+        satisfaction,
+        useful_yes,
+        useful_no,
+        exits,
+        avg_page_time,
         updated_at,
         created_at
       )
-      SELECT '#{month.id}', max(dimensions_edition_id), sum(pviews), sum(upviews), now(), now()
+      SELECT '#{month.id}',
+        max(dimensions_edition_id),
+        sum(pviews),
+        sum(upviews),
+        sum(entrances),
+        sum(searches),
+        sum(bounce_rate),
+        sum(feedex),
+        sum(satisfaction),
+        sum(useful_yes),
+        sum(useful_no),
+        sum(exits),
+        sum(avg_page_time),
+        now(),
+        now()
       FROM facts_metrics
       INNER JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
       INNER JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -10,13 +10,18 @@ class Etl::Aggregations::Monthly
   end
 
   def process
+    create_month
     delete_month
     aggregate_month
   end
 
 private
 
-  attr_reader :date
+  attr_reader :date, :month
+
+  def create_month
+    @month = Dimensions::Month.find_or_create(date)
+  end
 
   def delete_month
     ::Aggregations::MonthlyMetric.where(dimensions_month_id: month).delete_all
@@ -32,10 +37,6 @@ private
 
   def to
     date.end_of_month
-  end
-
-  def month
-    Dimensions::Month.build(from)
   end
 
   def aggregation_query

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -8,13 +8,21 @@ class Etl::Aggregations::Monthly
   end
 
   def process
-    ::Aggregations::MonthlyMetric.where(dimensions_month_id: month).delete_all
-    ActiveRecord::Base.connection.execute(query)
+    delete_month
+    aggregate_month
   end
 
 private
 
   attr_reader :date
+
+  def delete_month
+    Aggregations::MonthlyMetric.where(dimensions_month_id: month).delete_all
+  end
+
+  def aggregate_month
+    ActiveRecord::Base.connection.execute(aggregation_query)
+  end
 
   def from
     date.beginning_of_month
@@ -28,7 +36,7 @@ private
     Dimensions::Month.build(from)
   end
 
-  def query
+  def aggregation_query
     <<~SQL
       INSERT INTO aggregations_monthly_metrics (
         dimensions_month_id,

--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -27,6 +27,7 @@ class Etl::Master::MasterProcessor
         Monitor::Etl.run
         Monitor::Dimensions.run
         Monitor::Facts.run
+        Monitor::Aggregations.run
       end
     end
   end

--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -19,7 +19,7 @@ class Etl::Master::MasterProcessor
       Etl::GA::InternalSearchProcessor.process(date: date)
       Etl::Feedex::Processor.process(date: date)
 
-      Etl::Aggregations::Monthly.process(date: date)
+      Etl::Aggregations::Monthly.process(date: date) unless historic_data?
     end
 
     time(process: :monitor) do

--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -18,6 +18,8 @@ class Etl::Master::MasterProcessor
       Etl::GA::UserFeedbackProcessor.process(date: date)
       Etl::GA::InternalSearchProcessor.process(date: date)
       Etl::Feedex::Processor.process(date: date)
+
+      Etl::Aggregations::Monthly.process(date: date)
     end
 
     time(process: :monitor) do

--- a/app/domain/monitor/aggregations.rb
+++ b/app/domain/monitor/aggregations.rb
@@ -1,0 +1,32 @@
+class Monitor::Aggregations
+  def self.run(*args)
+    new(*args).run
+  end
+
+  def run
+    statsd_for_all_monthly_aggregations!
+    statsd_for_current_month!
+  end
+
+private
+
+  def statsd_for_all_monthly_aggregations!
+    path = path_for('all')
+    count = Aggregations::MonthlyMetric.count
+
+    GovukStatsd.count(path, count)
+  end
+
+  def statsd_for_current_month!
+    path = path_for('current')
+    count = Aggregations::MonthlyMetric
+              .where(dimensions_month: Dimensions::Month.current)
+              .count
+
+    GovukStatsd.count(path, count)
+  end
+
+  def path_for(item)
+    "monitor.aggregations.#{item}"
+  end
+end

--- a/app/models/aggregations.rb
+++ b/app/models/aggregations.rb
@@ -1,0 +1,5 @@
+module Aggregations
+  def self.table_name_prefix
+    'aggregations_'
+  end
+end

--- a/app/models/aggregations/monthly_metric.rb
+++ b/app/models/aggregations/monthly_metric.rb
@@ -1,0 +1,7 @@
+class Aggregations::MonthlyMetric < ApplicationRecord
+  belongs_to :dimensions_month, class_name: 'Dimensions::Month'
+  belongs_to :dimensions_edition, class_name: 'Dimensions::Edition'
+
+  validates :dimensions_month, presence: true
+  validates :dimensions_edition, presence: true
+end

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -17,6 +17,14 @@ class Dimensions::Month < ApplicationRecord
     build(Date.today)
   end
 
+  def self.find_or_create(date)
+    month = build(date)
+    month.save!
+    month
+  rescue ActiveRecord::RecordNotUnique
+    find(month.id)
+  end
+
   def self.build(date)
     new(
       id: format('%04d-%02d', date.year, date.month),

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -7,14 +7,8 @@ class Dimensions::Month < ApplicationRecord
   validates :month_name, presence: true, inclusion: { in: ::Date::MONTHNAMES }
   validates :month_name_abbreviated, presence: true, inclusion: { in: ::Date::ABBR_MONTHNAMES }
 
-  def self.build_from_string(month_s)
-    year, month = *month_s.split('-')
-
-    build Date.new(year.to_i, month.to_i, 1)
-  end
-
   def self.current
-    build(Date.today)
+    find_or_create(Date.today)
   end
 
   def self.find_or_create(date)

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -1,0 +1,18 @@
+class Dimensions::Month < ApplicationRecord
+  validates :year, presence: true, numericality: { only_integer: true }
+  validates :quarter, presence: true, numericality: { only_integer: true }, inclusion: { in: (1..4) }
+  validates :month_number, presence: true, numericality: { only_integer: true }, inclusion: { in: (1..12) }
+  validates :month_name, presence: true, inclusion: { in: ::Date::MONTHNAMES }
+  validates :month_name_abbreviated, presence: true, inclusion: { in: ::Date::ABBR_MONTHNAMES }
+
+  def self.build(date)
+    new(
+      id: format('%04d-%02d', date.year, date.month),
+      month_number: date.month,
+      month_name: date.strftime('%B'),
+      month_name_abbreviated: date.strftime('%b'),
+      year: date.year,
+      quarter: ((date.month - 1) / 3) + 1,
+    )
+  end
+end

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -5,6 +5,12 @@ class Dimensions::Month < ApplicationRecord
   validates :month_name, presence: true, inclusion: { in: ::Date::MONTHNAMES }
   validates :month_name_abbreviated, presence: true, inclusion: { in: ::Date::ABBR_MONTHNAMES }
 
+  def self.build_from_string(month_s)
+    year, month = *month_s.split('-')
+
+    build Date.new(year.to_i, month.to_i, 1)
+  end
+
   def self.build(date)
     new(
       id: format('%04d-%02d', date.year, date.month),

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -11,6 +11,10 @@ class Dimensions::Month < ApplicationRecord
     build Date.new(year.to_i, month.to_i, 1)
   end
 
+  def self.current
+    build(Date.today)
+  end
+
   def self.build(date)
     new(
       id: format('%04d-%02d', date.year, date.month),

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -1,4 +1,6 @@
 class Dimensions::Month < ApplicationRecord
+  self.primary_key = :id
+
   validates :year, presence: true, numericality: { only_integer: true }
   validates :quarter, presence: true, numericality: { only_integer: true }, inclusion: { in: (1..4) }
   validates :month_number, presence: true, numericality: { only_integer: true }, inclusion: { in: (1..12) }

--- a/db/migrate/20181031112754_create_dimensions_months.rb
+++ b/db/migrate/20181031112754_create_dimensions_months.rb
@@ -1,0 +1,15 @@
+class CreateDimensionsMonths < ActiveRecord::Migration[5.2]
+  def change
+    create_table :dimensions_months, id: false do |t|
+      t.string :id, null: false
+      t.string :month_name, null: false
+      t.string :month_name_abbreviated, null: false
+      t.integer :month_number, null: false
+      t.integer :quarter, null: false
+      t.integer :year, null: false
+
+      t.timestamps null: false
+      t.index :id, unique: true
+    end
+  end
+end

--- a/db/migrate/20181031124930_create_aggregations_monthly_metrics.rb
+++ b/db/migrate/20181031124930_create_aggregations_monthly_metrics.rb
@@ -1,0 +1,27 @@
+class CreateAggregationsMonthlyMetrics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :aggregations_monthly_metrics do |t|
+      t.string :dimensions_month_id, null: false
+      t.references :dimensions_edition, null: false
+
+      t.integer :pviews, null: false, default: 0
+      t.integer :upviews, null: false, default: 0
+      t.integer :feedex, null: false, default: 0
+      t.integer :useful_yes, null: false, default: 0
+      t.integer :useful_no, null: false, default: 0
+      t.integer :searches, null: false, default: 0
+      t.integer :exits, null: false, default: 0
+      t.integer :entrances, null: false, default: 0
+      t.integer :bounce_rate, null: false, default: 0
+      t.integer :avg_page_time, null: false, default: 0
+      t.integer :bounces, null: false, default: 0
+      t.integer :page_time, null: false, default: 0
+      t.float :satisfaction, null: false, default: 0.0
+
+      t.timestamps
+
+      t.index %w[dimensions_month_id]
+      t.index %w[dimensions_edition_id dimensions_month_id], name: 'index_editions_months_unique', unique: true
+    end
+  end
+end

--- a/db/migrate/20181101123329_add_foreign_key_to_monthly_aggregation.rb
+++ b/db/migrate/20181101123329_add_foreign_key_to_monthly_aggregation.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToMonthlyAggregation < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :aggregations_monthly_metrics, :dimensions_months, foreign_key: :dimensions_month_id, primary_key: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_31_124930) do
+ActiveRecord::Schema.define(version: 2018_11_01_163411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2018_10_31_124930) do
     t.integer "year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["id"], name: "index_dimensions_months_on_id", unique: true
   end
 
   create_table "events_feedexes", force: :cascade do |t|
@@ -193,6 +194,7 @@ ActiveRecord::Schema.define(version: 2018_10_31_124930) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "aggregations_monthly_metrics", "dimensions_months"
   add_foreign_key "facts_editions", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_editions", "dimensions_editions"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_01_163411) do
+ActiveRecord::Schema.define(version: 2018_10_31_112754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,12 +64,11 @@ ActiveRecord::Schema.define(version: 2018_11_01_163411) do
     t.string "previous_version"
     t.string "update_type"
     t.datetime "last_edited_at"
-    t.json "raw_json"
     t.string "warehouse_item_id", null: false
+    t.json "raw_json"
     t.boolean "withdrawn", null: false
     t.boolean "historical", null: false
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
-    t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
@@ -80,6 +79,17 @@ ActiveRecord::Schema.define(version: 2018_11_01_163411) do
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"
     t.index ["warehouse_item_id", "latest"], name: "index_dimensions_editions_warehouse_item_id_latest"
     t.index ["warehouse_item_id"], name: "index_dimensions_editions_warehouse_item_id"
+  end
+
+  create_table "dimensions_months", id: false, force: :cascade do |t|
+    t.string "id", null: false
+    t.string "month_name", null: false
+    t.string "month_name_abbreviated", null: false
+    t.integer "month_number", null: false
+    t.integer "quarter", null: false
+    t.integer "year", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "events_feedexes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_31_112754) do
+ActiveRecord::Schema.define(version: 2018_10_31_124930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "aggregations_monthly_metrics", force: :cascade do |t|
+    t.string "dimensions_month_id", null: false
+    t.bigint "dimensions_edition_id", null: false
+    t.integer "pviews", default: 0, null: false
+    t.integer "upviews", default: 0, null: false
+    t.integer "feedex", default: 0, null: false
+    t.integer "useful_yes", default: 0, null: false
+    t.integer "useful_no", default: 0, null: false
+    t.integer "searches", default: 0, null: false
+    t.integer "exits", default: 0, null: false
+    t.integer "entrances", default: 0, null: false
+    t.integer "bounce_rate", default: 0, null: false
+    t.integer "avg_page_time", default: 0, null: false
+    t.integer "bounces", default: 0, null: false
+    t.integer "page_time", default: 0, null: false
+    t.float "satisfaction", default: 0.0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dimensions_edition_id", "dimensions_month_id"], name: "index_editions_months_unique", unique: true
+    t.index ["dimensions_edition_id"], name: "index_aggregations_monthly_metrics_on_dimensions_edition_id"
+    t.index ["dimensions_month_id"], name: "index_aggregations_monthly_metrics_on_dimensions_month_id"
+  end
 
   create_table "dimensions_dates", primary_key: "date", id: :date, force: :cascade do |t|
     t.string "date_name", null: false

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Etl::Aggregations::Monthly do
+  subject { described_class }
+  let!(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
+  let!(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
+
+  it 'calculates the monthly aggregations for a month' do
+    create :metric, edition: edition1, date: '2018-02-20', pviews: 20, upviews: 10
+    create :metric, edition: edition1, date: '2018-02-21', pviews: 40, upviews: 20
+    create :metric, edition: edition1, date: '2018-02-22', pviews: 60, upviews: 30
+
+    create :metric, edition: edition2, date: '2018-02-20', pviews: 100, upviews: 10
+    create :metric, edition: edition2, date: '2018-02-21', pviews: 200, upviews: 20
+
+    subject.process(date: Date.new(2018, 2, 20))
+
+    results = Aggregations::MonthlyMetric.all
+
+    expect(results.count).to eq(2)
+    expect(results).to all(have_attributes(dimensions_month_id: '2018-02'))
+
+    expect(results.first).to have_attributes(
+      dimensions_edition_id: edition1.id,
+      pviews: 120,
+      upviews: 60
+    )
+    expect(results.second).to have_attributes(
+      dimensions_edition_id: edition2.id,
+      pviews: 300,
+      upviews: 30
+    )
+  end
+end

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Etl::Aggregations::Monthly do
   let(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
   let(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
 
-  before do
-  end
-
   it 'calculates monthly aggregations for a given date' do
     create :metric, edition: edition1, date: '2018-02-20', pviews: 20, upviews: 10
     create :metric, edition: edition1, date: '2018-02-21', pviews: 40, upviews: 20
@@ -52,6 +49,17 @@ RSpec.describe Etl::Aggregations::Monthly do
       pviews: 40,
       upviews: 20,
     )
+  end
+
+  Metric.daily_metrics.map(&:name).each do |metric_name|
+    it "Calculates aggregations for metric: `#{metric_name}`" do
+      create :metric, edition: edition1, date: '2018-02-21', metric_name => 10
+      create :metric, edition: edition1, date: '2018-02-22', metric_name => 20
+
+      subject.process(date: date)
+
+      expect(Aggregations::MonthlyMetric.first).to have_attributes(metric_name => 30)
+    end
   end
 
   describe 'it can run multiple times for any month' do

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe Etl::Aggregations::Monthly do
       upviews: 30
     )
   end
+
+  it 'does not include metrics from other months' do
+    create :metric, edition: edition1, date: '2018-01-31', pviews: 20, upviews: 10
+    create :metric, edition: edition1, date: '2018-02-21', pviews: 40, upviews: 20
+    create :metric, edition: edition1, date: '2018-03-01', pviews: 60, upviews: 30
+
+    subject.process(date: Date.new(2018, 2, 20))
+
+    results = Aggregations::MonthlyMetric.all
+
+    expect(results.count).to eq(1)
+    expect(results.first).to have_attributes(
+      dimensions_month_id: '2018-02',
+      dimensions_edition_id: edition1.id,
+      pviews: 40,
+      upviews: 20,
+    )
+  end
 end

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Etl::Aggregations::Monthly do
   let(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
 
   before do
-
   end
 
   it 'calculates monthly aggregations for a given date' do

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -1,7 +1,14 @@
 RSpec.describe Etl::Aggregations::Monthly do
   subject { described_class }
-  let!(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
-  let!(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
+
+  let(:date) { Date.new(2018, 2, 20) }
+
+  let(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
+  let(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
+
+  before do
+
+  end
 
   it 'calculates the monthly aggregations for a month' do
     create :metric, edition: edition1, date: '2018-02-20', pviews: 20, upviews: 10
@@ -11,7 +18,7 @@ RSpec.describe Etl::Aggregations::Monthly do
     create :metric, edition: edition2, date: '2018-02-20', pviews: 100, upviews: 10
     create :metric, edition: edition2, date: '2018-02-21', pviews: 200, upviews: 20
 
-    subject.process(date: Date.new(2018, 2, 20))
+    subject.process(date: date)
 
     results = Aggregations::MonthlyMetric.all
 
@@ -35,7 +42,7 @@ RSpec.describe Etl::Aggregations::Monthly do
     create :metric, edition: edition1, date: '2018-02-21', pviews: 40, upviews: 20
     create :metric, edition: edition1, date: '2018-03-01', pviews: 60, upviews: 30
 
-    subject.process(date: Date.new(2018, 2, 20))
+    subject.process(date: date)
 
     results = Aggregations::MonthlyMetric.all
 

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -53,10 +53,22 @@ RSpec.describe Etl::Master::MasterProcessor do
     subject.process
   end
 
-  it 'calculate the aggregations' do
-    expect(Etl::Aggregations::Monthly).to receive(:process).with(date: Date.new(2018, 2, 19))
+  describe 'Aggregations' do
+    context 'when the day before' do
+      it 'calculate the aggregations' do
+        expect(Etl::Aggregations::Monthly).to receive(:process).with(date: Date.new(2018, 2, 19))
 
-    subject.process
+        subject.process
+      end
+    end
+
+    context 'when not the day before' do
+      it 'does not calculate the aggregations' do
+        expect(Etl::Aggregations::Monthly).to_not receive(:process).with(date: Date.new(2018, 2, 18))
+
+        subject.process(date: Date.new(2018, 2, 18))
+      end
+    end
   end
 
   describe 'Monitoring' do

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe Etl::Master::MasterProcessor do
 
         subject.process
       end
+
+      it 'monitor Aggregations' do
+        expect(Monitor::Aggregations).to receive(:run)
+
+        subject.process
+      end
     end
 
     context 'not the day before' do

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Etl::Master::MasterProcessor do
     subject.process
   end
 
+  it 'calculate the aggregations' do
+    expect(Etl::Aggregations::Monthly).to receive(:process).with(date: Date.new(2018, 2, 19))
+
+    subject.process
+  end
+
   describe 'Monitoring' do
     context 'the day before' do
       it 'monitors ETL processes' do

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Etl::Master::MasterProcessor do
 
   it 'update GA metrics in the Facts table' do
     expect(Etl::GA::ViewsAndNavigationProcessor).to receive(:process).with(date: Date.new(2018, 2, 19))
+    expect(Etl::GA::UserFeedbackProcessor).to receive(:process).with(date: Date.new(2018, 2, 19))
+    expect(Etl::GA::InternalSearchProcessor).to receive(:process).with(date: Date.new(2018, 2, 19))
 
     subject.process
   end

--- a/spec/domain/monitor/aggregations_spec.rb
+++ b/spec/domain/monitor/aggregations_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Monitor::Aggregations do
+  around do |example|
+    Timecop.freeze(Date.new(2018, 3, 15)) { example.run }
+  end
+
+  let(:yesterday) { '2018-03-14' }
+
+  before { allow(GovukStatsd).to receive(:count) }
+
+  it 'sends StatsD counter for all the aggregations' do
+    expect(GovukStatsd).to receive(:count).with("monitor.aggregations.all", 2)
+
+    create_list :monthly_metric, 2
+
+    subject.run
+  end
+
+  it 'sends StatsD counter for `daily` metrics' do
+    expect(GovukStatsd).to receive(:count).with("monitor.aggregations.current", 3)
+
+    create_list :monthly_metric, 2, month: '2018-01'
+    create_list :monthly_metric, 3, month: '2018-03'
+
+    subject.run
+  end
+end

--- a/spec/factories/aggregations_monthly_metrics.rb
+++ b/spec/factories/aggregations_monthly_metrics.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :aggregations_monthly_metric, class: 'Aggregations::MonthlyMetric' do
+  end
+end

--- a/spec/factories/aggregations_monthly_metrics.rb
+++ b/spec/factories/aggregations_monthly_metrics.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :aggregations_monthly_metric, class: 'Aggregations::MonthlyMetric' do
-  end
-end

--- a/spec/factories/dimensions_months.rb
+++ b/spec/factories/dimensions_months.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :dimensions_month, class: 'Dimensions::Month' do
+  end
+end

--- a/spec/factories/monthly_metrics.rb
+++ b/spec/factories/monthly_metrics.rb
@@ -5,7 +5,12 @@ FactoryBot.define do
       edition { create :edition }
     end
 
-    dimensions_month { Dimensions::Month.build_from_string(month) }
+    dimensions_month do
+      y, m = *month.split('-').map(&:to_i)
+
+      Dimensions::Month.find_or_create(Date.new(y, m, 1))
+    end
+
     dimensions_edition { edition }
 
     pviews { 10 }

--- a/spec/factories/monthly_metrics.rb
+++ b/spec/factories/monthly_metrics.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :monthly_metric, class: 'Aggregations::MonthlyMetric' do
+    transient do
+      month { Dimensions::Month.build(Date.today).id }
+      edition { create :edition }
+    end
+
+    dimensions_month { Dimensions::Month.build_from_string(month) }
+    dimensions_edition { edition }
+
+    pviews { 10 }
+    upviews { 10 }
+    feedex { 10 }
+    useful_yes { 10 }
+    useful_no { 10 }
+    searches { 10 }
+    exits { 10 }
+    entrances { 10 }
+    bounce_rate { 10 }
+    avg_page_time { 10 }
+    bounces { 10 }
+    page_time { 10 }
+    satisfaction { 10.0 }
+  end
+end

--- a/spec/integration/master/daily_metrics_spec.rb
+++ b/spec/integration/master/daily_metrics_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Master process spec' do
     validate_facts_metrics!
     validate_google_analytics!
     validate_feedex!
+    validate_aggregations!
     validate_monitoring!
   end
 
@@ -54,6 +55,18 @@ RSpec.describe 'Master process spec' do
       useful_yes: 1,
       useful_no: 1,
       satisfaction: 0.5
+    )
+  end
+
+  def validate_aggregations!
+    expect(Aggregations::MonthlyMetric.count).to eq(2)
+
+    aggregation = Aggregations::MonthlyMetric.find_by(dimensions_edition_id: latest_version.id)
+    expect(aggregation).to have_attributes(
+      dimensions_month_id: '2018-02',
+      dimensions_edition_id: latest_version.id,
+      pviews: 11,
+      upviews: 12,
     )
   end
 

--- a/spec/models/aggregations/monthly_metric_spec.rb
+++ b/spec/models/aggregations/monthly_metric_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Aggregations::MonthlyMetric, type: :model do
+  it { is_expected.to validate_presence_of(:dimensions_month) }
+  it { is_expected.to validate_presence_of(:dimensions_edition) }
+end

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -18,23 +18,6 @@ RSpec.describe Dimensions::Month, type: :model do
   it { is_expected.to validate_numericality_of(:quarter).only_integer }
   it { is_expected.to validate_inclusion_of(:quarter).in_range(1..4) }
 
-  describe '.build_from_string' do
-    subject { described_class }
-
-    it 'builds a month dimension' do
-      date = subject.build_from_string('2018-12')
-
-      expect(date).to have_attributes(
-        id: '2018-12',
-        month_number: 12,
-        month_name: 'December',
-        month_name_abbreviated: 'Dec',
-        quarter: 4,
-        year: 2018,
-      )
-    end
-  end
-
   describe '.find_or_create' do
     subject { described_class }
 
@@ -66,7 +49,7 @@ RSpec.describe Dimensions::Month, type: :model do
 
     it 'returns current month' do
       Timecop.freeze(2018, 10, 12) do
-        current_month = Dimensions::Month.build_from_string('2018-10')
+        current_month = Dimensions::Month.find_or_create(Date.today)
 
         expect(subject.current).to eq(current_month)
       end

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -35,6 +35,32 @@ RSpec.describe Dimensions::Month, type: :model do
     end
   end
 
+  describe '.find_or_create' do
+    subject { described_class }
+
+    context 'when month does exist' do
+      before { subject.current.save }
+
+      it 'returns the month if it exists' do
+        expect(-> { subject.find_or_create(Date.today) }).to change(Dimensions::Month, :count).by(0)
+      end
+
+      it 'returns the month' do
+        expect(subject.find_or_create(Date.today)).to eq(Dimensions::Month.current)
+      end
+    end
+
+    context 'when month does not exist' do
+      it 'creates the month' do
+        expect(-> { subject.find_or_create(Date.today) }).to change(Dimensions::Month, :count).by(1)
+      end
+
+      it 'returns the month' do
+        expect(subject.find_or_create(Date.today)).to eq(Dimensions::Month.current)
+      end
+    end
+  end
+
   describe '.current' do
     subject { described_class }
 

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Dimensions::Month, type: :model do
+  it { is_expected.to validate_presence_of(:month_number) }
+  it { is_expected.to validate_numericality_of(:month_number).only_integer }
+  it { is_expected.to validate_inclusion_of(:month_number).in_range(1..12) }
+
+  it { is_expected.to validate_presence_of(:month_name) }
+  it { is_expected.to validate_inclusion_of(:month_name).in_array(%w(January February March April May June July August September October November December)) }
+
+  it { is_expected.to validate_presence_of(:month_name_abbreviated) }
+  it { is_expected.to validate_inclusion_of(:month_name_abbreviated).in_array(%w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)) }
+
+  it { is_expected.to validate_presence_of(:year) }
+  it { is_expected.to validate_numericality_of(:year).only_integer }
+
+  it { is_expected.to validate_presence_of(:quarter) }
+  it { is_expected.to validate_numericality_of(:quarter).only_integer }
+  it { is_expected.to validate_inclusion_of(:quarter).in_range(1..4) }
+
+  describe '.build' do
+    subject { described_class }
+
+    it 'builds a month dimension' do
+      date = subject.build(Date.new(2018, 12, 1))
+
+      expect(date).to have_attributes(
+        id: '2018-12',
+        month_number: 12,
+        month_name: 'December',
+        month_name_abbreviated: 'Dec',
+        quarter: 4,
+        year: 2018,
+      )
+    end
+
+    it 'uses two digits to build the month' do
+      date = subject.build(2018, 2)
+
+      expect(date).to have_attributes(id: '2018-02')
+    end
+  end
+end

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe Dimensions::Month, type: :model do
   it { is_expected.to validate_numericality_of(:quarter).only_integer }
   it { is_expected.to validate_inclusion_of(:quarter).in_range(1..4) }
 
+  describe '.build_from_string' do
+    subject { described_class }
+
+    it 'builds a month dimension' do
+      date = subject.build_from_string('2018-12')
+
+      expect(date).to have_attributes(
+        id: '2018-12',
+        month_number: 12,
+        month_name: 'December',
+        month_name_abbreviated: 'Dec',
+        quarter: 4,
+        year: 2018,
+      )
+    end
+  end
+
   describe '.build' do
     subject { described_class }
 

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Dimensions::Month, type: :model do
     end
 
     it 'uses two digits to build the month' do
-      date = subject.build(2018, 2)
+      date = subject.build(Date.new(2018, 12, 1))
 
-      expect(date).to have_attributes(id: '2018-02')
+      expect(date).to have_attributes(id: '2018-12')
     end
   end
 end

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe Dimensions::Month, type: :model do
     end
   end
 
+  describe '.current' do
+    subject { described_class }
+
+    it 'returns current month' do
+      Timecop.freeze(2018, 10, 12) do
+        current_month = Dimensions::Month.build_from_string('2018-10')
+
+        expect(subject.current).to eq(current_month)
+      end
+    end
+  end
+
   describe '.build' do
     subject { described_class }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/1g4cnQxR/792-5-monthly-aggregations-for-all-metrics)

### What

Build monthly aggregations of metrics.

### Why

The `index` page needs to perform really fast. We can't have queries that take more than 10 seconds to render the results. For this reason, if we create monthly aggregations for our metrics, we will store 30 times less data, which will improve performance in several levels of magnitude.

This is a common practice in Data Warehouses, and it is recommended in order to present results in big ranges of time. In our case, we need to allow to query data for the last two years.

### Notes

1. I am not calculating aggregations for historic data. This will help the repopulation of metrics
2. It takes around 4 minutes to aggregate all metrics for one month, which is ok with our master process, because it is currently taking around 7-10 minutes on a daily basis.
3. I have decided to create a new table instead of snowflaking the Date dimension because it feels easier to maintain in the long run

Related PR: https://github.com/alphagov/govuk-puppet/pull/8269