### PR TITLE
Filter out irrelevant content

### DIFF
--- a/app/domain/queries/find_all_document_types.rb
+++ b/app/domain/queries/find_all_document_types.rb
@@ -5,7 +5,7 @@ class Queries::FindAllDocumentTypes
 
   def retrieve
     Dimensions::Edition.latest
-      .live_content
+      .relevant_content
       .select(:document_type)
       .distinct
       .order(:document_type).to_a

--- a/app/domain/queries/find_all_document_types.rb
+++ b/app/domain/queries/find_all_document_types.rb
@@ -5,6 +5,7 @@ class Queries::FindAllDocumentTypes
 
   def retrieve
     Dimensions::Edition.latest
+      .live_content
       .select(:document_type)
       .distinct
       .order(:document_type).to_a

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -56,7 +56,7 @@ private
   end
 
   def slice_editions
-    editions = Dimensions::Edition.all
+    editions = Dimensions::Edition.live_content
     editions = editions.where('organisation_id = ?', organisation_id)
     editions = editions.where('document_type = ?', document_type) if document_type
     editions

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -56,7 +56,7 @@ private
   end
 
   def slice_editions
-    editions = Dimensions::Edition.live_content
+    editions = Dimensions::Edition.relevant_content
     editions = editions.where('organisation_id = ?', organisation_id)
     editions = editions.where('document_type = ?', document_type) if document_type
     editions

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -21,7 +21,7 @@ class Dimensions::Edition < ApplicationRecord
     latest_by_content_id(content_id, locale)
       .where.not(base_path: exclude_paths)
   end
-
+  scope :live_content, -> { where.not(document_type: %w[redirect gone]) }
   def promote!(old_edition)
     if old_edition
       old_edition.deprecate!

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -21,7 +21,8 @@ class Dimensions::Edition < ApplicationRecord
     latest_by_content_id(content_id, locale)
       .where.not(base_path: exclude_paths)
   end
-  scope :live_content, -> { where.not(document_type: %w[redirect gone]) }
+  scope :relevant_content, -> { where.not(document_type: %w[redirect gone]) }
+
   def promote!(old_edition)
     if old_edition
       old_edition.deprecate!

--- a/spec/domain/queries/find_all_document_types_spec.rb
+++ b/spec/domain/queries/find_all_document_types_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Queries::FindAllDocumentTypes do
       create :edition, document_type: 'travel_advice', latest: true
       create :edition, document_type: 'manual', latest: true
       create :edition, document_type: 'service-manual', latest: false
+      create :edition, document_type: 'gone', latest: true
+      create :edition, document_type: 'redirect', latest: true
     end
 
     it 'returns distinct document types of latest editions' do
@@ -16,6 +18,16 @@ RSpec.describe Queries::FindAllDocumentTypes do
     it 'does not return document types of editions that are not the latest' do
       results = described_class.retrieve
       expect(results.pluck(:document_type)).to_not include('service-manual')
+    end
+
+    it 'does not return `gone`' do
+      results = described_class.retrieve
+      expect(results.pluck(:document_type)).to_not include('gone')
+    end
+
+    it 'does not return `redirect`' do
+      results = described_class.retrieve
+      expect(results.pluck(:document_type)).to_not include('redirect')
     end
   end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(results).to match_array(edition1)
     end
 
-    it '.live_content' do
+    it '.relevant_content' do
       edition = create :edition, document_type: 'news_story'
       create :edition, document_type: 'redirect'
       create :edition, document_type: 'gone'
-      results = subject.live_content
+      results = subject.relevant_content
       expect(results).to match_array(edition)
     end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(results).to match_array(edition1)
     end
 
+    it '.live_content' do
+      edition = create :edition, document_type: 'news_story'
+      create :edition, document_type: 'redirect'
+      create :edition, document_type: 'gone'
+      results = subject.live_content
+      expect(results).to match_array(edition)
+    end
+
     describe '.outdated_subpages' do
       let(:content_id) { 'd5348817-0c34-4942-9111-2331e12cb1c5' }
       let(:locale) { 'fr' }

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe '/content' do
     end
   end
 
-  describe 'Live content' do
+  describe 'Relevant content' do
     subject { get '/content', params: { date_range: 'last-30-days', organisation_id: organisation_id } }
 
     before do

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe '/document_types' do
     create :edition, document_type: 'guide'
     create :edition, document_type: 'manual'
     create :edition, document_type: 'manual'
+    # `gone` and `redirect` should not appear in the results
+    create :edition, document_type: 'redirect'
+    create :edition, document_type: 'gone'
   end
 
   it 'returns distinct document types ordered by title' do


### PR DESCRIPTION
We store in the Data Warehouse events that are for "unpublished" state, or that are not relevant for content designers. We need to filter these out from the API's query to the Content Data Admin.

this includes the `/content` and `/document_types` endpoints.

Trello: https://trello.com/c/B0Wt3wFj/685-3-index-page-filter-out-non-relevant-content-items-from-displaying-in-content-data-admin