### PR TITLE
Fix /organisations endpoint returning Welsh versions

### DIFF
--- a/app/domain/queries/find_all_organisations.rb
+++ b/app/domain/queries/find_all_organisations.rb
@@ -5,7 +5,7 @@ class Queries::FindAllOrganisations
 
   def retrieve
     Dimensions::Edition.latest
-      .where(document_type: 'organisation')
+      .where(document_type: 'organisation', locale: 'en')
       .order(:title)
       .pluck(:content_id, :title)
       .map(&method(:convert_result))

--- a/spec/domain/queries/find_all_organisations_spec.rb
+++ b/spec/domain/queries/find_all_organisations_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Queries::FindAllOrganisations do
     before do
       create :user
       create :edition, document_type: 'organisation', content_id: 'org-1-id', title: 'z Org'
+      create :edition, document_type: 'organisation', content_id: 'org-1-id', title: 'aber Org', locale: 'cy'
       create :edition, document_type: 'organisation', content_id: 'org-2-id', title: 'a Org'
     end
 


### PR DESCRIPTION
# What
Filter out non `en` versions from `/content` endpoint

# Why

We are returning Welsh versions of organisations from the CPM /organisations endpoint. This is causing CDA to display the welsh version in the table header if it's higher in the list (alphabetically) as it just picks the first one with the correct content_id.

Trello: https://trello.com/c/LnIAKNN5/1021-fix-bug-bug-with-welsh-organisation-names