### PR TITLE
Improve handling of messages without a locale (reworked)

### DIFF
--- a/app/domain/streams/grow_dimension.rb
+++ b/app/domain/streams/grow_dimension.rb
@@ -37,6 +37,6 @@ private
   end
 
   def excluded_from_comparison?(key, _value)
-    %i[publishing_api_payload_version public_updated_at id update_at created_at latest].include? key
+    %i[publishing_api_payload_version public_updated_at id update_at created_at latest warehouse_item_id].include? key
   end
 end

--- a/app/domain/streams/handlers/single_item_handler.rb
+++ b/app/domain/streams/handlers/single_item_handler.rb
@@ -1,4 +1,7 @@
 class Streams::Handlers::SingleItemHandler < Streams::Handlers::BaseHandler
+  class MissingLocaleError < StandardError
+  end
+
   def self.process(*args)
     new(*args).process
   end
@@ -16,6 +19,8 @@ class Streams::Handlers::SingleItemHandler < Streams::Handlers::BaseHandler
 private
 
   def find_old_edition(content_id, locale)
+    raise MissingLocaleError unless locale
+
     Dimensions::Edition.find_by(content_id: content_id, locale: locale, latest: true)
   end
 end

--- a/spec/domain/streams/handlers/single_item_handler_spec.rb
+++ b/spec/domain/streams/handlers/single_item_handler_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe Streams::Handlers::SingleItemHandler do
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { '/base-path' }
+  let(:locale) { 'en' }
+
+  let(:old_edition) do
+    create(
+      :edition,
+      content_id: content_id,
+      base_path: base_path,
+      locale: 'en',
+      latest: true
+    )
+  end
+
+  subject { described_class.new(attrs) }
+
+  context 'when attrs match the old edition' do
+    let(:attrs) do
+      old_edition
+        .attributes
+        .slice('content_id', 'base_path', 'locale')
+        .symbolize_keys
+    end
+
+    context 'with a single english edition' do
+      it 'finds the old english edition when no attributes change' do
+        expect(subject).to receive(:update_editions).with(
+          [attrs: attrs, old_edition: old_edition]
+        )
+
+        subject.process
+      end
+    end
+
+    context 'with a single welsh edition' do
+      let(:base_path) { '/base-path.cy' }
+      let(:locale) { 'cy' }
+
+      it 'finds the old welsh edition when no attributes change' do
+        expect(subject).to receive(:update_editions).with(
+          [attrs: attrs, old_edition: old_edition]
+        )
+
+        subject.process
+      end
+    end
+  end
+
+  context 'when attrs differ from the old edition' do
+    context 'in the case of a redirect or gone with no locale' do
+      let(:attrs) do
+        {
+          content_id: content_id,
+          base_path: base_path
+        }
+      end
+
+      it 'raises an error' do
+        expect { subject.process }.to raise_error(
+          Streams::Handlers::SingleItemHandler::MissingLocaleError
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :edition, class: Dimensions::Edition do
     latest { true }
     locale { 'en' }
-    sequence(:content_id) { |i| "content_id - #{i}" }
+    sequence(:content_id) { SecureRandom.uuid }
     sequence(:title) { |i| "title - #{i}" }
-    sequence(:base_path) { |i| "link - #{i}" }
+    sequence(:base_path) { |i| "/base-path-#{i}" }
     sequence(:description) { |i| "description - #{i}" }
     sequence(:publishing_api_payload_version)
     schema_name { 'detailed_guide' }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -150,4 +150,28 @@ FactoryBot.define do
       end
     end
   end
+
+  factory :gone_message, parent: :message do
+    payload do
+      {
+        'document_type' => 'gone',
+        'schema_name' => 'gone',
+        'base_path' => base_path,
+        'locale' => locale,
+        'publishing_app' => 'whitehall',
+        'details' => {
+          'explanation' => '',
+          'alternative_path' => ''
+        },
+        'routes' => [
+          {
+            'path' => content_id,
+            'type' => 'exact'
+          }
+        ],
+        'content_id' => content_id,
+        'payload_version' => 1
+      }
+    end
+  end
 end

--- a/spec/integration/streams/single/grow_dimension_spec.rb
+++ b/spec/integration/streams/single/grow_dimension_spec.rb
@@ -5,14 +5,6 @@ RSpec.describe Streams::Consumer do
 
   let(:subject) { described_class.new }
 
-  it 'does not notify error if message is missing `locale`' do
-    message = build(:message)
-    message.payload.except!('locale')
-
-    expect(GovukError).not_to receive(:notify)
-    subject.process(message)
-  end
-
   it 'grows the dimension with update events' do
     expect {
       subject.process(build(:message))


### PR DESCRIPTION
Following on from https://github.com/alphagov/content-performance-manager/pull/1005

Now that the Publishing API will include the locale more often [1], shift to guarding against a missing locale.

1: https://github.com/alphagov/publishing-api/pull/1390
https://github.com/alphagov/publishing-api/pull/1391
https://github.com/alphagov/publishing-api/pull/1392