### PR TITLE
Add indexes to speed up healthchecks

### DIFF
--- a/db/migrate/20190207143213_add_index_facts_metrics_pviews.rb
+++ b/db/migrate/20190207143213_add_index_facts_metrics_pviews.rb
@@ -1,0 +1,7 @@
+class AddIndexFactsMetricsPviews < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :facts_metrics, %i(dimensions_date_id pviews), algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190207143221_add_index_facts_metrics_upviews.rb
+++ b/db/migrate/20190207143221_add_index_facts_metrics_upviews.rb
@@ -1,0 +1,7 @@
+class AddIndexFactsMetricsUpviews < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :facts_metrics, %i(dimensions_date_id upviews), algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190207143240_add_index_facts_metrics_searches.rb
+++ b/db/migrate/20190207143240_add_index_facts_metrics_searches.rb
@@ -1,0 +1,7 @@
+class AddIndexFactsMetricsSearches < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :facts_metrics, %i(dimensions_date_id searches), algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190207143301_add_index_facts_metrics_useful_no.rb
+++ b/db/migrate/20190207143301_add_index_facts_metrics_useful_no.rb
@@ -1,0 +1,7 @@
+class AddIndexFactsMetricsUsefulNo < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :facts_metrics, %i(dimensions_date_id useful_no), algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190207143313_add_index_facts_metrics_useful_feedex.rb
+++ b/db/migrate/20190207143313_add_index_facts_metrics_useful_feedex.rb
@@ -1,0 +1,7 @@
+class AddIndexFactsMetricsUsefulFeedex < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :facts_metrics, %i(dimensions_date_id feedex), algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_171432) do
+ActiveRecord::Schema.define(version: 2019_02_07_143313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,6 +174,11 @@ ActiveRecord::Schema.define(version: 2019_02_04_171432) do
     t.integer "page_time", default: 0, null: false
     t.float "satisfaction", default: 0.0, null: false
     t.index ["dimensions_date_id", "dimensions_edition_id"], name: "metrics_edition_id_date_id", unique: true
+    t.index ["dimensions_date_id", "feedex"], name: "index_facts_metrics_on_dimensions_date_id_and_feedex"
+    t.index ["dimensions_date_id", "pviews"], name: "index_facts_metrics_on_dimensions_date_id_and_pviews"
+    t.index ["dimensions_date_id", "searches"], name: "index_facts_metrics_on_dimensions_date_id_and_searches"
+    t.index ["dimensions_date_id", "upviews"], name: "index_facts_metrics_on_dimensions_date_id_and_upviews"
+    t.index ["dimensions_date_id", "useful_no"], name: "index_facts_metrics_on_dimensions_date_id_and_useful_no"
     t.index ["dimensions_edition_id"], name: "index_facts_metrics_on_dimensions_edition_id"
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/lJ0YzNDt/1145-3-raise-2ndline-alarms-when-the-core-google-analytics-metrics-are-not-collected-from-google)

Healthchecks validate that we have collected the right data for the day
before; It does so by checking the number of metrics that are not nil
for a given day. The metrics table is big, so we need to speed up the 
queries.