### PR TITLE
Refactor etl to make it consistent and dry tests

### DIFF
--- a/app/domain/etl/feedex/processor.rb
+++ b/app/domain/etl/feedex/processor.rb
@@ -22,7 +22,7 @@ private
 
   def extract_events
     batch = 1
-    feedex_service.find_in_batches do |events|
+    Etl::Feedex::Service.find_in_batches(date, BATCH_SIZE) do |events|
       log process: :feedex, message: "Processing #{events.length} events in batch #{batch}"
       Events::Feedex.import(events, batch_size: BATCH_SIZE)
       batch += 1
@@ -73,8 +73,4 @@ private
   end
 
   attr_reader :date
-
-  def feedex_service
-    @feedex_service ||= Etl::Feedex::Service.new(date, BATCH_SIZE)
-  end
 end

--- a/app/domain/etl/feedex/service.rb
+++ b/app/domain/etl/feedex/service.rb
@@ -3,6 +3,10 @@ require 'gds_api/support_api'
 class Etl::Feedex::Service
   attr_reader :date, :batch_size, :support_api
 
+  def self.find_in_batches(*args, &block)
+    new(*args).find_in_batches(&block)
+  end
+
   def initialize(date, batch_size, support_api = nil)
     @date = date
     @batch_size = batch_size

--- a/spec/domain/etl/feedex/processor_spec.rb
+++ b/spec/domain/etl/feedex/processor_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Etl::Feedex::Processor do
     let(:error) { StandardError.new }
     before do
       allow(GovukError).to receive(:notify)
-      allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_raise(error)
+      allow(Etl::Feedex::Service).to receive(:find_in_batches).and_raise(error)
     end
 
     it 'traps and logs the error to Sentry' do

--- a/spec/domain/etl/feedex/processor_spec.rb
+++ b/spec/domain/etl/feedex/processor_spec.rb
@@ -2,6 +2,7 @@ require 'gds-api-adapters'
 
 RSpec.describe Etl::Feedex::Processor do
   let(:date) { Date.new(2018, 2, 20) }
+  let(:subject) { described_class }
 
   context 'When the base_path matches the feedex path' do
     before { allow_any_instance_of(Etl::Feedex::Service).to receive(:find_in_batches).and_yield(feedex_response) }
@@ -105,18 +106,7 @@ RSpec.describe Etl::Feedex::Processor do
     end
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(Etl::Feedex::Service).to receive(:find_in_batches).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { described_class.process(date: date) }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
+  it_behaves_like 'traps and logs errors in process', Etl::Feedex::Service, :find_in_batches
 
 private
 

--- a/spec/domain/etl/ga/internal_search_processor_spec.rb
+++ b/spec/domain/etl/ga/internal_search_processor_spec.rb
@@ -73,19 +73,7 @@ RSpec.describe Etl::GA::InternalSearchProcessor do
     end
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(Etl::GA::InternalSearchService).to receive(:find_in_batches).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { subject.process(date: date) }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
-
+  it_behaves_like 'traps and logs errors in process', Etl::GA::InternalSearchService, :find_in_batches
 
 private
 

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -89,18 +89,7 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
     end
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { subject.process(date: date) }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
+  it_behaves_like 'traps and logs errors in process', Etl::GA::UserFeedbackService, :find_in_batches
 
 private
 

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -66,18 +66,7 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
     end
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(Etl::GA::ViewsAndNavigationService).to receive(:find_in_batches).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { subject.process(date: date) }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
+  it_behaves_like 'traps and logs errors in process', Etl::GA::ViewsAndNavigationService, :find_in_batches
 
   private
 

--- a/spec/domain/monitor/aggregations_spec.rb
+++ b/spec/domain/monitor/aggregations_spec.rb
@@ -24,16 +24,5 @@ RSpec.describe Monitor::Aggregations do
     subject.run
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(::Aggregations::MonthlyMetric).to receive(:count).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { subject.run }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
+  it_behaves_like 'traps and logs errors in run', ::Aggregations::MonthlyMetric, :count
 end

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -42,16 +42,5 @@ RSpec.describe Monitor::Dimensions do
     subject.run
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(Dimensions::Edition).to receive(:latest).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { subject.run }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
+  it_behaves_like 'traps and logs errors in run', Dimensions::Edition, :latest
 end

--- a/spec/domain/monitor/etl_spec.rb
+++ b/spec/domain/monitor/etl_spec.rb
@@ -26,16 +26,5 @@ RSpec.describe Monitor::Etl do
     end
   end
 
-  describe 'exception thrown by during processing' do
-    let(:error) { StandardError.new }
-    before do
-      allow(GovukError).to receive(:notify)
-      allow(Metric).to receive(:edition_metrics).and_raise(error)
-    end
-
-    it 'traps and logs the error to Sentry' do
-      expect { subject.run }.not_to raise_error
-      expect(GovukError).to have_received(:notify).with(error)
-    end
-  end
+  it_behaves_like 'traps and logs errors in run', Metric, :edition_metrics
 end

--- a/spec/domain/monitor/facts_spec.rb
+++ b/spec/domain/monitor/facts_spec.rb
@@ -54,4 +54,6 @@ RSpec.describe Monitor::Facts do
       expect(GovukError).to have_received(:notify).with(error)
     end
   end
+
+  it_behaves_like 'traps and logs errors in run', Facts::Metric, :count
 end

--- a/spec/support/shared/shared_traps_and_logs.rb
+++ b/spec/support/shared/shared_traps_and_logs.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'traps and logs errors in process' do |object, method|
+  let(:error) { StandardError.new }
+  before do
+    allow(GovukError).to receive(:notify)
+    allow(object).to receive(method).and_raise(error)
+  end
+
+  it 'traps and logs the error to Sentry' do
+    expect { subject.process(date: date) }.not_to raise_error
+    expect(GovukError).to have_received(:notify).with(error)
+  end
+end
+
+RSpec.shared_examples 'traps and logs errors in run' do |object, method|
+  let(:error) { StandardError.new }
+  before do
+    allow(GovukError).to receive(:notify)
+    allow(object).to receive(method).and_raise(error)
+  end
+
+  it 'traps and logs the error to Sentry' do
+    expect { subject.run }.not_to raise_error
+    expect(GovukError).to have_received(:notify).with(error)
+  end
+end


### PR DESCRIPTION
# What

Refactor `Etl::Fedex::Service` to be called in a consistent way to the other services.
Introduce shared behaviour to DRY up the [tests for error trapping in Etl.](https://github.com/alphagov/content-performance-manager/pull/1087)

# Why
To leave the code in a bit better state before I leave the team.

Trello: https://trello.com/c/9twND5fT/1022-give-the-code-some-love