### PR TITLE
Add a new route to handle the homepage.

### DIFF
--- a/app/domain/api/single_page_request.rb
+++ b/app/domain/api/single_page_request.rb
@@ -1,8 +1,6 @@
 class Api::SinglePageRequest < Api::BaseRequest
   attr_reader :metrics, :base_path
 
-  validates :base_path, presence: true
-
   def initialize(params)
     super(params)
     @base_path = params[:base_path]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   end
 
   get '/content', to: 'content#show'
-  get '/single_page/*base_path', to: 'single_item#show', defaults: { format: :json }
+  get '/single_page/(*base_path)', to: 'single_item#show', defaults: { format: :json }
   get '/organisations', to: 'organisation#index', defaults: { format: :json }
   get '/document_types', to: 'document_type#index', defaults: { format: :json }
 end

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe '/single_page', type: :request do
   end
 
   context 'when correct parameters supplied' do
+    context 'when the page is the homepage' do
+      before do
+        create :edition, base_path: '/', title: 'GOV.UK homepage'
+      end
+
+      it 'returns data for the homepage' do
+        get "/single_page", params: { from: '2018-01-01', to: '2018-01-31' }
+
+        body = JSON.parse(response.body).deep_symbolize_keys
+        expect(response).to have_http_status(200)
+        expect(body[:metadata][:title]).to eq('GOV.UK homepage')
+      end
+    end
+
     it 'returns the metadata' do
       get "/single_page/#{base_path}", params: { from: '2018-01-01', to: '2018-01-31' }
 

--- a/spec/routing/single_page_routing_spec.rb
+++ b/spec/routing/single_page_routing_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'single page endpoint routing' do
+  it 'routes /single-item/very/long/base/path' do
+    expect(get: '/single_page/very/long/base/path').to route_to(
+      controller: 'single_item',
+      action: 'show',
+      format: :json,
+      base_path: 'very/long/base/path'
+    )
+  end
+
+  it 'routes /single_page (for the homepage)' do
+    expect(get: '/single_page/').to route_to(
+      controller: 'single_item',
+      action: 'show',
+      format: :json
+    )
+  end
+end


### PR DESCRIPTION
Now we have allowed filtering by no organisation or
all organisations, the GOV.UK homepage now appears in the
results. This has highlighted a bug. The homepage's base_path
`/` doesn't map to a route in either app.

This commit introduces a route without the base path, which allows
the GOV.UK homepage to routed.

There is a [Related PR in content-data-admin](https://github.com/alphagov/content-data-admin/pull/248)

Trello: https://trello.com/c/q9YG0Ftm/915-fix-bug-with-rendering-the-govuk-homepage-in-content-data-admin