### PR TITLE
Fix withdrawn parsing from publishing api messages

### DIFF
--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -41,7 +41,7 @@ class Streams::Messages::BaseMessage
   end
 
   def withdrawn_notice?
-    @payload.dig('withdrawn_notice', :explanation).present?
+    @payload.dig('withdrawn_notice', "explanation").present?
   end
 
   def historically_political?

--- a/lib/tasks/editions.rake
+++ b/lib/tasks/editions.rake
@@ -1,0 +1,18 @@
+namespace :editions do
+  desc "Update withdrawn editions"
+  task set_withdrawn: :environment do
+    editions = Dimensions::Edition.all
+    puts "Updating #{editions.count} editions"
+
+    ActiveRecord::Base.transaction do
+      Dimensions::Edition.find_each(batch_size: 1000).each_with_index do |edition, index|
+        payload = edition.publishing_api_event.payload
+        edition.withdrawn = Streams::Messages::BaseMessage.new(payload, nil).withdrawn_notice?
+        edition.save!
+        puts "Updated editions #{index}" if (index % 5000).zero?
+      end
+    end
+
+    puts "Done!"
+  end
+end

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
       msg = build(:message, attributes: message_attributes)
       msg.payload['details']['body'] = '<p>some content</p>'
       msg.payload['details']['government'] = { 'current' => true }
-      msg.payload['withdrawn_notice'] = { explanation: 'something' }
+      msg.payload['withdrawn_notice'] = { "explanation" => 'something' }
       msg
     end
     let(:instance) { subject.new(message.payload, "routing_key") }

--- a/spec/support/shared/shared_messages.rb
+++ b/spec/support/shared/shared_messages.rb
@@ -42,7 +42,7 @@ RSpec.shared_examples 'BaseMessage#withdrawn_notice?' do
     subject { message.withdrawn_notice? }
 
     context 'when payload has withdrawn notice with explanation' do
-      before { payload['withdrawn_notice'] = { explanation: 'Not relevant' } }
+      before { payload['withdrawn_notice'] = { "explanation" => 'Not relevant' } }
       it { is_expected.to eq true }
     end
 


### PR DESCRIPTION
Previously, the message from publishing API was incorrectly parsed to determined withdrawn content. This address the parsing issues and adds a rake task `bundle exec rake editions:set_withdrawn` to re-parse existing editions to correct their withdrawn status.