### PR TITLE
Fix message in Healthechk alarm

### DIFF
--- a/app/domain/healthchecks/database_connection.rb
+++ b/app/domain/healthchecks/database_connection.rb
@@ -7,5 +7,13 @@ module Healthchecks
     def status
       Dimensions::Date.first ? OK : CRITICAL
     end
+
+    def message
+      "Can't connect to Database"
+    end
+
+    def enabled?
+      true
+    end
   end
 end


### PR DESCRIPTION
[Trello card ](https://trello.com/c/zdEK6FMr/1103-5-2nd-line-alarm-documentation-for-content-data-and-content-performance-manager)

Fixes the following issue

```
{
  "status": "critical",
  "checks": {
    "daily_metrics": {
      "status": "ok",
      "message": "currently disabled"
    },
  "database_status": {
     "status": "critical",
     "message": "uninitialized constant Healthchecks::DatabaseConnection::OK"
  }
  }
}
```