### PR TITLE
Document import data into VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To run the test suite:
  ```
 
 ## Populating data
-If you are a GOV.UK developer using the development VM, you can [run the replication script to populate the database](https://docs.publishing.service.gov.uk/manual/get-started.html#7-import-production-data).
+If you are a GOV.UK developer using the development VM, you can [run the replication script to populate the database](doc/import_production_data.md).
 
 To run the ETL process locally, you need to  [set up Google Analytics credentials in development](doc/google_analytics_setup.md).
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_06_120629) do
+ActiveRecord::Schema.define(version: 2018_12_12_113107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/doc/import_production_data.md
+++ b/doc/import_production_data.md
@@ -1,0 +1,29 @@
+# Import Production Data
+
+
+To import production data, follow the instructions at 
+[the GOV.UK developer docs](https://docs.publishing.service.gov.uk/manual/get-started.html#8-import-production-data)
+
+## Note
+The content_performance_manager database has grown very large and is no longer imported by default.
+
+There are some swiches you can provide to the replication script which are documented when you run:
+
+```
+./replicate-data-local.sh -h
+```
+
+If you want to download/import only the content_performance_manager database, add the following arguments to 
+those given in the instructions for both download and import:
+
+```
+-m -e -q -t -r -i "service-manual-publisher publishing_api link_checker_api email-alert-monitor content_data_admin content_tagger content_publisher organisations-publisher email-alert-api content-register policy-publisher content_audit_tool ckan local-links-manager support_contacts transition"
+```
+
+The important switches are: 
+
+`-m -e -q -t` - skip MongoDB, Elasticsearch, MySQL, Mapit
+
+`-r` - reset the ignore list (import content_performance_manager which is ignored)
+
+`-i "service-manual-publisher publishing_api ....` - ignore the other postgres databases


### PR DESCRIPTION
The CPM database is not included in the data import by default.

This commit documents how to import it.