### PR TITLE
Add healthcheck to validate Database Status

### DIFF
--- a/app/domain/healthchecks/database_connection.rb
+++ b/app/domain/healthchecks/database_connection.rb
@@ -1,0 +1,11 @@
+module Healthchecks
+  class DatabaseConnection
+    def name
+      :database_status
+    end
+
+    def status
+      Dimensions::Date.first ? OK : CRITICAL
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,6 @@ Rails.application.routes.draw do
   get '/single_page/(*base_path)', to: 'single_item#show', defaults: { format: :json }
   get '/healthcheck', to: GovukHealthcheck.rack_response(
     Healthchecks::DailyMetricsCheck,
-    GovukHealthcheck::ActiveRecord,
+    Healthchecks::DatabaseConnection,
   )
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe '/healthcheck' do
     get '/healthcheck'
     json = JSON.parse(response.body)
 
-    expect(json['checks']).to include('database_connectivity')
+    expect(json['checks']).to include('database_status')
   end
 
   it "is not cacheable" do


### PR DESCRIPTION
[Trello card](::ActiveRecord::Base.connected? ? OK : CRITICAL)

The existing validation in `GovukHealthcheck::ActiveRecord` from Govk app
config returns intermitent `critial` errors. We need to investigate this
further, but for the time being I am using a simple query to validate
its status.