### PR TITLE
Tweak testing around redirect messages

### DIFF
--- a/spec/domain/streams/messages/redirect_message_spec.rb
+++ b/spec/domain/streams/messages/redirect_message_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Streams::Messages::RedirectMessage do
   describe '#redirect?' do
     context 'when payload has redirect as schema type and no locale' do
       it 'returns true' do
-        expect(subject.is_redirect?(payload)).to eq(true)
+        expect(subject.is_redirect?(payload.except('locale'))).to eq(true)
       end
     end
   end

--- a/spec/factories/redirect_messages.rb
+++ b/spec/factories/redirect_messages.rb
@@ -24,7 +24,6 @@ FactoryBot.define do
         result['redirects'][0]['path'] = '/new/base-path'
         result['redirects'][0]['type'] = 'exact'
         result['redirects'][0]['destination'] = destination
-        result.except!('locale')
         result
       end
     end


### PR DESCRIPTION
Don't exclude the locale from the redirect in the RedirectMesssage
factory, as the schema (in govuk-content-schemas) now requires the
locale to be present.

This relates to this change in the Publishing API, to provide a locale for redirects https://github.com/alphagov/publishing-api/pull/1391 and is blocking the corresponding change in the govuk-content-schemas https://github.com/alphagov/govuk-content-schemas/pull/837 .