### PR TITLE
Remove timestamps from facts_metrics

### DIFF
--- a/db/migrate/20190116151317_remove_timestamps_from_facts_metrics.rb
+++ b/db/migrate/20190116151317_remove_timestamps_from_facts_metrics.rb
@@ -1,0 +1,6 @@
+class RemoveTimestampsFromFactsMetrics < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :facts_metrics, :created_at, :string
+    remove_column :facts_metrics, :updated_at, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_04_120051) do
+ActiveRecord::Schema.define(version: 2019_01_16_151317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,8 +165,6 @@ ActiveRecord::Schema.define(version: 2019_01_04_120051) do
   create_table "facts_metrics", force: :cascade do |t|
     t.date "dimensions_date_id", null: false
     t.bigint "dimensions_edition_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "pviews", default: 0, null: false
     t.integer "upviews", default: 0, null: false
     t.integer "feedex", default: 0, null: false


### PR DESCRIPTION
These are unused, and removing them might reduce the disk space used
by this table (~44GB in production).