### PR TITLE
Unique index for views: concurrent refresh of data

### DIFF
--- a/app/models/aggregations/search_last_month.rb
+++ b/app/models/aggregations/search_last_month.rb
@@ -1,6 +1,6 @@
 class Aggregations::SearchLastMonth < ApplicationRecord
   def self.refresh
     Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/app/models/aggregations/search_last_six_months.rb
+++ b/app/models/aggregations/search_last_six_months.rb
@@ -1,6 +1,6 @@
 class Aggregations::SearchLastSixMonths < ApplicationRecord
   def self.refresh
     Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/app/models/aggregations/search_last_thirty_days.rb
+++ b/app/models/aggregations/search_last_thirty_days.rb
@@ -1,6 +1,6 @@
 class Aggregations::SearchLastThirtyDays < ApplicationRecord
   def self.refresh
     Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/app/models/aggregations/search_last_three_months.rb
+++ b/app/models/aggregations/search_last_three_months.rb
@@ -1,6 +1,6 @@
 class Aggregations::SearchLastThreeMonths < ApplicationRecord
   def self.refresh
     Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/app/models/aggregations/search_last_twelve_months.rb
+++ b/app/models/aggregations/search_last_twelve_months.rb
@@ -1,6 +1,6 @@
 class Aggregations::SearchLastTwelveMonths < ApplicationRecord
   def self.refresh
     Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/db/migrate/20181204140034_add_unique_index_to_last_thirty_days.rb
+++ b/db/migrate/20181204140034_add_unique_index_to_last_thirty_days.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLastThirtyDays < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_search_last_thirty_days, %i(dimensions_edition_id warehouse_item_id), unique: true, name: 'index_on_search_last_thirty_days_unique'
+  end
+end

--- a/db/migrate/20181204140917_refresh_view_last_thirty_days.rb
+++ b/db/migrate/20181204140917_refresh_view_last_thirty_days.rb
@@ -1,0 +1,5 @@
+class RefreshViewLastThirtyDays < ActiveRecord::Migration[5.2]
+  def change
+    Aggregations::SearchLastThirtyDays.refresh
+  end
+end

--- a/db/migrate/20181204142533_add_unique_index_to_last_month.rb
+++ b/db/migrate/20181204142533_add_unique_index_to_last_month.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLastMonth < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_search_last_months, %i(dimensions_edition_id warehouse_item_id), unique: true, name: 'index_on_search_last_monthunique'
+  end
+end

--- a/db/migrate/20181204142554_refresh_view_last_month.rb
+++ b/db/migrate/20181204142554_refresh_view_last_month.rb
@@ -1,0 +1,5 @@
+class RefreshViewLastMonth < ActiveRecord::Migration[5.2]
+  def change
+    Aggregations::SearchLastMonth.refresh
+  end
+end

--- a/db/migrate/20181204143719_add_unique_index_to_last_three_months.rb
+++ b/db/migrate/20181204143719_add_unique_index_to_last_three_months.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLastThreeMonths < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_search_last_three_months, %i(dimensions_edition_id warehouse_item_id), unique: true, name: 'index_on_search_last_three_months_unique'
+  end
+end

--- a/db/migrate/20181204143802_refresh_view_last_three_months.rb
+++ b/db/migrate/20181204143802_refresh_view_last_three_months.rb
@@ -1,0 +1,5 @@
+class RefreshViewLastThreeMonths < ActiveRecord::Migration[5.2]
+  def change
+    Aggregations::SearchLastThreeMonths.refresh
+  end
+end

--- a/db/migrate/20181204144322_add_unique_index_to_last_six_months.rb
+++ b/db/migrate/20181204144322_add_unique_index_to_last_six_months.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLastSixMonths < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_search_last_six_months, %i(dimensions_edition_id warehouse_item_id), unique: true, name: 'index_on_search_last_six_months_unique'
+  end
+end

--- a/db/migrate/20181204144330_refresh_view_last_six_months.rb
+++ b/db/migrate/20181204144330_refresh_view_last_six_months.rb
@@ -1,0 +1,5 @@
+class RefreshViewLastSixMonths < ActiveRecord::Migration[5.2]
+  def change
+    Aggregations::SearchLastSixMonths.refresh
+  end
+end

--- a/db/migrate/20181204145152_add_unique_index_to_last_twelve_months.rb
+++ b/db/migrate/20181204145152_add_unique_index_to_last_twelve_months.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLastTwelveMonths < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_search_last_twelve_months, %i(dimensions_edition_id warehouse_item_id), unique: true, name: 'index_on_search_last_twelve_months_unique'
+  end
+end

--- a/db/migrate/20181204145159_refresh_view_last_twelve_months.rb
+++ b/db/migrate/20181204145159_refresh_view_last_twelve_months.rb
@@ -1,0 +1,5 @@
+class RefreshViewLastTwelveMonths < ActiveRecord::Migration[5.2]
+  def change
+    Aggregations::SearchLastTwelveMonths.refresh
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_29_125513) do
+ActiveRecord::Schema.define(version: 2018_12_04_140917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,22 +227,6 @@ ActiveRecord::Schema.define(version: 2018_11_29_125513) do
 
   add_index "aggregations_search_last_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_month_edition_id_upviews"
 
-  create_view "aggregations_search_last_thirty_days", materialized: true,  sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-      sum(facts_metrics.upviews) AS upviews,
-      sum(facts_metrics.useful_yes) AS useful_yes,
-      sum(facts_metrics.useful_no) AS useful_no,
-      sum(facts_metrics.searches) AS searches
-     FROM ((facts_metrics
-       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-       JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-    WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
-    GROUP BY dimensions_editions.warehouse_item_id;
-  SQL
-
-  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "upviews"], name: "index_on_last_thirty_days_edition_id_upviews"
-
   create_view "aggregations_search_last_six_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,
       max(agg.dimensions_edition_id) AS dimensions_edition_id,
@@ -277,6 +261,23 @@ ActiveRecord::Schema.define(version: 2018_11_29_125513) do
   SQL
 
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
+
+  create_view "aggregations_search_last_thirty_days", materialized: true,  sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM ((facts_metrics
+       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+       JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
+    WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
+    GROUP BY dimensions_editions.warehouse_item_id;
+  SQL
+
+  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "upviews"], name: "index_on_last_thirty_days_edition_id_upviews"
+  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_thirty_days_unique", unique: true
 
   create_view "aggregations_search_last_three_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_143802) do
+ActiveRecord::Schema.define(version: 2018_12_04_144330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -262,6 +262,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_143802) do
   SQL
 
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
+  add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_six_months_unique", unique: true
 
   create_view "aggregations_search_last_thirty_days", materialized: true,  sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_140917) do
+ActiveRecord::Schema.define(version: 2018_12_04_142554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,6 +226,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_140917) do
   SQL
 
   add_index "aggregations_search_last_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_month_edition_id_upviews"
+  add_index "aggregations_search_last_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_monthunique", unique: true
 
   create_view "aggregations_search_last_six_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_142554) do
+ActiveRecord::Schema.define(version: 2018_12_04_143802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -314,6 +314,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_142554) do
   SQL
 
   add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_three_months_edition_id_upviews"
+  add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_three_months_unique", unique: true
 
   create_view "aggregations_search_last_twelve_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_144330) do
+ActiveRecord::Schema.define(version: 2018_12_04_145159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -351,5 +351,6 @@ ActiveRecord::Schema.define(version: 2018_12_04_144330) do
   SQL
 
   add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_twelve_months_edition_id_upviews"
+  add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_twelve_months_unique", unique: true
 
 end

--- a/spec/support/shared/shared_masterialized_views.rb
+++ b/spec/support/shared/shared_masterialized_views.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'a materialized view' do |table_name|
   it 'refresh the materialized view' do
-    expect(Scenic.database).to receive(:refresh_materialized_view).with(table_name, concurrently: false, cascade: false)
+    expect(Scenic.database).to receive(:refresh_materialized_view).with(table_name, concurrently: true, cascade: false)
 
     subject.refresh
   end


### PR DESCRIPTION
Add a unique index to the view to allow concurrent rebuild of the data while
the users are reading from it. This is important in order to not blocking users
access.

See Scenic[1] documentation[2]

[1]: https://github.com/scenic-views/scenic
[2]: https://github.com/scenic-views/scenic#what-about-materialized-views