### PR TITLE
Use rubocup directly instead of govuk-lint-ruby cli

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+inherit_gem:
+  govuk-lint: "configs/rubocop/all.yml"
 AllCops:
     TargetRubyVersion: 2.3
 Metrics/BlockLength:

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Rails.application.load_tasks
 
 namespace :lint do
   task :ruby do
-    sh "bundle exec govuk-lint-ruby app config lib spec"
+    sh "bundle exec rubocop app config lib spec"
   end
 
   task :sass do

--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,7 @@ namespace :lint do
   task :ruby do
     sh "bundle exec rubocop app config lib spec"
   end
-
-  task :sass do
-    sh "bundle exec govuk-lint-sass app/assets/stylesheets"
-  end
 end
 
-task lint: ["lint:ruby", "lint:sass"]
+task lint: ["lint:ruby"]
 task default: %i[spec lint]


### PR DESCRIPTION
This adds an import for the rules in govuk-lint gem into to the local `.rubocup.yml`. This allows us to use rubocop directly rather than through govuk-lint cli which adds no extra functionality. This PR also removes sass linting which is no longer used in this project

Benefits include:
- Speeds up linting, by enabling parallel checking
- Lower overhead for new developers who are used to rubocop
- Better compatibility with developer environments - as most linting tools interface with rubocop
