### PR TITLE
Add api/v1/document_type endpoint

### DIFF
--- a/app/controllers/api/document_types_controller.rb
+++ b/app/controllers/api/document_types_controller.rb
@@ -1,6 +1,6 @@
 class Api::DocumentTypesController < Api::BaseController
   def index
-      @document_types = DocumentType.find_all
-      render json: @document_types
+    @document_types = DocumentType.find_all
+    render json: @document_types
   end
 end

--- a/app/controllers/api/document_types_controller.rb
+++ b/app/controllers/api/document_types_controller.rb
@@ -1,0 +1,6 @@
+class Api::DocumentTypesController < Api::BaseController
+  def index
+      @document_types = DocumentType.find_all
+      render json: @document_types
+  end
+end

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -17,7 +17,10 @@ class DocumentType
       .order(:document_type)
 
     editions.map do |edition|
-      self.new(id: edition[:document_type], name: edition[:document_type])
+      self.new(
+        id: edition[:document_type],
+        name: edition[:document_type].humanize
+      )
     end
   end
 end

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -1,0 +1,23 @@
+class DocumentType
+  include ActiveModel::Model
+  include ActiveModel::Serialization
+
+  attr_accessor :id, :name
+
+  def initialize(id:, name:)
+    @id = id
+    @name = name
+  end
+
+  def self.find_all
+    editions = Dimensions::Edition.latest
+      .relevant_content
+      .select(:document_type)
+      .distinct
+      .order(:document_type)
+
+    editions.map do |edition|
+      self.new(id: edition[:document_type], name: edition[:document_type])
+    end
+  end
+end

--- a/app/serializers/document_type_serializer.rb
+++ b/app/serializers/document_type_serializer.rb
@@ -1,0 +1,3 @@
+class DocumentTypeSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,12 @@
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'AAIB'
+  inflect.acronym 'CMA'
+  inflect.acronym 'DFID'
+  inflect.acronym 'ESI'
+  inflect.acronym 'FOI'
+  inflect.acronym 'HMRC'
+  inflect.acronym 'HTML'
+  inflect.acronym 'MAIB'
+  inflect.acronym 'RAIB'
+  inflect.acronym 'UTAAC'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     get '/v1/metrics/', to: "metrics#index"
     get '/v1/healthcheck', to: "healthcheck#index"
     get '/v1/organisations', to: 'organisations#index'
+    get '/v1/document_types', to: 'document_types#index'
   end
 
   get '/content', to: 'content#show', defaults: { format: :json }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,6 +27,16 @@ paths:
              application/json:
                schema:
                  $ref: '#/components/schemas/ArrayOfOrganisations'
+  '/document_types/':
+    get:
+      summary: Get all document types
+      responses:
+        '200':
+           description: A list of document types
+           content:
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/ArrayOfDocumentTypes'
   '/metrics/':
     get:
       summary: List all available metrics.
@@ -201,6 +211,19 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Organisation'
+    DocumentType:
+      requires:
+        - id
+        - name
+      properties:
+        id:
+          type: string 
+        name:
+          type: string
+    ArrayOfDocumentTypes:
+      type: array
+      items:
+        $ref: '#/components/schemas/DocumentType'
     Metric:
       description: |
         Information about a metric returned by the API.

--- a/spec/models/document_type_spec.rb
+++ b/spec/models/document_type_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe DocumentType do
+  describe '.find_all' do
+    it 'returns a list of document types' do
+      create(:edition, document_type: 'news_story')
+      create(:edition, document_type: 'guide')
+
+      expect(DocumentType.find_all).to all(be_a(DocumentType))
+    end
+
+    it 'filter irrelevent document types' do
+      create(:edition, document_type: 'guide')
+      create(:edition, document_type: 'redirect')
+      create(:edition, document_type: 'gone')
+      create(:edition, document_type: 'vanish')
+      create(:edition, document_type: 'unpublishing')
+      create(:edition, document_type: 'need')
+
+      expect(DocumentType.find_all).to match_array([
+        have_attributes(id: 'guide')
+      ])
+    end
+  end
+end

--- a/spec/models/document_type_spec.rb
+++ b/spec/models/document_type_spec.rb
@@ -19,5 +19,15 @@ RSpec.describe DocumentType do
         have_attributes(id: 'guide')
       ])
     end
+
+    it 'humanizes document type names' do
+      create(:edition, document_type: 'news_story')
+      create(:edition, document_type: 'aaib_report')
+
+      expect(DocumentType.find_all).to match_array([
+        have_attributes(name: 'News story'),
+        have_attributes(name: 'AAIB report')
+      ])
+    end
   end
 end


### PR DESCRIPTION
- Adds a model for DocumentType
- Adds humanised document type name to response
- Adds `/api/v1/document_types` endpoint
- Uses ActiveModel Serializers to generate json