### PR TITLE
Split migrations to prevent deadlock

### DIFF
--- a/db/migrate/20181030120956_add_withdrawn_and_historical_constraints.rb
+++ b/db/migrate/20181030120956_add_withdrawn_and_historical_constraints.rb
@@ -1,13 +1,9 @@
 class AddWithdrawnAndHistoricalConstraints < ActiveRecord::Migration[5.2]
   def up
-    Dimensions::Edition.where("withdrawn IS NULL").update_all(withdrawn: false)
-    Dimensions::Edition.where("historical IS NULL").update_all(historical: false)
-    change_column_null :dimensions_editions, :withdrawn, false
-    change_column_null :dimensions_editions, :historical, false
-  end
+    say 'Updating withdrawn for all editions'
+    Dimensions::Edition.update_all(withdrawn: false)
 
-  def down
-    change_column_null :dimensions_editions, :withdrawn, true
-    change_column_null :dimensions_editions, :historical, true
+    say 'Updating historical for all editions'
+    Dimensions::Edition.update_all(historical: false)
   end
 end

--- a/db/migrate/20181101163401_add_withdrawn_constraints.rb
+++ b/db/migrate/20181101163401_add_withdrawn_constraints.rb
@@ -1,0 +1,9 @@
+class AddWithdrawnConstraints < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :dimensions_editions, :withdrawn, false
+  end
+
+  def down
+    change_column_null :dimensions_editions, :withdrawn, true
+  end
+end

--- a/db/migrate/20181101163411_add_historical_constraints.rb
+++ b/db/migrate/20181101163411_add_historical_constraints.rb
@@ -1,0 +1,9 @@
+class AddHistoricalConstraints < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :dimensions_editions, :historical, false
+  end
+
+  def down
+    change_column_null :dimensions_editions, :historical, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_30_120956) do
+ActiveRecord::Schema.define(version: 2018_11_01_163411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We are getting a deadlock when running the migrations in production.
It wasn't happening in staging nor integration. Seems to be related to
other process that run at the same time (like the integration with 
PublishingAPI). 

By splitting the migration we decrease the scope of the transaction, and 
make it less likely the deadlocks.