### PR TITLE
Fix date ranges to accurately reflect dates

### DIFF
--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -23,33 +23,33 @@ private
     case time_period
     when 'past-30-days'
       {
-        from: (Date.today - 30.days).to_s,
-        to: Date.today.to_s
+        from: (Date.yesterday - 29.days).to_s,
+        to: Date.yesterday.to_s
       }
     when 'last-month'
       {
-        from: Date.today.last_month.beginning_of_month.to_s,
-        to: Date.today.last_month.end_of_month.to_s
+        from: Date.yesterday.last_month.beginning_of_month.to_s,
+        to: Date.yesterday.last_month.end_of_month.to_s
       }
     when 'past-3-months'
       {
-        from: (Date.today - 3.months).to_s,
-        to: Date.today.to_s
+        from: ((Date.yesterday - 3.months) + 1.day).to_s,
+        to: Date.yesterday.to_s
       }
     when 'past-6-months'
       {
-        from: (Date.today - 6.months).to_s,
-        to: Date.today.to_s
+        from: ((Date.yesterday - 6.months) + 1.day).to_s,
+        to: Date.yesterday.to_s
       }
     when 'past-year'
       {
-        from: (Date.today - 1.year).to_s,
-        to: Date.today.to_s
+        from: ((Date.yesterday - 1.year) + 1.day).to_s,
+        to: Date.yesterday.to_s
       }
     when 'past-2-years'
       {
-        from: (Date.today - 2.years).to_s,
-        to: Date.today.to_s
+        from: ((Date.yesterday - 2.years) + 1.day).to_s,
+        to: Date.yesterday.to_s
       }
     else
       raise ArgumentError.new(time_period)

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -9,7 +9,7 @@ class DateRange
   end
 
   def self.valid?(time_period)
-    time_period.in?(['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year', 'past-2-years'])
+    time_period.in?(['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year'])
   end
 
   def self.build(from:, to:)
@@ -44,11 +44,6 @@ private
     when 'past-year'
       {
         from: ((Date.yesterday - 1.year) + 1.day).to_s,
-        to: Date.yesterday.to_s
-      }
-    when 'past-2-years'
-      {
-        from: ((Date.yesterday - 2.years) + 1.day).to_s,
         to: Date.yesterday.to_s
       }
     else

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DateRange do
 
     subject { DateRange.new(time_period) }
 
-    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(to: '2018-12-24') }
     it { is_expected.to have_attributes(from: '2018-11-25') }
     it { is_expected.to have_attributes(time_period: 'past-30-days') }
   end
@@ -46,7 +46,7 @@ RSpec.describe DateRange do
 
     subject { DateRange.new(time_period) }
 
-    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(to: '2018-12-24') }
     it { is_expected.to have_attributes(from: '2018-09-25') }
     it { is_expected.to have_attributes(time_period: 'past-3-months') }
   end
@@ -56,7 +56,7 @@ RSpec.describe DateRange do
 
     subject { DateRange.new(time_period) }
 
-    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(to: '2018-12-24') }
     it { is_expected.to have_attributes(from: '2018-06-25') }
     it { is_expected.to have_attributes(time_period: 'past-6-months') }
   end
@@ -66,7 +66,7 @@ RSpec.describe DateRange do
 
     subject { DateRange.new(time_period) }
 
-    it { is_expected.to have_attributes(to: '2018-12-25') }
+    it { is_expected.to have_attributes(to: '2018-12-24') }
     it { is_expected.to have_attributes(from: '2017-12-25') }
     it { is_expected.to have_attributes(time_period: 'past-year') }
   end


### PR DESCRIPTION
Date ranges started a day early and ended on the current day. Fixed date ranges to generate the start date a day later and end date to be yesterday as expected.