### PR TITLE
Healthcheck: Google Analytics - Feedex

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,6 @@ Rails.application.routes.draw do
     Healthchecks::EtlGoogleAnalytics.build(:pviews),
     Healthchecks::EtlGoogleAnalytics.build(:upviews),
     Healthchecks::EtlGoogleAnalytics.build(:searches),
+    Healthchecks::EtlGoogleAnalytics.build(:feedex),
   )
 end

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -26,6 +26,17 @@ namespace :etl do
     end
   end
 
+  desc 'Run Etl::GA::UserFeedbackProcessor for range of dates'
+  task :repopulate_feedex, %i[from to] => [:environment] do |_t, args|
+    from = args[:from].to_date
+    to = args[:to].to_date
+    (from..to).each do |date|
+      console_log "repopulating feedex for #{date}"
+      Etl::GA::UserFeedbackProcessor.process(date: date)
+      console_log "finished repopulating feedex for #{date}"
+    end
+  end
+
   desc 'Delete existing metrics and Run Etl Master process across a range of dates'
   task :rerun_master, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe '/healthcheck' do
     expect(json['checks']).to include('database_status').
       and(include('etl_google_analytics_pviews')).
       and(include('etl_google_analytics_upviews')).
-      and(include('etl_google_analytics_searches'))
+      and(include('etl_google_analytics_feedex'))
   end
 
   it "is not cacheable" do

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe 'etl.rake', type: task do
     end
   end
 
+  describe 'rake etl:repopulate_feedex' do
+    it 'calls Etl::GA::UserFeedbackProcessor.process with each date' do
+      processor = class_double(Etl::GA::UserFeedbackProcessor, process: true).as_stubbed_const
+
+      Rake::Task['etl:repopulate_feedex'].invoke('2018-11-01', '2018-11-03')
+
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
+    end
+  end
+
   describe 'rake etl:rerun_master' do
     let!(:processor) do
       class_double(Etl::Master::MasterProcessor,


### PR DESCRIPTION
Merge after rebasing on top of https://github.com/alphagov/content-performance-manager/pull/1142
First two commits do not belong to this PR

[Trello card](https://trello.com/c/56rS8RRM/1147-2-raise-2ndline-alarms-when-user-feedback-metrics-are-not-created)

Raises `2ndline` alarms, following the similar approach to `daily_metrics_check.rb`, to notify when metrics collected from `Etl::GA::Etl::Feedex::Processor` are not present.

### Why

If the metrics are not present, then the ETL master process failed, and 2nd line needs to take an action
