### PR TITLE
Fix issue returning non-english content pages

### DIFF
--- a/app/domain/finders/aggregations.rb
+++ b/app/domain/finders/aggregations.rb
@@ -55,7 +55,6 @@ private
 
   def slice_editions
     editions = Dimensions::Edition.all
-    editions = editions.by_locale('en')
     editions = editions.by_base_path(@base_path) unless @base_path.blank?
     editions
   end

--- a/app/domain/finders/find_series.rb
+++ b/app/domain/finders/find_series.rb
@@ -45,7 +45,6 @@ private
 
   def slice_editions
     editions = Dimensions::Edition.all
-    editions = editions.by_locale('en')
     editions = editions.by_base_path(@base_path) unless @base_path.blank?
     editions
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   end
 
   get '/content', to: 'content#show', defaults: { format: :json }
-  get '/single_page/(*base_path)', to: 'single_item#show', defaults: { format: :json }
+  get '/single_page/(*base_path)', to: 'single_item#show', defaults: { format: :json }, format: false
   get '/healthcheck', to: GovukHealthcheck.rack_response(
     Healthchecks::DailyMetricsCheck,
     Healthchecks::DatabaseConnection,

--- a/spec/domain/finders/aggregations_spec.rb
+++ b/spec/domain/finders/aggregations_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Finders::Aggregations do
     expect(result.fetch(:pviews)).to eq(5)
   end
 
+  it 'repects base_path with locales' do
+    edition = create :edition, base_path: '/path.cy', date: '2018-01-01', locale: 'cy'
+    create :metric, edition: edition, date: '2018-01-01', pviews: 2
+    create :metric, edition: edition, date: '2018-01-02', pviews: 3
+
+    result = Finders::Aggregations.new.by_base_path('/path.cy').run
+    expect(result.fetch(:pviews)).to eq(5)
+  end
+
   it 'filters by from and to' do
     edition = create :edition, base_path: '/path/1', date: '2018-01-01'
     create :metric, edition: edition, date: '2018-01-01', pviews: 2

--- a/spec/domain/finders/find_series_spec.rb
+++ b/spec/domain/finders/find_series_spec.rb
@@ -76,5 +76,18 @@ RSpec.describe Finders::FindSeries do
         { date: "2018-01-14", value: 2 }
       ])
     end
+
+    it 'return the content items for non english locale' do
+      edition1 = create :edition, base_path: '/path1', date: '2018-1-12', facts: { words: 1 }, locale: 'en'
+      edition2 = create :edition, base_path: '/path1.cy', date: '2018-1-12', facts: { words: 2 }, locale: 'cy'
+
+      create :metric, edition: edition1, date: '2018-1-12'
+      create :metric, edition: edition2, date: '2018-1-13'
+
+      result = described_class.new.by_metrics(%w(words)).by_base_path('/path1.cy').run
+      expect(result.first.time_series).to eq([
+        { date: "2018-01-13", value: 2 },
+      ])
+    end
   end
 end

--- a/spec/routing/single_page_routing_spec.rb
+++ b/spec/routing/single_page_routing_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe 'single page endpoint routing' do
       format: :json
     )
   end
+
+  it 'routes /single_page/base/path.cy' do
+    expect(get: '/single_page/base/path.cy').to route_to(
+      controller: 'single_item',
+      action: 'show',
+      format: :json,
+      base_path: 'base/path.cy'
+    )
+  end
 end


### PR DESCRIPTION
This fixes an issue whereby base paths with locale extensions are removed from the result. i.e. `base/path.cy` => `base/path`

Additionally the metrics finders previously filtered editions by English locale, which has no been removed.