### PR TITLE
Update required minimum version of Rack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rails-controller-testing'
+  gem "rack", ">= 2.0.6"
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,6 +515,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
+  rack (>= 2.0.6)
   rack-proxy
   rails (~> 5.1)
   rails-controller-testing


### PR DESCRIPTION
This is to address security vulnerabilities with versions below 2.0.6.