### PR TITLE
Trap errors in etl processes

### DIFF
--- a/app/domain/etl/feedex/processor.rb
+++ b/app/domain/etl/feedex/processor.rb
@@ -1,5 +1,5 @@
 class Etl::Feedex::Processor
-  include Concerns::Traceable
+  include Concerns::TraceAndRecoverable
 
   def self.process(*args)
     new(*args).process
@@ -10,7 +10,7 @@ class Etl::Feedex::Processor
   end
 
   def process
-    time(process: :feedex) do
+    time_and_trap(process: :feedex) do
       extract_events
       load_metrics
     end

--- a/app/domain/etl/ga/internal_search_processor.rb
+++ b/app/domain/etl/ga/internal_search_processor.rb
@@ -1,5 +1,5 @@
 class Etl::GA::InternalSearchProcessor
-  include Concerns::Traceable
+  include Concerns::TraceAndRecoverable
   include Etl::GA::Concerns::TransformPath
 
   def self.process(*args)
@@ -11,7 +11,7 @@ class Etl::GA::InternalSearchProcessor
   end
 
   def process
-    time(process: :ga_search) do
+    time_and_trap(process: :ga_search) do
       extract_events
       transform_events
       load_metrics

--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -1,5 +1,5 @@
 class Etl::GA::UserFeedbackProcessor
-  include Concerns::Traceable
+  include Concerns::TraceAndRecoverable
   include Etl::GA::Concerns::TransformPath
 
   def self.process(*args)
@@ -11,7 +11,7 @@ class Etl::GA::UserFeedbackProcessor
   end
 
   def process
-    time(process: :ga_feedback) do
+    time_and_trap(process: :ga_feedback) do
       extract_events
       transform_events
       load_metrics

--- a/app/domain/etl/ga/views_and_navigation_processor.rb
+++ b/app/domain/etl/ga/views_and_navigation_processor.rb
@@ -1,6 +1,6 @@
-require_dependency 'concerns/traceable'
+require_dependency 'concerns/trace_and_recoverable'
 class Etl::GA::ViewsAndNavigationProcessor
-  include Concerns::Traceable
+  include Concerns::TraceAndRecoverable
   include Etl::GA::Concerns::TransformPath
 
   def self.process(*args)
@@ -12,7 +12,7 @@ class Etl::GA::ViewsAndNavigationProcessor
   end
 
   def process
-    time(process: :ga_views_navigation) do
+    time_and_trap(process: :ga_views_navigation) do
       extract_events
       transform_events
       load_metrics

--- a/app/domain/monitor/aggregations.rb
+++ b/app/domain/monitor/aggregations.rb
@@ -1,11 +1,15 @@
 class Monitor::Aggregations
+  include Concerns::TraceAndRecoverable
+
   def self.run(*args)
     new(*args).run
   end
 
   def run
-    statsd_for_all_monthly_aggregations!
-    statsd_for_current_month!
+    trap do
+      statsd_for_all_monthly_aggregations!
+      statsd_for_current_month!
+    end
   end
 
 private

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -1,14 +1,16 @@
 class Monitor::Dimensions
+  include Concerns::TraceAndRecoverable
   def self.run(*args)
     new(*args).run
   end
 
   def run
-    statsd_for_all_base_paths!
-    statsd_for_latest_base_paths!
-
-    statsd_for_all_content_items!
-    statsd_for_latest_content_items!
+    trap do
+      statsd_for_all_base_paths!
+      statsd_for_latest_base_paths!
+      statsd_for_all_content_items!
+      statsd_for_latest_content_items!
+    end
   end
 
 private

--- a/app/domain/monitor/etl.rb
+++ b/app/domain/monitor/etl.rb
@@ -1,11 +1,14 @@
 class Monitor::Etl
+  include Concerns::TraceAndRecoverable
   def self.run(*args)
     new(*args).run
   end
 
   def run
-    statsd_for_performance_metrics!
-    statsd_for_edition_metrics!
+    trap do
+      statsd_for_performance_metrics!
+      statsd_for_edition_metrics!
+    end
   end
 
 private

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -1,14 +1,17 @@
 class Monitor::Facts
+  include Concerns::TraceAndRecoverable
+
   def self.run(*args)
     new(*args).run
   end
 
   def run
-    statsd_for_all_metrics!
-    statsd_for_yesterday_metrics!
-
-    statsd_for_total_editions!
-    statsd_for_yesterday_editions!
+    trap do
+      statsd_for_all_metrics!
+      statsd_for_yesterday_metrics!
+      statsd_for_total_editions!
+      statsd_for_yesterday_editions!
+    end
   end
 
 private

--- a/app/models/concerns/trace_and_recoverable.rb
+++ b/app/models/concerns/trace_and_recoverable.rb
@@ -14,5 +14,15 @@ module Concerns::TraceAndRecoverable
         GovukError.notify(e)
       end
     end
+
+    def trap
+      raise ArgumentError "No block was given to TraceAndRecoverable#trap" unless block_given?
+
+      begin
+        yield
+      rescue StandardError => e
+        GovukError.notify(e)
+      end
+    end
   end
 end

--- a/app/models/concerns/trace_and_recoverable.rb
+++ b/app/models/concerns/trace_and_recoverable.rb
@@ -1,0 +1,18 @@
+require 'active_support/concern'
+
+module Concerns::TraceAndRecoverable
+  extend ActiveSupport::Concern
+  include Concerns::Traceable
+
+  included do
+    def time_and_trap(process:, &block)
+      raise ArgumentError "No block was given to TraceAndRecoverable#time_and_trap" unless block_given?
+
+      begin
+        time(process: process, &block)
+      rescue StandardError => e
+        GovukError.notify(e)
+      end
+    end
+  end
+end

--- a/spec/domain/etl/feedex/processor_spec.rb
+++ b/spec/domain/etl/feedex/processor_spec.rb
@@ -105,6 +105,19 @@ RSpec.describe Etl::Feedex::Processor do
     end
   end
 
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { described_class.process(date: date) }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
+
 private
 
   def feedex_response

--- a/spec/domain/etl/ga/internal_search_processor_spec.rb
+++ b/spec/domain/etl/ga/internal_search_processor_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe Etl::GA::InternalSearchProcessor do
     end
   end
 
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(Etl::GA::InternalSearchService).to receive(:find_in_batches).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.process(date: date) }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
+
+
 private
 
   def ga_response

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
     end
   end
 
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.process(date: date) }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
+
 private
 
   def ga_response(useful_yes: 1, useful_no: 1)

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
     end
   end
 
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(Etl::GA::ViewsAndNavigationService).to receive(:find_in_batches).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.process(date: date) }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
+
   private
 
   def ga_response

--- a/spec/domain/monitor/aggregations_spec.rb
+++ b/spec/domain/monitor/aggregations_spec.rb
@@ -23,4 +23,17 @@ RSpec.describe Monitor::Aggregations do
 
     subject.run
   end
+
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(::Aggregations::MonthlyMetric).to receive(:count).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.run }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
 end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -41,4 +41,17 @@ RSpec.describe Monitor::Dimensions do
     create :edition, content_id: 'id1', base_path: '/other', latest: false
     subject.run
   end
+
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(Dimensions::Edition).to receive(:latest).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.run }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
 end

--- a/spec/domain/monitor/etl_spec.rb
+++ b/spec/domain/monitor/etl_spec.rb
@@ -25,4 +25,17 @@ RSpec.describe Monitor::Etl do
       subject.run
     end
   end
+
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(Metric).to receive(:edition_metrics).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.run }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
 end

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -41,4 +41,18 @@ RSpec.describe Monitor::Facts do
 
     subject.run
   end
+  
+  describe 'exception thrown by during processing' do
+    let(:error) { StandardError.new }
+    before do
+      allow(GovukError).to receive(:notify)
+      allow(Facts::Metric).to receive(:count).and_raise(error)
+    end
+
+    it 'traps and logs the error to Sentry' do
+      expect { subject.run }.not_to raise_error
+      expect(GovukError).to have_received(:notify).with(error)
+    end
+  end
+
 end

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Monitor::Facts do
 
     subject.run
   end
-  
+
   describe 'exception thrown by during processing' do
     let(:error) { StandardError.new }
     before do
@@ -54,5 +54,4 @@ RSpec.describe Monitor::Facts do
       expect(GovukError).to have_received(:notify).with(error)
     end
   end
-
 end


### PR DESCRIPTION
# What
Traps errors during Etl processing

# Why

We want the master processor to continue if there are any errors
with the individual processes.

Trello: https://trello.com/c/8PqhrsdK/972-3-master-process-do-not-stop-if-a-single-etl-process-fails-to-run