### PR TITLE
Remove database constratints on base_path and warehouse_item_id

### DIFF
--- a/db/migrate/20181123142256_remove_constraints_base_path_latest.rb
+++ b/db/migrate/20181123142256_remove_constraints_base_path_latest.rb
@@ -1,0 +1,5 @@
+class RemoveConstraintsBasePathLatest < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :dimensions_editions, name: :index_dimensions_editions_on_latest_and_base_path
+  end
+end

--- a/db/migrate/20181123142713_remove_constraints_warehouse_item_id_latest.rb
+++ b/db/migrate/20181123142713_remove_constraints_warehouse_item_id_latest.rb
@@ -1,0 +1,5 @@
+class RemoveConstraintsWarehouseItemIdLatest < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :dimensions_editions, name: :index_dimensions_editions_on_latest_and_warehouse_item_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_22_105601) do
+ActiveRecord::Schema.define(version: 2018_11_23_142713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,10 +95,8 @@ ActiveRecord::Schema.define(version: 2018_11_22_105601) do
     t.index "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "dimensions_editions_base_path", using: :gin
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
-    t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
-    t.index ["latest", "warehouse_item_id"], name: "index_dimensions_editions_on_latest_and_warehouse_item_id", unique: true, where: "(latest = true)"
     t.index ["latest"], name: "index_dimensions_editions_on_latest"
     t.index ["organisation_id"], name: "index_dimensions_editions_organisation_id"
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -227,34 +227,6 @@ RSpec.describe Dimensions::Edition, type: :model do
     end
   end
 
-  describe 'Unique constraint on `warehouse_item_id` and `latest`' do
-    it 'prevent duplicating `warehouse_item_id` for latest items' do
-      create :edition, warehouse_item_id: 'value', latest: true
-
-      expect(-> { create :edition, warehouse_item_id: 'value', latest: true }).to raise_error(ActiveRecord::RecordNotUnique)
-    end
-
-    it 'does not prevent duplicating `warehouse_item_id` for old items' do
-      create :edition, warehouse_item_id: 'value', latest: true
-
-      expect(-> { create :edition, warehouse_item_id: 'value', latest: false }).to_not raise_error
-    end
-  end
-
-  describe 'Unique constraint on `base_path` and `latest`' do
-    it 'prevent duplicating `base_path` for latest items' do
-      create :edition, base_path: 'value', latest: true
-
-      expect(-> { create :edition, base_path: 'value', latest: true }).to raise_error(ActiveRecord::RecordNotUnique)
-    end
-
-    it 'does not prevent duplicating `base_path` for old items' do
-      create :edition, base_path: 'value', latest: true
-
-      expect(-> { create :edition, base_path: 'value', latest: false }).to_not raise_error
-    end
-  end
-
   describe '.search' do
     subject { Dimensions::Edition }
 


### PR DESCRIPTION
It removes the database constraints because they are raising too many
errors. The underlying issue seems to be fixed, but the data is not
consistent, so we are still getting the errors.

We need to repopulate so all content items hast the right locale, and
the warehouse_item_id.