### PR TITLE
Add indexes to optimise searches across all orgs

### DIFF
--- a/db/migrate/20190125223438_add_index_to_aggregations_upviews.rb
+++ b/db/migrate/20190125223438_add_index_to_aggregations_upviews.rb
@@ -1,0 +1,9 @@
+class AddIndexToAggregationsUpviews < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_search_last_thirty_days, :upviews
+    add_index :aggregations_search_last_months, :upviews
+    add_index :aggregations_search_last_three_months, :upviews
+    add_index :aggregations_search_last_six_months, :upviews
+    add_index :aggregations_search_last_twelve_months, :upviews
+  end
+end


### PR DESCRIPTION
# What/Why

We are seeing a timeout on production when we search for an item
from all organisations. The slowest aspect of the view we have on
the index page is sorting by upviews. Adding an index speeds it up
overall.