### PR TITLE
Add reading time

### DIFF
--- a/app/domain/etl/edition/content/reading_time.rb
+++ b/app/domain/etl/edition/content/reading_time.rb
@@ -1,0 +1,6 @@
+class Etl::Edition::Content::ReadingTime
+  def self.calculate(words)
+    # 200 words per minute. Rounds up to 1 anything less than 1 minute.
+    (words / 200.00).ceil
+  end
+end

--- a/app/domain/etl/edition/processor.rb
+++ b/app/domain/etl/edition/processor.rb
@@ -36,6 +36,7 @@ private
       chars: result.fetch('string_length'),
       sentences: result.fetch('sentence_count'),
       words: result.fetch('word_count'),
+      reading_time: Etl::Edition::Content::ReadingTime.calculate(result.fetch('word_count')),
     }
   end
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -9,7 +9,9 @@ class Facts::Metric < ApplicationRecord
     :readability,
     :chars,
     :sentences,
-    :words, to: :facts_edition
+    :words,
+    :reading_time,
+    to: :facts_edition
 
   validates :dimensions_date, presence: true
   validates :dimensions_edition, presence: true

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -58,3 +58,7 @@ edition:
   - name: 'words'
     description: "Total number of words detected in the text"
     source: 'custom'
+
+  - name: 'reading_time'
+    description: 'Typical time to read all words'
+    source: 'custom'

--- a/db/migrate/20190204150122_add_reading_time_to_facts_edition.rb
+++ b/db/migrate/20190204150122_add_reading_time_to_facts_edition.rb
@@ -1,0 +1,5 @@
+class AddReadingTimeToFactsEdition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :facts_editions, :reading_time, :integer
+  end
+end

--- a/db/migrate/20190204171432_update_reading_time.rb
+++ b/db/migrate/20190204171432_update_reading_time.rb
@@ -1,0 +1,18 @@
+class UpdateReadingTime < ActiveRecord::Migration[5.2]
+  class Facts::Edition < ApplicationRecord
+  end
+
+  class Dimensions::Edition < ApplicationRecord
+    has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_edition_id
+  end
+
+  def up
+    Dimensions::Edition.where(latest: true).find_each do |edition|
+      facts = edition.facts_edition
+      if facts.words.present? && facts.words > 0
+        reading_time = Etl::Edition::Content::ReadingTime.calculate(facts.words)
+        facts.update(reading_time: reading_time)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_102543) do
+ActiveRecord::Schema.define(version: 2019_02_04_150122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 2019_02_04_102543) do
     t.integer "words"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "reading_time"
     t.index ["dimensions_edition_id", "dimensions_date_id"], name: "facts_editions_edition_id_date_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_150122) do
+ActiveRecord::Schema.define(version: 2019_02_04_171432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/domain/etl/edition/content/reading_time_spec.rb
+++ b/spec/domain/etl/edition/content/reading_time_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Etl::Edition::Content::ReadingTime do
+  subject { described_class }
+
+  describe '#calculate' do
+    it 'calculate readability based on 200 words per minute' do
+      expected_reading_time = 400 / 200
+
+      expect(subject.calculate(400)).to eq(expected_reading_time)
+    end
+
+    it 'rounds up to 1 reading times that are between 0 and 1 minute' do
+      expect(subject.calculate(20)).to eq(1)
+    end
+  end
+end

--- a/spec/domain/finders/find_series_spec.rb
+++ b/spec/domain/finders/find_series_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Finders::FindSeries do
     it "returns a series of all metrics" do
       create :metric, date: Date.today, pviews: 1
 
-      expect(described_class.new.run.length).to eq(15)
+      expect(described_class.new.run.length).to eq(16)
     end
   end
 

--- a/spec/factories/facts_editions.rb
+++ b/spec/factories/facts_editions.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     words { 0 }
     chars { 0 }
     readability { 0 }
+    reading_time { 0 }
   end
 end

--- a/spec/models/facts/edition_spec.rb
+++ b/spec/models/facts/edition_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Facts::Edition do
       chars: 21,
       sentences: 1,
       words: 4,
+      reading_time: 5,
     }
   end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Metric do
       sentences
       chars
       words
+      reading_time
     ).freeze
 
   DAILY_METRICS =
@@ -25,7 +26,7 @@ RSpec.describe Metric do
     it "returns a list of all metrics" do
       metrics = Metric.find_all
 
-      expect(metrics.length).to eq(15)
+      expect(metrics.length).to eq(16)
       a_metric = metrics.first
       expect(a_metric).to be_an_instance_of(Metric)
     end
@@ -35,7 +36,7 @@ RSpec.describe Metric do
     it "returns a list of all metrics" do
       metric_names = Metric.find_all_names
 
-      expect(metric_names.length).to eq(15)
+      expect(metric_names.length).to eq(16)
       a_metric = metric_names.first
       expect(a_metric).to eq('chars')
     end


### PR DESCRIPTION
Calculates and returns the reading time for content based on the number of words and an assumed reading rate of 200 wpm.

Note: I initially set the db storage type to integer, but as we need to round up < 1 minute values to 1, and also because we may want to store smaller values in future (I'd already redone the migration a couple of times) it's easier to store the value as a float at this point.