### PR TITLE
Add NOT NULL constraint on facts_metrics columns

### DIFF
--- a/db/migrate/20181129125513_add_not_null_constraint_to_facts_metrics.rb
+++ b/db/migrate/20181129125513_add_not_null_constraint_to_facts_metrics.rb
@@ -1,0 +1,17 @@
+class AddNotNullConstraintToFactsMetrics < ActiveRecord::Migration[5.2]
+  COLS = %i[pviews upviews feedex searches exits entrances bounce_rate avg_page_time bounces page_time]
+
+    def up
+      COLS.each do |col|
+        change_column_null :facts_metrics, col, false
+        change_column_default :facts_metrics, col , 0
+      end
+    end
+
+    def down
+      COLS.each do |col|
+        change_column_null :facts_metrics, col, true
+        change_column_default :facts_metrics, col , nil
+      end
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_29_115927) do
+ActiveRecord::Schema.define(version: 2018_11_29_125513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,18 +166,18 @@ ActiveRecord::Schema.define(version: 2018_11_29_115927) do
     t.bigint "dimensions_edition_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "pviews"
-    t.integer "upviews"
-    t.integer "feedex"
+    t.integer "pviews", default: 0, null: false
+    t.integer "upviews", default: 0, null: false
+    t.integer "feedex", default: 0, null: false
     t.integer "useful_yes", default: 0, null: false
     t.integer "useful_no", default: 0, null: false
-    t.integer "searches"
-    t.integer "exits"
-    t.integer "entrances"
-    t.integer "bounce_rate"
-    t.integer "avg_page_time"
-    t.integer "bounces"
-    t.integer "page_time"
+    t.integer "searches", default: 0, null: false
+    t.integer "exits", default: 0, null: false
+    t.integer "entrances", default: 0, null: false
+    t.integer "bounce_rate", default: 0, null: false
+    t.integer "avg_page_time", default: 0, null: false
+    t.integer "bounces", default: 0, null: false
+    t.integer "page_time", default: 0, null: false
     t.float "satisfaction", default: 0.0, null: false
     t.index ["dimensions_date_id", "dimensions_edition_id"], name: "metrics_edition_id_date_id", unique: true
     t.index ["dimensions_edition_id"], name: "index_facts_metrics_on_dimensions_edition_id"


### PR DESCRIPTION
For metric columns in fact_metrics we should never have NULLs. We should always have a value for metrics of a content items when it exists. Additional work is to delete extra facts rows for content items when they did not exist.