### PR TITLE
Add default order to the index page

### DIFF
--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -12,7 +12,7 @@ class Queries::FindContent
     results = Aggregations::SearchLastThirtyDays.all
                 .joins('INNER JOIN dimensions_editions ON aggregations_search_last_thirty_days.dimensions_edition_id = dimensions_editions.id')
                 .merge(slice_editions)
-                .order('upviews desc')
+                .order(order_by)
                 .page(@page)
                 .per(@page_size)
     {
@@ -24,6 +24,10 @@ class Queries::FindContent
   end
 
 private
+
+  def order_by
+    'upviews desc'
+  end
 
   attr_reader :organisation_id, :document_type, :date_range
 

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe Queries::FindContent do
     end
   end
 
+  describe 'Order' do
+    it 'defaults order by unique pageviews' do
+      edition1 = create :edition, title: 'last', organisation_id: primary_org_id
+      edition2 = create :edition, title: 'middle', organisation_id: primary_org_id
+      edition3 = create :edition, title: 'first', organisation_id: primary_org_id
+
+      create :metric, edition: edition1, date: 15.days.ago, upviews: 1
+      create :metric, edition: edition2, date: 15.days.ago, upviews: 2
+      create :metric, edition: edition3, date: 15.days.ago, upviews: 3
+      recalculate_aggregations!
+
+      response = described_class.call(filter: filter)
+
+      titles = response.fetch(:results).map { |result| result.fetch(:title) }
+      expect(titles).to eq(%w(first middle last))
+    end
+  end
+
   describe 'when no useful_yes/no.. responses' do
     before do
       edition = create :edition, organisation_id: primary_org_id


### PR DESCRIPTION
When displaying the results we should order by unique pageviews becausde
this is, as per user research, the preferred way from a user
perspecrtive.