### PR TITLE
Use materialized views for the index page

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -15,7 +15,7 @@ private
   end
 
   def permitted_params
-    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size)
+    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range)
   end
 
   def validate_params!

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,4 +1,6 @@
-class Api::ContentRequest < Api::BaseRequest
+class Api::ContentRequest
+  include ActiveModel::Validations
+
   attr_reader :organisation_id, :document_type, :page, :page_size, :date_range
   validate :valid_organisation_id
   validate :valid_date_range
@@ -6,8 +8,6 @@ class Api::ContentRequest < Api::BaseRequest
   validates_numericality_of :page, :page_size, allow_nil: true
 
   def initialize(params)
-    super(params)
-
     @organisation_id = params[:organisation_id]
     @document_type = params[:document_type]
     @page = params[:page].try(:to_i)
@@ -22,8 +22,6 @@ class Api::ContentRequest < Api::BaseRequest
       date_range: date_range,
       page: page,
       page_size: page_size,
-      to: to,
-      from: from,
     }
   end
 

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,6 +1,8 @@
 class Api::ContentRequest < Api::BaseRequest
-  attr_reader :organisation_id, :document_type, :page, :page_size
+  attr_reader :organisation_id, :document_type, :page, :page_size, :date_range
   validate :valid_organisation_id
+  validate :valid_date_range
+
   validates_numericality_of :page, :page_size, allow_nil: true
 
   def initialize(params)
@@ -10,20 +12,28 @@ class Api::ContentRequest < Api::BaseRequest
     @document_type = params[:document_type]
     @page = params[:page].try(:to_i)
     @page_size = params[:page_size].try(:to_i)
+    @date_range = params[:date_range]
   end
 
   def to_filter
     {
       organisation_id: organisation_id,
       document_type: document_type,
-      from: from,
-      to: to,
+      date_range: date_range,
       page: page,
-      page_size: page_size
+      page_size: page_size,
+      to: to,
+      from: from,
     }
   end
 
 private
+
+  def valid_date_range
+    return true if DateRange.valid?(date_range) || date_range.blank?
+
+    errors.add('date_range', 'this is not a valid date range')
+  end
 
   def valid_organisation_id
     return true if UUID.validate organisation_id

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,35 +1,33 @@
 class Queries::FindContent
   DEFAULT_PAGE_SIZE = 100
+
   def self.call(filter:)
-    filter.assert_valid_keys :date_range, :organisation_id, :document_type, :page, :page_size, :from, :to
+    raise ArgumentError unless filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
+    filter.assert_valid_keys :date_range, :organisation_id, :document_type, :page, :page_size
 
     new(filter).call
   end
 
   def call
-    results = Facts::Metric.all
-      .joins(:dimensions_date).merge(slice_dates)
-      .joins(:dimensions_edition).merge(slice_editions)
-      .joins(latest_join)
-      .group('latest.warehouse_item_id', *group_columns)
-      .order(order_by)
-      .page(@page)
-      .per(@page_size)
+    results = Aggregations::SearchLastThirtyDays.all
+                .joins('INNER JOIN dimensions_editions ON aggregations_search_last_thirty_days.dimensions_edition_id = dimensions_editions.id')
+                .merge(slice_editions)
+                .order('upviews desc')
+                .page(@page)
+                .per(@page_size)
     {
-      results: results.pluck(*group_columns, *aggregates).map(&method(:array_to_hash)),
+      results: results.pluck(*aggregates).map(&method(:array_to_hash)),
       page: @page,
       total_pages: results.total_pages,
-      total_results: edition_count
+      total_results: slice_editions.count
     }
   end
 
 private
 
-  attr_reader :from, :to, :organisation_id, :document_type
+  attr_reader :organisation_id, :document_type, :date_range
 
   def initialize(filter)
-    @from = filter[:from] || filter.fetch(:date_range).from
-    @to = filter[:to] || filter.fetch(:date_range).to
     @organisation_id = filter.fetch(:organisation_id)
     @document_type = filter.fetch(:document_type)
     @page = filter[:page] || 1
@@ -37,28 +35,7 @@ private
   end
 
   def aggregates
-    [
-      sum('upviews'),
-      sum('useful_yes'),
-      sum('useful_no'),
-      sum('searches')
-    ]
-  end
-
-  def group_columns
-    %w[latest.base_path latest.title latest.document_type].map { |col| Arel.sql(col) }
-  end
-
-  def order_by
-    Arel.sql('latest.base_path')
-  end
-
-  def sum(column)
-    Arel.sql("SUM(#{column})")
-  end
-
-  def latest_join
-    "INNER JOIN dimensions_editions latest ON latest.warehouse_item_id = dimensions_editions.warehouse_item_id AND latest.latest = true"
+    %w(base_path title document_type upviews useful_yes useful_no searches)
   end
 
   def array_to_hash(array)
@@ -74,20 +51,10 @@ private
     }
   end
 
-  def edition_count
-    editions = Dimensions::Edition.latest.by_organisation_id(organisation_id)
-    editions = editions.by_document_type(document_type) if document_type
-    editions.count
-  end
-
   def slice_editions
     editions = Dimensions::Edition.all
-    editions = editions.where('latest.organisation_id = ?', organisation_id)
-    editions = editions.where('latest.document_type = ?', document_type) if document_type
+    editions = editions.where('organisation_id = ?', organisation_id)
+    editions = editions.where('document_type = ?', document_type) if document_type
     editions
-  end
-
-  def slice_dates
-    Dimensions::Date.between(from, to)
   end
 end

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,7 +1,7 @@
 class Queries::FindContent
   DEFAULT_PAGE_SIZE = 100
   def self.call(filter:)
-    filter.assert_valid_keys :from, :to, :organisation_id, :document_type, :page, :page_size
+    filter.assert_valid_keys :date_range, :organisation_id, :document_type, :page, :page_size, :from, :to
 
     new(filter).call
   end
@@ -28,8 +28,8 @@ private
   attr_reader :from, :to, :organisation_id, :document_type
 
   def initialize(filter)
-    @from = filter.fetch(:from)
-    @to = filter.fetch(:to)
+    @from = filter[:from] || filter.fetch(:date_range).from
+    @to = filter[:to] || filter.fetch(:date_range).to
     @organisation_id = filter.fetch(:organisation_id)
     @document_type = filter.fetch(:document_type)
     @page = filter[:page] || 1

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -1,0 +1,48 @@
+class DateRange
+  attr_reader :time_period, :to, :from
+
+  def initialize(time_period)
+    @time_period = time_period
+    @to = date_to_range[:to]
+    @from = date_to_range[:from]
+  end
+
+private
+
+  def date_to_range
+    case time_period
+    when 'last-30-days'
+      {
+        from: (Date.today - 30.days).to_s,
+        to: Date.today.to_s
+      }
+    when 'last-month'
+      {
+        from: Date.today.last_month.beginning_of_month.to_s,
+        to: Date.today.last_month.end_of_month.to_s
+      }
+    when 'last-3-months'
+      {
+        from: (Date.today - 3.months).to_s,
+        to: Date.today.to_s
+      }
+    when 'last-6-months'
+      {
+        from: (Date.today - 6.months).to_s,
+        to: Date.today.to_s
+      }
+    when 'last-year'
+      {
+        from: (Date.today - 1.year).to_s,
+        to: Date.today.to_s
+      }
+    when 'last-2-years'
+      {
+        from: (Date.today - 2.years).to_s,
+        to: Date.today.to_s
+      }
+    else
+      raise ArgumentError.new(time_period)
+    end
+  end
+end

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -1,10 +1,20 @@
 class DateRange
-  attr_reader :time_period, :to, :from
+  attr_reader :time_period
+  attr_accessor :to, :from
 
   def initialize(time_period)
     @time_period = time_period
     @to = date_to_range[:to]
     @from = date_to_range[:from]
+  end
+
+  def self.valid?(time_period)
+    time_period.in?(['last-30-days', 'last-month', 'last-3-months', 'last-6-months', 'last-year', 'last-2-years'])
+  end
+
+  def self.build(from:, to:)
+    @from = from
+    @to = to
   end
 
 private

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::ContentRequest do
         to: '2018-01-31',
         page: '1',
         page_size: '20',
+        date_range: 'last-30-days',
       )
 
       expect(request.to_filter).to eq(
@@ -17,6 +18,7 @@ RSpec.describe Api::ContentRequest do
         to: '2018-01-31',
         page: 1,
         page_size: 20,
+        date_range: 'last-30-days',
       )
     end
 
@@ -35,6 +37,7 @@ RSpec.describe Api::ContentRequest do
         to: nil,
         page: nil,
         page_size: nil,
+        date_range: nil,
       )
     end
   end

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe Api::ContentRequest do
       request = Api::ContentRequest.new(
         document_type: 'guide',
         organisation_id: 'the-id',
-        from: '2018-01-01',
-        to: '2018-01-31',
         page: '1',
         page_size: '20',
         date_range: 'last-30-days',
@@ -14,8 +12,6 @@ RSpec.describe Api::ContentRequest do
       expect(request.to_filter).to eq(
         document_type: 'guide',
         organisation_id: 'the-id',
-        from: '2018-01-01',
-        to: '2018-01-31',
         page: 1,
         page_size: 20,
         date_range: 'last-30-days',
@@ -26,15 +22,11 @@ RSpec.describe Api::ContentRequest do
       request = Api::ContentRequest.new(
         document_type: nil,
         organisation_id: nil,
-        from: nil,
-        to: nil,
       )
 
       expect(request.to_filter).to eq(
         document_type: nil,
         organisation_id: nil,
-        from: nil,
-        to: nil,
         page: nil,
         page_size: nil,
         date_range: nil,

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Queries::FindContent do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
 
@@ -24,8 +24,7 @@ RSpec.describe Queries::FindContent do
     create :metric, edition: edition2, date: 10.days.ago, upviews: 15, useful_yes: 8, useful_no: 19, searches: 10
     create :metric, edition: edition2, date: 11.days.ago, upviews: 10, useful_yes: 5, useful_no: 1, searches: 11
 
-    calculate_monthly_aggregations!
-    refresh_views
+    recalculate_aggregations!
 
     response = described_class.call(filter: filter)
     expect(response[:results]).to contain_exactly(
@@ -50,8 +49,7 @@ RSpec.describe Queries::FindContent do
     create :metric, edition: edition1, date: 15.days.ago
     create :metric, edition: edition2, date: 10.days.ago
 
-    calculate_monthly_aggregations!
-    refresh_views
+    recalculate_aggregations!
 
     response = described_class.call(filter: filter)
     expect(response[:results]).to contain_exactly(
@@ -67,8 +65,7 @@ RSpec.describe Queries::FindContent do
         create :metric, edition: edition, date: 15.days.ago, upviews: (100 - n)
       end
 
-      calculate_monthly_aggregations!
-      refresh_views
+      recalculate_aggregations!
     end
 
     it 'returns the first page of data with pagination info' do
@@ -103,8 +100,7 @@ RSpec.describe Queries::FindContent do
       edition = create :edition, organisation_id: primary_org_id
       create :metric, edition: edition, date: 15.days.ago, useful_yes: 0, useful_no: 0
 
-      calculate_monthly_aggregations!
-      refresh_views
+      recalculate_aggregations!
     end
 
     it 'returns the nil for the satisfaction' do
@@ -120,8 +116,7 @@ RSpec.describe Queries::FindContent do
     before do
       create :edition, date: '2018-02-01'
 
-      calculate_monthly_aggregations!
-      refresh_views
+      recalculate_aggregations!
     end
 
     it 'returns a empty array' do

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -1,12 +1,11 @@
 RSpec.describe Queries::FindContent do
+  include MonthlyAggregations
+
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
-  let(:warehouse_item_id) { '87d87ac6-e5b5-4065-a8b5-b7a43db648d2' }
-  let(:another_warehouse_item_id) { 'ebf0dd2f-9d99-48e3-84d0-e94a2108ef45' }
 
   let(:filter) do
     {
-      from: '2018-01-01',
-      to: '2018-02-01',
+      date_range: 'last-30-days',
       organisation_id: primary_org_id,
       document_type: nil
     }
@@ -16,180 +15,96 @@ RSpec.describe Queries::FindContent do
     create :user
   end
 
-  context 'metrics on multiple days' do
-    before do
-      edition = create :edition,
-        base_path: '/path/1',
-        date: '2018-01-01',
-        title: 'item 1 title',
-        document_type: 'news_story',
-        organisation_id: primary_org_id,
-        warehouse_item_id: warehouse_item_id
+  it 'returns the aggregations for the last 30 days' do
+    edition1 = create :edition, base_path: '/path1', date: 2.months.ago, organisation_id: primary_org_id
+    edition2 = create :edition, base_path: '/path2', date: 2.months.ago, organisation_id: primary_org_id
 
-      create :metric, edition: edition, date: '2018-01-01', upviews: 100, useful_yes: 50, useful_no: 20, searches: 20
-      create :metric, edition: edition, date: '2018-01-02', upviews: 133, useful_yes: 150, useful_no: 30, searches: 200
+    create :metric, edition: edition1, date: 15.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
+    create :metric, edition: edition1, date: 10.days.ago, upviews: 20, useful_yes: 5, useful_no: 1, searches: 1
+    create :metric, edition: edition2, date: 10.days.ago, upviews: 15, useful_yes: 8, useful_no: 19, searches: 10
+    create :metric, edition: edition2, date: 11.days.ago, upviews: 10, useful_yes: 5, useful_no: 1, searches: 11
 
-      other_edition = create :edition,
-        base_path: '/path/2',
-        date: '2018-01-01',
-        title: 'item 2 title',
-        document_type: 'press_release',
-        organisation_id: primary_org_id,
-        warehouse_item_id: another_warehouse_item_id
-      create :metric, edition: other_edition, date: '2018-01-01', upviews: 5, useful_yes: 5, useful_no: 4, searches: 4
-      create :metric, edition: other_edition, date: '2018-01-02', upviews: 15, useful_yes: 5, useful_no: 6, searches: 3
-    end
+    calculate_monthly_aggregations!
+    refresh_views
 
-    it 'aggregates the data by content item' do
-      results = described_class.call(filter: filter)
-      expect(results[:results]).to eq(
-        [
-          {
-            base_path: '/path/1',
-            title: 'item 1 title',
-            upviews: 233,
-            document_type: 'news_story',
-            satisfaction: 0.8,
-            satisfaction_score_responses: 250,
-            searches: 220
-          },
-          {
-            base_path: '/path/2',
-            title: 'item 2 title',
-            upviews: 20,
-            document_type: 'press_release',
-            satisfaction: 0.5,
-            satisfaction_score_responses: 20,
-            searches: 7
-          }
-        ]
-      )
-    end
+    response = described_class.call(filter: filter)
+    expect(response[:results]).to contain_exactly(
+      hash_including(upviews: 35, searches: 11, satisfaction: 0.5652173913043478, satisfaction_score_responses: 23),
+      hash_including(upviews: 25, searches: 21, satisfaction: 0.3939393939393939, satisfaction_score_responses: 33),
+    )
   end
 
-  context 'the attributes we are displaying have changed over time' do
-    before do
-      old_edition = create :edition,
-        date: '2018-01-01',
-        organisation_id: 'another-primary-org-id',
-        latest: false,
-        warehouse_item_id: warehouse_item_id
-      create :metric, edition: old_edition, date: '2018-01-02', upviews: 100, useful_yes: 10, useful_no: 10, searches: 15
+  it 'returns the metadata for the last 30 days' do
+    edition1 = create :edition,
+      base_path: '/path1',
+      organisation_id: primary_org_id,
+      title: 'title-01',
+      document_type: 'document-type-01'
 
-      new_edition = create :edition,
-        replaces: old_edition,
-        base_path: '/new/base/path',
-        date: '2018-01-02',
-        title: 'new title',
-        document_type: 'press_release',
-        organisation_id: primary_org_id
-      create :metric, edition: new_edition, date: '2018-01-02', upviews: 100, useful_yes: 50, useful_no: 50, searches: 5
-    end
+    edition2 = create :edition,
+      base_path: '/path2',
+      organisation_id: primary_org_id,
+      title: 'title-02',
+      document_type: 'document-type-02'
 
-    it 'returns aggregated metrics from all versions with metadata from the latest version' do
-      results = described_class.call(filter: filter)
-      expect(results[:results]).to eq(
-        [{
-          base_path: '/new/base/path',
-          title: 'new title',
-          upviews: 200,
-          document_type: 'press_release',
-          satisfaction: 0.5,
-          satisfaction_score_responses: 120,
-          searches: 20,
-        }]
-      )
-    end
+    create :metric, edition: edition1, date: 15.days.ago
+    create :metric, edition: edition2, date: 10.days.ago
 
-    it 'returns items matching the document_type of the latest version' do
-      results = described_class.call(filter: filter.merge(document_type: 'press_release'))
+    calculate_monthly_aggregations!
+    refresh_views
 
-      expect(results[:results].first).to include(document_type: 'press_release')
-    end
-
-    it 'does not return items matching the document_type of older versions' do
-      results = described_class.call(filter: filter.merge(document_type: 'news_story'))
-      expect(results[:results].count).to eq(0)
-    end
+    response = described_class.call(filter: filter)
+    expect(response[:results]).to contain_exactly(
+      hash_including(base_path: '/path1'),
+      hash_including(base_path: '/path2'),
+    )
   end
 
-  context 'when pagination parameters are provided' do
+  describe 'Pagination' do
     before do
-      (1..4).each do |n|
-        edition = create :edition,
-                         date: '2018-01-01',
-                         base_path: "/path/#{n}",
-                         organisation_id: primary_org_id
-        create :metric, edition: edition, date: '2018-01-01'
+      4.times do |n|
+        edition = create :edition, base_path: "/path/#{n}", organisation_id: primary_org_id
+        create :metric, edition: edition, date: 15.days.ago, upviews: (100 - n)
       end
+
+      calculate_monthly_aggregations!
+      refresh_views
     end
 
     it 'returns the first page of data with pagination info' do
-      results = described_class.call(filter: filter.merge(page: 1, page_size: 2))
-      paths = results[:results].map { |hsh| hsh[:base_path] }
-      expect(paths).to eq(['/path/1', '/path/2'])
-      expect(results).to include(
+      response = described_class.call(filter: filter.merge(page: 1, page_size: 2))
+      expect(response[:results]).to contain_exactly(
+        hash_including(base_path: '/path/0'),
+        hash_including(base_path: '/path/1'),
+      )
+      expect(response).to include(
         page: 1,
         total_pages: 2,
         total_results: 4,
-                         )
+      )
     end
 
     it 'returns the second page of data' do
-      results = described_class.call(filter: filter.merge(page: 2, page_size: 2))
-      paths = results[:results].map { |hsh| hsh[:base_path] }
-      expect(paths).to eq(['/path/3', '/path/4'])
-      expect(results).to include(
+      response = described_class.call(filter: filter.merge(page: 2, page_size: 2))
+      expect(response[:results]).to contain_exactly(
+        hash_including(base_path: '/path/2'),
+        hash_including(base_path: '/path/3'),
+      )
+      expect(response).to include(
         page: 2,
         total_pages: 2,
         total_results: 4,
-                         )
-    end
-
-    it 'responds to the page_size parameter' do
-      results = described_class.call(filter: filter.merge(page: 1, page_size: 5))
-      paths = results[:results].map { |hsh| hsh[:base_path] }
-      expect(paths).to eq(['/path/1', '/path/2', '/path/3', '/path/4'])
-      expect(results).to include(
-        page: 1,
-        total_pages: 1,
-        total_results: 4,
-                         )
+      )
     end
   end
 
-  context 'when no pagination parameters are provided' do
+  describe 'when no useful_yes/no.. responses' do
     before do
-      (1..101).each do |n|
-        edition = create :edition,
-                         date: '2018-01-01',
-                         base_path: "/path/#{n}",
-                         organisation_id: primary_org_id
-        create :metric, edition: edition, date: '2018-01-01'
-      end
-    end
+      edition = create :edition, organisation_id: primary_org_id
+      create :metric, edition: edition, date: 15.days.ago, useful_yes: 0, useful_no: 0
 
-    it 'defaults to page 1 with page size of 100' do
-      results = described_class.call(filter: filter)
-      expect(results[:results].count).to eq(100)
-      expect(results).to include(
-        page: 1,
-        total_pages: 2,
-        total_results: 101
-                         )
-    end
-  end
-
-  context 'when no useful_yes/no.. responses' do
-    before do
-      edition = create :edition,
-        date: '2018-01-01',
-        organisation_id: primary_org_id
-      create :metric,
-        edition: edition,
-        date: '2018-01-01',
-        useful_yes: 0,
-        useful_no: 0
+      calculate_monthly_aggregations!
+      refresh_views
     end
 
     it 'returns the nil for the satisfaction' do
@@ -201,8 +116,13 @@ RSpec.describe Queries::FindContent do
     end
   end
 
-  context 'when no metrics in the date range' do
-    before { create :edition, date: '2018-02-01' }
+  describe 'when no metrics in the date range' do
+    before do
+      create :edition, date: '2018-02-01'
+
+      calculate_monthly_aggregations!
+      refresh_views
+    end
 
     it 'returns a empty array' do
       results = described_class.call(filter: filter)
@@ -210,36 +130,17 @@ RSpec.describe Queries::FindContent do
     end
   end
 
-  context 'when no items exist for the organisation' do
-    it 'returns a empty array' do
-      results = described_class.call(filter: filter)
-      expect(results[:results]).to be_empty
-    end
-  end
-
-  context 'when invalid filter' do
+  describe 'when invalid filter' do
     it 'raises an error if no `organisation_id` attribute' do
       filter.delete :organisation_id
 
-      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
+      expect(-> { described_class.call(filter: filter) }).to raise_error(ArgumentError)
     end
 
-    it 'raises an error if no `document_type` attribute' do
-      filter.delete :document_type
+    it 'raises an error if no `date_range` attribute' do
+      filter.delete :date_range
 
-      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
-    end
-
-    it 'raises an error if no `to` attribute' do
-      filter.delete :to
-
-      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
-    end
-
-    it 'raises an error if no `from` attribute' do
-      filter.delete :from
-
-      expect(-> { described_class.call(filter: filter) }).to raise_error(KeyError)
+      expect(-> { described_class.call(filter: filter) }).to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     schema_name { 'detailed_guide' }
     document_type { 'detailed_guide' }
     warehouse_item_id { "#{content_id}:#{locale}:#{base_path}" }
+    organisation_id { '17d84dc6-e5b5-4065-a8b5-8783bd934938' }
     withdrawn { false }
     historical { false }
 

--- a/spec/models/aggregations/search_last_month_spec.rb
+++ b/spec/models/aggregations/search_last_month_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Aggregations::SearchLastMonth, type: :model do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   subject { described_class }
 
@@ -14,8 +14,7 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
     create :metric, edition: edition1, date: to, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
     create :metric, edition: edition1, date: (from + 15.days), upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(
@@ -34,8 +33,7 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
     create :metric, edition: edition1, date: from + 1.day
     create :metric, edition: edition2, date: from + 2.days
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
@@ -46,8 +44,7 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: (from - 1.day)
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(0)
     end
@@ -56,8 +53,7 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: (to + 1.day)
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(0)
     end
@@ -70,8 +66,7 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
     create :metric, edition: edition1, date: from
     create :metric, edition: edition2, date: from + 1.day
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)

--- a/spec/models/aggregations/search_last_six_months_spec.rb
+++ b/spec/models/aggregations/search_last_six_months_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   subject { described_class }
 
@@ -11,8 +11,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
     create :metric, edition: edition1, date: 3.months.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
     create :metric, edition: edition1, date: 7.months.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
@@ -26,8 +25,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
     create :metric, edition: edition1, date: 4.months.ago
     create :metric, edition: edition2, date: 5.months.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
@@ -37,8 +35,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: (6.months.ago - 1.day)
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(0)
     end
@@ -47,8 +44,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: Date.yesterday
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(1)
     end
@@ -62,8 +58,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
     create :metric, edition: edition1, date: 3.months.ago
     create :metric, edition: edition2, date: 4.month.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)

--- a/spec/models/aggregations/search_last_thirty_days_spec.rb
+++ b/spec/models/aggregations/search_last_thirty_days_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   subject { described_class }
 
@@ -11,8 +11,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     create :metric, edition: edition1, date: 15.days.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
     create :metric, edition: edition1, date: 31.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
@@ -26,8 +25,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     create :metric, edition: edition1, date: 16.days.ago
     create :metric, edition: edition2, date: 30.days.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
@@ -37,8 +35,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: 31.days.ago
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(0)
     end
@@ -47,8 +44,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: Date.yesterday
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(1)
     end
@@ -62,8 +58,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     create :metric, edition: edition1, date: 15.days.ago
     create :metric, edition: edition2, date: 15.days.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)

--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   subject { described_class }
 
@@ -11,8 +11,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
     create :metric, edition: edition1, date: 2.months.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
     create :metric, edition: edition1, date: 4.months.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
@@ -26,8 +25,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
     create :metric, edition: edition1, date: 2.months.ago
     create :metric, edition: edition2, date: 3.months.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
@@ -37,8 +35,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: (3.months.ago - 1.day)
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(0)
     end
@@ -47,8 +44,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: Date.yesterday
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(1)
     end
@@ -62,8 +58,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
     create :metric, edition: edition1, date: 2.months.ago
     create :metric, edition: edition2, date: 1.month.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)

--- a/spec/models/aggregations/search_last_twelve_months_spec.rb
+++ b/spec/models/aggregations/search_last_twelve_months_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   subject { described_class }
 
@@ -11,8 +11,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
     create :metric, edition: edition1, date: 6.months.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
     create :metric, edition: edition1, date: 13.months.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
@@ -26,8 +25,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
     create :metric, edition: edition1, date: 7.months.ago
     create :metric, edition: edition2, date: 10.months.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
@@ -37,8 +35,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
       create :metric, edition: edition1, date: (12.months.ago - 1.day)
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(0)
     end
@@ -47,8 +44,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 11.months.ago
       create :metric, edition: edition1, date: Date.yesterday
 
-      calculate_monthly_aggregations!
-      subject.refresh
+      recalculate_aggregations!
 
       expect(subject.count).to eq(1)
     end
@@ -62,8 +58,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
     create :metric, edition: edition1, date: 2.months.ago
     create :metric, edition: edition2, date: 1.month.ago
 
-    calculate_monthly_aggregations!
-    subject.refresh
+    recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe DateRange do
     end
   end
 
+  describe '.valid?' do
+    it 'returns false if invalid parameter' do
+      expect(DateRange.valid?(:invalid_parameter)).to be_falsey
+    end
+
+    it 'returns true if valid parameters' do
+      expect(DateRange.valid?('last-30-days')).to be_truthy
+    end
+  end
+
   context 'When invalid parameters' do
     it 'raises an ArgumentError' do
       expect(-> { DateRange.new(:invalid_parameter) }).to raise_error(ArgumentError)

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe DateRange do
+  around do |example|
+    Timecop.freeze Date.new(2018, 12, 25) do
+      example.run
+    end
+  end
+
+  context 'When invalid parameters' do
+    it 'raises an ArgumentError' do
+      expect(-> { DateRange.new(:invalid_parameter) }).to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'for last 30 days' do
+    let(:time_period) { 'last-30-days' }
+
+    subject { DateRange.new(time_period) }
+
+    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(from: '2018-11-25') }
+    it { is_expected.to have_attributes(time_period: 'last-30-days') }
+  end
+
+  describe 'for last month' do
+    let(:time_period) { 'last-month' }
+
+    subject { DateRange.new(time_period) }
+
+    it { is_expected.to have_attributes(to: '2018-11-30') }
+    it { is_expected.to have_attributes(from: '2018-11-01') }
+    it { is_expected.to have_attributes(time_period: 'last-month') }
+  end
+
+  describe 'for last 3 months' do
+    let(:time_period) { 'last-3-months' }
+
+    subject { DateRange.new(time_period) }
+
+    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(from: '2018-09-25') }
+    it { is_expected.to have_attributes(time_period: 'last-3-months') }
+  end
+
+  describe 'for last 6 months' do
+    let(:time_period) { 'last-6-months' }
+
+    subject { DateRange.new(time_period) }
+
+    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(from: '2018-06-25') }
+    it { is_expected.to have_attributes(time_period: 'last-6-months') }
+  end
+
+  describe 'for last year' do
+    let(:time_period) { 'last-year' }
+
+    subject { DateRange.new(time_period) }
+
+    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(from: '2017-12-25') }
+    it { is_expected.to have_attributes(time_period: 'last-year') }
+  end
+end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe '/content' do
-  include MonthlyAggregations
+  include AggregationsSupport
 
   before { create :user }
 
@@ -16,8 +16,7 @@ RSpec.describe '/content' do
       edition3 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: '/path-02'
       create :metric, date: 10.days.ago, edition: edition3, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
 
-      calculate_monthly_aggregations!
-      refresh_views
+      recalculate_aggregations!
     end
 
     subject { get '/content', params: { date_range: 'last-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' } }
@@ -59,8 +58,7 @@ RSpec.describe '/content' do
       edition2 = create :edition, date: 1.month.ago, organisation_id: organisation_id
       create :metric, date: 10.days.ago, edition: edition2, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
 
-      calculate_monthly_aggregations!
-      refresh_views
+      recalculate_aggregations!
     end
 
     subject { get '/content', params: { date_range: 'last-30-days', document_type: 'a-document-type', organisation_id: organisation_id } }
@@ -87,8 +85,7 @@ RSpec.describe '/content' do
       edition2 = create :edition, organisation_id: organisation_id, base_path: '/path-02'
       create :metric, date: 10.days.ago, edition: edition2, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
 
-      calculate_monthly_aggregations!
-      refresh_views
+      recalculate_aggregations!
     end
 
     it 'returns the first page of the data' do

--- a/spec/support/aggregations_support.rb
+++ b/spec/support/aggregations_support.rb
@@ -1,5 +1,12 @@
-module MonthlyAggregations
-  def calculate_monthly_aggregations!
+module AggregationsSupport
+  def recalculate_aggregations!
+    refresh_last_year_of_monthly_aggregations
+    refresh_views
+  end
+
+private
+
+  def refresh_last_year_of_monthly_aggregations
     Etl::Aggregations::Monthly.process(date: Date.today)
 
     12.times { |index| Etl::Aggregations::Monthly.process(date: index.month.ago) }

--- a/spec/support/monthly_aggregations.rb
+++ b/spec/support/monthly_aggregations.rb
@@ -4,4 +4,12 @@ module MonthlyAggregations
 
     12.times { |index| Etl::Aggregations::Monthly.process(date: index.month.ago) }
   end
+
+  def refresh_views
+    ::Aggregations::SearchLastThirtyDays.refresh
+    ::Aggregations::SearchLastMonth.refresh
+    ::Aggregations::SearchLastThreeMonths.refresh
+    ::Aggregations::SearchLastSixMonths.refresh
+    ::Aggregations::SearchLastTwelveMonths.refresh
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/F8o9c3Ai/797-5-use-monthly-aggregations-aggregations-table-to-render-the-index-page): 

Depends on: https://trello.com/c/1g4cnQxR/923-monthly-aggregations-for-all-metrics

## What

Use the monthly aggregations table to render the index page

## Why

For performance reasons, we should be using the monthly aggregated table to render the index page.
