### PR TITLE
Filter out irrelevant content part 2

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -22,7 +22,7 @@ class Dimensions::Edition < ApplicationRecord
     latest_by_content_id(content_id, locale)
       .where.not(base_path: exclude_paths)
   end
-  scope :relevant_content, -> { where.not(document_type: %w[redirect gone]) }
+  scope :relevant_content, -> { where.not(document_type: %w[redirect gone vanish unpublishing need]) }
 
   def self.search(query)
     sql = <<~SQL

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe Dimensions::Edition, type: :model do
       edition = create :edition, document_type: 'news_story'
       create :edition, document_type: 'redirect'
       create :edition, document_type: 'gone'
+      create :edition, document_type: 'vanish'
+      create :edition, document_type: 'unpublishing'
+      create :edition, document_type: 'need'
       results = subject.relevant_content
       expect(results).to match_array(edition)
     end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -334,10 +334,13 @@ RSpec.describe '/content' do
       create_edition_and_metric('redirect')
       create_edition_and_metric('gone')
       create_edition_and_metric('news_story')
+      create_edition_and_metric('vanish')
+      create_edition_and_metric('unpublishing')
+      create_edition_and_metric('need')
       recalculate_aggregations!
     end
 
-    it 'filters out `gone` and `redirect`' do
+    it 'filters out `gone`, `redirect`, `vanish`, `unpublishing` and `need`' do
       subject
 
       json = JSON.parse(response.body).deep_symbolize_keys

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe '/document_types' do
     create :edition, document_type: 'guide'
     create :edition, document_type: 'manual'
     create :edition, document_type: 'manual'
-    # `gone` and `redirect` should not appear in the results
+    # the document types below should not appear in the results
     create :edition, document_type: 'redirect'
     create :edition, document_type: 'gone'
+    create :edition, document_type: 'vanish'
+    create :edition, document_type: 'unpublishing'
+    create :edition, document_type: 'need'
   end
 
   it 'returns distinct document types ordered by title' do


### PR DESCRIPTION
#What
We show some document types in the filter list that aren't relevant for publishers. We need to filter these out from the API's query to the Content Data Admin and remove them from the document type filter list

We need to filter out:

- `vanish`
- `unpublishing`
- `need`

#Why
Content Data should only show content that is relevant to publishers.

This commit filters the following document types
from the /content and /document_types endpoints.

* vanish
* unpublishing
* need

## Screenshots

### Before
![screen shot 2018-12-04 at 14 28 54](https://user-images.githubusercontent.com/511319/49449100-14dcaf00-f7d2-11e8-8c7f-7d6b719c6d9a.png)
### After
![screen shot 2018-12-04 at 14 36 14](https://user-images.githubusercontent.com/511319/49449122-1dcd8080-f7d2-11e8-8765-04f6f7683eaa.png)
