### PR TITLE
Healthcheck: Aggregations

### DIFF
--- a/app/domain/healthchecks/monthly_aggregations.rb
+++ b/app/domain/healthchecks/monthly_aggregations.rb
@@ -11,7 +11,7 @@ module Healthchecks
     end
 
     def message
-      "ETL :: no aggregations of metrics for yesterday" if status == :critical
+      "ETL :: no monthly aggregations of metrics for yesterday" if status == :critical
     end
 
   private

--- a/app/domain/healthchecks/monthly_aggregations.rb
+++ b/app/domain/healthchecks/monthly_aggregations.rb
@@ -1,0 +1,23 @@
+module Healthchecks
+  class MonthlyAggregations
+    include Concerns::Deactivable
+
+    def name
+      :aggregations
+    end
+
+    def status
+      aggregations.positive? ? :ok : :critical
+    end
+
+    def message
+      "ETL :: no aggregations of metrics for yesterday" if status == :critical
+    end
+
+  private
+
+    def aggregations
+      @aggregations ||= Aggregations::MonthlyMetric.where(created_at: Date.today).count
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get '/content', to: 'content#show', defaults: { format: :json }
   get '/single_page/(*base_path)', to: 'single_item#show', defaults: { format: :json }, format: false
   get '/healthcheck', to: GovukHealthcheck.rack_response(
+    Healthchecks::MonthlyAggregations,
     Healthchecks::DailyMetricsCheck,
     Healthchecks::DatabaseConnection,
     Healthchecks::EtlGoogleAnalytics.build(:pviews),

--- a/db/migrate/20190225113933_add_index_to_monthly_aggregation_created_at.rb
+++ b/db/migrate/20190225113933_add_index_to_monthly_aggregation_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToMonthlyAggregationCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    add_index :aggregations_monthly_metrics, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_20_161718) do
+ActiveRecord::Schema.define(version: 2019_02_25_113933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_02_20_161718) do
     t.float "satisfaction", default: 0.0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_aggregations_monthly_metrics_on_created_at"
     t.index ["dimensions_edition_id", "dimensions_month_id"], name: "index_editions_months_unique", unique: true
     t.index ["dimensions_edition_id"], name: "index_aggregations_monthly_metrics_on_dimensions_edition_id"
     t.index ["dimensions_month_id"], name: "index_aggregations_monthly_metrics_on_dimensions_month_id"
@@ -243,7 +244,7 @@ ActiveRecord::Schema.define(version: 2019_02_20_161718) do
             GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
   SQL
   add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
   add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
@@ -287,7 +288,7 @@ ActiveRecord::Schema.define(version: 2019_02_20_161718) do
             GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
   SQL
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_month_gin_title", using: :gin
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -4,6 +4,17 @@ namespace :etl do
     Etl::Master::MasterProcessor.process
   end
 
+  desc 'Run Etl::Aggregations::Monthly for range of dates'
+  task :repopulate_aggregations_month, %i[from to] => [:environment] do |_t, args|
+    from = args[:from].to_date
+    to = args[:to].to_date
+    (from..to).each do |date|
+      console_log "repopulating Monthly Aggregation for #{date}"
+      Etl::Aggregations::Monthly.process(date: date)
+      console_log "finished repopulating Monthly Aggregation for #{date}"
+    end
+  end
+
   desc 'Run Etl::GA::ViewsAndNavigationProcessor for range of dates'
   task :repopulateviews, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date

--- a/spec/domain/healthchecks/monthly_aggregations_spec.rb
+++ b/spec/domain/healthchecks/monthly_aggregations_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Healthchecks::MonthlyAggregations do
+  include_examples 'Healthcheck enabled/disabled within time range'
+
+  around do |example|
+    Timecop.freeze(Date.new(2019, 2, 22)) { example.run }
+  end
+
+  its(:name) { is_expected.to eq(:aggregations) }
+
+  describe '#status' do
+    context 'When there are monthly aggregations' do
+      before do
+        date = Date.today
+        edition = create :edition
+        create :monthly_metric, edition: edition, month: Dimensions::Month.build(date).id
+      end
+
+      its(:status) { is_expected.to eq(:ok) }
+      its(:message) { is_expected.to eq(nil) }
+    end
+
+    context 'When there are no aggregations' do
+      its(:status) { is_expected.to eq(:critical) }
+    end
+  end
+end

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -2,15 +2,30 @@ RSpec.describe 'etl.rake', type: task do
   describe 'rake etl:master'
   it "calls Etl::Master::MasterProcessor.process" do
     processor = class_double(Etl::Master::MasterProcessor, process: true).as_stubbed_const
+
     expect(processor).to receive(:process)
 
     Rake::Task['etl:master'].invoke
   end
 
+  describe 'rake etl:repopulate_aggregations_month' do
+    it 'calls Etl::Aggregations::Monthly with each date' do
+      processor = class_double(Etl::Aggregations::Monthly, process: true).as_stubbed_const
+
+      Rake::Task['etl:repopulate_aggregations_month'].invoke('2018-11-01', '2018-11-03')
+
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
+    end
+  end
+
   describe 'rake etl:repopulateviews' do
     it 'calls Etl::GA::ViewsAndNavigationProcessor with each date' do
       processor = class_double(Etl::GA::ViewsAndNavigationProcessor, process: true).as_stubbed_const
+
       Rake::Task['etl:repopulateviews'].invoke('2018-11-01', '2018-11-03')
+
       expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
       expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
       expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))


### PR DESCRIPTION
## What

Raises `2ndline` alarms, following the similar approach to `daily_metrics_check.rb`, to notify when metric aggregations collected from `Etl::Aggregations::Monthly.process(date: date)` are missing.

## Why 
If the metrics are not present, then the ETL master process failed, and 2nd line needs to take an action