### PR TITLE
Add handler for Redirect publising events

### DIFF
--- a/app/domain/streams/handlers/redirect_handler.rb
+++ b/app/domain/streams/handlers/redirect_handler.rb
@@ -10,7 +10,11 @@ class Streams::Handlers::RedirectHandler < Streams::Handlers::BaseHandler
   attr_reader :attrs, :old_edition
 
   def process
-    update_editions [attrs: attrs, old_edition: find_old_edition(attrs[:base_path])]
+    old_edition = find_old_edition(attrs[:base_path])
+    raise 'Redirect without a previous edition?' unless old_edition.present?
+
+    attrs[:warehouse_item_id] = old_edition.warehouse_item_id
+    update_editions [attrs: attrs, old_edition: old_edition]
   end
 
 private

--- a/app/domain/streams/handlers/redirect_handler.rb
+++ b/app/domain/streams/handlers/redirect_handler.rb
@@ -1,0 +1,21 @@
+class Streams::Handlers::RedirectHandler < Streams::Handlers::BaseHandler
+  def self.process(*args)
+    new(*args).process
+  end
+
+  def initialize(attrs)
+    @attrs = attrs
+  end
+
+  attr_reader :attrs, :old_edition
+
+  def process
+    update_editions [attrs: attrs, old_edition: find_old_edition(attrs[:base_path])]
+  end
+
+private
+
+  def find_old_edition(base_path)
+    Dimensions::Edition.find_by(base_path: base_path, latest: true)
+  end
+end

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -5,7 +5,7 @@ class Streams::Messages::BaseMessage
     @payload = payload
   end
 
-  def build_attributes(base_path:, title:, document_text:, warehouse_item_id:)
+  def build_attributes(base_path:, title: nil, document_text: nil, warehouse_item_id:)
     {
       content_id: content_id,
       base_path: base_path,

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -5,7 +5,7 @@ class Streams::Messages::BaseMessage
     @payload = payload
   end
 
-  def build_attributes(base_path:, title: nil, document_text: nil, warehouse_item_id:)
+  def build_attributes(base_path:, title: nil, document_text: nil, warehouse_item_id: nil)
     {
       content_id: content_id,
       base_path: base_path,

--- a/app/domain/streams/messages/factory.rb
+++ b/app/domain/streams/messages/factory.rb
@@ -1,7 +1,9 @@
 module Streams::Messages
   class Factory
     def self.build(payload)
-      if MultipartMessage.is_multipart?(payload)
+      if RedirectMessage.is_redirect?(payload)
+        RedirectMessage.new(payload)
+      elsif MultipartMessage.is_multipart?(payload)
         MultipartMessage.new(payload)
       else
         SingleItemMessage.new(payload)

--- a/app/domain/streams/messages/redirect_message.rb
+++ b/app/domain/streams/messages/redirect_message.rb
@@ -1,0 +1,32 @@
+module Streams
+  class Messages::RedirectMessage < Messages::BaseMessage
+    def initialize(payload)
+      super
+    end
+
+    def extract_edition_attributes
+      build_attributes(
+        base_path: base_path,
+        warehouse_item_id: content_id.to_s
+      )
+    end
+
+    def self.is_redirect?(payload)
+      payload['document_type'] == 'redirect'
+    end
+
+    def handler
+      Streams::Handlers::RedirectHandler.new(extract_edition_attributes)
+    end
+
+  private
+
+    def base_path
+      @payload['base_path']
+    end
+
+    def title
+      "Redirect to: #{base_path}"
+    end
+  end
+end

--- a/app/domain/streams/messages/redirect_message.rb
+++ b/app/domain/streams/messages/redirect_message.rb
@@ -5,10 +5,7 @@ module Streams
     end
 
     def extract_edition_attributes
-      build_attributes(
-        base_path: base_path,
-        warehouse_item_id: content_id.to_s
-      )
+      build_attributes(base_path: base_path)
     end
 
     def self.is_redirect?(payload)

--- a/spec/domain/streams/messages/redirect_message_spec.rb
+++ b/spec/domain/streams/messages/redirect_message_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Streams::Messages::RedirectMessage do
       expect(attributes).to include(
         document_type: 'redirect',
         content_id: message.payload['content_id'],
-        warehouse_item_id: message.payload['content_id'].to_s,
+        warehouse_item_id: nil,
         raw_json: message.payload
       )
     end

--- a/spec/domain/streams/messages/redirect_message_spec.rb
+++ b/spec/domain/streams/messages/redirect_message_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Streams::Messages::RedirectMessage do
+  include PublishingEventProcessingSpecHelper
+
+  subject { described_class }
+
+  let(:payload) { build(:redirect_message).payload }
+  let(:message) { described_class.new(payload) }
+
+  describe '#redirect?' do
+    context 'when payload has redirect as schema type and no locale' do
+      it 'returns true' do
+        expect(subject.is_redirect?(payload)).to eq(true)
+      end
+    end
+  end
+
+  describe '#extract_edition_attributes' do
+    let(:instance) { subject.new(message.payload) }
+
+    it 'returns the attributes' do
+      attributes = instance.extract_edition_attributes
+
+      expect(attributes).to include(
+        document_type: 'redirect',
+        content_id: message.payload['content_id'],
+        warehouse_item_id: message.payload['content_id'].to_s,
+        raw_json: message.payload
+      )
+    end
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,9 +1,13 @@
 require 'govuk_message_queue_consumer/test_helpers/mock_message'
 
 FactoryBot.define do
+  sequence :payload do |i|
+    10 + i
+  end
+
   factory :message, class: GovukMessageQueueConsumer::MockMessage do
     transient do
-      sequence(:payload_version) { |i| 10 + i }
+      payload_version { generate :payload }
       schema_name { 'detailed_guide' }
       document_type { 'detailed_guide' }
       base_path { '/base-path' }

--- a/spec/factories/redirect_messages.rb
+++ b/spec/factories/redirect_messages.rb
@@ -1,0 +1,32 @@
+require 'govuk_message_queue_consumer/test_helpers/mock_message'
+
+FactoryBot.define do
+  factory :redirect_message, class: GovukMessageQueueConsumer::MockMessage do
+    transient do
+      base_path { '/base-path' }
+      content_id { SecureRandom.uuid }
+      destination { '/new/base-path' }
+      sequence(:payload_version) { |i| 10 + i }
+    end
+
+    delivery_info { OpenStruct.new(routing_key: 'redirect.links') }
+
+    payload do
+      GovukSchemas::RandomExample.for_schema(notification_schema: 'redirect') do |result|
+        result['base_path'] = base_path
+        result['content_id'] = content_id
+        result['payload_version'] = payload_version
+        result['document_type'] = 'redirect'
+        result['update_type'] = 'republish'
+        result['schema_name'] = 'redirect'
+        result['publishing_app'] = 'whitehall'
+        result['redirects'] ||= [{}]
+        result['redirects'][0]['path'] = '/new/base-path'
+        result['redirects'][0]['type'] = 'exact'
+        result['redirects'][0]['destination'] = destination
+        result.except!('locale')
+        result
+      end
+    end
+  end
+end

--- a/spec/factories/redirect_messages.rb
+++ b/spec/factories/redirect_messages.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       base_path { '/base-path' }
       content_id { SecureRandom.uuid }
       destination { '/new/base-path' }
-      sequence(:payload_version) { |i| 10 + i }
+      payload_version { generate :payload }
     end
 
     delivery_info { OpenStruct.new(routing_key: 'redirect.links') }

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -15,15 +15,4 @@ RSpec.describe 'Process all schemas' do
       end
     end
   end
-
-  describe 'redirect schema' do
-    let(:schema) { GovukSchemas::Schema.find(notification_schema: 'redirect') }
-    let(:message) { build(:redirect_message) }
-
-    it 'handles events for redirect with no errors for republish update' do
-      expect(GovukError).not_to receive(:notify)
-
-      subject.process(message)
-    end
-  end
 end

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -4,15 +4,26 @@ RSpec.describe 'Process all schemas' do
   let(:subject) { Streams::Consumer.new }
 
   SchemasIterator.each_schema do |schema_name, schema|
+    next if schema_name == 'redirect'
     %w{major minor links republish unpublish}.each do |update_type|
       it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do
         expect(GovukError).not_to receive(:notify)
 
         payload = SchemasIterator.payload_for(schema_name, schema)
         message = build(:message, payload: payload, routing_key: "#{schema_name}.#{update_type}")
-
         subject.process(message)
       end
+    end
+  end
+
+  describe 'redirect schema' do
+    let(:schema) { GovukSchemas::Schema.find(notification_schema: 'redirect') }
+    let(:message) { build(:redirect_message) }
+
+    it 'handles events for redirect with no errors for republish update' do
+      expect(GovukError).not_to receive(:notify)
+
+      subject.process(message)
     end
   end
 end

--- a/spec/integration/streams/redirects/multipart_redirects_grow_dimensions_spec.rb
+++ b/spec/integration/streams/redirects/multipart_redirects_grow_dimensions_spec.rb
@@ -1,0 +1,24 @@
+require 'govuk_message_queue_consumer/test_helpers/mock_message'
+
+RSpec.describe "Process redirect sub-pages for multipart content types" do
+  include PublishingEventProcessingSpecHelper
+
+  let(:subject) { Streams::Consumer.new }
+  let(:content_id) { SecureRandom.uuid }
+
+  it "grows the dimension for each subpage" do
+    message = build(:message, :with_parts, base_path: '/base-path', payload_version: 2, attributes: {
+      'content_id' => content_id,
+      'locale' => 'en',
+      'title' => 'Main Title'
+    })
+
+    redirect_part_message = build :redirect_message, base_path: '/base-path/part2'
+
+    subject.process(message)
+    subject.process(redirect_part_message)
+
+    part_edition = Dimensions::Edition.find_by(base_path: '/base-path/part2')
+    expect(part_edition.document_type).to eq('redirect')
+  end
+end

--- a/spec/integration/streams/redirects/redirects_grow_dimensions_spec.rb
+++ b/spec/integration/streams/redirects/redirects_grow_dimensions_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Streams::Consumer do
+  include PublishingEventProcessingSpecHelper
+
+  let(:subject) { described_class.new }
+  let(:content_id) { SecureRandom.uuid }
+
+  it 'grows the dimension' do
+    message1 = build :message, base_path: '/base-path', content_id: content_id, attributes: { 'payload_version' => 2 }
+    message2 = build :redirect_message, base_path: '/base-path', content_id: content_id
+
+    subject.process(message1)
+    old_edition = Dimensions::Edition.find_by(base_path: '/base-path', latest: true)
+
+    subject.process(message2)
+
+    expect(old_edition.reload).to have_attributes(latest: false, base_path: '/base-path')
+    expect(old_edition.document_type).to_not eq('redirect')
+
+    new_edition = Dimensions::Edition.find_by(base_path: '/base-path', latest: true)
+    expect(new_edition).to have_attributes(
+      latest: true,
+      content_id: content_id,
+      base_path: '/base-path',
+      document_type: 'redirect',
+    )
+  end
+
+  context 'when multiple locales for the same content_id' do
+    it 'grows the dimensions for en and fr' do
+      fr_message = build :message, base_path: '/base-path/french', content_id: content_id, attributes: { 'payload_version' => 2 }
+      en_message = build :message, base_path: '/base-path/english', content_id: content_id, attributes: { 'payload_version' => 3 }
+
+      subject.process(fr_message)
+      subject.process(en_message)
+
+      fr_redirect_message = build :redirect_message, base_path: '/base-path/french', content_id: content_id
+      subject.process(fr_redirect_message)
+
+      fr_edition = Dimensions::Edition.find_by(base_path: '/base-path/french', latest: true)
+      expect(fr_edition).to have_attributes(
+        latest: true,
+        content_id: content_id,
+        base_path: '/base-path/french',
+        document_type: 'redirect'
+      )
+
+      en_edition = Dimensions::Edition.find_by(base_path: '/base-path/english', latest: true)
+      expect(en_edition).to have_attributes(
+        latest: true,
+        content_id: content_id,
+        base_path: '/base-path/english'
+      )
+      expect(en_edition.document_type).to_not eq('redirect')
+    end
+  end
+end

--- a/spec/integration/streams/redirects/redirects_grow_dimensions_spec.rb
+++ b/spec/integration/streams/redirects/redirects_grow_dimensions_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Streams::Consumer do
 
   context 'when multiple locales for the same content_id' do
     it 'grows the dimensions for en and fr' do
-      fr_message = build :message, base_path: '/base-path/french', content_id: content_id, attributes: { 'payload_version' => 2 }
-      en_message = build :message, base_path: '/base-path/english', content_id: content_id, attributes: { 'payload_version' => 3 }
+      fr_message = build :message, base_path: '/base-path/french', content_id: content_id, attributes: { 'payload_version' => 2 }, locale: 'fr'
+      en_message = build :message, base_path: '/base-path/english', content_id: content_id, attributes: { 'payload_version' => 3 }, locale: 'en'
 
       subject.process(fr_message)
       subject.process(en_message)


### PR DESCRIPTION
Redirects do not have a locale, which causes errors in the data
warehouse as we had assumed all content items will have one. We
had added a constraint on locale.

In this change we treat Redirects as a different type of message
to consume from the publishing-api events stream. We also add a
new handler, but the our existing code for processing is largely
re-usable.

Apologies for the huge single commit, but there wasn't an obvious
and clean way to split it.

Has been tested on Integration where I unpublished a page in
Whitehall and set it to redirect.