### PR TITLE
Add parent_content_id to Dimensions::Editions

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -52,6 +52,15 @@ class Dimensions::Edition < ApplicationRecord
     dirty
   end
 
+  def parent_content_id
+    return '' unless document_type == 'manual_section'
+
+    _, segment1, segment2 = base_path.split('/')
+    parent_path = "/#{segment1}/#{segment2}"
+    parent = Dimensions::Edition.find_by(base_path: parent_path)
+    parent.content_id
+  end
+
   def metadata
     {
       title: title,
@@ -63,7 +72,8 @@ class Dimensions::Edition < ApplicationRecord
       document_type: document_type,
       primary_organisation_title: primary_organisation_title,
       withdrawn: withdrawn,
-      historical: historical
+      historical: historical,
+      parent_content_id: parent_content_id
     }
   end
 end

--- a/spec/domain/queries/find_metadata_spec.rb
+++ b/spec/domain/queries/find_metadata_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Queries::FindMetadata do
 
   it "returns metadata for latest edition" do
     metadata = described_class.run('/base_path')
+
     expect(metadata).to eq(
       title: 'the title',
       base_path: base_path,
@@ -40,7 +41,8 @@ RSpec.describe Queries::FindMetadata do
       public_updated_at: '2018-07-17T10:35:57.000Z',
       primary_organisation_title: 'The ministry',
       withdrawn: false,
-      historical: false
+      historical: false,
+      parent_content_id: ''
     )
   end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -221,8 +221,18 @@ RSpec.describe Dimensions::Edition, type: :model do
         document_type: 'guide',
         primary_organisation_title: 'The ministry',
         withdrawn: false,
-        historical: false
+        historical: false,
+        parent_content_id: ''
       )
+    end
+  end
+
+  describe '#parent_content_id' do
+    it 'returns content_id of parent manual for a manual_section' do
+      create :edition, content_id: 'the-parent', base_path: '/prefix-path/the-parent-path', document_type: 'manual'
+      child = create :edition, base_path: '/prefix-path/the-parent-path/child-path', document_type: 'manual_section'
+
+      expect(child.parent_content_id).to eq('the-parent')
     end
   end
 


### PR DESCRIPTION
We need the content_id of the parent manual that a manual_section
belongs to in order to generate the link to the Manuals Publisher.

Rather that store this unnecessarily in the database to handle manuals
and manuals_section as an edge case, sending that as part of metadata
is slightly better where most things would have this set to nil.

In future if we need to store the parent_content_id then we can refactor
it, or indeed implement this better.