### PR TITLE
[WIP] Increase `work_mem` to speed up queries in Index page

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -8,6 +8,8 @@ class Finders::Content
   end
 
   def call
+    DatabaseHelper.increase_work_mem_for_current_transaction(megabytes: 64)
+
     {
       results: results.map(&method(:array_to_hash)),
       page: @page,

--- a/app/models/aggregations/materialized_view.rb
+++ b/app/models/aggregations/materialized_view.rb
@@ -1,5 +1,5 @@
 class Aggregations::MaterializedView
   def self.prepare
-    DatabaseHelper.increase_work_mem_for_current_transaction
+    DatabaseHelper.increase_work_mem_for_current_transaction(megabytes: 500)
   end
 end

--- a/app/models/aggregations/materialized_view.rb
+++ b/app/models/aggregations/materialized_view.rb
@@ -1,16 +1,5 @@
 class Aggregations::MaterializedView
   def self.prepare
-    increase_work_mem_for_current_transaction
-  end
-
-  # `work_mem` speeds up the query because it is a big aggregations with sorting
-  # that needs to perform the operation in memory
-  # we are setting the work_mem locally, which means that will only be active
-  # for the current transaction. This is a safe operation because views are only
-  # refreshed once per day, and in a single thread.
-  #
-  # This should never be enabled globally.
-  def self.increase_work_mem_for_current_transaction
-    ActiveRecord::Base.connection.execute("set local work_mem = '500MB'")
+    DatabaseHelper.increase_work_mem_for_current_transaction
   end
 end

--- a/app/models/database_helper.rb
+++ b/app/models/database_helper.rb
@@ -1,5 +1,4 @@
 class DatabaseHelper
-
   # `work_mem` speeds up the query because it is a big aggregations with sorting
   # that needs to perform the operation in memory
   # we are setting the work_mem locally, which means that will only be active
@@ -7,7 +6,7 @@ class DatabaseHelper
   # refreshed once per day, and in a single thread.
   #
   # This should never be enabled globally.
-  def self.increase_work_mem_for_current_transaction
-    ActiveRecord::Base.connection.execute("set local work_mem = '500MB'")
+  def self.increase_work_mem_for_current_transaction(megabytes:)
+    ActiveRecord::Base.connection.execute("set local work_mem = '#{megabytes}MB'")
   end
 end

--- a/app/models/database_helper.rb
+++ b/app/models/database_helper.rb
@@ -1,0 +1,13 @@
+class DatabaseHelper
+
+  # `work_mem` speeds up the query because it is a big aggregations with sorting
+  # that needs to perform the operation in memory
+  # we are setting the work_mem locally, which means that will only be active
+  # for the current transaction. This is a safe operation because views are only
+  # refreshed once per day, and in a single thread.
+  #
+  # This should never be enabled globally.
+  def self.increase_work_mem_for_current_transaction
+    ActiveRecord::Base.connection.execute("set local work_mem = '500MB'")
+  end
+end


### PR DESCRIPTION
The following query is taking more than 10 seconds to run. The reason for this performance is the GIN index on the fields `title` and `base_path` when the result is a big collection (like 150K content items) it perform several operation in batches because it has memory constraints.

This is the query:

```sql
explain analyze SELECT     base_path, 
           title, 
           organisation_id, 
           document_type, 
           "aggregations_search_last_thirty_days"."upviews", 
           "aggregations_search_last_thirty_days"."pviews", 
           "aggregations_search_last_thirty_days"."useful_yes", 
           "aggregations_search_last_thirty_days"."useful_no", 
           "aggregations_search_last_thirty_days"."searches", 
           "aggregations_search_last_thirty_days"."feedex", 
           pdf_count, 
           words 
FROM       "aggregations_search_last_thirty_days" 
INNER JOIN dimensions_editions 
ON         aggregations_search_last_thirty_days.dimensions_edition_id = dimensions_editions.id 
INNER JOIN facts_editions 
ON         dimensions_editions.id = facts_editions.dimensions_edition_id 
WHERE      "dimensions_editions"."document_type" NOT IN ('redirect', 
                                                         'gone') 
AND        ( 
                      To_tsvector('english',title) @@ plainto_tsquery('english', '/government/publication')
           or         to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ plainto_tsquery('english', ' government publication'))
ORDER BY   upviews DESC limit 100 offset 1;
```

By increasing the memory to `64MB` we decrease the time to 1.5 seconds, which is acceptable considering that these queries are not too frequent.

## Without the memory increase: 

```
 Limit  (cost=204057.75..204058.00 rows=100 width=252) (actual time=9940.531..9940.552 rows=100 loops=1)
   ->  Sort  (cost=204057.74..204272.82 rows=86029 width=252) (actual time=9940.529..9940.545 rows=101 loops=1)
         Sort Key: aggregations_search_last_thirty_days.upviews DESC
         Sort Method: top-N heapsort  Memory: 59kB
         ->  Hash Join  (cost=169052.41..200763.60 rows=86029 width=252) (actual time=9524.722..9902.169 rows=136683 loops=1)
               Hash Cond: (aggregations_search_last_thirty_days.dimensions_edition_id = dimensions_editions.id)
               ->  Seq Scan on aggregations_search_last_thirty_days  (cost=0.00..16052.38 rows=514538 width=56) (actual time=0.022..115.362 rows=514538 loops=1)
               ->  Hash  (cost=165069.85..165069.85 rows=93085 width=220) (actual time=9524.364..9524.364 rows=150004 loops=1)
                     Buckets: 16384 (originally 16384)  Batches: 16 (originally 8)  Memory Usage: 3969kB
                     ->  Hash Join  (cost=134531.15..165069.85 rows=93085 width=220) (actual time=9117.982..9460.695 rows=150004 loops=1)
                           Hash Cond: (facts_editions.dimensions_edition_id = dimensions_editions.id)
                           ->  Seq Scan on facts_editions  (cost=0.00..19457.62 rows=555262 width=16) (actual time=0.012..115.665 rows=556829 loops=1)
                           ->  Hash  (cost=130720.50..130720.50 rows=93332 width=204) (actual time=9116.496..9116.496 rows=150004 loops=1)
                                 Buckets: 32768 (originally 32768)  Batches: 16 (originally 8)  Memory Usage: 3841kB
                                 ->  Bitmap Heap Scan on dimensions_editions  (cost=1101.58..130720.50 rows=93332 width=204) (actual time=125.869..8976.190 rows=150004 loops=1)
                                       Recheck Cond: ((to_tsvector('english'::regconfig, (title)::text) @@ '''/government/publication'''::tsquery) OR (to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ '''govern'' & ''public'''::tsquery))
                                       Rows Removed by Index Recheck: 129819
                                       Filter: ((document_type)::text <> ALL ('{redirect,gone}'::text[]))
                                       Rows Removed by Filter: 14840
                                       Heap Blocks: exact=26930 lossy=26487
                                       ->  BitmapOr  (cost=1101.58..1101.58 rows=104922 width=0) (actual time=113.139..113.139 rows=0 loops=1)
                                             ->  Bitmap Index Scan on dimensions_editions_title  (cost=0.00..42.44 rows=325 width=0) (actual time=0.344..0.344 rows=0 loops=1)
                                                   Index Cond: (to_tsvector('english'::regconfig, (title)::text) @@ '''/government/publication'''::tsquery)
                                             ->  Bitmap Index Scan on dimensions_editions_base_path  (cost=0.00..1012.48 rows=104598 width=0) (actual time=112.793..112.793 rows=164874 loops=1)
                                                   Index Cond: (to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ '''govern'' & ''public'''::tsquery)
 Planning time: 2.003 ms
 Execution time: 9940.714 ms
(27 rows)

```

With the memory increase:

```
 Limit  (cost=177506.43..177506.68 rows=100 width=252) (actual time=1459.419..1459.442 rows=100 loops=1)
   ->  Sort  (cost=177506.43..177721.50 rows=86029 width=252) (actual time=1459.416..1459.430 rows=101 loops=1)
         Sort Key: aggregations_search_last_thirty_days.upviews DESC
         Sort Method: top-N heapsort  Memory: 59kB
         ->  Hash Join  (cost=151809.85..174212.28 rows=86029 width=252) (actual time=1000.994..1409.458 rows=136683 loops=1)
               Hash Cond: (facts_editions.dimensions_edition_id = aggregations_search_last_thirty_days.dimensions_edition_id)
               ->  Seq Scan on facts_editions  (cost=0.00..19457.62 rows=555262 width=16) (actual time=0.014..176.902 rows=556831 loops=1)
               ->  Hash  (cost=150731.63..150731.63 rows=86258 width=260) (actual time=1000.631..1000.631 rows=136683 loops=1)
                     Buckets: 262144 (originally 131072)  Batches: 1 (originally 1)  Memory Usage: 41598kB
                     ->  Hash Join  (cost=131887.15..150731.63 rows=86258 width=260) (actual time=529.762..890.804 rows=136683 loops=1)
                           Hash Cond: (aggregations_search_last_thirty_days.dimensions_edition_id = dimensions_editions.id)
                           ->  Seq Scan on aggregations_search_last_thirty_days  (cost=0.00..16052.38 rows=514538 width=56) (actual time=0.015..54.551 rows=514538 loops=1)
                           ->  Hash  (cost=130720.50..130720.50 rows=93332 width=204) (actual time=529.420..529.420 rows=150006 loops=1)
                                 Buckets: 262144 (originally 131072)  Batches: 1 (originally 1)  Memory Usage: 36929kB
                                 ->  Bitmap Heap Scan on dimensions_editions  (cost=1101.58..130720.50 rows=93332 width=204) (actual time=126.891..391.323 rows=150006 loops=1)
                                       Recheck Cond: ((to_tsvector('english'::regconfig, (title)::text) @@ '''/government/publication'''::tsquery) OR (to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ '''govern'' & ''public'''::tsquery))
                                       Filter: ((document_type)::text <> ALL ('{redirect,gone}'::text[]))
                                       Rows Removed by Filter: 14840
                                       Heap Blocks: exact=53418
                                       ->  BitmapOr  (cost=1101.58..1101.58 rows=104922 width=0) (actual time=102.859..102.859 rows=0 loops=1)
                                             ->  Bitmap Index Scan on dimensions_editions_title  (cost=0.00..42.44 rows=325 width=0) (actual time=0.344..0.344 rows=0 loops=1)
                                                   Index Cond: (to_tsvector('english'::regconfig, (title)::text) @@ '''/government/publication'''::tsquery)
                                             ->  Bitmap Index Scan on dimensions_editions_base_path  (cost=0.00..1012.48 rows=104598 width=0) (actual time=102.512..102.512 rows=164880 loops=1)
                                                   Index Cond: (to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text)) @@ '''govern'' & ''public'''::tsquery)
 Planning time: 2.707 ms
 Execution time: 1466.839 ms
(26 rows)
```

Some notes:

1. The memory is only increased for this particular query (local transaction)
2. The index query will by cached, so the changes of having multiple users running the same query multiple times and increasing the overall memory are minimal.