### PR TITLE
Add /organisations endpoint in v1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'plek'
 
 # Third party gems
 gem 'activerecord-import'
+gem 'active_model_serializers'
 gem 'awesome_print'
 gem 'chartkick'
 gem 'google-api-client', '~> 0.27'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.8)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.2)
       activesupport (= 5.2.2)
       globalid (>= 0.3.6)
@@ -76,6 +81,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     chartkick (3.0.1)
     coderay (1.1.2)
     coffee-script (2.4.1)
@@ -198,6 +205,7 @@ GEM
     json (2.1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
+    jsonapi-renderer (0.2.0)
     jwt (2.1.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -482,6 +490,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   activerecord-import
   awesome_print
   better_errors
@@ -539,4 +548,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -1,0 +1,6 @@
+class Api::OrganisationsController < Api::BaseController
+  def index
+    @organisations = Organisation.find_all
+    render json: @organisations
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,22 @@
+class Organisation
+  include ActiveModel::Model
+  include ActiveModel::Serialization
+
+  attr_accessor :id, :name
+
+  def initialize(id:, name:)
+    @id = id
+    @name = name
+  end
+
+  def self.find_all(locale: 'en')
+    editions = Dimensions::Edition.latest
+      .select(:content_id, :title, :locale)
+      .where(document_type: 'organisation', locale: locale)
+      .order(:title)
+
+    editions.map do |edition|
+      self.new(id: edition[:content_id], name: edition[:title])
+    end
+  end
+end

--- a/app/serializers/organisation_serializer.rb
+++ b/app/serializers/organisation_serializer.rb
@@ -1,0 +1,3 @@
+class OrganisationSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/config/initializers/ams.rb
+++ b/config/initializers/ams.rb
@@ -1,0 +1,3 @@
+require 'active_model_serializers'
+
+ActiveModel::Serializer.config.adapter = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     get '/v1/metrics/', to: "metrics#index"
     get '/v1/healthcheck', to: "healthcheck#index"
+    get '/v1/organisations', to: 'organisations#index'
   end
 
   get '/content', to: 'content#show'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,6 +17,16 @@ servers:
   - url: 'http://content-performance-manager.dev.gov.uk/api/v1'
     description: Development
 paths:
+  '/organisations/':
+    get:
+      summary: Get all organisations
+      responses:
+        '200':
+           description: A list of organisations
+           content:
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/ArrayOfOrganisations'
   '/metrics/':
     get:
       summary: List all available metrics.
@@ -178,6 +188,19 @@ components:
       type: http
       scheme: bearer
   schemas:
+    Organisation:
+      requires:
+        - id
+        - name
+      properties:
+        id:
+          type: string 
+        name:
+          type: string
+    ArrayOfOrganisations:
+      type: array
+      items:
+        $ref: '#/components/schemas/Organisation'
     Metric:
       description: |
         Information about a metric returned by the API.

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Organisation do
+  describe '.find_all' do
+    context 'sorting' do
+      before do
+        create(:edition, document_type: 'organisation', title: 'Organisation C')
+        create(:edition, document_type: 'organisation', title: 'Organisation A')
+        create(:edition, document_type: 'organisation', title: 'Organisation B')
+      end
+
+      it 'returns a list of organisations' do
+        organisations = Organisation.find_all
+        expect(organisations).to all be_a(Organisation)
+      end
+
+      it 'returns a list sorted by title' do
+        organisations = Organisation.find_all
+
+        expect(organisations).to be_sorted_by(&:name)
+      end
+    end
+
+    context 'locales' do
+      before do
+        create(:edition, document_type: 'organisation', content_id: '1', title: 'English Name', locale: 'en')
+        create(:edition, document_type: 'organisation', content_id: '1', title: 'Enw Cymraeg', locale: 'cy')
+      end
+
+      it 'returns only english locales by default' do
+        organisations = Organisation.find_all
+
+        expect(organisations).to match_array([have_attributes(name: 'English Name')])
+      end
+
+      it 'returns welsh locales when specified' do
+        organisations = Organisation.find_all(locale: 'cy')
+
+        expect(organisations).to match_array([have_attributes(name: 'Enw Cymraeg')])
+      end
+    end
+  end
+end

--- a/spec/support/matchers/be_sorted_by_attribute_matcher.rb
+++ b/spec/support/matchers/be_sorted_by_attribute_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :be_sorted_by do
+  match do |array|
+    array.each_cons(2).all? do |a, b|
+      (block_arg.call(a) <=> block_arg.call(b)) <= 0
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses the following:
- Add organisations endpoint to the /v1 path. 
- Restructured the organisations controller to use ActiveModel serialization.
- Now have the option to specify locales, with english being returned by default.