### PR TITLE
Healthcheck: Google Analytics core metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem 'pry-rails'
   gem "rack", ">= 2.0.6"
   gem 'rails-controller-testing'
+  gem 'rspec-its'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (1.11.2)
+    govuk_app_config (1.11.3)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -264,7 +264,7 @@ GEM
       rack (>= 1.2, < 3)
     odyssey (0.2.0)
       require_all
-    oj (3.7.6)
+    oj (3.7.8)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,6 +359,9 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
@@ -516,6 +519,7 @@ DEPENDENCIES
   rack-proxy
   rails (~> 5.2)
   rails-controller-testing
+  rspec-its
   rspec-rails
   ruby-progressbar
   sass-rails

--- a/app/domain/healthchecks/concerns/deactivable.rb
+++ b/app/domain/healthchecks/concerns/deactivable.rb
@@ -1,6 +1,6 @@
 require 'active_support/concern'
 
-module Healthchecks::Concerns::TimeRange
+module Healthchecks::Concerns::Deactivable
   extend ActiveSupport::Concern
 
   included do
@@ -9,10 +9,6 @@ module Healthchecks::Concerns::TimeRange
     end
 
   private
-
-    def adition_of_metric_values
-      Facts::Metric.for_yesterday.sum(:pviews)
-    end
 
     def healthchecks_enabled?
       ENV['ETL_HEALTHCHECK_ENABLED'] == '1'

--- a/app/domain/healthchecks/concerns/time_range.rb
+++ b/app/domain/healthchecks/concerns/time_range.rb
@@ -1,0 +1,27 @@
+require 'active_support/concern'
+
+module Healthchecks::Concerns::TimeRange
+  extend ActiveSupport::Concern
+
+  included do
+    def enabled?
+      healthchecks_enabled? && within_time_range?
+    end
+
+  private
+
+    def adition_of_metric_values
+      Facts::Metric.for_yesterday.sum(:pviews)
+    end
+
+    def healthchecks_enabled?
+      ENV['ETL_HEALTHCHECK_ENABLED'] == '1'
+    end
+
+    def within_time_range?
+      time = Time.zone.now
+
+      time.hour >= Integer(ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'])
+    end
+  end
+end

--- a/app/domain/healthchecks/daily_metrics_check.rb
+++ b/app/domain/healthchecks/daily_metrics_check.rb
@@ -1,5 +1,7 @@
 module Healthchecks
   class DailyMetricsCheck
+    include Concerns::TimeRange
+
     def name
       :daily_metrics
     end
@@ -12,21 +14,7 @@ module Healthchecks
       "ETL :: no daily metrics for yesterday"
     end
 
-    def enabled?
-      healthchecks_enabled? && within_time_range?
-    end
-
   private
-
-    def healthchecks_enabled?
-      ENV['ETL_HEALTHCHECK_ENABLED'] == '1'
-    end
-
-    def within_time_range?
-      time = Time.zone.now
-
-      time.hour >= Integer(ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'])
-    end
 
     def metrics
       @metrics ||= Facts::Metric.where(dimensions_date_id: Date.yesterday)

--- a/app/domain/healthchecks/daily_metrics_check.rb
+++ b/app/domain/healthchecks/daily_metrics_check.rb
@@ -1,6 +1,6 @@
 module Healthchecks
   class DailyMetricsCheck
-    include Concerns::TimeRange
+    include Concerns::Deactivable
 
     def name
       :daily_metrics

--- a/app/domain/healthchecks/database_connection.rb
+++ b/app/domain/healthchecks/database_connection.rb
@@ -9,7 +9,7 @@ module Healthchecks
     end
 
     def message
-      "Can't connect to Database"
+      "Can't connect to Database" if status == :critical
     end
 
     def enabled?

--- a/app/domain/healthchecks/etl_google_analytics.rb
+++ b/app/domain/healthchecks/etl_google_analytics.rb
@@ -1,0 +1,35 @@
+module Healthchecks
+  class EtlGoogleAnalytics
+    def name
+      :etl_google_analytics_pviews
+    end
+
+    def enabled?
+      healthchecks_enabled? && within_time_range?
+    end
+
+    def status
+      if adition_of_metric_values.positive?
+        :ok
+      else
+        :critical
+      end
+    end
+
+  private
+
+    def adition_of_metric_values
+      Facts::Metric.for_yesterday.sum(:pviews)
+    end
+
+    def healthchecks_enabled?
+      ENV['ETL_HEALTHCHECK_ENABLED'] == '1'
+    end
+
+    def within_time_range?
+      time = Time.zone.now
+
+      time.hour >= Integer(ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'])
+    end
+  end
+end

--- a/app/domain/healthchecks/etl_google_analytics.rb
+++ b/app/domain/healthchecks/etl_google_analytics.rb
@@ -24,7 +24,7 @@ module Healthchecks
   private
 
     def adition_of_metric_values
-      Facts::Metric.for_yesterday.sum(:pviews)
+      Facts::Metric.for_yesterday.where('pviews > 0').count
     end
   end
 end

--- a/app/domain/healthchecks/etl_google_analytics.rb
+++ b/app/domain/healthchecks/etl_google_analytics.rb
@@ -1,9 +1,16 @@
 module Healthchecks
   class EtlGoogleAnalytics
+    include ActiveModel::Model
     include Concerns::TimeRange
 
+    attr_accessor :metric
+
+    def self.build(metric)
+      new(metric: metric)
+    end
+
     def name
-      :etl_google_analytics_pviews
+      "etl_google_analytics_#{metric}".to_sym
     end
 
     def status

--- a/app/domain/healthchecks/etl_google_analytics.rb
+++ b/app/domain/healthchecks/etl_google_analytics.rb
@@ -1,11 +1,9 @@
 module Healthchecks
   class EtlGoogleAnalytics
+    include Concerns::TimeRange
+
     def name
       :etl_google_analytics_pviews
-    end
-
-    def enabled?
-      healthchecks_enabled? && within_time_range?
     end
 
     def status
@@ -20,16 +18,6 @@ module Healthchecks
 
     def adition_of_metric_values
       Facts::Metric.for_yesterday.sum(:pviews)
-    end
-
-    def healthchecks_enabled?
-      ENV['ETL_HEALTHCHECK_ENABLED'] == '1'
-    end
-
-    def within_time_range?
-      time = Time.zone.now
-
-      time.hour >= Integer(ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'])
     end
   end
 end

--- a/app/domain/healthchecks/etl_google_analytics.rb
+++ b/app/domain/healthchecks/etl_google_analytics.rb
@@ -14,17 +14,21 @@ module Healthchecks
     end
 
     def status
-      if adition_of_metric_values.positive?
+      if addition_of_metric_values.positive?
         :ok
       else
         :critical
       end
     end
 
+    def message
+      "ETL :: no #{metric} for yesterday" if status == :critical
+    end
+
   private
 
-    def adition_of_metric_values
-      Facts::Metric.for_yesterday.where('pviews > 0').count
+    def addition_of_metric_values
+      Facts::Metric.for_yesterday.where("#{metric} > 0").count
     end
   end
 end

--- a/app/domain/healthchecks/etl_google_analytics.rb
+++ b/app/domain/healthchecks/etl_google_analytics.rb
@@ -1,7 +1,7 @@
 module Healthchecks
   class EtlGoogleAnalytics
     include ActiveModel::Model
-    include Concerns::TimeRange
+    include Concerns::Deactivable
 
     attr_accessor :metric
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,6 @@ Rails.application.routes.draw do
   get '/healthcheck', to: GovukHealthcheck.rack_response(
     Healthchecks::DailyMetricsCheck,
     Healthchecks::DatabaseConnection,
-    Healthchecks::EtlGoogleAnalytics,
+    Healthchecks::EtlGoogleAnalytics.build(:pviews),
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
     Healthchecks::DailyMetricsCheck,
     Healthchecks::DatabaseConnection,
     Healthchecks::EtlGoogleAnalytics.build(:pviews),
+    Healthchecks::EtlGoogleAnalytics.build(:upviews),
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,6 @@ Rails.application.routes.draw do
   get '/healthcheck', to: GovukHealthcheck.rack_response(
     Healthchecks::DailyMetricsCheck,
     Healthchecks::DatabaseConnection,
+    Healthchecks::EtlGoogleAnalytics,
   )
 end

--- a/spec/domain/healthchecks/daily_metrics_check_spec.rb
+++ b/spec/domain/healthchecks/daily_metrics_check_spec.rb
@@ -1,9 +1,5 @@
 RSpec.describe Healthchecks::DailyMetricsCheck do
-  let(:today) { Time.new(2018, 1, 15, 16, 0, 0) }
-
-  around do |example|
-    Timecop.freeze(today) { example.run }
-  end
+  include_examples 'Healthcheck enabled/disabled within time range'
 
   describe '#status' do
     context 'When there are metrics' do
@@ -22,45 +18,6 @@ RSpec.describe Healthchecks::DailyMetricsCheck do
       it 'returns status :ok' do
         expect(subject.status).to eq(:critical)
       end
-    end
-  end
-
-  describe '#enabled?' do
-    around do |example|
-      @healthcheck_enabled = ENV['ETL_HEALTHCHECK_ENABLED']
-      @healthcheck_hour = ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR']
-      example.run
-      ENV['ETL_HEALTHCHECK_ENABLED'] = @healthcheck_enabled
-      ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'] = @healthcheck_hour
-    end
-
-    context 'when ETL checks are enabled' do
-      before do
-        ENV['ETL_HEALTHCHECK_ENABLED'] = '1'
-        ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'] = '9'
-      end
-
-      context 'within time range' do
-        let(:today) { Time.new(2018, 1, 15, 9, 1, 0) }
-
-        it { is_expected.to be_enabled }
-      end
-
-      context 'out of time range' do
-        let(:today) { Time.new(2018, 1, 15, 1, 0, 0) }
-
-        it { is_expected.to_not be_enabled }
-      end
-    end
-
-    context 'when ETL checks are not enabled' do
-      before do
-        ENV.delete 'ETL_HEALTHCHECK_ENABLED'
-      end
-
-      let(:today) { Time.new(2018, 1, 15, 20, 0, 0) }
-
-      it { is_expected.to_not be_enabled }
     end
   end
 end

--- a/spec/domain/healthchecks/database_connection_spec.rb
+++ b/spec/domain/healthchecks/database_connection_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Healthchecks::DatabaseConnection do
+  it { is_expected.to be_enabled }
+
+  its(:name) { is_expected.to eq(:database_status) }
+
+  describe '#status' do
+    context 'when the connection is valid' do
+      before { Dimensions::Date.create_with(Date.today) }
+
+      its(:status) { is_expected.to eq(:ok) }
+      its(:message) { is_expected.to be_blank }
+    end
+
+    context 'when the connection is not valid' do
+      before { Dimensions::Date.delete_all }
+
+      its(:status) { is_expected.to eq(:critical) }
+      its(:message) { is_expected.to eq("Can't connect to Database") }
+    end
+  end
+end

--- a/spec/domain/healthchecks/etl_google_analytics_spec.rb
+++ b/spec/domain/healthchecks/etl_google_analytics_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Healthchecks::EtlGoogleAnalytics do
 
   include_examples 'Healthcheck enabled/disabled within time range'
 
+  subject { described_class.build(:pviews) }
+
   describe "#status" do
     let(:yesterday) { Date.yesterday }
 

--- a/spec/domain/healthchecks/etl_google_analytics_spec.rb
+++ b/spec/domain/healthchecks/etl_google_analytics_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Healthchecks::EtlGoogleAnalytics do
+  its(:name) { is_expected.to eq(:etl_google_analytics_pviews) }
+
+  include_examples 'Healthcheck enabled/disabled within time range'
+
+  describe "#status" do
+    let(:yesterday) { Date.yesterday }
+
+    context 'when there are no metrics' do
+      its(:status) { is_expected.to eq(:critical) }
+    end
+
+    context 'when there are no pviews for yesterday' do
+      before do
+        edition = create :edition
+        create :metric, edition: edition, date: yesterday, pviews: 0
+        create :metric, edition: edition, date: Date.today, pviews: 10
+      end
+
+      its(:status) { is_expected.to eq(:critical) }
+    end
+
+    context 'when there are pviews for yesterday' do
+      before do
+        edition = create :edition
+        create :metric, edition: edition, date: yesterday, pviews: 10
+        create :metric, edition: edition, date: Date.today, pviews: 0
+      end
+
+      its(:status) { is_expected.to eq(:ok) }
+    end
+  end
+end

--- a/spec/domain/healthchecks/etl_google_analytics_spec.rb
+++ b/spec/domain/healthchecks/etl_google_analytics_spec.rb
@@ -5,31 +5,27 @@ RSpec.describe Healthchecks::EtlGoogleAnalytics do
 
   subject { described_class.build(:pviews) }
 
-  describe "#status" do
-    let(:yesterday) { Date.yesterday }
+  let(:yesterday) { Date.yesterday }
 
-    context 'when there are no metrics' do
-      its(:status) { is_expected.to eq(:critical) }
+  context 'when there are no pviews for yesterday' do
+    before do
+      edition = create :edition
+      create :metric, edition: edition, date: yesterday, pviews: 0
+      create :metric, edition: edition, date: Date.today, pviews: 10
     end
 
-    context 'when there are no pviews for yesterday' do
-      before do
-        edition = create :edition
-        create :metric, edition: edition, date: yesterday, pviews: 0
-        create :metric, edition: edition, date: Date.today, pviews: 10
-      end
+    its(:status) { is_expected.to eq(:critical) }
+    its(:message) { is_expected.to eq('ETL :: no pviews for yesterday') }
+  end
 
-      its(:status) { is_expected.to eq(:critical) }
+  context 'when there are pviews for yesterday' do
+    before do
+      edition = create :edition
+      create :metric, edition: edition, date: yesterday, pviews: 10
+      create :metric, edition: edition, date: Date.today, pviews: 10
     end
 
-    context 'when there are pviews for yesterday' do
-      before do
-        edition = create :edition
-        create :metric, edition: edition, date: yesterday, pviews: 10
-        create :metric, edition: edition, date: Date.today, pviews: 0
-      end
-
-      its(:status) { is_expected.to eq(:ok) }
-    end
+    its(:status) { is_expected.to eq(:ok) }
+    its(:message) { is_expected.to be_nil }
   end
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe '/healthcheck' do
     get '/healthcheck'
     json = JSON.parse(response.body)
 
-    expect(json['checks']).to include('database_status')
+    expect(json['checks']).to include('database_status').
+      and(include('etl_google_analytics_pviews'))
   end
 
   it "is not cacheable" do

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe '/healthcheck' do
     json = JSON.parse(response.body)
 
     expect(json['checks']).to include('database_status').
-      and(include('etl_google_analytics_pviews'))
+      and(include('etl_google_analytics_pviews')).
+      and(include('etl_google_analytics_upviews'))
   end
 
   it "is not cacheable" do

--- a/spec/support/shared/shared_healthcheck_enabled.rb
+++ b/spec/support/shared/shared_healthcheck_enabled.rb
@@ -1,0 +1,46 @@
+RSpec.shared_examples 'Healthcheck enabled/disabled within time range' do
+  around do |example|
+    @healthcheck_enabled = ENV['ETL_HEALTHCHECK_ENABLED']
+    @healthcheck_hour = ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR']
+    example.run
+    ENV['ETL_HEALTHCHECK_ENABLED'] = @healthcheck_enabled
+    ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'] = @healthcheck_hour
+  end
+
+  describe '#enabled?' do
+    let(:today) { Time.new(2018, 1, 15, 16, 0, 0) }
+
+    around do |example|
+      Timecop.freeze(today) { example.run }
+    end
+
+    context 'when ETL checks are enabled' do
+      before do
+        ENV['ETL_HEALTHCHECK_ENABLED'] = '1'
+        ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'] = '9'
+      end
+
+      context 'within time range' do
+        let(:today) { Time.new(2018, 1, 15, 9, 1, 0) }
+
+        it { is_expected.to be_enabled }
+      end
+
+      context 'out of time range' do
+        let(:today) { Time.new(2018, 1, 15, 1, 0, 0) }
+
+        it { is_expected.to_not be_enabled }
+      end
+    end
+
+    context 'when ETL checks are not enabled' do
+      before do
+        ENV.delete 'ETL_HEALTHCHECK_ENABLED'
+      end
+
+      let(:today) { Time.new(2018, 1, 15, 20, 0, 0) }
+
+      it { is_expected.to_not be_enabled }
+    end
+  end
+end

--- a/spec/support/shared/shared_healthcheck_enabled.rb
+++ b/spec/support/shared/shared_healthcheck_enabled.rb
@@ -42,5 +42,16 @@ RSpec.shared_examples 'Healthcheck enabled/disabled within time range' do
 
       it { is_expected.to_not be_enabled }
     end
+
+    context 'when ETL check is misconfigured' do
+      before do
+        ENV['ETL_HEALTHCHECK_ENABLED'] = '1'
+        ENV['ETL_HEALTHCHECK_ENABLED_FROM_HOUR'] = '9'
+      end
+
+      let(:today) { Time.new(2018, 1, 15, 1, 0, 0) }
+
+      it { is_expected.to_not be_enabled }
+    end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/lJ0YzNDt/1145-3-raise-2ndline-alarms-when-the-core-google-analytics-metrics-are-not-collected-from-google)

Raises `2ndline` alarms, following the similar approach to `daily_metrics_check.rb`, to notify when metrics collected from `Etl::GA::ViewsAndNavigationProcessor` are not present.

### Why

If the metrics are not present, then the ETL master process failed, and 2nd line needs to take an action

**Note**

I am adding migrations in a separate PR
