### PR TITLE
Rake task to re-populate GA pviews, upviews etc.

### DIFF
--- a/app/domain/etl/ga/views_and_navigation_processor.rb
+++ b/app/domain/etl/ga/views_and_navigation_processor.rb
@@ -1,3 +1,4 @@
+require_dependency 'concerns/traceable'
 class Etl::GA::ViewsAndNavigationProcessor
   include Concerns::Traceable
   include Etl::GA::Concerns::TransformPath

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -4,6 +4,17 @@ namespace :etl do
     Etl::Master::MasterProcessor.process
   end
 
+  desc 'Run Etl::GA::ViewsAndNavigationProcessor for range of dates'
+  task :repopulateviews, %i[from to] => [:environment] do |_t, args|
+    from = args[:from].to_date
+    to = args[:to].to_date
+    (from..to).each do |date|
+      puts "repopulating GA pviews for #{date}"
+      Etl::GA::ViewsAndNavigationProcessor.process(date: date)
+      puts "finished repopulating GA pviews for #{date}"
+    end
+  end
+
   desc 'Populate GA metrics for a date'
   task :ga, [:date] => [:environment] do |_t, args|
     date = args[:date]

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -1,8 +1,19 @@
-RSpec.describe 'rake etl:master', type: task do
+RSpec.describe 'etl.rake', type: task do
+  describe 'rake etl:master'
   it "calls Etl::Master::MasterProcessor.process" do
     processor = class_double(Etl::Master::MasterProcessor, process: true).as_stubbed_const
     expect(processor).to receive(:process)
 
     Rake::Task['etl:master'].invoke
+  end
+
+  describe 'rake etl:repopulateviews' do
+    it 'calls Etl::GA::ViewsAndNavigationProcessor with each date' do
+      processor = class_double(Etl::GA::ViewsAndNavigationProcessor, process: true).as_stubbed_const
+      Rake::Task['etl:repopulateviews'].invoke('2018-11-01', '2018-11-03')
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
+    end
   end
 end


### PR DESCRIPTION
Adds a rake task to run `Etl::GA::ViewsAndNavigationProcessor.process`
for each date across a range of dates.

You can run the task as follows:
```
bundle exec rake etl:repopulateviews[2018-09-01,2018-09-30]
```
Or if you are using zsh:
```
bundle exec rake etl:repopulateviews\[2018-09-01,2018-09-30\]
```