### PR TITLE
Healthcheck: Google Analytics - number of internal searches

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     Healthchecks::DatabaseConnection,
     Healthchecks::EtlGoogleAnalytics.build(:pviews),
     Healthchecks::EtlGoogleAnalytics.build(:upviews),
+    Healthchecks::EtlGoogleAnalytics.build(:searches),
   )
 end

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -15,6 +15,17 @@ namespace :etl do
     end
   end
 
+  desc 'Run Etl::GA::InternalSearchProcessor for range of dates'
+  task :repopulate_searches, %i[from to] => [:environment] do |_t, args|
+    from = args[:from].to_date
+    to = args[:to].to_date
+    (from..to).each do |date|
+      console_log "repopulating searches for #{date}"
+      Etl::GA::InternalSearchProcessor.process(date: date)
+      console_log "finished repopulating searches for #{date}"
+    end
+  end
+
   desc 'Delete existing metrics and Run Etl Master process across a range of dates'
   task :rerun_master, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe '/healthcheck' do
 
     expect(json['checks']).to include('database_status').
       and(include('etl_google_analytics_pviews')).
-      and(include('etl_google_analytics_upviews'))
+      and(include('etl_google_analytics_upviews')).
+      and(include('etl_google_analytics_searches'))
   end
 
   it "is not cacheable" do

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe 'etl.rake', type: task do
     end
   end
 
+  describe 'rake etl:repopulate_searches' do
+    it 'calls Etl::GA::InternalSearchProcessor with each date' do
+      processor = class_double(Etl::GA::InternalSearchProcessor, process: true).as_stubbed_const
+
+      Rake::Task['etl:repopulate_searches'].invoke('2018-11-01', '2018-11-03')
+
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
+    end
+  end
+
   describe 'rake etl:rerun_master' do
     let!(:processor) do
       class_double(Etl::Master::MasterProcessor,


### PR DESCRIPTION
[Trello card](https://trello.com/c/gcw7CXav/1146-3-raise-2ndline-alarms-when-the-number-of-searches-metrics-are-not-collected-from-google)

Raises `2ndline` alarms, following the similar approach to `daily_metrics_check.rb`, to notify when metrics collected from `Etl::GA::InternalSearchProcessor` are not present.

### Why

If the metrics are not present, then the ETL master process failed, and 2nd line needs to take an action
