### PR TITLE
Add transaction to build aggregations

### DIFF
--- a/app/domain/etl/aggregations/search.rb
+++ b/app/domain/etl/aggregations/search.rb
@@ -6,10 +6,17 @@ class Etl::Aggregations::Search
   end
 
   def process
-    time(process: :aggregations_thirty_days) { ::Aggregations::SearchLastThirtyDays.refresh }
-    time(process: :aggregations_last_month) { ::Aggregations::SearchLastMonth.refresh }
-    time(process: :aggregations_last_three_months) { ::Aggregations::SearchLastThreeMonths.refresh }
-    time(process: :aggregations_last_six_months) { ::Aggregations::SearchLastSixMonths.refresh }
-    time(process: :aggregations_last_twelve_months) { ::Aggregations::SearchLastTwelveMonths.refresh }
+    do_process(::Aggregations::SearchLastThirtyDays)
+    do_process(::Aggregations::SearchLastMonth)
+    do_process(::Aggregations::SearchLastThreeMonths)
+    do_process(::Aggregations::SearchLastSixMonths)
+    do_process(::Aggregations::SearchLastTwelveMonths)
+  end
+
+private
+
+  def do_process(klass)
+    name = klass.name.demodulize.underscore
+    time(process: name) { klass.refresh }
   end
 end

--- a/app/domain/etl/aggregations/search.rb
+++ b/app/domain/etl/aggregations/search.rb
@@ -17,6 +17,10 @@ private
 
   def do_process(klass)
     name = klass.name.demodulize.underscore
-    time(process: name) { klass.refresh }
+    time(process: name) do
+      ActiveRecord::Base.transaction do
+        klass.refresh
+      end
+    end
   end
 end


### PR DESCRIPTION
Open transaction each time a view is refreshed

So far we are [getting the error][1] when running the master process.

```bash
  $ WARNING:  SET LOCAL can only be used in transaction blocks
```

It seems to be related with not opening a transaction each time we change
the the database parameter `work_mem`. By opening the transaction,
we managed to make the process effective an we move from 4 min to 1 min
of processing time.

From:

```
[1] pry(main)> Benchmark.measure { Aggregations::SearchLastThirtyDays.refresh }
WARNING:  SET LOCAL can only be used in transaction blocks
   (0.2ms)  set local work_mem = '500MB'
   (248771.3ms)  REFRESH MATERIALIZED VIEW "aggregations_search_last_thirty_days";
=> #<Benchmark::Tms:0x000055c42ea78990
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=248.85927314998116,
 @stime=0.016000000000000014,
 @total=0.020000000000000018,
 @utime=0.0040000000000000036>
```

To:

```
[4] pry(main)> Benchmark.measure { ActiveRecord::Base.transaction {Aggregations::SearchLastTwelveMonths.refresh }}
=> #<Benchmark::Tms:0x000055598ec54af8
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=7.61372552200919,
 @stime=0.0,
 @total=0.0,
 @utime=0.0>
```

[1]: https://deploy.publishing.service.gov.uk/job/run-rake-task/10492/console