### PR TITLE
Improve performance for finding all document types

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -23,7 +23,7 @@ class Dimensions::Edition < ApplicationRecord
     latest_by_content_id(content_id, locale)
       .where.not(base_path: exclude_paths)
   end
-  scope :relevant_content, -> { where.not(document_type: %w[redirect gone vanish unpublishing need]) }
+  scope :relevant_content, -> { where.not(document_type: DocumentType::IGNORED_TYPES) }
 
   def self.search(query)
     sql = <<~SQL

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -2,6 +2,8 @@ class DocumentType
   include ActiveModel::Model
   include ActiveModel::Serialization
 
+  IGNORED_TYPES = %w[redirect gone vanish unpublishing need].freeze
+
   attr_accessor :id, :name
 
   def initialize(id:, name:)
@@ -10,17 +12,29 @@ class DocumentType
   end
 
   def self.find_all
-    editions = Dimensions::Edition.latest
-      .relevant_content
-      .select(:document_type)
-      .distinct
-      .order(:document_type)
+    all_document_types = ActiveRecord::Base.connection
+      .execute(distinct_document_types_sql)
+      .field_values('document_type')
 
-    editions.map do |edition|
-      self.new(
-        id: edition[:document_type],
-        name: edition[:document_type].humanize
-      )
+    document_types = all_document_types.reject { |t| IGNORED_TYPES.include? t }
+
+    document_types.map do |document_type|
+      new(id: document_type, name: document_type.humanize)
     end
   end
+
+  def self.distinct_document_types_sql
+    <<-SQL
+      WITH RECURSIVE temp AS (
+        (SELECT document_type FROM dimensions_editions WHERE latest ORDER BY document_type LIMIT 1)
+        UNION ALL
+        SELECT (SELECT document_type FROM dimensions_editions WHERE document_type > temp.document_type AND latest ORDER BY document_type LIMIT 1)
+        FROM temp
+        WHERE temp.document_type IS NOT NULL
+      )
+      SELECT document_type FROM temp WHERE document_type IS NOT NULL;
+    SQL
+  end
+
+  private_class_method :distinct_document_types_sql
 end

--- a/db/migrate/20190104120051_add_not_null_constraint_and_index_to_document_types.rb
+++ b/db/migrate/20190104120051_add_not_null_constraint_and_index_to_document_types.rb
@@ -1,0 +1,6 @@
+class AddNotNullConstraintAndIndexToDocumentTypes < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :dimensions_editions, :document_type, false
+    add_index :dimensions_editions, :document_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_11_120306) do
+ActiveRecord::Schema.define(version: 2019_01_04_120051) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "fuzzystrmatch"
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "aggregations_monthly_metrics", force: :cascade do |t|
@@ -67,7 +69,7 @@ ActiveRecord::Schema.define(version: 2018_12_11_120306) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "latest"
-    t.string "document_type"
+    t.string "document_type", null: false
     t.string "content_purpose_document_supertype"
     t.datetime "first_published_at"
     t.datetime "public_updated_at"
@@ -94,7 +96,9 @@ ActiveRecord::Schema.define(version: 2018_12_11_120306) do
     t.index "to_tsvector('english'::regconfig, (title)::text)", name: "dimensions_editions_title", using: :gin
     t.index "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "dimensions_editions_base_path", using: :gin
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
+    t.index ["content_id", "latest"], name: "idx_latest_content_id"
     t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
+    t.index ["document_type"], name: "index_dimensions_editions_on_document_type"
     t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
     t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
     t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"

--- a/spec/models/document_type_spec.rb
+++ b/spec/models/document_type_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe DocumentType do
   describe '.find_all' do
+
     it 'returns a list of document types' do
       create(:edition, document_type: 'news_story')
       create(:edition, document_type: 'guide')
@@ -27,6 +28,22 @@ RSpec.describe DocumentType do
       expect(DocumentType.find_all).to match_array([
         have_attributes(name: 'News story'),
         have_attributes(name: 'AAIB report')
+      ])
+    end
+
+    it 'sorts result by name' do
+      create(:edition, document_type: 'news_story')
+      create(:edition, document_type: 'aaib_report')
+
+      expect(DocumentType.find_all).to be_sorted_by(&:name)
+    end
+
+    it 'returns only document types of latest editions' do
+      create(:edition, document_type: 'news_story')
+      create(:edition, document_type: 'guidance', latest: false)
+
+      expect(DocumentType.find_all).to match_array([
+        have_attributes(id: 'news_story'),
       ])
     end
   end

--- a/spec/models/document_type_spec.rb
+++ b/spec/models/document_type_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe DocumentType do
   describe '.find_all' do
-
     it 'returns a list of document types' do
       create(:edition, document_type: 'news_story')
       create(:edition, document_type: 'guide')


### PR DESCRIPTION
The document type endpoint lists all the document types for the content available in the data warehouse. 

The previous SQL query used was `SELECT DISTINCT document_type FROM dimensions_editions WHERE ....`. Unfortunately, Postgres does not optimise this (even with an index) and will perform a sequential scan through all the `dimensions_editions` rows. Testing on my dev machine saw query times averaging 300ms.

This PR proposes a [loose indexscan](https://wiki.postgresql.org/wiki/Loose_indexscan) query as follows:
- Add an index for document types
- Make the document types not nullable.
- Use a recursive CTE query to make Postgres use only information from the index and prevent sequential scan.

Testing on my dev machine saw the query time drop to about 5ms. 