### PR TITLE
Update views with date range staring in yesterday

### DIFF
--- a/db/migrate/20181122134132_remove_default_zeros_from_facts_metrics.rb
+++ b/db/migrate/20181122134132_remove_default_zeros_from_facts_metrics.rb
@@ -1,5 +1,5 @@
 class RemoveDefaultZerosFromFactsMetrics < ActiveRecord::Migration[5.2]
-  COLS = %i[pviews upviews searches feedex exits entrances bounces bounce_rate avg_page_time page_time]
+  COLS = %i[pviews upviews searches feedex exits entrances bounces bounce_rate avg_page_time page_time].freeze
 
   def up
     COLS.each do |col|

--- a/db/migrate/20181122142744_remove_default_zeros_from_events_gas.rb
+++ b/db/migrate/20181122142744_remove_default_zeros_from_events_gas.rb
@@ -1,5 +1,5 @@
 class RemoveDefaultZerosFromEventsGas < ActiveRecord::Migration[5.2]
-  COLS = %i[pviews upviews searches exits entrances bounces bounce_rate avg_page_time page_time]
+  COLS = %i[pviews upviews searches exits entrances bounces bounce_rate avg_page_time page_time].freeze
 
   def up
     COLS.each do |col|

--- a/db/migrate/20181122152546_remove_default_zeros_from_aggregations_monthly_metrics.rb
+++ b/db/migrate/20181122152546_remove_default_zeros_from_aggregations_monthly_metrics.rb
@@ -1,6 +1,6 @@
 class RemoveDefaultZerosFromAggregationsMonthlyMetrics < ActiveRecord::Migration[5.2]
-  COLS = %i[pviews upviews feedex searches exits entrances bounces bounce_rate avg_page_time page_time]
-  
+  COLS = %i[pviews upviews feedex searches exits entrances bounces bounce_rate avg_page_time page_time].freeze
+
   def up
     COLS.each do |col|
       change_column_default(:aggregations_monthly_metrics, col, nil)

--- a/db/migrate/20181126120610_update_aggregations_search_last_thirty_days_to_version_2.rb
+++ b/db/migrate/20181126120610_update_aggregations_search_last_thirty_days_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastThirtyDaysToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_thirty_days, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/migrate/20181126135420_update_aggregations_search_last_six_months_to_version_2.rb
+++ b/db/migrate/20181126135420_update_aggregations_search_last_six_months_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastSixMonthsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_six_months, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/migrate/20181126151050_update_aggregations_search_last_three_months_to_version_2.rb
+++ b/db/migrate/20181126151050_update_aggregations_search_last_three_months_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastThreeMonthsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_three_months, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/migrate/20181126152658_update_aggregations_search_last_twelve_months_to_version_2.rb
+++ b/db/migrate/20181126152658_update_aggregations_search_last_twelve_months_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastTwelveMonthsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_twelve_months, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_26_120610) do
+ActiveRecord::Schema.define(version: 2018_11_26_135420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -245,7 +245,7 @@ ActiveRecord::Schema.define(version: 2018_11_26_120610) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '2 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM-01'::text))::date))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL
@@ -268,7 +268,7 @@ ActiveRecord::Schema.define(version: 2018_11_26_120610) do
              FROM ((aggregations_monthly_metrics
                JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
                JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
-            WHERE ((dimensions_months.id)::text >= to_char((now() - '5 mons'::interval), 'YYYY-MM'::text))
+            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM'::text))
             GROUP BY dimensions_editions.warehouse_item_id
           UNION
            SELECT dimensions_editions.warehouse_item_id,
@@ -280,7 +280,7 @@ ActiveRecord::Schema.define(version: 2018_11_26_120610) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '5 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (('yesterday'::text)::date - '5 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(version: 2018_11_26_120610) do
              FROM ((facts_metrics
                JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('now'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (('now'::text)::date - '11 mons'::interval)))
+            WHERE ((facts_metrics.dimensions_date_id >= (CURRENT_DATE - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (CURRENT_DATE - '11 mons'::interval)))
             GROUP BY dimensions_editions.warehouse_item_id) agg
     GROUP BY agg.warehouse_item_id;
   SQL

--- a/db/views/aggregations_search_last_six_months_v02.sql
+++ b/db/views/aggregations_search_last_six_months_v02.sql
@@ -1,0 +1,35 @@
+SELECT  warehouse_item_id,
+  max(agg.dimensions_edition_id) AS dimensions_edition_id,
+  sum(agg.upviews) AS upviews,
+  sum(agg.useful_yes) AS useful_yes,
+  sum(agg.useful_no) AS useful_no,
+  sum(agg.searches) AS searches
+FROM(
+    -- Use monthly aggregations
+    SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '5 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  UNION
+    -- Use daily metrics
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+    WHERE facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - interval '6 month')
+         AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '5 month'),'YYYY-MM-01')::date
+    GROUP BY warehouse_item_id
+) as agg
+GROUP BY warehouse_item_id

--- a/db/views/aggregations_search_last_thirty_days_v02.sql
+++ b/db/views/aggregations_search_last_thirty_days_v02.sql
@@ -1,0 +1,12 @@
+SELECT warehouse_item_id,
+  max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+  sum(facts_metrics.upviews) AS upviews,
+  sum(facts_metrics.useful_yes) AS useful_yes,
+  sum(facts_metrics.useful_no) AS useful_no,
+  sum(facts_metrics.searches) AS searches
+ FROM facts_metrics
+   JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+   JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+ WHERE (facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '30 days'::interval day))
+   AND (facts_metrics.dimensions_date_id < ('now'::text)::date)
+GROUP BY warehouse_item_id

--- a/db/views/aggregations_search_last_three_months_v02.sql
+++ b/db/views/aggregations_search_last_three_months_v02.sql
@@ -1,0 +1,35 @@
+SELECT  warehouse_item_id,
+  max(agg.dimensions_edition_id) AS dimensions_edition_id,
+  sum(agg.upviews) AS upviews,
+  sum(agg.useful_yes) AS useful_yes,
+  sum(agg.useful_no) AS useful_no,
+  sum(agg.searches) AS searches
+FROM(
+    -- Use monthly aggregations
+    SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  UNION
+    -- Use daily metrics
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+    WHERE facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - interval '3 month')
+         AND facts_metrics.dimensions_date_id < to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM-01')::date
+    GROUP BY warehouse_item_id
+) as agg
+GROUP BY warehouse_item_id

--- a/db/views/aggregations_search_last_twelve_months_v02.sql
+++ b/db/views/aggregations_search_last_twelve_months_v02.sql
@@ -1,0 +1,35 @@
+SELECT  warehouse_item_id,
+  max(agg.dimensions_edition_id) AS dimensions_edition_id,
+  sum(agg.upviews) AS upviews,
+  sum(agg.useful_yes) AS useful_yes,
+  sum(agg.useful_no) AS useful_no,
+  sum(agg.searches) AS searches
+FROM(
+    -- Use monthly aggregations
+    SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '11 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  UNION
+    -- Use daily metrics
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+    WHERE facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - interval '12 month')
+         AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '11 month'),'YYYY-MM-01')::date
+    GROUP BY warehouse_item_id
+) as agg
+GROUP BY warehouse_item_id

--- a/spec/models/aggregations/search_last_six_months_spec.rb
+++ b/spec/models/aggregations/search_last_six_months_spec.rb
@@ -30,26 +30,47 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundaries' do
-    it 'does not include metrics before 3 months' do
+  describe 'Boundary: last six months from yesterday' do
+    it 'include metrics from 6 months ago starting in yesterday' do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (6.months.ago - 1.day)
+      create :metric, edition: edition1, date: (Date.yesterday - 6.months), upviews: 10
 
       recalculate_aggregations!
 
-      expect(subject.count).to eq(0)
+      expect(subject.sum(:upviews)).to eq(10)
+    end
+
+    it 'does not include metrics from 6 months and 2 days ago' do
+      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+      create :metric, edition: edition1, date: (6.months.ago - 2.days), upviews: 10
+
+      recalculate_aggregations!
+
+      expect(subject.sum(:upviews)).to eq(0.0)
     end
 
     it 'does include yesterday' do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday
+      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
 
       recalculate_aggregations!
 
-      expect(subject.count).to eq(1)
+      expect(subject.sum(:upviews)).to eq(10.0)
     end
   end
 
+  it 'does not count metrics twice' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    to = Date.yesterday
+    from = Date.yesterday - 6.months
+    (from..to).each do |date|
+      create :metric, edition: edition1, date: date, upviews: 10
+    end
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
+  end
 
   it 'is linked to the latest dimension edition' do
     edition1 = create :edition

--- a/spec/models/aggregations/search_last_thirty_days_spec.rb
+++ b/spec/models/aggregations/search_last_thirty_days_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
     create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
     create :metric, edition: edition1, date: 15.days.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
-    create :metric, edition: edition1, date: 31.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
+    create :metric, edition: edition1, date: 32.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
     recalculate_aggregations!
 
@@ -30,23 +30,41 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundaries' do
-    it 'does not include 31 days ago' do
+  describe 'Boundary: last thirty days from yesterday' do
+    it 'include days 31 days ago' do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: 31.days.ago
+      create :metric, edition: edition1, date: 31.days.ago, upviews: 10
 
       recalculate_aggregations!
 
-      expect(subject.count).to eq(0)
+      expect(subject.sum(:upviews)).to eq(10)
+    end
+
+    it 'does not include 32 days ago' do
+      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+      create :metric, edition: edition1, date: 32.days.ago, upviews: 10
+
+      recalculate_aggregations!
+
+      expect(subject.sum(:upviews)).to eq(0.0)
+    end
+
+    it 'does not include today' do
+      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+      create :metric, edition: edition1, date: Date.today, upviews: 10
+
+      recalculate_aggregations!
+
+      expect(subject.sum(:upviews)).to eq(0)
     end
 
     it 'does include yesterday' do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday
+      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
 
       recalculate_aggregations!
 
-      expect(subject.count).to eq(1)
+      expect(subject.sum(:upviews)).to eq(10.0)
     end
   end
 

--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -30,26 +30,47 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundaries' do
-    it 'does not include metrics before 3 months' do
+  describe 'Boundary: last three months from yesterday' do
+    it 'include metrics from 3 months ago starting in yesterday' do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (3.months.ago - 1.day)
+      create :metric, edition: edition1, date: (Date.yesterday - 3.months), upviews: 10
 
       recalculate_aggregations!
 
-      expect(subject.count).to eq(0)
+      expect(subject.sum(:upviews)).to eq(10)
+    end
+
+    it 'does not include metrics from 3 months and 2 days ago' do
+      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+      create :metric, edition: edition1, date: (3.months.ago - 2.days), upviews: 10
+
+      recalculate_aggregations!
+
+      expect(subject.sum(:upviews)).to eq(0.0)
     end
 
     it 'does include yesterday' do
       edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday
+      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
 
       recalculate_aggregations!
 
-      expect(subject.count).to eq(1)
+      expect(subject.sum(:upviews)).to eq(10.0)
     end
   end
 
+  it 'does not count metrics twice' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    to = Date.yesterday
+    from = Date.yesterday - 3.months
+    (from..to).each do |date|
+      create :metric, edition: edition1, date: date, upviews: 10
+    end
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
+  end
 
   it 'is linked to the latest dimension edition' do
     edition1 = create :edition

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe '/content' do
 
   describe 'Aggregations' do
     before do
-      this_month_date = Date.today.beginning_of_month
-      last_month_date = Date.today - 1.month
+      this_month_date = Date.yesterday.beginning_of_month
+      last_month_date = Date.yesterday - 1.month
       edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id
       create :metric, date: this_month_date, edition: edition1, upviews: 100, useful_yes: 50, useful_no: 20, searches: 20
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/fDmMuIwT/891-2-update-time-range-in-index-page-so-aggregations-match-with-single-data-page)

1. Fixes an issue when we were counting metrics twice 
2. It shifts the starting day to aggregate the views from today to yesterday