### PR TITLE
Remove defaults from facts_metrics and events_gas

### DIFF
--- a/db/migrate/20181122134132_remove_default_zeros_from_facts_metrics.rb
+++ b/db/migrate/20181122134132_remove_default_zeros_from_facts_metrics.rb
@@ -1,0 +1,15 @@
+class RemoveDefaultZerosFromFactsMetrics < ActiveRecord::Migration[5.2]
+  COLS = %i[pviews upviews searches feedex exits entrances bounces bounce_rate avg_page_time page_time]
+
+  def up
+    COLS.each do |col|
+      change_column_default(:facts_metrics, col, nil)
+    end
+  end
+
+  def down
+    COLS.each do |col|
+      change_column_default(:facts_metrics, col, 0)
+    end
+  end
+end

--- a/db/migrate/20181122142744_remove_default_zeros_from_events_gas.rb
+++ b/db/migrate/20181122142744_remove_default_zeros_from_events_gas.rb
@@ -1,0 +1,15 @@
+class RemoveDefaultZerosFromEventsGas < ActiveRecord::Migration[5.2]
+  COLS = %i[pviews upviews searches exits entrances bounces bounce_rate avg_page_time page_time]
+
+  def up
+    COLS.each do |col|
+      change_column_default(:events_gas, col, nil)
+    end
+  end
+
+  def down
+    COLS.each do |col|
+      change_column_default(:events_gas, col, 0)
+    end
+  end
+end

--- a/db/migrate/20181122152546_remove_default_zeros_from_aggregations_monthly_metrics.rb
+++ b/db/migrate/20181122152546_remove_default_zeros_from_aggregations_monthly_metrics.rb
@@ -1,0 +1,17 @@
+class RemoveDefaultZerosFromAggregationsMonthlyMetrics < ActiveRecord::Migration[5.2]
+  COLS = %i[pviews upviews feedex searches exits entrances bounces bounce_rate avg_page_time page_time]
+  
+  def up
+    COLS.each do |col|
+      change_column_default(:aggregations_monthly_metrics, col, nil)
+      change_column_null(:aggregations_monthly_metrics, col, true)
+    end
+  end
+
+  def down
+    COLS.each do |col|
+      change_column_default(:aggregations_monthly_metrics, col, 0)
+      change_column_null(:aggregations_monthly_metrics, col, false)
+    end
+  end
+end

--- a/db/migrate/20181123120108_disable_extensions.rb
+++ b/db/migrate/20181123120108_disable_extensions.rb
@@ -1,0 +1,6 @@
+class DisableExtensions < ActiveRecord::Migration[5.2]
+  def change
+    disable_extension "fuzzystrmatch"
+    disable_extension "pg_trgm"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_23_120108) do
+ActiveRecord::Schema.define(version: 2018_11_23_142713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,10 +95,8 @@ ActiveRecord::Schema.define(version: 2018_11_23_120108) do
     t.index "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "dimensions_editions_base_path", using: :gin
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
-    t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
-    t.index ["latest", "warehouse_item_id"], name: "index_dimensions_editions_on_latest_and_warehouse_item_id", unique: true, where: "(latest = true)"
     t.index ["latest"], name: "index_dimensions_editions_on_latest"
     t.index ["organisation_id"], name: "index_dimensions_editions_organisation_id"
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_22_105601) do
+ActiveRecord::Schema.define(version: 2018_11_23_120108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,18 +18,18 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
   create_table "aggregations_monthly_metrics", force: :cascade do |t|
     t.string "dimensions_month_id", null: false
     t.bigint "dimensions_edition_id", null: false
-    t.integer "pviews", default: 0, null: false
-    t.integer "upviews", default: 0, null: false
-    t.integer "feedex", default: 0, null: false
+    t.integer "pviews"
+    t.integer "upviews"
+    t.integer "feedex"
     t.integer "useful_yes", default: 0, null: false
     t.integer "useful_no", default: 0, null: false
-    t.integer "searches", default: 0, null: false
-    t.integer "exits", default: 0, null: false
-    t.integer "entrances", default: 0, null: false
-    t.integer "bounce_rate", default: 0, null: false
-    t.integer "avg_page_time", default: 0, null: false
-    t.integer "bounces", default: 0, null: false
-    t.integer "page_time", default: 0, null: false
+    t.integer "searches"
+    t.integer "exits"
+    t.integer "entrances"
+    t.integer "bounce_rate"
+    t.integer "avg_page_time"
+    t.integer "bounces"
+    t.integer "page_time"
     t.float "satisfaction", default: 0.0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -128,20 +128,20 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
   create_table "events_gas", force: :cascade do |t|
     t.date "date"
     t.string "page_path"
-    t.integer "pviews", default: 0
-    t.integer "upviews", default: 0
+    t.integer "pviews"
+    t.integer "upviews"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "useful_yes", default: 0
     t.integer "useful_no", default: 0
     t.integer "process_name", null: false
-    t.integer "searches", default: 0
-    t.integer "exits", default: 0
-    t.integer "entrances", default: 0
-    t.integer "bounce_rate", default: 0
-    t.integer "avg_page_time", default: 0
-    t.integer "bounces", default: 0
-    t.integer "page_time", default: 0
+    t.integer "searches"
+    t.integer "exits"
+    t.integer "entrances"
+    t.integer "bounce_rate"
+    t.integer "avg_page_time"
+    t.integer "bounces"
+    t.integer "page_time"
     t.index ["page_path", "date"], name: "index_events_gas_on_page_path_and_date"
     t.index ["process_name", "date", "page_path"], name: "index_events_gas_on_process_name_and_date_and_page_path", unique: true
   end
@@ -165,18 +165,18 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
     t.bigint "dimensions_edition_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "pviews", default: 0
-    t.integer "upviews", default: 0
-    t.integer "feedex", default: 0
+    t.integer "pviews"
+    t.integer "upviews"
+    t.integer "feedex"
     t.integer "useful_yes", default: 0, null: false
     t.integer "useful_no", default: 0, null: false
-    t.integer "searches", default: 0
-    t.integer "exits", default: 0
-    t.integer "entrances", default: 0
-    t.integer "bounce_rate", default: 0
-    t.integer "avg_page_time", default: 0
-    t.integer "bounces", default: 0
-    t.integer "page_time", default: 0
+    t.integer "searches"
+    t.integer "exits"
+    t.integer "entrances"
+    t.integer "bounce_rate"
+    t.integer "avg_page_time"
+    t.integer "bounces"
+    t.integer "page_time"
     t.float "satisfaction", default: 0.0, null: false
     t.index ["dimensions_date_id", "dimensions_edition_id"], name: "metrics_edition_id_date_id", unique: true
     t.index ["dimensions_edition_id"], name: "index_facts_metrics_on_dimensions_edition_id"
@@ -212,7 +212,7 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
      FROM ((facts_metrics
        JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
        JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-    WHERE (facts_metrics.dimensions_date_id >= (CURRENT_DATE - '30 days'::interval day))
+    WHERE (facts_metrics.dimensions_date_id >= (('now'::text)::date - '30 days'::interval day))
     GROUP BY dimensions_editions.warehouse_item_id;
   SQL
 
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '2 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '2 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL
@@ -297,7 +297,7 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '5 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '5 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL
@@ -332,7 +332,7 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '11 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '11 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL


### PR DESCRIPTION
Why
When repopulating data we are getting zeros in metrics columns
across the dates we have repopulated. Some of these are from before
the item was published.

These columns should only have data when we have actually received it
from the source (i.e. it's been published and we collected some data).

This fixes https://trello.com/c/Wxq2pQxH/890-data-bug-repopulating-1-oct-to-11-nov-has-added-zero-values-for-pages-that-hadnt-been-published-yet