### PR TITLE
Add all orgs and no orgs to filter

### DIFF
--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -36,6 +36,7 @@ private
   end
 
   def valid_organisation_id
+    return true if %w[all].include? organisation_id
     return true if UUID.validate organisation_id
     errors.add('organisation_id', 'this is not a valid organisation id')
   end

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -36,7 +36,7 @@ private
   end
 
   def valid_organisation_id
-    return true if %w[all].include? organisation_id
+    return true if %w[all none].include? organisation_id
     return true if UUID.validate organisation_id
     errors.add('organisation_id', 'this is not a valid organisation id')
   end

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,5 +1,7 @@
 class Queries::FindContent
   DEFAULT_PAGE_SIZE = 100
+  ALL = 'all'.freeze
+  NONE = 'none'.freeze
 
   def self.call(filter:)
     raise ArgumentError unless filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
@@ -60,10 +62,10 @@ private
 
   def slice_editions
     editions = Dimensions::Edition.relevant_content
-    if organisation_id == 'none'
+    if organisation_id == NONE
       editions = editions.where('organisation_id IS NULL')
     else
-      editions = editions.where('organisation_id = ?', organisation_id) unless organisation_id == 'all'
+      editions = editions.where('organisation_id = ?', organisation_id) unless organisation_id == ALL
     end
     editions = editions.where('document_type = ?', document_type) if document_type
     editions = editions.search(search_term) if search_term.present?

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -64,8 +64,8 @@ private
     editions = Dimensions::Edition.relevant_content
     if organisation_id == NONE
       editions = editions.where('organisation_id IS NULL')
-    else
-      editions = editions.by_organisation_id(organisation_id) unless organisation_id == ALL
+    elsif  organisation_id != ALL
+      editions = editions.by_organisation_id(organisation_id)
     end
     editions = editions.where('document_type = ?', document_type) if document_type
     editions = editions.search(search_term) if search_term.present?

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -60,7 +60,11 @@ private
 
   def slice_editions
     editions = Dimensions::Edition.relevant_content
-    editions = editions.where('organisation_id = ?', organisation_id) unless organisation_id == 'all'
+    if organisation_id == 'none'
+      editions = editions.where('organisation_id IS NULL')
+    else
+      editions = editions.where('organisation_id = ?', organisation_id) unless organisation_id == 'all'
+    end
     editions = editions.where('document_type = ?', document_type) if document_type
     editions = editions.search(search_term) if search_term.present?
     editions

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -65,7 +65,7 @@ private
     if organisation_id == NONE
       editions = editions.where('organisation_id IS NULL')
     else
-      editions = editions.where('organisation_id = ?', organisation_id) unless organisation_id == ALL
+      editions = editions.by_organisation_id(organisation_id) unless organisation_id == ALL
     end
     editions = editions.where('document_type = ?', document_type) if document_type
     editions = editions.search(search_term) if search_term.present?

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -60,7 +60,7 @@ private
 
   def slice_editions
     editions = Dimensions::Edition.relevant_content
-    editions = editions.where('organisation_id = ?', organisation_id)
+    editions = editions.where('organisation_id = ?', organisation_id) unless organisation_id == 'all'
     editions = editions.where('document_type = ?', document_type) if document_type
     editions = editions.search(search_term) if search_term.present?
     editions

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -156,6 +156,33 @@ RSpec.describe Queries::FindContent do
     end
   end
 
+  describe 'Filter by all organisations' do
+    let(:filter) do
+      {
+        date_range: 'last-30-days',
+        organisation_id: 'all',
+        document_type: nil
+      }
+    end
+
+    let(:edition1) { create :edition, date: 15.days.ago }
+    let(:edition2) { create :edition, date: 15.days.ago }
+
+    before do
+      create :metric, edition: edition1, upviews: 20, date: 15.days.ago
+      create :metric, edition: edition2, upviews: 10, date: 15.days.ago
+      recalculate_aggregations!
+    end
+
+    it 'returns content from all organisations' do
+      response = described_class.call(filter: filter)
+      expect(response[:results]).to contain_exactly(
+        hash_including(base_path: edition1.base_path),
+        hash_including(base_path: edition2.base_path)
+      )
+    end
+  end
+
   describe 'Pagination' do
     before do
       4.times do |n|

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Queries::FindContent do
     end
 
     let(:edition1) { create :edition, date: 15.days.ago }
-    let(:edition2) { create :edition, date: 15.days.ago }
+    let(:edition2) { create :edition, date: 15.days.ago, organisation_id: nil }
 
     before do
       create :metric, edition: edition1, upviews: 20, date: 15.days.ago

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -285,6 +285,29 @@ RSpec.describe '/content' do
     end
   end
 
+  describe 'Filter by all organisations' do
+    let(:another_org_id) { 'c97bbc95-967a-4678-848b-6f393171f194' }
+    let(:edition1) { create :edition, organisation_id: organisation_id, date: 15.days.ago }
+    let(:edition2) { create :edition, organisation_id: another_org_id, date: 15.days.ago }
+
+    subject { get '/content', params: { date_range: 'last-30-days', organisation_id: 'all' } }
+
+    before do
+      create :metric, edition: edition1, date: 15.days.ago
+      create :metric, edition: edition2, date: 15.days.ago
+      recalculate_aggregations!
+    end
+
+    it 'returns data from both organisations' do
+      subject
+
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:results].count).to eq(2)
+      expected_results = [edition1.base_path, edition2.base_path]
+      expect(json[:results].map { |res| res[:base_path] }).to eq(expected_results)
+    end
+  end
+
   describe 'Relevant content' do
     subject { get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id } }
 


### PR DESCRIPTION
# What

Allow organisation_id parameter to accept `all` and `none`.

`all` will not apply the organisation filter.
`none` will return content that has a nil organisation_id.

This is a non-breaking change.

Trello: https://trello.com/c/oWvlfbPR/878-3-index-page-add-all-organisations-and-no-organisations-to-the-organisation-filter