### PR TITLE
Show correct number of PDFs

### DIFF
--- a/app/domain/etl/edition/metadata/number_of_files.rb
+++ b/app/domain/etl/edition/metadata/number_of_files.rb
@@ -23,7 +23,7 @@ module Etl::Edition::Metadata::NumberOfFiles
 
   def self.filter_links(all_links, extensions_regex)
     # Sample: \.(doc|docx|docm)$
-    regex = /\.(#{extensions_regex.join('|')})$/
+    regex = /\.(#{extensions_regex.join('|')})$/i
 
     all_links.grep(regex).length
   end

--- a/spec/domain/etl/edition/metadata/number_of_pdfs_spec.rb
+++ b/spec/domain/etl/edition/metadata/number_of_pdfs_spec.rb
@@ -34,6 +34,11 @@ module Performance
       expect(subject.parse(response)).to eq(0)
     end
 
+    it "returns 1 if the attachment file is `.PDF`" do
+      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.PDF\">1</a>\n\n\n\n</div>')
+      expect(subject.parse(response)).to eq(1)
+    end
+
     def build_response(details)
       content_item_for_base_path('/a-base-path').merge('details' => details)
     end


### PR DESCRIPTION
[Trello card](https://trello.com/c/7PsDeH5Q/832-3-number-of-pdfs-in-content-data-does-not-match-govuk-page)

We have a bug which shows an incorrect number of PDFs attachments for some content.

This is because we use regex to search for pdf but it is case sensitive.

This PR makes the regex expression case insensitive because some content has
attachments which have the pdf extension in upper case.