### PR TITLE
Add a rake task to repopulate metrics

### DIFF
--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -5,6 +5,10 @@ class Etl::Master::MasterProcessor
     new(*args).process
   end
 
+  def self.process_aggregations(*args)
+    new(*args).process_aggregations
+  end
+
   def initialize(date: Date.yesterday)
     @date = date
   end
@@ -19,10 +23,7 @@ class Etl::Master::MasterProcessor
       Etl::GA::InternalSearchProcessor.process(date: date)
       Etl::Feedex::Processor.process(date: date)
 
-      unless historic_data?
-        Etl::Aggregations::Monthly.process(date: date)
-        Etl::Aggregations::Search.process
-      end
+      process_aggregations unless historic_data?
     end
 
     time(process: :monitor) do
@@ -33,6 +34,11 @@ class Etl::Master::MasterProcessor
         Monitor::Aggregations.run
       end
     end
+  end
+
+  def process_aggregations
+    Etl::Aggregations::Monthly.process(date: date)
+    Etl::Aggregations::Search.process
   end
 
   def already_run?

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -19,7 +19,8 @@ namespace :etl do
   task :rerun_master, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date
     to = args[:to].to_date
-    (from..to).each do |date|
+    date_range = (from..to)
+    date_range.each do |date|
       ActiveRecord::Base.transaction do
         console_log "Deleting existing metrics for #{date}"
         Facts::Metric.where(dimensions_date_id: date).delete_all
@@ -28,12 +29,21 @@ namespace :etl do
         console_log "finished running Etl::Master for #{date}"
       end
     end
+
+    extract_month_ends(date_range).each do |date|
+      console_log "Running monthly and search aggregations for #{date}"
+      Etl::Master::MasterProcessor.process_aggregations(date: date)
+    end
   end
 
   desc 'Populate GA metrics for a date'
   task :ga, [:date] => [:environment] do |_t, args|
     date = args[:date]
     GA.process(date: date.to_date)
+  end
+
+  def extract_month_ends(date_range)
+    date_range.map(&:end_of_month).uniq
   end
 
   def console_log(str)

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -9,9 +9,9 @@ namespace :etl do
     from = args[:from].to_date
     to = args[:to].to_date
     (from..to).each do |date|
-      puts "repopulating GA pviews for #{date}"
+      console_log "repopulating GA pviews for #{date}"
       Etl::GA::ViewsAndNavigationProcessor.process(date: date)
-      puts "finished repopulating GA pviews for #{date}"
+      console_log "finished repopulating GA pviews for #{date}"
     end
   end
 
@@ -21,11 +21,11 @@ namespace :etl do
     to = args[:to].to_date
     (from..to).each do |date|
       ActiveRecord::Base.transaction do
-        puts "Deleting existing metrics for #{date}"
+        console_log "Deleting existing metrics for #{date}"
         Facts::Metric.where(dimensions_date_id: date).delete_all
-        puts "Running Etl::Master process for #{date}"
+        console_log "Running Etl::Master process for #{date}"
         Etl::Master::MasterProcessor.process(date: date)
-        puts "finished running Etl::Master for #{date}"
+        console_log "finished running Etl::Master for #{date}"
       end
     end
   end
@@ -34,5 +34,9 @@ namespace :etl do
   task :ga, [:date] => [:environment] do |_t, args|
     date = args[:date]
     GA.process(date: date.to_date)
+  end
+
+  def console_log(str)
+    puts str unless Rails.env.test?
   end
 end

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -15,6 +15,19 @@ namespace :etl do
     end
   end
 
+  desc 'Delete existing metrics and Run Etl Master process across a range of dates'
+  task :rerun_master, %i[from to] => [:environment] do |_t, args|
+    from = args[:from].to_date
+    to = args[:to].to_date
+    (from..to).each do |date|
+      puts "Deleting existing metrics for #{date}"
+      Facts::Metric.where(dimensions_date_id: date).delete_all
+      puts "Running Etl::Master process for #{date}"
+      Etl::Master::MasterProcessor.process(date: date)
+      puts "finished running Etl::Master for #{date}"
+    end
+  end
+
   desc 'Populate GA metrics for a date'
   task :ga, [:date] => [:environment] do |_t, args|
     date = args[:date]

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -20,11 +20,13 @@ namespace :etl do
     from = args[:from].to_date
     to = args[:to].to_date
     (from..to).each do |date|
-      puts "Deleting existing metrics for #{date}"
-      Facts::Metric.where(dimensions_date_id: date).delete_all
-      puts "Running Etl::Master process for #{date}"
-      Etl::Master::MasterProcessor.process(date: date)
-      puts "finished running Etl::Master for #{date}"
+      ActiveRecord::Base.transaction do
+        puts "Deleting existing metrics for #{date}"
+        Facts::Metric.where(dimensions_date_id: date).delete_all
+        puts "Running Etl::Master process for #{date}"
+        Etl::Master::MasterProcessor.process(date: date)
+        puts "finished running Etl::Master for #{date}"
+      end
     end
   end
 

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -142,4 +142,18 @@ RSpec.describe Etl::Master::MasterProcessor do
     expect(Etl::GA::ViewsAndNavigationProcessor).to have_received(:process).with(date: another_date)
     expect(Etl::Feedex::Processor).to have_received(:process).with(date: another_date)
   end
+
+  describe '.process_aggregations' do
+    before do
+      subject.process_aggregations(date: date)
+    end
+
+    it 'runs the Aggregations::Monthly process' do
+      expect(Etl::Aggregations::Monthly).to have_received(:process).with(date: date)
+    end
+
+    it 'runs the Aggregations::Search process' do
+      expect(Etl::Aggregations::Monthly).to have_received(:process)
+    end
+  end
 end

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -18,20 +18,37 @@ RSpec.describe 'etl.rake', type: task do
   end
 
   describe 'rake etl:rerun_master' do
-    let!(:processor) { class_double(Etl::Master::MasterProcessor, process: true).as_stubbed_const }
-    before do
-      edition = create :edition, date: '2018-11-01'
-      create :metric, edition: edition, date: '2018-11-02'
-      create :metric, edition: edition, date: '2018-11-03'
-      create :metric, edition: edition, date: '2018-11-06'
+    let!(:processor) do
+      class_double(Etl::Master::MasterProcessor,
+                   process: true,
+                   process_aggregations: true).as_stubbed_const
     end
 
-    it 'calls Etl::Master::MasterProcessor.process with each date after deleting existing metrics' do
-      Rake::Task['etl:rerun_master'].invoke('2018-11-03', '2018-11-05')
-      [Date.new(2018, 11, 3), Date.new(2018, 11, 4), Date.new(2018, 11, 5)].each do |date|
-        expect(processor).to have_received(:process).with(date: date)
+    before do
+      edition = create :edition, date: '2018-10-03'
+      create :metric, edition: edition, date: '2018-10-30'
+      create :metric, edition: edition, date: '2018-10-31'
+      create :metric, edition: edition, date: '2018-11-01'
+      create :metric, edition: edition, date: '2018-11-02'
+      create :metric, edition: edition, date: '2018-11-03'
+      Rake::Task['etl:rerun_master'].reenable
+      Rake::Task['etl:rerun_master'].invoke('2018-10-31', '2018-11-02')
+    end
+
+    it 'deletes the existing metrics' do
+      expect(Facts::Metric.pluck(:dimensions_date_id)).to eq([Date.new(2018, 10, 30), Date.new(2018, 11, 3)])
+    end
+
+    it 'calls Etl::Master::MasterProcessor.process with each date' do
+      [Date.new(2018, 10, 31), Date.new(2018, 11, 1), Date.new(2018, 11, 2)].each do |date|
+        expect(processor).to have_received(:process).once.with(date: date)
       end
-      expect(Facts::Metric.pluck(:dimensions_date_id)).to eq([Date.new(2018, 11, 2), Date.new(2018, 11, 6)])
+    end
+
+    it 'runs the aggregations process for each month in the range' do
+      [Date.new(2018, 10, 31), Date.new(2018, 11, 30)].each do |date|
+        expect(processor).to have_received(:process_aggregations).once.with(date: date)
+      end
     end
   end
 end

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -16,4 +16,22 @@ RSpec.describe 'etl.rake', type: task do
       expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
     end
   end
+
+  describe 'rake etl:rerun_master' do
+    let!(:processor) { class_double(Etl::Master::MasterProcessor, process: true).as_stubbed_const }
+    before do
+      edition = create :edition, date: '2018-11-01'
+      create :metric, edition: edition, date: '2018-11-02'
+      create :metric, edition: edition, date: '2018-11-03'
+      create :metric, edition: edition, date: '2018-11-06'
+    end
+
+    it 'calls Etl::Master::MasterProcessor.process with each date after deleting existing metrics' do
+      Rake::Task['etl:rerun_master'].invoke('2018-11-03', '2018-11-05')
+      [Date.new(2018, 11, 3), Date.new(2018, 11, 4), Date.new(2018, 11, 5)].each do |date|
+        expect(processor).to have_received(:process).with(date: date)
+      end
+      expect(Facts::Metric.pluck(:dimensions_date_id)).to eq([Date.new(2018, 11, 2), Date.new(2018, 11, 6)])
+    end
+  end
 end


### PR DESCRIPTION
Adds a rake task `rake etl:rerun_master`

This can be run across a range of dates and does the following:

* Delete the metrics for each day.
* Run the Etl::Master process for each day.

You can run the task as follows:

```
bundle exec rake etl:rerun_master[2018-10-01,2018-11-11]
```

Or if you are using zsh:

```
bundle exec rake etl:rerun_master\[2018-10-01,2018-11-11\]
```

Trello: https://trello.com/c/lDZPun1o/838-3-repopulate-data-from-1-oct-to-11-nov-2018#