### PR TITLE
Add bearer tokens for support-api authentication

### DIFF
--- a/app/domain/etl/feedex/service.rb
+++ b/app/domain/etl/feedex/service.rb
@@ -24,7 +24,10 @@ class Etl::Feedex::Service
 private
 
   def support_api_with_long_timeout
-    GdsApi::SupportApi.new(Plek.new.find('support-api')).tap do |client|
+    GdsApi::SupportApi.new(
+      Plek.new.find('support-api'),
+      bearer_token: ENV['SUPPORT_API_BEARER_TOKEN'],
+    ).tap do |client|
       client.options[:timeout] = 15
     end
   end

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe '/content' do
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expected_results = [edition1.base_path, edition2.base_path]
-      expect(json[:results].map { |res| res[:base_path] }).to eq(expected_results)
+      expect(json[:results].map { |res| res[:base_path] }).to match_array(expected_results)
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/WR2MNxo6

Related to: 
* https://github.com/alphagov/govuk-puppet/pull/8479
* https://github.com/alphagov/support-api/pull/266

Passes the bearer token needed to authenticate with support-api using signon.