### PR TITLE
Update total_results calculation

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -55,7 +55,7 @@ private
       .joins("INNER JOIN dimensions_editions ON aggregations_search_#{view[:table_name]}.dimensions_edition_id = dimensions_editions.id")
       .joins("INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id")
       .merge(slice_editions)
-      .length
+      .count
   end
 
   def parse_search_term(search_term)

--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -39,10 +39,14 @@ private
     @view ||= Finders::SelectView.new(date_range).run
   end
 
-  def results
+  def editions_with_facts_editions
     view[:model_name].all
       .joins("INNER JOIN dimensions_editions ON aggregations_search_#{view[:table_name]}.dimensions_edition_id = dimensions_editions.id")
       .joins("INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id")
+  end
+
+  def results
+    editions_with_facts_editions
       .merge(slice_editions)
       .order(sanitized_order(@sort_attribute, @sort_direction))
       .page(@page)
@@ -51,9 +55,7 @@ private
   end
 
   def total_results
-    view[:model_name].all
-      .joins("INNER JOIN dimensions_editions ON aggregations_search_#{view[:table_name]}.dimensions_edition_id = dimensions_editions.id")
-      .joins("INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id")
+    editions_with_facts_editions
       .merge(slice_editions)
       .count
   end

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe Finders::Content do
     )
   end
 
+  context 'Newly created editions before ETL process' do
+    it 'returns total_results for editions with facts metrics' do
+      edition1 = create :edition, base_path: '/path1', date: 10.days.ago, organisation_id: primary_org_id
+      create :edition, base_path: '/path2', date: 10.days.ago, organisation_id: primary_org_id
+
+      create :metric, edition: edition1, date: 10.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
+
+      recalculate_aggregations!
+
+      response = described_class.call(filter: filter)
+
+      expect(response[:total_results]).to eq(1)
+    end
+  end
+
   describe 'Other date ranges' do
     let(:this_month_date) { Date.today }
     let(:edition1) { create :edition, base_path: '/path1', date: 2.months.ago, organisation_id: primary_org_id }


### PR DESCRIPTION
Users are seeing a discrepancy in the number provided by
total_results and the actual total returned.

This scenario occurs when a content item has been newly published, but
the ETL process has not yet run. The result set will exclude the new item
until the ETL process has run by the next day, but the total_result
still counts that Edition.

## Before
<img width="748" alt="screenshot at feb 08 11-17-40 pm" src="https://user-images.githubusercontent.com/424772/52511530-4f126480-2bf8-11e9-89cd-02c104c947ff.png">


## After
<img width="776" alt="screenshot at feb 08 11-18-12 pm" src="https://user-images.githubusercontent.com/424772/52511546-5e91ad80-2bf8-11e9-92a0-76dbe043d52e.png">

