### PR TITLE
Add Publishing API events table

### DIFF
--- a/app/domain/etl/edition/processor.rb
+++ b/app/domain/etl/edition/processor.rb
@@ -19,8 +19,8 @@ private
 
   def create_new_edition
     Facts::Edition.create!(
-      pdf_count: Etl::Edition::Metadata::NumberOfPdfs.parse(new_edition.raw_json),
-      doc_count: Etl::Edition::Metadata::NumberOfWordFiles.parse(new_edition.raw_json),
+      pdf_count: Etl::Edition::Metadata::NumberOfPdfs.parse(new_edition.publishing_api_event.payload),
+      doc_count: Etl::Edition::Metadata::NumberOfWordFiles.parse(new_edition.publishing_api_event.payload),
       dimensions_date: dimensions_date,
       dimensions_edition: new_edition,
       **quality_metrics

--- a/app/domain/streams/grow_dimension.rb
+++ b/app/domain/streams/grow_dimension.rb
@@ -37,6 +37,6 @@ private
   end
 
   def excluded_from_comparison?(key, _value)
-    %i[publishing_api_payload_version public_updated_at id update_at created_at latest warehouse_item_id].include? key
+    %i[publishing_api_payload_version public_updated_at id update_at created_at latest warehouse_item_id publishing_api_event_id].include? key
   end
 end

--- a/app/domain/streams/handlers/base_handler.rb
+++ b/app/domain/streams/handlers/base_handler.rb
@@ -1,16 +1,19 @@
 class Streams::Handlers::BaseHandler
   def update_editions(items_with_old_editions)
-    items_to_grow = items_with_old_editions.keep_if do |hsh|
-      Streams::GrowDimension.should_grow? old_edition: hsh[:old_edition], attrs: hsh[:attrs]
+    publishing_api_event = Events::PublishingApi.new(payload: @payload, routing_key: @routing_key)
+    items_with_old_editions.each do |item|
+      if Streams::GrowDimension.should_grow? old_edition: item[:old_edition], attrs: item[:attrs]
+        update_edition(item[:attrs], item[:old_edition], publishing_api_event)
+      end
     end
-    items_to_grow.each(&method(:update_edition))
   end
 
 private
 
-  def update_edition(hash)
-    new_edition = Dimensions::Edition.new(hash[:attrs])
-    new_edition.facts_edition = Etl::Edition::Processor.process(hash[:old_edition], new_edition)
-    new_edition.promote!(hash[:old_edition])
+  def update_edition(new_edition_attr, old_edition, publishing_api_event)
+    attributes = new_edition_attr.merge(publishing_api_event: publishing_api_event)
+    new_edition = Dimensions::Edition.new(attributes)
+    new_edition.facts_edition = Etl::Edition::Processor.process(old_edition, new_edition)
+    new_edition.promote!(old_edition)
   end
 end

--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -1,8 +1,10 @@
 class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
-  def initialize(attr_list, content_id, locale)
+  def initialize(attr_list, content_id, locale, payload, routing_key)
     @attr_list = attr_list
     @content_id = content_id
     @locale = locale
+    @payload = payload
+    @routing_key = routing_key
   end
 
   attr_reader :attr_list, :content_id, :locale

--- a/app/domain/streams/handlers/single_item_handler.rb
+++ b/app/domain/streams/handlers/single_item_handler.rb
@@ -6,8 +6,10 @@ class Streams::Handlers::SingleItemHandler < Streams::Handlers::BaseHandler
     new(*args).process
   end
 
-  def initialize(attrs)
+  def initialize(attrs, payload, routing_key)
     @attrs = attrs
+    @payload = payload
+    @routing_key = routing_key
   end
 
   attr_reader :attrs, :old_edition

--- a/app/domain/streams/message_processor_job.rb
+++ b/app/domain/streams/message_processor_job.rb
@@ -5,7 +5,7 @@ module Streams
     retry_on ActiveRecord::RecordNotUnique, wait: 5.seconds, attempts: 3
 
     def perform(payload, routing_key)
-      message = Streams::Messages::Factory.build(payload)
+      message = Streams::Messages::Factory.build(payload, routing_key)
 
       if message.invalid?
         Monitor::Messages.increment_discarded

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -33,7 +33,6 @@ class Streams::Messages::BaseMessage
       warehouse_item_id: warehouse_item_id,
       withdrawn: withdrawn_notice?,
       historical: historically_political?,
-      raw_json: @payload
     }
   end
 

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -1,8 +1,9 @@
 class Streams::Messages::BaseMessage
   attr_reader :payload
 
-  def initialize(payload)
+  def initialize(payload, routing_key)
     @payload = payload
+    @routing_key = routing_key
   end
 
   def build_attributes(base_path:, title:, document_text:, warehouse_item_id:)

--- a/app/domain/streams/messages/factory.rb
+++ b/app/domain/streams/messages/factory.rb
@@ -1,10 +1,10 @@
 module Streams::Messages
   class Factory
-    def self.build(payload)
+    def self.build(payload, routing_key)
       if MultipartMessage.is_multipart?(payload)
-        MultipartMessage.new(payload)
+        MultipartMessage.new(payload, routing_key)
       else
-        SingleItemMessage.new(payload)
+        SingleItemMessage.new(payload, routing_key)
       end
     end
   end

--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -12,7 +12,9 @@ module Streams
       Streams::Handlers::MultipartHandler.new(
         extract_edition_attributes,
         content_id,
-        locale
+        locale,
+        @payload,
+        @routing_key
       )
     end
 

--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -1,7 +1,7 @@
 module Streams
   class Messages::MultipartMessage < Messages::BaseMessage
-    def initialize(payload)
-      super
+    def initialize(payload, routing_key)
+      super(payload, routing_key)
     end
 
     def self.is_multipart?(payload)

--- a/app/domain/streams/messages/single_item_message.rb
+++ b/app/domain/streams/messages/single_item_message.rb
@@ -1,7 +1,7 @@
 module Streams
   class Messages::SingleItemMessage < Messages::BaseMessage
-    def initialize(payload)
-      super
+    def initialize(payload, routing_key)
+      super(payload, routing_key)
     end
 
     def extract_edition_attributes

--- a/app/domain/streams/messages/single_item_message.rb
+++ b/app/domain/streams/messages/single_item_message.rb
@@ -14,7 +14,11 @@ module Streams
     end
 
     def handler
-      Streams::Handlers::SingleItemHandler.new(extract_edition_attributes)
+      Streams::Handlers::SingleItemHandler.new(
+        extract_edition_attributes,
+        @payload,
+        @routing_key
+      )
     end
 
   private

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -2,6 +2,7 @@ require 'json'
 
 class Dimensions::Edition < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_edition_id
+  belongs_to :publishing_api_event, class_name: "Events::PublishingApi", foreign_key: :publishing_api_event_id
   validates :content_id, presence: true
   validates :base_path, presence: true
   validates :schema_name, presence: true

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -46,7 +46,7 @@ class Dimensions::Edition < ApplicationRecord
   end
 
   def change_from?(attributes)
-    assign_attributes(attributes.reject { |k, _| k == :raw_json })
+    assign_attributes(attributes)
     dirty = changed?
     reload
     dirty

--- a/app/models/events/publishing_api.rb
+++ b/app/models/events/publishing_api.rb
@@ -1,0 +1,4 @@
+class Events::PublishingApi < ApplicationRecord
+  self.table_name = "publishing_api_events"
+  has_many :dimensions_editions, class_name: "Dimensions::Edition"
+end

--- a/db/migrate/20181126095403_recreate_publishing_api_events.rb
+++ b/db/migrate/20181126095403_recreate_publishing_api_events.rb
@@ -1,0 +1,12 @@
+class RecreatePublishingApiEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :publishing_api_events do |t|
+      t.string :routing_key
+      t.jsonb :payload
+
+      t.timestamps
+    end
+
+    add_reference :dimensions_editions, :publishing_api_event, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20181126152543_remove_raw_json_from_dimension_editions.rb
+++ b/db/migrate/20181126152543_remove_raw_json_from_dimension_editions.rb
@@ -1,0 +1,5 @@
+class RemoveRawJsonFromDimensionEditions < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :dimensions_editions, :raw_json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_23_142713) do
+ActiveRecord::Schema.define(version: 2018_11_26_095403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
     t.json "raw_json"
     t.boolean "withdrawn", null: false
     t.boolean "historical", null: false
+    t.bigint "publishing_api_event_id"
     t.index "to_tsvector('english'::regconfig, (title)::text)", name: "dimensions_editions_title", using: :gin
     t.index "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "dimensions_editions_base_path", using: :gin
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
@@ -101,6 +102,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
     t.index ["latest", "warehouse_item_id"], name: "index_dimensions_editions_on_latest_and_warehouse_item_id", unique: true, where: "(latest = true)"
     t.index ["latest"], name: "index_dimensions_editions_on_latest"
     t.index ["organisation_id"], name: "index_dimensions_editions_organisation_id"
+    t.index ["publishing_api_event_id"], name: "index_dimensions_editions_on_publishing_api_event_id"
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"
     t.index ["warehouse_item_id", "latest"], name: "index_dimensions_editions_warehouse_item_id_latest"
     t.index ["warehouse_item_id"], name: "index_dimensions_editions_warehouse_item_id"
@@ -182,6 +184,13 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
     t.index ["dimensions_edition_id"], name: "index_facts_metrics_on_dimensions_edition_id"
   end
 
+  create_table "publishing_api_events", force: :cascade do |t|
+    t.string "routing_key"
+    t.jsonb "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -197,6 +206,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
   end
 
   add_foreign_key "aggregations_monthly_metrics", "dimensions_months"
+  add_foreign_key "dimensions_editions", "publishing_api_events"
   add_foreign_key "facts_editions", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_editions", "dimensions_editions"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
@@ -212,7 +222,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
      FROM ((facts_metrics
        JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
        JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-    WHERE (facts_metrics.dimensions_date_id >= (('now'::text)::date - '30 days'::interval day))
+    WHERE (facts_metrics.dimensions_date_id >= (CURRENT_DATE - '30 days'::interval day))
     GROUP BY dimensions_editions.warehouse_item_id;
   SQL
 
@@ -262,7 +272,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '2 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '2 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL
@@ -297,7 +307,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '5 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '5 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL
@@ -332,7 +342,7 @@ ActiveRecord::Schema.define(version: 2018_11_23_142713) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '11 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '11 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_26_095403) do
+ActiveRecord::Schema.define(version: 2018_11_26_152543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,7 +88,6 @@ ActiveRecord::Schema.define(version: 2018_11_26_095403) do
     t.string "update_type"
     t.datetime "last_edited_at"
     t.string "warehouse_item_id", null: false
-    t.json "raw_json"
     t.boolean "withdrawn", null: false
     t.boolean "historical", null: false
     t.bigint "publishing_api_event_id"

--- a/spec/domain/streams/handlers/single_item_handler_spec.rb
+++ b/spec/domain/streams/handlers/single_item_handler_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Streams::Handlers::SingleItemHandler do
     )
   end
 
-  subject { described_class.new(attrs) }
+  subject { described_class.new(attrs, {}, "routing_key") }
 
   context 'when attrs match the old edition' do
     let(:attrs) do

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Streams::Messages::MultipartMessage do
   end
 
   describe '#extract_edition_attributes' do
-    let(:instance) { subject.new(message.payload) }
+    let(:instance) { subject.new(message.payload, "routing_key") }
 
     context 'when the schema is a Guide' do
       let(:message) do

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Streams::Messages::MultipartMessage do
         attributes = instance.extract_edition_attributes
         common_attributes = expected_raw_attributes(
           content_id: message.payload['content_id'],
-          raw_json: message.payload,
           schema_name: 'guide'
         )
         expect(attributes).to eq([
@@ -74,7 +73,6 @@ RSpec.describe Streams::Messages::MultipartMessage do
         attributes = instance.extract_edition_attributes
         common_attributes = expected_raw_attributes(
           content_id: message.payload['content_id'],
-          raw_json: message.payload,
           schema_name: 'travel_advice',
           document_type: 'travel_advice'
         )

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
       msg.payload['withdrawn_notice'] = { explanation: 'something' }
       msg
     end
-    let(:instance) { subject.new(message.payload) }
+    let(:instance) { subject.new(message.payload, "routing_key") }
 
     it 'returns the attributes' do
       attributes = instance.extract_edition_attributes

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Streams::Messages::SingleItemMessage do
           historical: false,
           warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
           withdrawn: true,
-          raw_json: message.payload
         )
       )
     end

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     organisation_id { '17d84dc6-e5b5-4065-a8b5-8783bd934938' }
     withdrawn { false }
     historical { false }
+    association :publishing_api_event
 
     transient do
       date { Time.zone.today }

--- a/spec/factories/publishing_api_events.rb
+++ b/spec/factories/publishing_api_events.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :publishing_api_event, class: Events::PublishingApi do
+    payload { {} }
+    routing_key { 'routing_key' }
+  end
+end

--- a/spec/integration/streams/multiple/grow_dimension_spec.rb
+++ b/spec/integration/streams/multiple/grow_dimension_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe "Process sub-pages for multipart content types" do
     }.to change(Dimensions::Edition, :count).by(4)
   end
 
+  it "grows the publishing api events with message" do
+    message = build(:message, :with_parts)
+
+    expect {
+      subject.process(message)
+    }.to change(Events::PublishingApi, :count).by(1)
+  end
+
   context 'for a guide' do
     let(:content_id) { '3079e1a9-4b07-4012-af68-8b86f918fae9' }
 

--- a/spec/integration/streams/single/grow_dimension_spec.rb
+++ b/spec/integration/streams/single/grow_dimension_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Streams::Consumer do
     }.to change(Dimensions::Edition, :count).by(1)
   end
 
+  it 'grows the publishing api events with message' do
+    expect {
+      subject.process(build(:message))
+    }.to change(Events::PublishingApi, :count).by(1)
+  end
+
   it 'is idempotent' do
     message = build :message
 

--- a/spec/integration/streams/single/grow_dimension_spec.rb
+++ b/spec/integration/streams/single/grow_dimension_spec.rb
@@ -135,11 +135,9 @@ RSpec.describe Streams::Consumer do
 
       second_gone_message = build :message, payload: first_gone_message.payload.dup
       second_gone_message.payload['payload_version'] = base_payload_version + 2
-
       expect {
         subject.process(first_gone_message)
       }.to change(Dimensions::Edition, :count).by(1)
-
       expect {
         subject.process(second_gone_message)
       }.to change(Dimensions::Edition, :count).by(0)

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -190,10 +190,6 @@ RSpec.describe Dimensions::Edition, type: :model do
     it 'returns false if would not be changed by the given attributes' do
       expect(edition.change_from?(attrs)).to eq(false)
     end
-
-    it 'ignores the raw_json attribute' do
-      expect(edition.change_from?(attrs.merge(raw_json: '{}'))).to eq(false)
-    end
   end
 
   describe '#metadata' do

--- a/spec/support/shared/shared_messages.rb
+++ b/spec/support/shared/shared_messages.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'BaseMessage#historically_political?' do
   describe '#historically_political?' do
     let(:payload) { build(:message).payload }
-    let(:message) { described_class.new(payload) }
+    let(:message) { described_class.new(payload, "routing_key") }
     subject { message.historically_political? }
 
     context 'when payload has current goverment as false and has political as true' do
@@ -38,7 +38,7 @@ end
 RSpec.shared_examples 'BaseMessage#withdrawn_notice?' do
   describe '#withdrawn_notice?' do
     let(:payload) { build(:message).payload }
-    let(:message) { described_class.new(payload) }
+    let(:message) { described_class.new(payload, "routing_key") }
     subject { message.withdrawn_notice? }
 
     context 'when payload has withdrawn notice with explanation' do


### PR DESCRIPTION
This add a Publishing API events table to store messages sent from the Publishing API from which dimension editions are made from. 

Essentially moving the `Dimensions::Edition.raw_json` to `Events::PublishingAPI.payload`. The Publishing API events table also stores the routing key of the original message. 