### PR TITLE
Search by base_path and title in the Editions table

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -15,7 +15,7 @@ private
   end
 
   def permitted_params
-    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range)
+    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range, :q)
   end
 
   def validate_params!

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,7 +1,7 @@
 class Api::ContentRequest
   include ActiveModel::Validations
 
-  attr_reader :organisation_id, :document_type, :page, :page_size, :date_range
+  attr_reader :organisation_id, :document_type, :page, :page_size, :date_range, :q
   validate :valid_organisation_id
   validate :valid_date_range
 
@@ -11,6 +11,7 @@ class Api::ContentRequest
     @organisation_id = params[:organisation_id]
     @document_type = params[:document_type]
     @page = params[:page].try(:to_i)
+    @q = params[:q]
     @page_size = params[:page_size].try(:to_i)
     @date_range = params[:date_range]
   end
@@ -20,6 +21,7 @@ class Api::ContentRequest
       organisation_id: organisation_id,
       document_type: document_type,
       date_range: date_range,
+      q: q,
       page: page,
       page_size: page_size,
     }

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -3,7 +3,7 @@ class Queries::FindContent
 
   def self.call(filter:)
     raise ArgumentError unless filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
-    filter.assert_valid_keys :date_range, :organisation_id, :document_type, :page, :page_size
+    filter.assert_valid_keys :q, :date_range, :organisation_id, :document_type, :page, :page_size
 
     new(filter).call
   end
@@ -29,11 +29,12 @@ private
     'upviews desc'
   end
 
-  attr_reader :organisation_id, :document_type, :date_range
+  attr_reader :organisation_id, :document_type, :date_range, :q
 
   def initialize(filter)
     @organisation_id = filter.fetch(:organisation_id)
     @document_type = filter.fetch(:document_type)
+    @q = filter[:q]
     @page = filter[:page] || 1
     @page_size = filter[:page_size] || DEFAULT_PAGE_SIZE
   end
@@ -59,6 +60,7 @@ private
     editions = Dimensions::Edition.relevant_content
     editions = editions.where('organisation_id = ?', organisation_id)
     editions = editions.where('document_type = ?', document_type) if document_type
+    editions = editions.search(q) if q.present?
     editions
   end
 end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -23,6 +23,10 @@ class Dimensions::Edition < ApplicationRecord
   end
   scope :relevant_content, -> { where.not(document_type: %w[redirect gone]) }
 
+  def self.search(query)
+    where("to_tsvector('english',title) @@ plainto_tsquery('english', :q)", q: query)
+  end
+
   def promote!(old_edition)
     if old_edition
       old_edition.deprecate!

--- a/db/migrate/20181121135744_add_full_text_index_title.rb
+++ b/db/migrate/20181121135744_add_full_text_index_title.rb
@@ -1,0 +1,9 @@
+class AddFullTextIndexTitle < ActiveRecord::Migration[5.2]
+  def up
+    execute "create index dimensions_editions_title on dimensions_editions using gin(to_tsvector('english', title ))"
+  end
+
+  def down
+    execute 'drop index dimensions_editions_title'
+  end
+end

--- a/db/migrate/20181122105601_add_full_text_index_base_path.rb
+++ b/db/migrate/20181122105601_add_full_text_index_base_path.rb
@@ -1,0 +1,9 @@
+class AddFullTextIndexBasePath < ActiveRecord::Migration[5.2]
+  def up
+    execute "create index dimensions_editions_base_path on dimensions_editions using gin(to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)))"
+  end
+
+  def down
+    execute 'drop index dimensions_editions_base_path'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_170246) do
+ActiveRecord::Schema.define(version: 2018_11_21_135744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_170246) do
     t.json "raw_json"
     t.boolean "withdrawn", null: false
     t.boolean "historical", null: false
+    t.index "to_tsvector('english'::regconfig, COALESCE((title)::text, ''::text))", name: "dimensions_editions_title", using: :gin
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_21_135744) do
+ActiveRecord::Schema.define(version: 2018_11_22_105601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,7 +91,8 @@ ActiveRecord::Schema.define(version: 2018_11_21_135744) do
     t.json "raw_json"
     t.boolean "withdrawn", null: false
     t.boolean "historical", null: false
-    t.index "to_tsvector('english'::regconfig, COALESCE((title)::text, ''::text))", name: "dimensions_editions_title", using: :gin
+    t.index "to_tsvector('english'::regconfig, (title)::text)", name: "dimensions_editions_title", using: :gin
+    t.index "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "dimensions_editions_base_path", using: :gin
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
     t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Api::ContentRequest do
       request = Api::ContentRequest.new(
         document_type: 'guide',
         organisation_id: 'the-id',
+        q: 'a title or url',
         page: '1',
         page_size: '20',
         date_range: 'last-30-days',
@@ -12,6 +13,7 @@ RSpec.describe Api::ContentRequest do
       expect(request.to_filter).to eq(
         document_type: 'guide',
         organisation_id: 'the-id',
+        q: 'a title or url',
         page: 1,
         page_size: 20,
         date_range: 'last-30-days',
@@ -28,6 +30,7 @@ RSpec.describe Api::ContentRequest do
         document_type: nil,
         organisation_id: nil,
         page: nil,
+        q: nil,
         page_size: nil,
         date_range: nil,
       )

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -156,4 +156,34 @@ RSpec.describe Queries::FindContent do
       expect(-> { described_class.call(filter: filter) }).to raise_error(ArgumentError)
     end
   end
+
+  describe 'Filter by title / url' do
+    it 'returns the editions matching a title' do
+      edition1 = create :edition, title: 'this is a big title', date: 2.months.ago, organisation_id: primary_org_id
+      edition2 = create :edition, title: 'this is a small title', date: 2.months.ago, organisation_id: primary_org_id
+
+      create :metric, edition: edition1, date: 15.days.ago
+      create :metric, edition: edition2, date: 14.days.ago
+      recalculate_aggregations!
+
+      result = described_class.call(filter: filter.merge(q: 'big title'))
+      expect(result[:results]).to contain_exactly(
+        hash_including(title: 'this is a big title'),
+      )
+    end
+
+    it 'returns the editions matching a base_path' do
+      edition1 = create :edition, base_path: '/this/is/a/big/base-path', date: 2.months.ago, organisation_id: primary_org_id
+      edition2 = create :edition, base_path: '/this/is/a/small/base-path', date: 2.months.ago, organisation_id: primary_org_id
+
+      create :metric, edition: edition1, date: 15.days.ago
+      create :metric, edition: edition2, date: 14.days.ago
+      recalculate_aggregations!
+
+      result = described_class.call(filter: filter.merge(q: 'big base-path'))
+      expect(result[:results]).to contain_exactly(
+        hash_including(base_path: '/this/is/a/big/base-path'),
+      )
+    end
+  end
 end

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       end
 
       it 'matches all words' do
-        edition = create :edition, title: 'How to change your car'
+        create :edition, title: 'How to change your car'
         create :edition
 
         expect(subject.search('How to change your car another-word')).to be_empty
@@ -293,6 +293,52 @@ RSpec.describe Dimensions::Edition, type: :model do
           create :edition
 
           expect(subject.search('how changing cars')).to match_array(edition)
+        end
+      end
+    end
+
+    context 'by base_path' do
+      it 'returns matching base_paths' do
+        edition = create :edition, base_path: '/foo/bar/me'
+        create :edition
+
+        expect(subject.search('/foo/bar/me')).to match_array(edition)
+      end
+
+      it 'returns matching base_paths ignoring the `/`' do
+        edition = create :edition, base_path: ' foo bar me'
+        create :edition
+
+        expect(subject.search('/foo/bar/me')).to match_array(edition)
+      end
+
+      it 'is not case sensitive' do
+        edition = create :edition, base_path: 'foo bar me'
+        create :edition
+
+        expect(subject.search('foo bars me')).to match_array(edition)
+      end
+
+      it 'matches all words' do
+        create :edition, base_path: 'foo bar me'
+        create :edition
+
+        expect(subject.search('foo bar nothing')).to be_empty
+      end
+
+      describe 'stemming' do
+        it 'include plurals' do
+          edition = create :edition, base_path: '/foo/bar/renew-your-license'
+          create :edition
+
+          expect(subject.search('renew your license')).to match_array(edition)
+        end
+
+        it 'include similar words' do
+          edition = create :edition, base_path: '/driving/license/for-your-car'
+          create :edition
+
+          expect(subject.search('for-your-cars')).to match_array(edition)
         end
       end
     end

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -254,4 +254,47 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(-> { create :edition, base_path: 'value', latest: false }).to_not raise_error
     end
   end
+
+  describe '.search' do
+    subject { Dimensions::Edition }
+
+    context 'by title' do
+      it 'returns matching titles' do
+        edition = create :edition, title: 'a long title'
+        create :edition
+
+        expect(subject.search('a long title')).to match_array(edition)
+      end
+
+      it 'is not case sensitive' do
+        edition = create :edition, title: 'Getting married in Spain'
+        create :edition
+
+        expect(subject.search('getting married in Spain')).to match_array(edition)
+      end
+
+      it 'matches all words' do
+        edition = create :edition, title: 'How to change your car'
+        create :edition
+
+        expect(subject.search('How to change your car another-word')).to be_empty
+      end
+
+      describe 'stemming' do
+        it 'include plurals' do
+          edition = create :edition, title: 'How to change your car'
+          create :edition
+
+          expect(subject.search('How to change your cars')).to match_array(edition)
+        end
+
+        it 'include similar words' do
+          edition = create :edition, title: 'How to change your car'
+          create :edition
+
+          expect(subject.search('how changing cars')).to match_array(edition)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -77,6 +77,60 @@ RSpec.describe '/content' do
     end
   end
 
+  describe 'Filter by title' do
+    before do
+      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, title: 'title1'
+      edition2 = create :edition, date: 1.month.ago, organisation_id: organisation_id, title: 'title2'
+
+      create :metric, date: 15.days.ago, edition: edition1
+      create :metric, date: 10.days.ago, edition: edition2
+
+      recalculate_aggregations!
+    end
+
+    subject { get '/content', params: { date_range: 'last-30-days', q: 'title1', organisation_id: organisation_id } }
+
+    it 'returns 200 status' do
+      subject
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'filters by title' do
+      subject
+
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:results].count).to eq(1)
+    end
+  end
+
+  describe 'Filter by base_path' do
+    before do
+      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: 'base_path1'
+      edition2 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: 'base_path2'
+
+      create :metric, date: 15.days.ago, edition: edition1
+      create :metric, date: 10.days.ago, edition: edition2
+
+      recalculate_aggregations!
+    end
+
+    subject { get '/content', params: { date_range: 'last-30-days', q: 'base_path1', organisation_id: organisation_id } }
+
+    it 'returns 200 status' do
+      subject
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'filters by base_path' do
+      subject
+
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:results].count).to eq(1)
+    end
+  end
+
   describe 'Relevant content' do
     subject { get '/content', params: { date_range: 'last-30-days', organisation_id: organisation_id } }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/l2T9VoVG/725-5-index-page-filter-by-title-url)

**As a** Content Designer
**I want** to filter the content by title / url
**So that** I can be more precise when searching 

It uses PostgreSQL full text search capabilities to search though all
the base_paths. I have tried with [pg_search][1], but I have finally
decided not to use it because there is no way to skip the sorting by
ranking.

In our scenario, we don't want the results to be sorted by ranking
because we already have an existing sorting criteria. It is just better
to rely on simple text searching with no aditional sorting.

I have created two indexes that significantly improves the performance of
the query.

Important to note here is that when creating the index on the base_path 
I am removing  the `/` because this was issues because the `/` where 
considered letters and making the whole match to fail.

Also important to note how the index and the query share the same way
to remove the `/` so the query planner can effectively choose the right index.

paired with @cbaines 

[1]: https://github.com/Casecommons/pg_search