### PR TITLE
Retries Job before raising Sentry errors

### DIFF
--- a/app/domain/streams/message_processor_job.rb
+++ b/app/domain/streams/message_processor_job.rb
@@ -1,5 +1,7 @@
 module Streams
   class MessageProcessorJob < ActiveJob::Base
+    retry_on ActiveRecord::RecordNotUnique, wait: 5.seconds, attempts: 3
+
     def perform(payload, routing_key)
       message = Messages::Factory.build(payload)
 

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -29,23 +29,6 @@ RSpec.describe 'Import edition metrics' do
     }
   end
 
-  it 'clones the existing edition if the content has not changed' do
-    create :edition, base_path: '/same-content', date: Date.today,
-        document_text: 'the same content',
-        publishing_api_payload_version: 1,
-        facts: existing_quality_metrics
-
-    message = build(:message,
-      schema_name: 'publication',
-      base_path: '/same-content',
-      payload_version: 2)
-    message.payload['details']['body'] = '<p>the same content</p>'
-
-    subject.process(message)
-
-    expect(find_latest_edition('/same-content')).to have_attributes(existing_quality_metrics)
-  end
-
   def find_latest_edition(base_path)
     Dimensions::Edition.latest_by_base_path([base_path]).first.facts_edition
   end


### PR DESCRIPTION
We expect to have errors related to duplicated editions from time to time 
because we can’t guarantee the order in which we receive the messages. 
Sometimes they might run at the same time.

By adding the retry at the Job level, we aim to prevent having actionable
errors in Sentry.