### PR TITLE
Fix total_count returned from /content

### DIFF
--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -22,7 +22,7 @@ class Queries::FindContent
       results: results.pluck(*aggregates).map(&method(:array_to_hash)),
       page: @page,
       total_pages: results.total_pages,
-      total_results: slice_editions.count
+      total_results: slice_editions.latest.count
     }
   end
 

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -212,9 +212,21 @@ RSpec.describe Queries::FindContent do
   describe 'Pagination' do
     before do
       4.times do |n|
-        edition = create :edition, base_path: "/path/#{n}", organisation_id: primary_org_id
+        edition = create :edition,
+          base_path: "/path/#{n}",
+          organisation_id: primary_org_id,
+          warehouse_item_id: "item-#{n}"
         create :metric, edition: edition, date: 15.days.ago, upviews: (100 - n)
       end
+
+      # not latest edition - should not affect total results
+      old_edition = create :edition,
+        base_path: '/path/0',
+        organisation_id: primary_org_id,
+        latest: false,
+        warehouse_item_id: 'item-0'
+      create :metric, edition: old_edition, date: 15.days.ago
+
 
       recalculate_aggregations!
     end


### PR DESCRIPTION
We have an error where the total_results returned from
this endpoint does not match the number of rows returned.

The cause of this is that `latest: true` is not included
in the criteria in `Queries::FindContent#slice_editions`
and `slice_editions.count` is how we retreive the `total_results`
returned.

Refactored the code to use `slice_editions.latest.count` and
added a test to check that old editions are excluded from the
count.

Trello: https://trello.com/c/cx3X7pIT/934-2-filter-description-says-3-results-instead-of-2-results

# Screenshots

## Before
<img width="765" alt="before" src="https://user-images.githubusercontent.com/511319/49734911-a8ecc180-fc7d-11e8-9c2c-0771dde9785d.png">

## After
<img width="729" alt="after" src="https://user-images.githubusercontent.com/511319/49734935-b30ec000-fc7d-11e8-9b2f-1e2a30b94440.png">
