### PR TITLE
Change date-range parameters to match front-end

### DIFF
--- a/app/domain/queries/select_view.rb
+++ b/app/domain/queries/select_view.rb
@@ -16,11 +16,11 @@ private
     case date_range
     when 'last-month'
       Aggregations::SearchLastMonth
-    when 'last-3-months'
+    when 'past-3-months'
       Aggregations::SearchLastThreeMonths
-    when 'last-6-months'
+    when 'past-6-months'
       Aggregations::SearchLastSixMonths
-    when 'last-year'
+    when 'past-year'
       Aggregations::SearchLastTwelveMonths
     else
       Aggregations::SearchLastThirtyDays
@@ -31,11 +31,11 @@ private
     case date_range
     when 'last-month'
       'last_months'
-    when 'last-3-months'
+    when 'past-3-months'
       'last_three_months'
-    when 'last-6-months'
+    when 'past-6-months'
       'last_six_months'
-    when 'last-year'
+    when 'past-year'
       'last_twelve_months'
     else
       'last_thirty_days'
@@ -43,7 +43,7 @@ private
   end
 
   def valid_date_range?
-    ['last-30-days', 'last-month', 'last-3-months', 'last-6-months', 'last-year'].include?(date_range)
+    ['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year'].include?(date_range)
   end
 
   class InvalidDateRangeError < StandardError

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -9,7 +9,7 @@ class DateRange
   end
 
   def self.valid?(time_period)
-    time_period.in?(['last-30-days', 'last-month', 'last-3-months', 'last-6-months', 'last-year', 'last-2-years'])
+    time_period.in?(['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year', 'past-2-years'])
   end
 
   def self.build(from:, to:)
@@ -21,7 +21,7 @@ private
 
   def date_to_range
     case time_period
-    when 'last-30-days'
+    when 'past-30-days'
       {
         from: (Date.today - 30.days).to_s,
         to: Date.today.to_s
@@ -31,22 +31,22 @@ private
         from: Date.today.last_month.beginning_of_month.to_s,
         to: Date.today.last_month.end_of_month.to_s
       }
-    when 'last-3-months'
+    when 'past-3-months'
       {
         from: (Date.today - 3.months).to_s,
         to: Date.today.to_s
       }
-    when 'last-6-months'
+    when 'past-6-months'
       {
         from: (Date.today - 6.months).to_s,
         to: Date.today.to_s
       }
-    when 'last-year'
+    when 'past-year'
       {
         from: (Date.today - 1.year).to_s,
         to: Date.today.to_s
       }
-    when 'last-2-years'
+    when 'past-2-years'
       {
         from: (Date.today - 2.years).to_s,
         to: Date.today.to_s

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::ContentRequest do
         search_term: 'a title or url',
         page: '1',
         page_size: '20',
-        date_range: 'last-30-days',
+        date_range: 'past-30-days',
       )
 
       expect(request.to_filter).to eq(
@@ -16,7 +16,7 @@ RSpec.describe Api::ContentRequest do
         search_term: 'a title or url',
         page: 1,
         page_size: 20,
-        date_range: 'last-30-days',
+        date_range: 'past-30-days',
       )
     end
 

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Queries::FindContent do
 
   let(:filter) do
     {
-      date_range: 'last-30-days',
+      date_range: 'past-30-days',
       organisation_id: primary_org_id,
       document_type: nil
     }
@@ -15,7 +15,7 @@ RSpec.describe Queries::FindContent do
     create :user
   end
 
-  it 'returns the aggregations for the last 30 days' do
+  it 'returns the aggregations for the past 30 days' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago, organisation_id: primary_org_id
     edition2 = create :edition, base_path: '/path2', date: 2.months.ago, organisation_id: primary_org_id
 
@@ -33,7 +33,7 @@ RSpec.describe Queries::FindContent do
     )
   end
 
-  it 'returns the metadata for the last 30 days' do
+  it 'returns the metadata for the past 30 days' do
     edition1 = create :edition,
       base_path: '/path1',
       organisation_id: primary_org_id,
@@ -86,7 +86,7 @@ RSpec.describe Queries::FindContent do
       )
     end
 
-    it 'returns aggregations for last 3 months' do
+    it 'returns aggregations for past 3 months' do
       two_months_ago_date = (Date.today - 2.month)
       create :metric, edition: edition1, date: this_month_date, upviews: 15, useful_yes: 1, useful_no: 4, searches: 10
       create :metric, edition: edition1, date: two_months_ago_date, upviews: 20, useful_yes: 4, useful_no: 1, searches: 1
@@ -94,7 +94,7 @@ RSpec.describe Queries::FindContent do
       create :metric, edition: edition2, date: two_months_ago_date, upviews: 10, useful_yes: 4, useful_no: 1, searches: 11
 
       filter = {
-        date_range: 'last-3-months',
+        date_range: 'past-3-months',
         organisation_id: primary_org_id,
         document_type: nil
       }
@@ -109,7 +109,7 @@ RSpec.describe Queries::FindContent do
       )
     end
 
-    it 'returns aggregations for last 6 months' do
+    it 'returns aggregations for past 6 months' do
       five_months_ago_date = (Date.today - 5.month)
       create :metric, edition: edition1, date: this_month_date, upviews: 15, useful_yes: 1, useful_no: 4, searches: 10
       create :metric, edition: edition1, date: five_months_ago_date, upviews: 20, useful_yes: 4, useful_no: 1, searches: 1
@@ -117,7 +117,7 @@ RSpec.describe Queries::FindContent do
       create :metric, edition: edition2, date: five_months_ago_date, upviews: 10, useful_yes: 4, useful_no: 1, searches: 11
 
       filter = {
-        date_range: 'last-6-months',
+        date_range: 'past-6-months',
         organisation_id: primary_org_id,
         document_type: nil
       }
@@ -132,7 +132,7 @@ RSpec.describe Queries::FindContent do
       )
     end
 
-    it 'returns aggregations for last year' do
+    it 'returns aggregations for past year' do
       eleven_months_ago_date = (Date.today - 11.month)
       create :metric, edition: edition1, date: this_month_date, upviews: 15, useful_yes: 1, useful_no: 4, searches: 10
       create :metric, edition: edition1, date: eleven_months_ago_date, upviews: 20, useful_yes: 4, useful_no: 1, searches: 1
@@ -140,7 +140,7 @@ RSpec.describe Queries::FindContent do
       create :metric, edition: edition2, date: eleven_months_ago_date, upviews: 10, useful_yes: 4, useful_no: 1, searches: 11
 
       filter = {
-        date_range: 'last-year',
+        date_range: 'past-year',
         organisation_id: primary_org_id,
         document_type: nil
       }

--- a/spec/domain/queries/select_view_spec.rb
+++ b/spec/domain/queries/select_view_spec.rb
@@ -2,24 +2,24 @@ RSpec.describe Queries::SelectView do
   let(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
 
   describe '#select_view' do
-    it 'returns last 30 days view if date range is `last-30-days`' do
-      expect(described_class.new('last-30-days').run).to eq(model_name: Aggregations::SearchLastThirtyDays, table_name: 'last_thirty_days')
+    it 'returns last 30 days view if date range is `past-30-days`' do
+      expect(described_class.new('past-30-days').run).to eq(model_name: Aggregations::SearchLastThirtyDays, table_name: 'last_thirty_days')
     end
 
     it 'returns last month view if date range is `last-month`' do
       expect(described_class.new('last-month').run).to eq(model_name: Aggregations::SearchLastMonth, table_name: 'last_months')
     end
 
-    it 'returns last 3 months view if date range is `last-3-months`' do
-      expect(described_class.new('last-3-months').run).to eq(model_name: Aggregations::SearchLastThreeMonths, table_name: 'last_three_months')
+    it 'returns last 3 months view if date range is `past-3-months`' do
+      expect(described_class.new('past-3-months').run).to eq(model_name: Aggregations::SearchLastThreeMonths, table_name: 'last_three_months')
     end
 
-    it 'returns last 6 months view if date range is `last-6-months`' do
-      expect(described_class.new('last-6-months').run).to eq(model_name: Aggregations::SearchLastSixMonths, table_name: 'last_six_months')
+    it 'returns last 6 months view if date range is `past-6-months`' do
+      expect(described_class.new('past-6-months').run).to eq(model_name: Aggregations::SearchLastSixMonths, table_name: 'last_six_months')
     end
 
-    it 'returns last year view if date range is `last-year`' do
-      expect(described_class.new('last-year').run).to eq(model_name: Aggregations::SearchLastTwelveMonths, table_name: 'last_twelve_months')
+    it 'returns last year view if date range is `past-year`' do
+      expect(described_class.new('past-year').run).to eq(model_name: Aggregations::SearchLastTwelveMonths, table_name: 'last_twelve_months')
     end
   end
 end

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DateRange do
     end
 
     it 'returns true if valid parameters' do
-      expect(DateRange.valid?('last-30-days')).to be_truthy
+      expect(DateRange.valid?('past-30-days')).to be_truthy
     end
   end
 
@@ -22,13 +22,13 @@ RSpec.describe DateRange do
   end
 
   describe 'for last 30 days' do
-    let(:time_period) { 'last-30-days' }
+    let(:time_period) { 'past-30-days' }
 
     subject { DateRange.new(time_period) }
 
     it { is_expected.to have_attributes(to: '2018-12-25') }
     it { is_expected.to have_attributes(from: '2018-11-25') }
-    it { is_expected.to have_attributes(time_period: 'last-30-days') }
+    it { is_expected.to have_attributes(time_period: 'past-30-days') }
   end
 
   describe 'for last month' do
@@ -42,32 +42,32 @@ RSpec.describe DateRange do
   end
 
   describe 'for last 3 months' do
-    let(:time_period) { 'last-3-months' }
+    let(:time_period) { 'past-3-months' }
 
     subject { DateRange.new(time_period) }
 
     it { is_expected.to have_attributes(to: '2018-12-25') }
     it { is_expected.to have_attributes(from: '2018-09-25') }
-    it { is_expected.to have_attributes(time_period: 'last-3-months') }
+    it { is_expected.to have_attributes(time_period: 'past-3-months') }
   end
 
   describe 'for last 6 months' do
-    let(:time_period) { 'last-6-months' }
+    let(:time_period) { 'past-6-months' }
 
     subject { DateRange.new(time_period) }
 
     it { is_expected.to have_attributes(to: '2018-12-25') }
     it { is_expected.to have_attributes(from: '2018-06-25') }
-    it { is_expected.to have_attributes(time_period: 'last-6-months') }
+    it { is_expected.to have_attributes(time_period: 'past-6-months') }
   end
 
   describe 'for last year' do
-    let(:time_period) { 'last-year' }
+    let(:time_period) { 'past-year' }
 
     subject { DateRange.new(time_period) }
 
     it { is_expected.to have_attributes(to: '2018-12-25') }
     it { is_expected.to have_attributes(from: '2017-12-25') }
-    it { is_expected.to have_attributes(time_period: 'last-year') }
+    it { is_expected.to have_attributes(time_period: 'past-year') }
   end
 end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe '/content' do
 
     context 'last 30 days' do
       it 'returns 200 status' do
-        get '/content', params: { date_range: 'last-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         expect(response).to have_http_status(200)
       end
 
       it 'returns aggregated metrics' do
-        get '/content', params: { date_range: 'last-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:results]).to contain_exactly(
           a_hash_including(
@@ -75,12 +75,12 @@ RSpec.describe '/content' do
 
     context 'last 3 months' do
       it 'returns 200 status' do
-        get '/content', params: { date_range: 'last-3-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-3-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         expect(response).to have_http_status(200)
       end
 
       it 'returns aggregated metrics' do
-        get '/content', params: { date_range: 'last-3-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-3-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         json = JSON.parse(response.body).deep_symbolize_keys
 
         expect(json[:results]).to contain_exactly(
@@ -104,12 +104,12 @@ RSpec.describe '/content' do
 
     context 'last 6 months' do
       it 'returns 200 status' do
-        get '/content', params: { date_range: 'last-6-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-6-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         expect(response).to have_http_status(200)
       end
 
       it 'returns aggregated metrics' do
-        get '/content', params: { date_range: 'last-6-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-6-months', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:results]).to contain_exactly(
           a_hash_including(
@@ -132,12 +132,12 @@ RSpec.describe '/content' do
 
     context 'last year' do
       it 'returns 200 status' do
-        get '/content', params: { date_range: 'last-year', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-year', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         expect(response).to have_http_status(200)
       end
 
       it 'returns aggregated metrics' do
-        get '/content', params: { date_range: 'last-year', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+        get '/content', params: { date_range: 'past-year', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:results]).to contain_exactly(
           a_hash_including(
@@ -170,7 +170,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'last-30-days', document_type: 'a-document-type', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', document_type: 'a-document-type', organisation_id: organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -197,7 +197,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'last-30-days', search_term: 'title1', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', search_term: 'title1', organisation_id: organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -224,7 +224,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'last-30-days', search_term: 'base_path1', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', search_term: 'base_path1', organisation_id: organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -241,7 +241,7 @@ RSpec.describe '/content' do
   end
 
   describe 'Relevant content' do
-    subject { get '/content', params: { date_range: 'last-30-days', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id } }
 
     before do
       create_edition_and_metric('redirect')
@@ -280,7 +280,7 @@ RSpec.describe '/content' do
     end
 
     it 'returns the first page of the data' do
-      get '/content', params: { date_range: 'last-30-days', organisation_id: organisation_id, page: 1, page_size: 1 }
+      get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id, page: 1, page_size: 1 }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:results]).to contain_exactly(a_hash_including(base_path: '/path-01'))
@@ -288,7 +288,7 @@ RSpec.describe '/content' do
     end
 
     it 'returns the second page of the data' do
-      get '/content', params: { date_range: 'last-30-days', organisation_id: organisation_id, page: 2, page_size: 1 }
+      get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id, page: 2, page_size: 1 }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:results]).to contain_exactly(a_hash_including(base_path: '/path-02'))
@@ -296,7 +296,7 @@ RSpec.describe '/content' do
     end
   end
 
-  include_examples 'API response', '/content', date_range: 'last-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2'
+  include_examples 'API response', '/content', date_range: 'past-30-days', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2'
 
   context 'with invalid params' do
     it 'returns an error for badly formatted dates' do
@@ -316,7 +316,7 @@ RSpec.describe '/content' do
     end
 
     it 'returns an error for invalid organisation_id' do
-      get '/content/', params: { date_range: 'last-30-days', organisation_id: 'blah' }
+      get '/content/', params: { date_range: 'past-30-days', organisation_id: 'blah' }
 
       expect(response.status).to eq(400)
 


### PR DESCRIPTION
The date-range parameters have been renamed as follows:

last-30-days => past-30-days
last-3-months => past-3-months
last-6-months => past-6-months
last-year => past-year

There will be a related PR in content-data-admin before this can be merged