### PR TITLE
Fix date ranges in views

### DIFF
--- a/db/migrate/20181205154240_update_aggregations_search_last_thirty_days_to_version_3.rb
+++ b/db/migrate/20181205154240_update_aggregations_search_last_thirty_days_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastThirtyDaysToVersion3 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_thirty_days, version: 3, revert_to_version: 2, materialized: true
+  end
+end

--- a/db/migrate/20181205165620_update_aggregations_search_last_three_months_to_version_3.rb
+++ b/db/migrate/20181205165620_update_aggregations_search_last_three_months_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastThreeMonthsToVersion3 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_three_months, version: 3, revert_to_version: 2, materialized: true
+  end
+end

--- a/db/migrate/20181206115804_update_aggregations_search_last_six_months_to_version_3.rb
+++ b/db/migrate/20181206115804_update_aggregations_search_last_six_months_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastSixMonthsToVersion3 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_six_months, version: 3, revert_to_version: 2, materialized: true
+  end
+end

--- a/db/migrate/20181206120629_update_aggregations_search_last_twelve_months_to_version_3.rb
+++ b/db/migrate/20181206120629_update_aggregations_search_last_twelve_months_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateAggregationsSearchLastTwelveMonthsToVersion3 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_twelve_months, version: 3, revert_to_version: 2, materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_145159) do
+ActiveRecord::Schema.define(version: 2018_12_05_154240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -264,23 +264,6 @@ ActiveRecord::Schema.define(version: 2018_12_04_145159) do
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_six_months_unique", unique: true
 
-  create_view "aggregations_search_last_thirty_days", materialized: true,  sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-      sum(facts_metrics.upviews) AS upviews,
-      sum(facts_metrics.useful_yes) AS useful_yes,
-      sum(facts_metrics.useful_no) AS useful_no,
-      sum(facts_metrics.searches) AS searches
-     FROM ((facts_metrics
-       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-       JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-    WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
-    GROUP BY dimensions_editions.warehouse_item_id;
-  SQL
-
-  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "upviews"], name: "index_on_last_thirty_days_edition_id_upviews"
-  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_thirty_days_unique", unique: true
-
   create_view "aggregations_search_last_three_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,
       max(agg.dimensions_edition_id) AS dimensions_edition_id,
@@ -352,5 +335,22 @@ ActiveRecord::Schema.define(version: 2018_12_04_145159) do
 
   add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_twelve_months_edition_id_upviews"
   add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_twelve_months_unique", unique: true
+
+  create_view "aggregations_search_last_thirty_days", materialized: true,  sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM ((facts_metrics
+       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+       JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
+    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
+    GROUP BY dimensions_editions.warehouse_item_id;
+  SQL
+
+  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "upviews"], name: "index_on_last_thirty_days_edition_id_upviews"
+  add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_thirty_days_unique", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_05_165620) do
+ActiveRecord::Schema.define(version: 2018_12_06_115804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,42 +228,6 @@ ActiveRecord::Schema.define(version: 2018_12_05_165620) do
   add_index "aggregations_search_last_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_month_edition_id_upviews"
   add_index "aggregations_search_last_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_monthunique", unique: true
 
-  create_view "aggregations_search_last_six_months", materialized: true,  sql_definition: <<-SQL
-      SELECT agg.warehouse_item_id,
-      max(agg.dimensions_edition_id) AS dimensions_edition_id,
-      sum(agg.upviews) AS upviews,
-      sum(agg.useful_yes) AS useful_yes,
-      sum(agg.useful_no) AS useful_no,
-      sum(agg.searches) AS searches
-     FROM ( SELECT dimensions_editions.warehouse_item_id,
-              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(aggregations_monthly_metrics.upviews) AS upviews,
-              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-              sum(aggregations_monthly_metrics.searches) AS searches
-             FROM ((aggregations_monthly_metrics
-               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-               JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
-            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM'::text))
-            GROUP BY dimensions_editions.warehouse_item_id
-          UNION
-           SELECT dimensions_editions.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM-01'::text))::date))
-            GROUP BY dimensions_editions.warehouse_item_id) agg
-    GROUP BY agg.warehouse_item_id;
-  SQL
-
-  add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
-  add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_six_months_unique", unique: true
-
   create_view "aggregations_search_last_twelve_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,
       max(agg.dimensions_edition_id) AS dimensions_edition_id,
@@ -352,5 +316,41 @@ ActiveRecord::Schema.define(version: 2018_12_05_165620) do
 
   add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_three_months_edition_id_upviews"
   add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_three_months_unique", unique: true
+
+  create_view "aggregations_search_last_six_months", materialized: true,  sql_definition: <<-SQL
+      SELECT agg.warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.searches) AS searches
+     FROM ( SELECT dimensions_editions.warehouse_item_id,
+              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(aggregations_monthly_metrics.upviews) AS upviews,
+              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+              sum(aggregations_monthly_metrics.searches) AS searches
+             FROM ((aggregations_monthly_metrics
+               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+               JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
+            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM'::text))
+            GROUP BY dimensions_editions.warehouse_item_id
+          UNION
+           SELECT dimensions_editions.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM-01'::text))::date))
+            GROUP BY dimensions_editions.warehouse_item_id) agg
+    GROUP BY agg.warehouse_item_id;
+  SQL
+
+  add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
+  add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_six_months_unique", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_06_115804) do
+ActiveRecord::Schema.define(version: 2018_12_06_120629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,42 +228,6 @@ ActiveRecord::Schema.define(version: 2018_12_06_115804) do
   add_index "aggregations_search_last_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_month_edition_id_upviews"
   add_index "aggregations_search_last_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_monthunique", unique: true
 
-  create_view "aggregations_search_last_twelve_months", materialized: true,  sql_definition: <<-SQL
-      SELECT agg.warehouse_item_id,
-      max(agg.dimensions_edition_id) AS dimensions_edition_id,
-      sum(agg.upviews) AS upviews,
-      sum(agg.useful_yes) AS useful_yes,
-      sum(agg.useful_no) AS useful_no,
-      sum(agg.searches) AS searches
-     FROM ( SELECT dimensions_editions.warehouse_item_id,
-              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(aggregations_monthly_metrics.upviews) AS upviews,
-              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-              sum(aggregations_monthly_metrics.searches) AS searches
-             FROM ((aggregations_monthly_metrics
-               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-               JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
-            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM'::text))
-            GROUP BY dimensions_editions.warehouse_item_id
-          UNION
-           SELECT dimensions_editions.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM-01'::text))::date))
-            GROUP BY dimensions_editions.warehouse_item_id) agg
-    GROUP BY agg.warehouse_item_id;
-  SQL
-
-  add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_twelve_months_edition_id_upviews"
-  add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_twelve_months_unique", unique: true
-
   create_view "aggregations_search_last_thirty_days", materialized: true,  sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
       max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
@@ -352,5 +316,41 @@ ActiveRecord::Schema.define(version: 2018_12_06_115804) do
 
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_six_months_unique", unique: true
+
+  create_view "aggregations_search_last_twelve_months", materialized: true,  sql_definition: <<-SQL
+      SELECT agg.warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.searches) AS searches
+     FROM ( SELECT dimensions_editions.warehouse_item_id,
+              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(aggregations_monthly_metrics.upviews) AS upviews,
+              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+              sum(aggregations_monthly_metrics.searches) AS searches
+             FROM ((aggregations_monthly_metrics
+               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+               JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
+            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM'::text))
+            GROUP BY dimensions_editions.warehouse_item_id
+          UNION
+           SELECT dimensions_editions.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM-01'::text))::date))
+            GROUP BY dimensions_editions.warehouse_item_id) agg
+    GROUP BY agg.warehouse_item_id;
+  SQL
+
+  add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_twelve_months_edition_id_upviews"
+  add_index "aggregations_search_last_twelve_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_twelve_months_unique", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_05_154240) do
+ActiveRecord::Schema.define(version: 2018_12_05_165620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -264,42 +264,6 @@ ActiveRecord::Schema.define(version: 2018_12_05_154240) do
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_six_months_edition_id_upviews"
   add_index "aggregations_search_last_six_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_six_months_unique", unique: true
 
-  create_view "aggregations_search_last_three_months", materialized: true,  sql_definition: <<-SQL
-      SELECT agg.warehouse_item_id,
-      max(agg.dimensions_edition_id) AS dimensions_edition_id,
-      sum(agg.upviews) AS upviews,
-      sum(agg.useful_yes) AS useful_yes,
-      sum(agg.useful_no) AS useful_no,
-      sum(agg.searches) AS searches
-     FROM ( SELECT dimensions_editions.warehouse_item_id,
-              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(aggregations_monthly_metrics.upviews) AS upviews,
-              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-              sum(aggregations_monthly_metrics.searches) AS searches
-             FROM ((aggregations_monthly_metrics
-               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-               JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
-            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM'::text))
-            GROUP BY dimensions_editions.warehouse_item_id
-          UNION
-           SELECT dimensions_editions.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id >= (('yesterday'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM-01'::text))::date))
-            GROUP BY dimensions_editions.warehouse_item_id) agg
-    GROUP BY agg.warehouse_item_id;
-  SQL
-
-  add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_three_months_edition_id_upviews"
-  add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_three_months_unique", unique: true
-
   create_view "aggregations_search_last_twelve_months", materialized: true,  sql_definition: <<-SQL
       SELECT agg.warehouse_item_id,
       max(agg.dimensions_edition_id) AS dimensions_edition_id,
@@ -352,5 +316,41 @@ ActiveRecord::Schema.define(version: 2018_12_05_154240) do
 
   add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "upviews"], name: "index_on_last_thirty_days_edition_id_upviews"
   add_index "aggregations_search_last_thirty_days", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_thirty_days_unique", unique: true
+
+  create_view "aggregations_search_last_three_months", materialized: true,  sql_definition: <<-SQL
+      SELECT agg.warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.searches) AS searches
+     FROM ( SELECT dimensions_editions.warehouse_item_id,
+              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(aggregations_monthly_metrics.upviews) AS upviews,
+              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+              sum(aggregations_monthly_metrics.searches) AS searches
+             FROM ((aggregations_monthly_metrics
+               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+               JOIN dimensions_editions ON ((dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id)))
+            WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM'::text))
+            GROUP BY dimensions_editions.warehouse_item_id
+          UNION
+           SELECT dimensions_editions.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions ON ((dimensions_editions.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM-01'::text))::date))
+            GROUP BY dimensions_editions.warehouse_item_id) agg
+    GROUP BY agg.warehouse_item_id;
+  SQL
+
+  add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "upviews"], name: "index_on_last_three_months_edition_id_upviews"
+  add_index "aggregations_search_last_three_months", ["dimensions_edition_id", "warehouse_item_id"], name: "index_on_search_last_three_months_unique", unique: true
 
 end

--- a/db/views/aggregations_search_last_six_months_v03.sql
+++ b/db/views/aggregations_search_last_six_months_v03.sql
@@ -1,0 +1,35 @@
+SELECT  warehouse_item_id,
+  max(agg.dimensions_edition_id) AS dimensions_edition_id,
+  sum(agg.upviews) AS upviews,
+  sum(agg.useful_yes) AS useful_yes,
+  sum(agg.useful_no) AS useful_no,
+  sum(agg.searches) AS searches
+FROM(
+    -- Use monthly aggregations
+    SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '5 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  UNION
+    -- Use daily metrics
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+    WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '6 month')
+         AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '5 month'),'YYYY-MM-01')::date
+    GROUP BY warehouse_item_id
+) as agg
+GROUP BY warehouse_item_id

--- a/db/views/aggregations_search_last_thirty_days_v03.sql
+++ b/db/views/aggregations_search_last_thirty_days_v03.sql
@@ -1,0 +1,12 @@
+SELECT warehouse_item_id,
+  max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+  sum(facts_metrics.upviews) AS upviews,
+  sum(facts_metrics.useful_yes) AS useful_yes,
+  sum(facts_metrics.useful_no) AS useful_no,
+  sum(facts_metrics.searches) AS searches
+ FROM facts_metrics
+   JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+   JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+ WHERE (facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day))
+   AND (facts_metrics.dimensions_date_id < ('now'::text)::date)
+GROUP BY warehouse_item_id

--- a/db/views/aggregations_search_last_three_months_v03.sql
+++ b/db/views/aggregations_search_last_three_months_v03.sql
@@ -1,0 +1,35 @@
+SELECT  warehouse_item_id,
+  max(agg.dimensions_edition_id) AS dimensions_edition_id,
+  sum(agg.upviews) AS upviews,
+  sum(agg.useful_yes) AS useful_yes,
+  sum(agg.useful_no) AS useful_no,
+  sum(agg.searches) AS searches
+FROM(
+    -- Use monthly aggregations
+    SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  UNION
+    -- Use daily metrics
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+    WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '3 month')
+         AND facts_metrics.dimensions_date_id < to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM-01')::date
+    GROUP BY warehouse_item_id
+) as agg
+GROUP BY warehouse_item_id

--- a/db/views/aggregations_search_last_twelve_months_v03.sql
+++ b/db/views/aggregations_search_last_twelve_months_v03.sql
@@ -1,0 +1,35 @@
+SELECT  warehouse_item_id,
+  max(agg.dimensions_edition_id) AS dimensions_edition_id,
+  sum(agg.upviews) AS upviews,
+  sum(agg.useful_yes) AS useful_yes,
+  sum(agg.useful_no) AS useful_no,
+  sum(agg.searches) AS searches
+FROM(
+    -- Use monthly aggregations
+    SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '11 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  UNION
+    -- Use daily metrics
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+    WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '12 month')
+         AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '11 month'),'YYYY-MM-01')::date
+    GROUP BY warehouse_item_id
+) as agg
+GROUP BY warehouse_item_id

--- a/spec/models/aggregations/search_last_six_months_spec.rb
+++ b/spec/models/aggregations/search_last_six_months_spec.rb
@@ -30,49 +30,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundary: last six months from yesterday' do
-    it 'include metrics from 6 months ago starting in yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (Date.yesterday - 6.months), upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10)
-    end
-
-    it 'does not include metrics from 6 months and 2 days ago' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (6.months.ago - 2.days), upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(0.0)
-    end
-
-    it 'does include yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10.0)
-    end
-  end
-
-  it 'does not count metrics twice' do
-    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-    to = Date.yesterday
-    from = Date.yesterday - 6.months
-    (from..to).each do |date|
-      create :metric, edition: edition1, date: date, upviews: 10
-    end
-
-    recalculate_aggregations!
-
-    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
-  end
-
-  it 'is linked to the latest dimension edition' do
+  it 'references the latest dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 
@@ -83,5 +41,39 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)
+  end
+
+
+  it 'does not include metrics older than 6 months ago' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: 6.months.ago, upviews: 10
+    create :metric, edition: edition1, date: 6.months.ago - 1.day, upviews: 100
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10)
+  end
+
+  it 'includes metrics for yesterday' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 10
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0)
+  end
+
+  it 'does not count metrics twice' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    start_date = Date.yesterday
+    end_date = 6.months.ago
+
+    (start_date..end_date).each do |date|
+      create :metric, edition: edition1, date: date, upviews: 10
+    end
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
   end
 end

--- a/spec/models/aggregations/search_last_thirty_days_spec.rb
+++ b/spec/models/aggregations/search_last_thirty_days_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
 
   it 'aggregates metrics for the last 30 days' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
+    create :metric, edition: edition1, date: Date.today, upviews: 1, useful_yes: 1, useful_no: 1, searches: 1
     create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
     create :metric, edition: edition1, date: 15.days.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
-    create :metric, edition: edition1, date: 32.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
+    create :metric, edition: edition1, date: 31.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
     recalculate_aggregations!
 
@@ -30,46 +31,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundary: last thirty days from yesterday' do
-    it 'include days 31 days ago' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: 31.days.ago, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10)
-    end
-
-    it 'does not include 32 days ago' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: 32.days.ago, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(0.0)
-    end
-
-    it 'does not include today' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.today, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(0)
-    end
-
-    it 'does include yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10.0)
-    end
-  end
-
-
-  it 'is linked to the latest dimension edition' do
+  it 'references the latest dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 
@@ -80,5 +42,25 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)
+  end
+
+  it 'does not include metrics older than 30 days ago' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: 30.days.ago, upviews: 10
+    create :metric, edition: edition1, date: 31.days.ago, upviews: 100
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10)
+  end
+
+  it 'does not include metrics newer than yesterday' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: Date.today, upviews: 100
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 10
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10)
   end
 end

--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -30,49 +30,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundary: last three months from yesterday' do
-    it 'include metrics from 3 months ago starting in yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (Date.yesterday - 3.months), upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10)
-    end
-
-    it 'does not include metrics from 3 months and 2 days ago' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (3.months.ago - 2.days), upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(0.0)
-    end
-
-    it 'does include yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10.0)
-    end
-  end
-
-  it 'does not count metrics twice' do
-    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-    to = Date.yesterday
-    from = Date.yesterday - 3.months
-    (from..to).each do |date|
-      create :metric, edition: edition1, date: date, upviews: 10
-    end
-
-    recalculate_aggregations!
-
-    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
-  end
-
-  it 'is linked to the latest dimension edition' do
+  it 'references the latest dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 
@@ -83,5 +41,38 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)
+  end
+
+  it 'does not include metrics older than 3 months ago' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: 3.months.ago, upviews: 10
+    create :metric, edition: edition1, date: 3.months.ago - 1.day, upviews: 100
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10)
+  end
+
+  it 'includes metrics for yesterday' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 10
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0)
+  end
+
+  it 'does not count metrics twice' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    start_date = Date.yesterday
+    end_date = 3.months.ago
+
+    (start_date..end_date).each do |date|
+      create :metric, edition: edition1, date: date, upviews: 10
+    end
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
   end
 end

--- a/spec/models/aggregations/search_last_twelve_months_spec.rb
+++ b/spec/models/aggregations/search_last_twelve_months_spec.rb
@@ -30,50 +30,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  describe 'Boundary: last twelve months from yesterday' do
-    it 'include metrics from 12 months ago starting in yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (Date.yesterday - 12.months), upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10)
-    end
-
-    it 'does not include metrics from 12 months and 2 days ago' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: (12.months.ago - 2.days), upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(0.0)
-    end
-
-    it 'does include yesterday' do
-      edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-      create :metric, edition: edition1, date: Date.yesterday, upviews: 10
-
-      recalculate_aggregations!
-
-      expect(subject.sum(:upviews)).to eq(10.0)
-    end
-  end
-
-  it 'does not count metrics twice' do
-    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-    to = Date.yesterday
-    from = Date.yesterday - 12.months
-    (from..to).each do |date|
-      create :metric, edition: edition1, date: date, upviews: 10
-    end
-
-    recalculate_aggregations!
-
-    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
-  end
-
-
-  it 'is linked to the latest dimension edition' do
+  it 'references the latest dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 
@@ -84,5 +41,38 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(dimensions_edition_id: edition2.id)
+  end
+
+  it 'does not include metrics older than 12 months ago' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: 12.months.ago, upviews: 10
+    create :metric, edition: edition1, date: 12.months.ago - 1.day, upviews: 100
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10)
+  end
+
+  it 'includes metrics for yesterday' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 10
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0)
+  end
+
+  it 'does not count metrics twice' do
+    edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
+    start_date = Date.yesterday
+    end_date = 12.months.ago
+
+    (start_date..end_date).each do |date|
+      create :metric, edition: edition1, date: date, upviews: 10
+    end
+
+    recalculate_aggregations!
+
+    expect(subject.sum(:upviews)).to eq(10.0 * Facts::Metric.count)
   end
 end


### PR DESCRIPTION
The views for past 3, 6, 12 months and 30 days contained a previous day at the beginning of the time period. This PR includes migrations to update the views and tests to makes sure views return the correct time period. 