### PR TITLE
Renames parameter from `q` to `search_term`

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -15,7 +15,7 @@ private
   end
 
   def permitted_params
-    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range, :q)
+    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range, :search_term)
   end
 
   def validate_params!

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,7 +1,7 @@
 class Api::ContentRequest
   include ActiveModel::Validations
 
-  attr_reader :organisation_id, :document_type, :page, :page_size, :date_range, :q
+  attr_reader :organisation_id, :document_type, :page, :page_size, :date_range, :search_term
   validate :valid_organisation_id
   validate :valid_date_range
 
@@ -11,7 +11,7 @@ class Api::ContentRequest
     @organisation_id = params[:organisation_id]
     @document_type = params[:document_type]
     @page = params[:page].try(:to_i)
-    @q = params[:q]
+    @search_term = params[:search_term]
     @page_size = params[:page_size].try(:to_i)
     @date_range = params[:date_range]
   end
@@ -21,7 +21,7 @@ class Api::ContentRequest
       organisation_id: organisation_id,
       document_type: document_type,
       date_range: date_range,
-      q: q,
+      search_term: search_term,
       page: page,
       page_size: page_size,
     }

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -3,7 +3,7 @@ class Queries::FindContent
 
   def self.call(filter:)
     raise ArgumentError unless filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
-    filter.assert_valid_keys :q, :date_range, :organisation_id, :document_type, :page, :page_size
+    filter.assert_valid_keys :search_term, :date_range, :organisation_id, :document_type, :page, :page_size
 
     new(filter).call
   end
@@ -29,12 +29,12 @@ private
     'upviews desc'
   end
 
-  attr_reader :organisation_id, :document_type, :date_range, :q
+  attr_reader :organisation_id, :document_type, :date_range, :search_term
 
   def initialize(filter)
     @organisation_id = filter.fetch(:organisation_id)
     @document_type = filter.fetch(:document_type)
-    @q = filter[:q]
+    @search_term = filter[:search_term]
     @page = filter[:page] || 1
     @page_size = filter[:page_size] || DEFAULT_PAGE_SIZE
   end
@@ -60,7 +60,7 @@ private
     editions = Dimensions::Edition.relevant_content
     editions = editions.where('organisation_id = ?', organisation_id)
     editions = editions.where('document_type = ?', document_type) if document_type
-    editions = editions.search(q) if q.present?
+    editions = editions.search(search_term) if search_term.present?
     editions
   end
 end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -25,11 +25,11 @@ class Dimensions::Edition < ApplicationRecord
 
   def self.search(query)
     sql = <<~SQL
-      to_tsvector('english',title) @@ plainto_tsquery('english', :q) or
-      to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ plainto_tsquery('english', :q2)
+      to_tsvector('english',title) @@ plainto_tsquery('english', :search_term) or
+      to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ plainto_tsquery('english', :search_term_without_slash)
     SQL
 
-    where(sql, q: query, q2: query.tr('/', ' '))
+    where(sql, search_term: query, search_term_without_slash: query.tr('/', ' '))
   end
 
   def promote!(old_edition)

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::ContentRequest do
       request = Api::ContentRequest.new(
         document_type: 'guide',
         organisation_id: 'the-id',
-        q: 'a title or url',
+        search_term: 'a title or url',
         page: '1',
         page_size: '20',
         date_range: 'last-30-days',
@@ -13,7 +13,7 @@ RSpec.describe Api::ContentRequest do
       expect(request.to_filter).to eq(
         document_type: 'guide',
         organisation_id: 'the-id',
-        q: 'a title or url',
+        search_term: 'a title or url',
         page: 1,
         page_size: 20,
         date_range: 'last-30-days',
@@ -30,7 +30,7 @@ RSpec.describe Api::ContentRequest do
         document_type: nil,
         organisation_id: nil,
         page: nil,
-        q: nil,
+        search_term: nil,
         page_size: nil,
         date_range: nil,
       )

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Queries::FindContent do
       create :metric, edition: edition2, date: 14.days.ago
       recalculate_aggregations!
 
-      result = described_class.call(filter: filter.merge(q: 'big title'))
+      result = described_class.call(filter: filter.merge(search_term: 'big title'))
       expect(result[:results]).to contain_exactly(
         hash_including(title: 'this is a big title'),
       )
@@ -180,7 +180,7 @@ RSpec.describe Queries::FindContent do
       create :metric, edition: edition2, date: 14.days.ago
       recalculate_aggregations!
 
-      result = described_class.call(filter: filter.merge(q: 'big base-path'))
+      result = described_class.call(filter: filter.merge(search_term: 'big base-path'))
       expect(result[:results]).to contain_exactly(
         hash_including(base_path: '/this/is/a/big/base-path'),
       )

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'last-30-days', q: 'title1', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'last-30-days', search_term: 'title1', organisation_id: organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -115,7 +115,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'last-30-days', q: 'base_path1', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'last-30-days', search_term: 'base_path1', organisation_id: organisation_id } }
 
     it 'returns 200 status' do
       subject


### PR DESCRIPTION
[Trello card](https://trello.com/c/l2T9VoVG/725-5-index-page-filter-by-title-url)

Using q is causing issues:

1. It is not obvious to all developers
2. Lint is complaining about being too short.