### PR TITLE
Move valid message logic to BaseMessage

### DIFF
--- a/app/domain/streams/consumer.rb
+++ b/app/domain/streams/consumer.rb
@@ -1,7 +1,7 @@
 module Streams
   class Consumer
     def process(message)
-      if valid_message?(message)
+      if valid_routing_key?(message)
         Streams::MessageProcessorJob.perform_later(message.payload, message.delivery_info.routing_key)
       else
         Monitor::Messages.increment_discarded
@@ -14,15 +14,6 @@ module Streams
     end
 
   private
-
-    def valid_message?(message)
-      valid_routing_key?(message) &&
-        valid_schema?(message)
-    end
-
-    def valid_schema?(message)
-      !message.payload['schema_name'].include?('placeholder')
-    end
 
     def valid_routing_key?(message)
       routing_key = message.delivery_info.routing_key

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -37,8 +37,7 @@ class Streams::Messages::BaseMessage
   end
 
   def invalid?
-    mandatory_fields = @payload.values_at('base_path', 'schema_name')
-    mandatory_fields.any?(&:nil?)
+    mandatory_fields_nil? || placeholder_schema?
   end
 
   def withdrawn_notice?
@@ -74,5 +73,14 @@ private
 
   def historical?
     @payload.dig('details', 'government').present? && !@payload.dig('details', 'government', 'current')
+  end
+
+  def mandatory_fields_nil?
+    mandatory_fields = @payload.values_at('base_path', 'schema_name')
+    mandatory_fields.any?(&:nil?)
+  end
+
+  def placeholder_schema?
+    @payload['schema_name'].include?('placeholder')
   end
 end

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Streams::Messages::MultipartMessage do
   include PublishingEventProcessingSpecHelper
 
   subject { described_class }
+  include_examples 'BaseMessage#invalid?'
   include_examples 'BaseMessage#historically_political?'
   include_examples 'BaseMessage#withdrawn_notice?'
 

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
   include PublishingEventProcessingSpecHelper
 
   subject { described_class }
+  include_examples 'BaseMessage#invalid?'
   include_examples 'BaseMessage#historically_political?'
   include_examples 'BaseMessage#withdrawn_notice?'
 

--- a/spec/support/shared/shared_messages.rb
+++ b/spec/support/shared/shared_messages.rb
@@ -52,3 +52,30 @@ RSpec.shared_examples 'BaseMessage#withdrawn_notice?' do
     end
   end
 end
+
+RSpec.shared_examples 'BaseMessage#invalid?' do
+  describe '#invalid?' do
+    let(:payload) { build(:message).payload }
+    let(:message) { described_class.new(payload) }
+    subject { message.invalid? }
+
+    context 'with normal payload' do
+      it { is_expected.to eq false }
+    end
+
+    context 'when schema name is placeholder' do
+      before { payload['schema_name'] = 'placeholder' }
+      it { is_expected.to eq true }
+    end
+
+    context 'when base path is nil' do
+      before { payload.delete('base_path') }
+      it { is_expected.to eq true }
+    end
+
+    context 'when schema name is nil' do
+      before { payload.delete('schema_name') }
+      it { is_expected.to eq true }
+    end
+  end
+end


### PR DESCRIPTION
This moves checking the schema placeholder from the `Consumer` class to `BaseMessage` class, where other similar message "validation" occurs. The `Consumer` class shouldn't be concerned with the contents of the payload.