### PR TITLE
Add reading time metric to /content endpoint

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -61,7 +61,7 @@ private
   end
 
   def aggregates
-    %w(base_path title organisation_id document_type upviews pviews useful_yes useful_no searches feedex pdf_count words)
+    %w(base_path title organisation_id document_type upviews pviews useful_yes useful_no searches feedex pdf_count words reading_time)
   end
 
   def array_to_hash(array)
@@ -81,6 +81,7 @@ private
       searches: array[:searches].to_i,
       pdf_count: array[:pdf_count].to_i,
       words: array[:words].to_i,
+      reading_time: array[:reading_time].to_i
     }
   end
 

--- a/app/views/content/show.json.jbuilder
+++ b/app/views/content/show.json.jbuilder
@@ -13,6 +13,7 @@ json.results @content_items do |content_item|
   json.searches content_item[:searches]
   json.pdf_count content_item[:pdf_count]
   json.word_count content_item[:words]
+  json.reading_time content_item[:reading_time]
 end
 
 json.page @page

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe '/content' do
 
   describe 'content item attributes' do
     it 'contains the expected metrics' do
-      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: '/path-01', facts: { pdf_count: 10, words: 300 }
+      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: '/path-01', facts: { pdf_count: 10, words: 300, reading_time: 2 }
       create :metric, date: 1.day.ago, edition: edition1, pviews: 1, upviews: 1, feedex: 1, useful_no: 1, useful_yes: 1, searches: 1
       recalculate_aggregations!
 
@@ -24,7 +24,8 @@ RSpec.describe '/content' do
           satisfaction_score_responses: 2,
           searches: 1,
           pdf_count: 10,
-          word_count: 300
+          word_count: 300,
+          reading_time: 2
         )
       )
     end


### PR DESCRIPTION
Adding the reading time metric to the /content endpoint. Has only been added to the /single_page endpoint, but is needed by the content-data-admin to export reading time in the search results CSV.