### PR TITLE
Fix infinite loop when Support API returns no results

### DIFF
--- a/app/domain/etl/feedex/service.rb
+++ b/app/domain/etl/feedex/service.rb
@@ -19,7 +19,7 @@ class Etl::Feedex::Service
       response = support_api.feedback_by_day(date, current_page, @batch_size)
       yield convert_results(response['results'])
 
-      break if response['pages'] == current_page
+      break if response['pages'].zero? || response['pages'] == current_page
 
       current_page += 1
     end

--- a/spec/domain/etl/feedex/service_spec.rb
+++ b/spec/domain/etl/feedex/service_spec.rb
@@ -3,93 +3,95 @@ RSpec.describe Etl::Feedex::Service do
   let(:subject) { described_class.new(date, 20, support_api) }
 
   describe '#find_in_batches' do
-    let(:date) { Date.new(2018, 2, 1) }
-    let(:response_1) do
-      {
-        'results' => [
-          { 'path' => '/path/1', 'count' => 3 },
-          { 'path' => '/path/2', 'count' => 1 }
-        ],
-        'pages' => 3,
-        'current_page' => 1
-      }
-    end
-    let(:response_2) do
-      {
-        'results' => [
-          { 'path' => '/path/3', 'count' => 5 },
-          { 'path' => '/path/4', 'count' => 2 }
-        ],
-        'pages' => 3,
-        'current_page' => 2
-      }
-    end
-    let(:response_3) do
-      {
-        'results' => [
-          { 'path' => '/path/5', 'count' => 1 },
-          { 'path' => '/path/6', 'count' => 7 }
-        ],
-        'pages' => 3,
-        'current_page' => 3
-      }
-    end
+    context 'when there are results' do
+      let(:date) { Date.new(2018, 2, 1) }
+      let(:response_1) do
+        {
+          'results' => [
+            { 'path' => '/path/1', 'count' => 3 },
+            { 'path' => '/path/2', 'count' => 1 }
+          ],
+          'pages' => 3,
+          'current_page' => 1
+        }
+      end
+      let(:response_2) do
+        {
+          'results' => [
+            { 'path' => '/path/3', 'count' => 5 },
+            { 'path' => '/path/4', 'count' => 2 }
+          ],
+          'pages' => 3,
+          'current_page' => 2
+        }
+      end
+      let(:response_3) do
+        {
+          'results' => [
+            { 'path' => '/path/5', 'count' => 1 },
+            { 'path' => '/path/6', 'count' => 7 }
+          ],
+          'pages' => 3,
+          'current_page' => 3
+        }
+      end
 
-    before :each do
-      allow(support_api).to receive(:feedback_by_day)
-        .with(date, 1, 20).and_return(response_1)
-      allow(support_api).to receive(:feedback_by_day)
-        .with(date, 2, 20).and_return(response_2)
-      allow(support_api).to receive(:feedback_by_day)
-        .with(date, 3, 20).and_return(response_3)
-    end
+      before :each do
+        allow(support_api).to receive(:feedback_by_day)
+                                .with(date, 1, 20).and_return(response_1)
+        allow(support_api).to receive(:feedback_by_day)
+                                .with(date, 2, 20).and_return(response_2)
+        allow(support_api).to receive(:feedback_by_day)
+                                .with(date, 3, 20).and_return(response_3)
+      end
 
-    it 'makes the correct request and yields the first page' do
-      expected_date = Date.parse('01/02/2018')
+      it 'makes the correct request and yields the first page' do
+        expected_date = Date.parse('01/02/2018')
 
-      expect { |b| subject.find_in_batches(&b) }.to yield_successive_args(
-        [
-          {
-            date: expected_date,
-            page_path: '/path/1',
-            feedex_comments: 3
-          },
-          {
-            date: expected_date,
-            page_path: '/path/2',
-            feedex_comments: 1
-          }
-        ],
-        [
-          {
-            date: expected_date,
-            page_path: '/path/3',
-            feedex_comments: 5
-          },
-          {
-            date: expected_date,
-            page_path: '/path/4',
-            feedex_comments: 2
-          }
-        ],
-        [
-          {
-            date: expected_date,
-            page_path: '/path/5',
-            feedex_comments: 1
-          },
-          {
-            date: expected_date,
-            page_path: '/path/6',
-            feedex_comments: 7
-          }
-        ]
-      )
+        expect { |b| subject.find_in_batches(&b) }.to yield_successive_args(
+          [
+            {
+              date: expected_date,
+              page_path: '/path/1',
+              feedex_comments: 3
+            },
+            {
+              date: expected_date,
+              page_path: '/path/2',
+              feedex_comments: 1
+            }
+          ],
+          [
+            {
+              date: expected_date,
+              page_path: '/path/3',
+              feedex_comments: 5
+            },
+            {
+              date: expected_date,
+              page_path: '/path/4',
+              feedex_comments: 2
+            }
+          ],
+          [
+            {
+              date: expected_date,
+              page_path: '/path/5',
+              feedex_comments: 1
+            },
+            {
+              date: expected_date,
+              page_path: '/path/6',
+              feedex_comments: 7
+            }
+          ]
+        )
 
-      expect(support_api).to have_received(:feedback_by_day).with(expected_date, 1, 20)
-      expect(support_api).to have_received(:feedback_by_day).with(expected_date, 2, 20)
-      expect(support_api).to have_received(:feedback_by_day).with(expected_date, 3, 20)
-      expect(support_api).not_to have_received(:feedback_by_day).with(expected_date, 4, 20)
+        expect(support_api).to have_received(:feedback_by_day).with(expected_date, 1, 20)
+        expect(support_api).to have_received(:feedback_by_day).with(expected_date, 2, 20)
+        expect(support_api).to have_received(:feedback_by_day).with(expected_date, 3, 20)
+        expect(support_api).not_to have_received(:feedback_by_day).with(expected_date, 4, 20)
+      end
     end
   end
 end

--- a/spec/domain/etl/feedex/service_spec.rb
+++ b/spec/domain/etl/feedex/service_spec.rb
@@ -3,8 +3,25 @@ RSpec.describe Etl::Feedex::Service do
   let(:subject) { described_class.new(date, 20, support_api) }
 
   describe '#find_in_batches' do
+    let(:date) { Date.new(2018, 2, 1) }
+
+    context 'when there are no results' do
+      let(:response) { { 'results' => [], 'current_page' => 1, 'pages' => 0 } }
+
+      before do
+        allow(support_api).to receive(:feedback_by_day).with(date, 1, 20).and_return(response)
+      end
+
+      it 'yields no results' do
+        expected_date = Date.parse('01/02/2018')
+
+        expect { |b| subject.find_in_batches(&b) }.to yield_successive_args([])
+        expect(support_api).to have_received(:feedback_by_day).with(expected_date, 1, 20)
+        expect(support_api).not_to have_received(:feedback_by_day).with(expected_date, 2, 20)
+      end
+    end
+
     context 'when there are results' do
-      let(:date) { Date.new(2018, 2, 1) }
       let(:response_1) do
         {
           'results' => [


### PR DESCRIPTION
[Trello card](https://trello.com/c/T3kojrLT/1156-etl-feedex-enters-in-a-loop-if-no-results-integration-staging)

### What

Feedex processor enters in an infinite loop when Support API returns no responses.

### Why

This is not likely in production, but it happens on staging and integration, so we need to fix it urgently in order to exercise the Icinga alarms.