### PR TITLE
Add sort parameter to /content endpoint

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -18,7 +18,7 @@ private
   end
 
   def permitted_params
-    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range, :search_term)
+    params.permit(:from, :to, :organisation_id, :document_type, :format, :page, :page_size, :date_range, :search_term, :sort)
   end
 
   def validate_params!

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,4 +1,5 @@
 class Api::ContentRequest
+  VAILD_SORT_ATTRIBUTES = (Metric.daily_metrics.map(&:name) + %w[title document_type]).freeze
   VALID_SORT_DIRECTIONS = %w[asc desc].freeze
   VALID_TIME_PERIODS = ['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year'].freeze
   include ActiveModel::Validations
@@ -41,8 +42,7 @@ private
   end
 
   def valid_sort_attribute
-    valid_attributes = Metric.daily_metrics.map(&:name)
-    return true if @sort_attribute.in?(valid_attributes) || @sort_attribute.nil?
+    return true if @sort_attribute.in?(VAILD_SORT_ATTRIBUTES) || @sort_attribute.nil?
 
     errors.add('sort', 'this is not a valid sort attribute')
   end

--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,10 +1,13 @@
 class Api::ContentRequest
+  VALID_SORT_DIRECTIONS = %w[asc desc].freeze
   VALID_TIME_PERIODS = ['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year'].freeze
   include ActiveModel::Validations
 
   attr_reader :organisation_id, :document_type, :page, :page_size, :date_range, :search_term
   validate :valid_organisation_id
   validate :valid_date_range
+  validate :valid_sort_attribute
+  validate :valid_sort_direction
 
   validates_numericality_of :page, :page_size, allow_nil: true
 
@@ -15,6 +18,7 @@ class Api::ContentRequest
     @search_term = params[:search_term]
     @page_size = params[:page_size].try(:to_i)
     @date_range = params[:date_range]
+    @sort_attribute, @sort_direction = parse_sort_parameter(params[:sort])
   end
 
   def to_filter
@@ -25,10 +29,29 @@ class Api::ContentRequest
       search_term: search_term,
       page: page,
       page_size: page_size,
+      sort_attribute: @sort_attribute,
+      sort_direction: @sort_direction
     }
   end
 
 private
+
+  def parse_sort_parameter(sort_param)
+    sort_param.present? ? sort_param.split(':', 2) : [nil, nil]
+  end
+
+  def valid_sort_attribute
+    valid_attributes = Metric.daily_metrics.map(&:name)
+    return true if @sort_attribute.in?(valid_attributes) || @sort_attribute.nil?
+
+    errors.add('sort', 'this is not a valid sort attribute')
+  end
+
+  def valid_sort_direction
+    return true if @sort_direction.in?(VALID_SORT_DIRECTIONS) || @sort_direction.nil?
+
+    errors.add('sort', 'this is not a valid sort direction')
+  end
 
   def valid_date_range
     return true if date_range.in?(VALID_TIME_PERIODS) || date_range.blank?

--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -57,7 +57,7 @@ private
     raise "Order atrribute of #{column} not permitted."    unless aggregates.include?(column.to_s)
     raise "Order direction of #{direction} not permitted." unless %w[ASC DESC].include?(direction.upcase)
 
-    { column => direction }
+    "#{column} #{direction}"
   end
 
   def aggregates

--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -13,7 +13,7 @@ class Finders::Content
                 .joins("INNER JOIN dimensions_editions ON aggregations_search_#{view[:table_name]}.dimensions_edition_id = dimensions_editions.id")
                 .joins("INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id")
                 .merge(slice_editions)
-                .order(sanitized_order)
+                .order(sanitized_order(@sort_attribute, @sort_direction))
                 .page(@page)
                 .per(@page_size)
                 .select(*aggregates)
@@ -53,12 +53,15 @@ private
       gsub(domain, '')
   end
 
-  def sanitized_order
-    { @sort_attribute.to_sym => @sort_direction.to_sym }
+  def sanitized_order(column, direction)
+    raise "Order atrribute of #{column} not permitted."    unless aggregates.include?(column.to_s)
+    raise "Order direction of #{direction} not permitted." unless %w[ASC DESC].include?(direction.upcase)
+
+    { column => direction }
   end
 
   def aggregates
-    %i(base_path title organisation_id document_type upviews pviews useful_yes useful_no searches feedex pdf_count words)
+    %w(base_path title organisation_id document_type upviews pviews useful_yes useful_no searches feedex pdf_count words)
   end
 
   def array_to_hash(array)

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -43,10 +43,16 @@ RSpec.describe Api::ContentRequest do
       )
     end
 
-    it 'allows a valid sort attribute without direction' do
-      request = Api::ContentRequest.new(params.merge(sort: 'feedex'))
+    allowed_sort_attributes = %w[
+      title document_type upviews pviews useful_yes useful_no searches feedex pdf_count words
+    ]
 
-      expect(request.to_filter).to include(sort_attribute: 'feedex', sort_direction: nil)
+    allowed_sort_attributes.each do |attribute|
+      it "allows #{attribute} as sort attribute" do
+        request = Api::ContentRequest.new(params.merge(sort: attribute))
+
+        expect(request.to_filter).to include(sort_attribute: attribute, sort_direction: nil)
+      end
     end
 
     it 'allows a valid sort attribute with asc direction' do

--- a/spec/domain/api/content_request_spec.rb
+++ b/spec/domain/api/content_request_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::ContentRequest do
+  let(:params) { { date_range: 'past-30-days', organisation_id: 'all' } }
+
   describe '#to_filter' do
     it 'returns a hash with the parameters' do
       request = Api::ContentRequest.new(
@@ -8,6 +10,7 @@ RSpec.describe Api::ContentRequest do
         page: '1',
         page_size: '20',
         date_range: 'past-30-days',
+        sort: 'feedex:asc'
       )
 
       expect(request.to_filter).to eq(
@@ -17,6 +20,8 @@ RSpec.describe Api::ContentRequest do
         page: 1,
         page_size: 20,
         date_range: 'past-30-days',
+        sort_attribute: 'feedex',
+        sort_direction: 'asc'
       )
     end
 
@@ -33,7 +38,55 @@ RSpec.describe Api::ContentRequest do
         search_term: nil,
         page_size: nil,
         date_range: nil,
+        sort_attribute: nil,
+        sort_direction: nil
       )
+    end
+
+    it 'allows a valid sort attribute without direction' do
+      request = Api::ContentRequest.new(params.merge(sort: 'feedex'))
+
+      expect(request.to_filter).to include(sort_attribute: 'feedex', sort_direction: nil)
+    end
+
+    it 'allows a valid sort attribute with asc direction' do
+      request = Api::ContentRequest.new(params.merge(sort: 'feedex:asc'))
+
+      expect(request.to_filter).to include(sort_attribute: 'feedex', sort_direction: 'asc')
+    end
+
+    it 'allows a valid sort attribute with desc direction' do
+      request = Api::ContentRequest.new(params.merge(sort: 'feedex:desc'))
+
+      expect(request.to_filter).to include(sort_attribute: 'feedex', sort_direction: 'desc')
+    end
+
+    describe '#sort_attribute' do
+      it 'validates value' do
+        request = Api::ContentRequest.new(params.merge(sort: 'invalid'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort attribute")
+      end
+
+      it 'validates presence' do
+        request = Api::ContentRequest.new(params.merge(sort: ':desc'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort attribute")
+      end
+    end
+
+    describe '#sort_direction' do
+      it 'validates value' do
+        request = Api::ContentRequest.new(params.merge(sort: 'feedex:invalid'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort direction")
+      end
+
+      it 'validates presence' do
+        request = Api::ContentRequest.new(params.merge(sort: 'feedex:'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort direction")
+      end
     end
   end
 end

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Finders::Content do
       expect(titles).to eq(%w(last middle first))
     end
 
-    it 'order in acending' do
+    it 'order in ascending' do
       response = described_class.call(filter: filter.merge(sort_direction: 'asc'))
 
       titles = response.fetch(:results).map { |result| result.fetch(:title) }

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    it 'sorts results by daily metric attribute acending' do
+    it 'sorts results by daily metric attribute ascending' do
       get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: 'searches:asc' }
 
       response_body = JSON.parse(response.body).deep_symbolize_keys

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -274,6 +274,37 @@ RSpec.describe '/content' do
     end
   end
 
+  describe 'Sort by' do
+    before do
+      edition1 = create :edition, date: 1.month.ago, title: 'Edition A'
+      create :metric, date: 15.days.ago, edition: edition1, upviews: 100, useful_yes: 100, useful_no: 100, searches: 1
+
+      edition2 = create :edition, date: 1.month.ago, title: 'Edition B'
+      create :metric, date: 10.days.ago, edition: edition2, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
+
+      edition3 = create :edition, date: 1.month.ago, title: 'Edition C'
+      create :metric, date: 10.days.ago, edition: edition3, upviews: 1, useful_yes: 1, useful_no: 1, searches: 100
+
+      recalculate_aggregations!
+    end
+
+    it 'sorts results by daily metric attribute acending' do
+      get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: 'searches:asc' }
+
+      response_body = JSON.parse(response.body).deep_symbolize_keys
+      content_item_titles = response_body[:results].map { |i| i[:title] }
+      expect(content_item_titles).to eq(['Edition A', 'Edition B', 'Edition C'])
+    end
+
+    it 'sorts results by descending' do
+      get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: 'searches:desc' }
+
+      response_body = JSON.parse(response.body).deep_symbolize_keys
+      content_item_titles = response_body[:results].map { |i| i[:title] }
+      expect(content_item_titles).to eq(['Edition C', 'Edition B', 'Edition A'])
+    end
+  end
+
   describe 'Relevant content' do
     subject { get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id } }
 


### PR DESCRIPTION
This adds the sort parameter to the /content endpoint. Adds validation to the sort parameter in the api requests class and enables the content finder to query the database using the parameters.

The sort parameter is specified like so `attribute:direction`, where attribute is the key on which to sort and direction is either `asc` or `desc`.

Currently, valid sort attributed are daily metrics, 'title' and 'document_type'.