### PR TITLE
Fix incorrect pdf_count for mainstream documents

### DIFF
--- a/app/domain/etl/edition/metadata/number_of_files.rb
+++ b/app/domain/etl/edition/metadata/number_of_files.rb
@@ -5,12 +5,12 @@ module Etl::Edition::Metadata::NumberOfFiles
     filter_links all_links, extensions_regex
   end
 
-  ALL_LINKS_XPATH = "//*[contains(@class, 'attachment-details')]//a/@href".freeze
+  ALL_LINKS_XPATH = "//*[contains(@class, 'attachment-details') or contains(@class, 'form-download')]//a/@href".freeze
 
   def self.extract_documents(content_item_details)
     return nil unless content_item_details.is_a?(Hash)
 
-    document_keys = %w(documents final_outcome_documents)
+    document_keys = %w(documents final_outcome_documents body)
     document = document_keys.map { |key| content_item_details.dig('details', key) }
 
     Nokogiri::HTML(document.join(''))

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -1,5 +1,6 @@
 require 'json'
 
+
 class Dimensions::Edition < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_edition_id
   belongs_to :publishing_api_event, class_name: "Events::PublishingApi", foreign_key: :publishing_api_event_id

--- a/lib/tasks/repopulate_pdf_count.rake
+++ b/lib/tasks/repopulate_pdf_count.rake
@@ -1,0 +1,15 @@
+namespace :temp do
+  desc "Update withdrawn editions"
+  task repopulate_pdf_count: :environment do
+    Dimensions::Edition.latest.relevant_content.includes(:publishing_api_event).in_batches do |group|
+      group.each do |edition|
+        if edition.publishing_api_event
+          pdf_count = Etl::Edition::Metadata::NumberOfPdfs.parse(edition.publishing_api_event.payload)
+          edition.facts_edition.update!(pdf_count: pdf_count)
+        end
+      end
+      putc '.'
+    end
+    puts '\nDone!\n'
+  end
+end

--- a/spec/domain/etl/edition/metadata/number_of_pdfs_spec.rb
+++ b/spec/domain/etl/edition/metadata/number_of_pdfs_spec.rb
@@ -6,37 +6,57 @@ module Performance
 
     subject { described_class }
 
-    it "returns the number of pdfs present" do
-      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>')
-      expect(subject.parse(response)).to eq(1)
+    context 'when the pdf links are under details > documents' do
+      it "returns the number of pdfs present" do
+        response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdf\">1</a>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(1)
+      end
+
+      it "returns 0 if no pdfs are present" do
+        response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(0)
+      end
+
+      it "returns 0 if no document keys are present" do
+        expect(subject.parse({})).to eq(0)
+      end
+
+      it "returns 0 if the details is nil" do
+        expect(subject.parse({})).to eq(0)
+      end
+
+      it "returns 0 if the attachment ends with `pdf`, but with no `dot`" do
+        response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"linkpdf\">1</a>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(0)
+      end
+
+      it "returns 0 if the attachment file extension starts with `.pdf`, but ends with 'p'" do
+        response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdfp\">1</a>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(0)
+      end
+
+      it "returns 1 if the attachment file is `.PDF`" do
+        response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.PDF\">1</a>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(1)
+      end
     end
 
-    it "returns 0 if no pdfs are present" do
-      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.txt\">1</a>\n\n\n\n</div>')
-      expect(subject.parse(response)).to eq(0)
-    end
+    context 'when the pdf links are under details > body' do
+      it 'returns 1 if the container has the class `form-download`' do
+        response = build_response('body' => '<div class=\"form-download">\n<p><a href=\"link.pdf\">1</a></p>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(1)
+      end
 
-    it "returns 0 if no document keys are present" do
-      expect(subject.parse({})).to eq(0)
-    end
+      it 'returns 2 if a container with the class `form-download` contains 2 links' do
+        body = '<div class=\"form-download">\n<p><a href=\"link.pdf\">1</a></p><p><a href=\"link2.pdf\">2</a></p>\n\n\n\n</div>'
+        response = build_response('body' => body)
+        expect(subject.parse(response)).to eq(2)
+      end
 
-    it "returns 0 if the details is nil" do
-      expect(subject.parse({})).to eq(0)
-    end
-
-    it "returns 0 if the attachment ends with `pdf`, but with no `dot`" do
-      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"linkpdf\">1</a>\n\n\n\n</div>')
-      expect(subject.parse(response)).to eq(0)
-    end
-
-    it "returns 0 if the attachment file extension starts with `.pdf`, but ends with 'p'" do
-      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.pdfp\">1</a>\n\n\n\n</div>')
-      expect(subject.parse(response)).to eq(0)
-    end
-
-    it "returns 1 if the attachment file is `.PDF`" do
-      response = build_response('documents' => '<div class=\"attachment-details\">\n<a href=\"link.PDF\">1</a>\n\n\n\n</div>')
-      expect(subject.parse(response)).to eq(1)
+      it 'returns 0 if the container has a class other than `form-download` or `attachment-details`' do
+        response = build_response('body' => '<div class=\"another-download">\n<p><a href=\"link.pdf\">1</a></p>\n\n\n\n</div>')
+        expect(subject.parse(response)).to eq(0)
+      end
     end
 
     def build_response(details)


### PR DESCRIPTION
Mainstream documents are showing 0 for pdf_count.

The cause if this is that other content has the PDF links
under details > documents in the json and are nested under a div
with the class `attachment-details`.

Mainstream documents have the PDF links under details > body
and are nested under a div with the class `form-download`.

This commit changes the number_of_pdfs processor to find
pdf links in this location.

Trello: https://trello.com/c/YH8MUtuv/936-2-no-of-pdfs-not-working-on-mainstream