### PR TITLE
Search with full protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,8 @@ group :development, :test do
   gem 'phantomjs'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'rails-controller-testing'
   gem "rack", ">= 2.0.6"
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -1,8 +1,4 @@
 class Queries::FindContent
-  DEFAULT_PAGE_SIZE = 100
-  ALL = 'all'.freeze
-  NONE = 'none'.freeze
-
   def self.call(filter:)
     raise ArgumentError unless filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
 
@@ -28,6 +24,10 @@ class Queries::FindContent
   end
 
 private
+
+  DEFAULT_PAGE_SIZE = 100
+  ALL = 'all'.freeze
+  NONE = 'none'.freeze
 
   def order_by
     'upviews desc'

--- a/app/domain/queries/find_content.rb
+++ b/app/domain/queries/find_content.rb
@@ -38,10 +38,19 @@ private
   def initialize(filter)
     @organisation_id = filter.fetch(:organisation_id)
     @document_type = filter.fetch(:document_type)
-    @search_term = filter[:search_term]
+    @search_term = parse_search_term(filter[:search_term]) if filter[:search_term]
     @page = filter[:page] || 1
     @page_size = filter[:page_size] || DEFAULT_PAGE_SIZE
     @date_range = filter.fetch(:date_range)
+  end
+
+  def parse_search_term(search_term)
+    protocol = /http(s)?:\/\//
+    domain = /(www\.)?gov\.uk/
+
+    search_term.
+      gsub(protocol, '').
+      gsub(domain, '')
   end
 
   def aggregates

--- a/spec/domain/queries/find_content_spec.rb
+++ b/spec/domain/queries/find_content_spec.rb
@@ -227,7 +227,6 @@ RSpec.describe Queries::FindContent do
         warehouse_item_id: 'item-0'
       create :metric, edition: old_edition, date: 15.days.ago
 
-
       recalculate_aggregations!
     end
 
@@ -347,6 +346,58 @@ RSpec.describe Queries::FindContent do
       expect(result[:results]).to contain_exactly(
         hash_including(base_path: '/this/is/a/big/base-path'),
       )
+    end
+
+    describe 'search by base_path with full URLs' do
+      before do
+        edition1 = create :edition, base_path: '/base-path', date: 2.months.ago, organisation_id: primary_org_id
+
+        create :metric, edition: edition1, date: 15.days.ago
+        recalculate_aggregations!
+      end
+
+      subject { described_class.call(filter: filter.merge(search_term: search_term))[:results] }
+
+
+      context 'when search terms include the protocol (http)' do
+        let(:search_term) { 'http://base-path' }
+
+        it 'return editions matching the base_path' do
+          expect(subject).to contain_exactly(
+            hash_including(base_path: '/base-path'),
+          )
+        end
+      end
+
+      context 'when search terms include the protocol (https)' do
+        let(:search_term) { 'https://base-path' }
+
+        it 'return editions matching the base_path' do
+          expect(subject).to contain_exactly(
+            hash_including(base_path: '/base-path'),
+          )
+        end
+      end
+
+      context 'when search terms include domain gov.uk' do
+        let(:search_term) { 'gov.uk/base-path' }
+
+        it 'return editions matching the base_path' do
+          expect(subject).to contain_exactly(
+            hash_including(base_path: '/base-path'),
+          )
+        end
+      end
+
+      context 'when search terms include domain www.gov.uk' do
+        let(:search_term) { 'www.gov.uk/base-path' }
+
+        it 'return editions matching the base_path' do
+          expect(subject).to contain_exactly(
+            hash_including(base_path: '/base-path'),
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/FrWQ0ON2/941-2-index-page-search-by-whole-url-in-search-box)

The base_path of the editions does not include the protocol or the domain,
so queries passing full URLs don’t return the expected results.

This commit removes the protocol and the domain from the search terms as
they are not needed.