### PR TITLE
Make TransformPath more resilient

### DIFF
--- a/app/domain/etl/ga/concerns/transform_path.rb
+++ b/app/domain/etl/ga/concerns/transform_path.rb
@@ -20,8 +20,12 @@ private
     attributes = { page_path: sanitised_page_path }
 
     if duplicate_event
-      attributes[:pviews] = event.pviews + duplicate_event.pviews
-      attributes[:upviews] = event.upviews + duplicate_event.upviews
+      if event.pviews || duplicate_event.pviews
+        attributes[:pviews] = (event.pviews || 0) + (duplicate_event.pviews || 0)
+      end
+      if event.upviews || duplicate_event.upviews
+        attributes[:upviews] = (event.upviews || 0) + (duplicate_event.upviews || 0)
+      end
 
       duplicate_event.destroy
     end


### PR DESCRIPTION
The pviews and upviews fields are nullable in the database, so don't
assume that they won't be nil here.

I think it's useful to avoid inventing a 0 value out of nowhere, so
the 0 value is only used as a default if either of the fields actually
have a value.