### PR TITLE
Change the warehouse_item_ids for multipart messages

### DIFF
--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -18,12 +18,11 @@ module Streams
 
     def extract_edition_attributes
       parts.map.with_index do |part, index|
-        base_path = base_path_for_part(part, index)
         build_attributes(
-          base_path: base_path,
+          base_path: base_path_for_part(part, index),
           title: title_for(part),
           document_text: document_text_for_part(part['slug']),
-          warehouse_item_id: "#{content_id}:#{locale}:#{base_path}"
+          warehouse_item_id: warehouse_item_id_for_part(part, index)
         )
       end
     end
@@ -47,10 +46,29 @@ module Streams
     end
 
     def base_path_for_part(part, index)
-      slug = part.fetch('slug')
-      return base_path if index.zero?
+      part_sub_path = sub_path_for_part(part, index)
 
-      "#{base_path}/#{slug}"
+      if part_sub_path
+        "#{base_path}/#{part_sub_path}"
+      else
+        base_path
+      end
+    end
+
+    def sub_path_for_part(part, index)
+      return nil if index.zero?
+
+      part.fetch('slug')
+    end
+
+    def warehouse_item_id_for_part(part, index)
+      if index.zero?
+        "#{content_id}:#{locale}"
+      else
+        part_sub_path = sub_path_for_part(part, index)
+
+        "#{content_id}:#{locale}:#{part_sub_path}"
+      end
     end
 
     attr_reader :payload, :message_parts

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -35,25 +35,25 @@ RSpec.describe Streams::Messages::MultipartMessage do
         )
         expect(attributes).to eq([
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
             document_text: 'Here 1',
             title: 'the-title: Part 1',
             base_path: '/base-path'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path/part2",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part2",
             document_text: 'be 2',
             title: 'the-title: Part 2',
             base_path: '/base-path/part2'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path/part3",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part3",
             document_text: 'some 3',
             title: 'the-title: Part 3',
             base_path: '/base-path/part3'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path/part4",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part4",
             document_text: 'content 4.',
             title: 'the-title: Part 4',
             base_path: '/base-path/part4'
@@ -80,19 +80,19 @@ RSpec.describe Streams::Messages::MultipartMessage do
         )
         expect(attributes).to eq([
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
             document_text: 'summary content',
             title: 'the-title: Summary',
             base_path: '/base-path'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path/part1",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part1",
             document_text: 'Here 1',
             title: 'the-title: Part 1',
             base_path: '/base-path/part1'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:/base-path/part2",
+            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part2",
             document_text: 'be 2',
             title: 'the-title: Part 2',
             base_path: '/base-path/part2'

--- a/spec/integration/streams/multiple/grow_dimension_spec.rb
+++ b/spec/integration/streams/multiple/grow_dimension_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe "Process sub-pages for multipart content types" do
       parts = Dimensions::Edition.pluck(:base_path, :title, :warehouse_item_id).to_set
 
       expect(parts).to eq Set[
-        ["/base-path", "Main Title: Part 1", "#{content_id}:en:/base-path"],
-        ["/base-path/part2", "Main Title: Part 2", "#{content_id}:en:/base-path/part2"],
-        ["/base-path/part3", "Main Title: Part 3", "#{content_id}:en:/base-path/part3"],
-        ["/base-path/part4", "Main Title: Part 4", "#{content_id}:en:/base-path/part4"]
+        ["/base-path", "Main Title: Part 1", "#{content_id}:en"],
+        ["/base-path/part2", "Main Title: Part 2", "#{content_id}:en:part2"],
+        ["/base-path/part3", "Main Title: Part 3", "#{content_id}:en:part3"],
+        ["/base-path/part4", "Main Title: Part 4", "#{content_id}:en:part4"]
       ]
     end
   end
@@ -52,9 +52,9 @@ RSpec.describe "Process sub-pages for multipart content types" do
       parts = Dimensions::Edition.pluck(:base_path, :title, :warehouse_item_id).to_set
 
       expect(parts).to eq Set[
-        ["/travel/advice", "The Title: Summary", "#{content_id}:fr:/travel/advice"],
-        ["/travel/advice/part1", "The Title: Part 1", "#{content_id}:fr:/travel/advice/part1"],
-        ["/travel/advice/part2", "The Title: Part 2", "#{content_id}:fr:/travel/advice/part2"],
+        ["/travel/advice", "The Title: Summary", "#{content_id}:fr"],
+        ["/travel/advice/part1", "The Title: Part 1", "#{content_id}:fr:part1"],
+        ["/travel/advice/part2", "The Title: Part 2", "#{content_id}:fr:part2"],
       ]
     end
   end


### PR DESCRIPTION
Previously the warehouse_item_ids for multipart messages included the
full path. This means that if the base_path for the content item in
the Publishing API were to change, the warehouse_item_id would be
different.

This somewhat defeats the point of the warehouse_item_id, which should
stay the same for the same page, even if it moves.

To improve the situation, just include the "sub" path, the bit after
the base path (from the Publishing API). For example, with a bit of
content with two pages /basepath and /basepath/subthing, the
warehouse_item_id of the two pages would be:

 - /basepath          => 176a6aab-...583e61f45:en
 - /basepath/subthing => 176a6aab-...583e61f45:en:subthing

As the warehouse_item_id can be used to spot uniqueness issues, even
though the dimensions_editions entry for /basepath corresponds to a
multipart message, having the warehouse_item_id not contain anything
special should be more effective at avoiding duplicates.

For the dimensions_editions entry for /basepath/subthing, I decided to
omit the leading /, as I though that might be confusing (as it would
look like an absolute path).