### PR TITLE
Add ability to sort by satisfaction

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -102,7 +102,7 @@ private
     raise "Order atrribute of #{column} not permitted." unless aggregates.include?(column.to_s)
     raise "Order direction of #{direction} not permitted." unless %w[ASC DESC].include?(direction.upcase)
 
-    "#{column} #{direction}, warehouse_item_id #{direction}"
+    "#{column} #{direction} NULLS LAST, warehouse_item_id #{direction}"
   end
 
   def aggregates

--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -106,11 +106,10 @@ private
   end
 
   def aggregates
-    %w(base_path title organisation_id document_type upviews pviews useful_yes useful_no searches feedex pdf_count words reading_time)
+    %w(base_path title organisation_id document_type upviews pviews useful_yes useful_no satisfaction searches feedex pdf_count words reading_time)
   end
 
   def array_to_hash(array)
-    satisfaction_responses = array[:useful_yes].to_i + array[:useful_no].to_i
     {
       base_path: array[:base_path],
       title: array[:title],
@@ -121,8 +120,7 @@ private
       useful_yes: array[:useful_yes].to_i,
       useful_no: array[:useful_no].to_i,
       feedex: array[:feedex].to_i,
-      satisfaction: satisfaction_responses.zero? ? nil : (array[:useful_yes].to_f / satisfaction_responses).to_f,
-      satisfaction_score_responses: satisfaction_responses.to_i,
+      satisfaction: array[:satisfaction],
       searches: array[:searches].to_i,
       pdf_count: array[:pdf_count].to_i,
       words: array[:words].to_i,

--- a/app/views/content/show.json.jbuilder
+++ b/app/views/content/show.json.jbuilder
@@ -9,7 +9,6 @@ json.results @content_items do |content_item|
   json.useful_yes content_item[:useful_yes]
   json.useful_no content_item[:useful_no]
   json.satisfaction content_item[:satisfaction]
-  json.satisfaction_score_responses content_item[:satisfaction_score_responses]
   json.searches content_item[:searches]
   json.pdf_count content_item[:pdf_count]
   json.word_count content_item[:words]

--- a/db/migrate/20190218113118_update_aggregations_search_last_thirty_days_to_version_6.rb
+++ b/db/migrate/20190218113118_update_aggregations_search_last_thirty_days_to_version_6.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastThirtyDaysToVersion6 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_thirty_days,
+      version: 6,
+      revert_to_version: 5,
+      materialized: true
+  end
+end

--- a/db/migrate/20190218121734_update_aggregations_search_last_months_to_version_4.rb
+++ b/db/migrate/20190218121734_update_aggregations_search_last_months_to_version_4.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastMonthsToVersion4 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_months,
+      version: 4,
+      revert_to_version: 3,
+      materialized: true
+  end
+end

--- a/db/migrate/20190218122820_update_aggregations_search_last_three_months_to_version_6.rb
+++ b/db/migrate/20190218122820_update_aggregations_search_last_three_months_to_version_6.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastThreeMonthsToVersion6 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_three_months,
+      version: 6,
+      revert_to_version: 5,
+      materialized: true
+  end
+end

--- a/db/migrate/20190218123800_update_aggregations_search_last_six_months_to_version_6.rb
+++ b/db/migrate/20190218123800_update_aggregations_search_last_six_months_to_version_6.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastSixMonthsToVersion6 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_six_months,
+      version: 6,
+      revert_to_version: 5,
+      materialized: true
+  end
+end

--- a/db/migrate/20190218124214_update_aggregations_search_last_twelve_months_to_version_6.rb
+++ b/db/migrate/20190218124214_update_aggregations_search_last_twelve_months_to_version_6.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastTwelveMonthsToVersion6 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_twelve_months,
+      version: 6,
+      revert_to_version: 5,
+      materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_121734) do
+ActiveRecord::Schema.define(version: 2019_02_18_122820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,69 +207,6 @@ ActiveRecord::Schema.define(version: 2019_02_18_121734) do
   add_foreign_key "facts_editions", "dimensions_editions"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
-
-  create_view "aggregations_search_last_three_months", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT agg.warehouse_item_id,
-              max(agg.dimensions_edition_id) AS dimensions_edition_id,
-              sum(agg.upviews) AS upviews,
-              sum(agg.pviews) AS pviews,
-              sum(agg.useful_yes) AS useful_yes,
-              sum(agg.useful_no) AS useful_no,
-              sum(agg.feedex) AS feedex,
-              sum(agg.searches) AS searches
-             FROM ( SELECT dimensions_editions_1.warehouse_item_id,
-                      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-                      sum(aggregations_monthly_metrics.upviews) AS upviews,
-                      sum(aggregations_monthly_metrics.pviews) AS pviews,
-                      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-                      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-                      sum(aggregations_monthly_metrics.feedex) AS feedex,
-                      sum(aggregations_monthly_metrics.searches) AS searches
-                     FROM ((aggregations_monthly_metrics
-                       JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
-                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM'::text))
-                    GROUP BY dimensions_editions_1.warehouse_item_id
-                  UNION
-                   SELECT dimensions_editions_1.warehouse_item_id,
-                      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-                      sum(facts_metrics.upviews) AS upviews,
-                      sum(facts_metrics.pviews) AS pviews,
-                      sum(facts_metrics.useful_yes) AS useful_yes,
-                      sum(facts_metrics.useful_no) AS useful_no,
-                      sum(facts_metrics.feedex) AS feedex,
-                      sum(facts_metrics.searches) AS searches
-                     FROM ((facts_metrics
-                       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM-01'::text))::date))
-                    GROUP BY dimensions_editions_1.warehouse_item_id) agg
-            GROUP BY agg.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
-  SQL
-  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_three_months_gin_title", using: :gin
-  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
-  add_index "aggregations_search_last_three_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_three_months_document_type"
-  add_index "aggregations_search_last_three_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
-  add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews"
-  add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
 
   create_view "aggregations_search_last_six_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
@@ -476,7 +413,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_121734) do
             GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
   SQL
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_month_gin_title", using: :gin
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin
@@ -484,5 +421,72 @@ ActiveRecord::Schema.define(version: 2019_02_18_121734) do
   add_index "aggregations_search_last_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_month_organisation_id"
   add_index "aggregations_search_last_months", ["upviews", "warehouse_item_id"], name: "search_last_month_upviews"
   add_index "aggregations_search_last_months", ["warehouse_item_id"], name: "aggregations_search_last_months_pk", unique: true
+
+  create_view "aggregations_search_last_three_months", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT agg.warehouse_item_id,
+              max(agg.dimensions_edition_id) AS dimensions_edition_id,
+              sum(agg.upviews) AS upviews,
+              sum(agg.pviews) AS pviews,
+              sum(agg.useful_yes) AS useful_yes,
+              sum(agg.useful_no) AS useful_no,
+              sum(agg.feedex) AS feedex,
+              sum(agg.searches) AS searches
+             FROM ( SELECT dimensions_editions_1.warehouse_item_id,
+                      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+                      sum(aggregations_monthly_metrics.upviews) AS upviews,
+                      sum(aggregations_monthly_metrics.pviews) AS pviews,
+                      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+                      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+                      sum(aggregations_monthly_metrics.feedex) AS feedex,
+                      sum(aggregations_monthly_metrics.searches) AS searches
+                     FROM ((aggregations_monthly_metrics
+                       JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
+                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM'::text))
+                    GROUP BY dimensions_editions_1.warehouse_item_id
+                  UNION
+                   SELECT dimensions_editions_1.warehouse_item_id,
+                      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+                      sum(facts_metrics.upviews) AS upviews,
+                      sum(facts_metrics.pviews) AS pviews,
+                      sum(facts_metrics.useful_yes) AS useful_yes,
+                      sum(facts_metrics.useful_no) AS useful_no,
+                      sum(facts_metrics.feedex) AS feedex,
+                      sum(facts_metrics.searches) AS searches
+                     FROM ((facts_metrics
+                       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM-01'::text))::date))
+                    GROUP BY dimensions_editions_1.warehouse_item_id) agg
+            GROUP BY agg.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_three_months_gin_title", using: :gin
+  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
+  add_index "aggregations_search_last_three_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_three_months_document_type"
+  add_index "aggregations_search_last_three_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
+  add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews"
+  add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_113305) do
+ActiveRecord::Schema.define(version: 2019_02_18_113118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,46 +208,6 @@ ActiveRecord::Schema.define(version: 2019_02_14_113305) do
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
 
-  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.pviews) AS pviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.feedex) AS feedex,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
-            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
-  SQL
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
-  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
-  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
-  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews"
-  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
-
   create_view "aggregations_search_last_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
       dimensions_editions.title,
@@ -279,7 +239,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_113305) do
             GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
   SQL
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_month_gin_title", using: :gin
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin
@@ -342,7 +302,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_113305) do
             GROUP BY agg.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
   SQL
   add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_three_months_gin_title", using: :gin
   add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
@@ -405,7 +365,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_113305) do
             GROUP BY agg.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
   SQL
   add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_six_months_gin_title", using: :gin
   add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_six_months_gin_base_path", using: :gin
@@ -468,7 +428,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_113305) do
             GROUP BY agg.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
   SQL
   add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_twelve_months_gin_title", using: :gin
   add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
@@ -476,5 +436,49 @@ ActiveRecord::Schema.define(version: 2019_02_14_113305) do
   add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
   add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews"
   add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
+
+  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.pviews) AS pviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.feedex) AS feedex,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
+            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
+  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
+  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
+  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews"
+  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_123800) do
+ActiveRecord::Schema.define(version: 2019_02_18_124214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,69 +207,6 @@ ActiveRecord::Schema.define(version: 2019_02_18_123800) do
   add_foreign_key "facts_editions", "dimensions_editions"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
-
-  create_view "aggregations_search_last_twelve_months", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT agg.warehouse_item_id,
-              max(agg.dimensions_edition_id) AS dimensions_edition_id,
-              sum(agg.upviews) AS upviews,
-              sum(agg.pviews) AS pviews,
-              sum(agg.useful_yes) AS useful_yes,
-              sum(agg.useful_no) AS useful_no,
-              sum(agg.feedex) AS feedex,
-              sum(agg.searches) AS searches
-             FROM ( SELECT dimensions_editions_1.warehouse_item_id,
-                      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-                      sum(aggregations_monthly_metrics.upviews) AS upviews,
-                      sum(aggregations_monthly_metrics.pviews) AS pviews,
-                      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-                      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-                      sum(aggregations_monthly_metrics.feedex) AS feedex,
-                      sum(aggregations_monthly_metrics.searches) AS searches
-                     FROM ((aggregations_monthly_metrics
-                       JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
-                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM'::text))
-                    GROUP BY dimensions_editions_1.warehouse_item_id
-                  UNION
-                   SELECT dimensions_editions_1.warehouse_item_id,
-                      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-                      sum(facts_metrics.upviews) AS upviews,
-                      sum(facts_metrics.pviews) AS pviews,
-                      sum(facts_metrics.useful_yes) AS useful_yes,
-                      sum(facts_metrics.useful_no) AS useful_no,
-                      sum(facts_metrics.feedex) AS feedex,
-                      sum(facts_metrics.searches) AS searches
-                     FROM ((facts_metrics
-                       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM-01'::text))::date))
-                    GROUP BY dimensions_editions_1.warehouse_item_id) agg
-            GROUP BY agg.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
-  SQL
-  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_twelve_months_gin_title", using: :gin
-  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
-  add_index "aggregations_search_last_twelve_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_document_type"
-  add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
-  add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews"
-  add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
 
   create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
@@ -492,5 +429,72 @@ ActiveRecord::Schema.define(version: 2019_02_18_123800) do
   add_index "aggregations_search_last_six_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_six_months_organisation_id"
   add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews"
   add_index "aggregations_search_last_six_months", ["warehouse_item_id"], name: "aggregations_search_last_six_months_pk", unique: true
+
+  create_view "aggregations_search_last_twelve_months", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT agg.warehouse_item_id,
+              max(agg.dimensions_edition_id) AS dimensions_edition_id,
+              sum(agg.upviews) AS upviews,
+              sum(agg.pviews) AS pviews,
+              sum(agg.useful_yes) AS useful_yes,
+              sum(agg.useful_no) AS useful_no,
+              sum(agg.feedex) AS feedex,
+              sum(agg.searches) AS searches
+             FROM ( SELECT dimensions_editions_1.warehouse_item_id,
+                      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+                      sum(aggregations_monthly_metrics.upviews) AS upviews,
+                      sum(aggregations_monthly_metrics.pviews) AS pviews,
+                      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+                      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+                      sum(aggregations_monthly_metrics.feedex) AS feedex,
+                      sum(aggregations_monthly_metrics.searches) AS searches
+                     FROM ((aggregations_monthly_metrics
+                       JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
+                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM'::text))
+                    GROUP BY dimensions_editions_1.warehouse_item_id
+                  UNION
+                   SELECT dimensions_editions_1.warehouse_item_id,
+                      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+                      sum(facts_metrics.upviews) AS upviews,
+                      sum(facts_metrics.pviews) AS pviews,
+                      sum(facts_metrics.useful_yes) AS useful_yes,
+                      sum(facts_metrics.useful_no) AS useful_no,
+                      sum(facts_metrics.feedex) AS feedex,
+                      sum(facts_metrics.searches) AS searches
+                     FROM ((facts_metrics
+                       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM-01'::text))::date))
+                    GROUP BY dimensions_editions_1.warehouse_item_id) agg
+            GROUP BY agg.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_twelve_months_gin_title", using: :gin
+  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
+  add_index "aggregations_search_last_twelve_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_document_type"
+  add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
+  add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews"
+  add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_122820) do
+ActiveRecord::Schema.define(version: 2019_02_18_123800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,69 +207,6 @@ ActiveRecord::Schema.define(version: 2019_02_18_122820) do
   add_foreign_key "facts_editions", "dimensions_editions"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
-
-  create_view "aggregations_search_last_six_months", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT agg.warehouse_item_id,
-              max(agg.dimensions_edition_id) AS dimensions_edition_id,
-              sum(agg.upviews) AS upviews,
-              sum(agg.pviews) AS pviews,
-              sum(agg.useful_yes) AS useful_yes,
-              sum(agg.useful_no) AS useful_no,
-              sum(agg.feedex) AS feedex,
-              sum(agg.searches) AS searches
-             FROM ( SELECT dimensions_editions_1.warehouse_item_id,
-                      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-                      sum(aggregations_monthly_metrics.upviews) AS upviews,
-                      sum(aggregations_monthly_metrics.pviews) AS pviews,
-                      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-                      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-                      sum(aggregations_monthly_metrics.feedex) AS feedex,
-                      sum(aggregations_monthly_metrics.searches) AS searches
-                     FROM ((aggregations_monthly_metrics
-                       JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
-                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM'::text))
-                    GROUP BY dimensions_editions_1.warehouse_item_id
-                  UNION
-                   SELECT dimensions_editions_1.warehouse_item_id,
-                      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-                      sum(facts_metrics.upviews) AS upviews,
-                      sum(facts_metrics.pviews) AS pviews,
-                      sum(facts_metrics.useful_yes) AS useful_yes,
-                      sum(facts_metrics.useful_no) AS useful_no,
-                      sum(facts_metrics.feedex) AS feedex,
-                      sum(facts_metrics.searches) AS searches
-                     FROM ((facts_metrics
-                       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM-01'::text))::date))
-                    GROUP BY dimensions_editions_1.warehouse_item_id) agg
-            GROUP BY agg.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL (ARRAY[('gone'::character varying)::text, ('vanish'::character varying)::text, ('need'::character varying)::text, ('unpublishing'::character varying)::text, ('redirect'::character varying)::text]));
-  SQL
-  add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_six_months_gin_title", using: :gin
-  add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_six_months_gin_base_path", using: :gin
-  add_index "aggregations_search_last_six_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_six_months_document_type"
-  add_index "aggregations_search_last_six_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_six_months_organisation_id"
-  add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews"
-  add_index "aggregations_search_last_six_months", ["warehouse_item_id"], name: "aggregations_search_last_six_months_pk", unique: true
 
   create_view "aggregations_search_last_twelve_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
@@ -488,5 +425,72 @@ ActiveRecord::Schema.define(version: 2019_02_18_122820) do
   add_index "aggregations_search_last_three_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
   add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews"
   add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
+
+  create_view "aggregations_search_last_six_months", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT agg.warehouse_item_id,
+              max(agg.dimensions_edition_id) AS dimensions_edition_id,
+              sum(agg.upviews) AS upviews,
+              sum(agg.pviews) AS pviews,
+              sum(agg.useful_yes) AS useful_yes,
+              sum(agg.useful_no) AS useful_no,
+              sum(agg.feedex) AS feedex,
+              sum(agg.searches) AS searches
+             FROM ( SELECT dimensions_editions_1.warehouse_item_id,
+                      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+                      sum(aggregations_monthly_metrics.upviews) AS upviews,
+                      sum(aggregations_monthly_metrics.pviews) AS pviews,
+                      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+                      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+                      sum(aggregations_monthly_metrics.feedex) AS feedex,
+                      sum(aggregations_monthly_metrics.searches) AS searches
+                     FROM ((aggregations_monthly_metrics
+                       JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
+                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM'::text))
+                    GROUP BY dimensions_editions_1.warehouse_item_id
+                  UNION
+                   SELECT dimensions_editions_1.warehouse_item_id,
+                      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+                      sum(facts_metrics.upviews) AS upviews,
+                      sum(facts_metrics.pviews) AS pviews,
+                      sum(facts_metrics.useful_yes) AS useful_yes,
+                      sum(facts_metrics.useful_no) AS useful_no,
+                      sum(facts_metrics.feedex) AS feedex,
+                      sum(facts_metrics.searches) AS searches
+                     FROM ((facts_metrics
+                       JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+                       JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '6 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '5 mons'::interval), 'YYYY-MM-01'::text))::date))
+                    GROUP BY dimensions_editions_1.warehouse_item_id) agg
+            GROUP BY agg.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_six_months_gin_title", using: :gin
+  add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_six_months_gin_base_path", using: :gin
+  add_index "aggregations_search_last_six_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_six_months_document_type"
+  add_index "aggregations_search_last_six_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_six_months_organisation_id"
+  add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews"
+  add_index "aggregations_search_last_six_months", ["warehouse_item_id"], name: "aggregations_search_last_six_months_pk", unique: true
 
 end

--- a/db/views/aggregations_search_last_months_v04.sql
+++ b/db/views/aggregations_search_last_months_v04.sql
@@ -1,0 +1,38 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.pviews) AS pviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.feedex) AS feedex,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id = to_char(NOW() - interval '1 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_six_months_v06.sql
+++ b/db/views/aggregations_search_last_six_months_v06.sql
@@ -1,0 +1,66 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '5 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '6 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '5 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_thirty_days_v06.sql
+++ b/db/views/aggregations_search_last_thirty_days_v06.sql
@@ -1,0 +1,40 @@
+SELECT
+  dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.pviews) AS pviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.feedex) AS feedex,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+     WHERE (facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day))
+       AND (facts_metrics.dimensions_date_id < ('now'::text)::date)
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_three_months_v06.sql
+++ b/db/views/aggregations_search_last_three_months_v06.sql
@@ -1,0 +1,66 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '3 month')
+             AND facts_metrics.dimensions_date_id < to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_twelve_months_v06.sql
+++ b/db/views/aggregations_search_last_twelve_months_v06.sql
@@ -1,0 +1,67 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT  warehouse_item_id,
+    max(agg.dimensions_edition_id) AS dimensions_edition_id,
+    sum(agg.upviews) AS upviews,
+    sum(agg.pviews) AS pviews,
+    sum(agg.useful_yes) AS useful_yes,
+    sum(agg.useful_no) AS useful_no,
+    sum(agg.feedex) AS feedex,
+    sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '11 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '12 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '11 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')
+

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -245,6 +245,33 @@ RSpec.describe Finders::Content do
   end
 
   describe 'Order' do
+    context 'when there are NULLS' do
+      before do
+        edition1 = create :edition, title: 'first', organisation_id: primary_org_id
+        edition2 = create :edition, title: 'second', organisation_id: primary_org_id
+        edition3 = create :edition, title: 'null', organisation_id: primary_org_id
+
+        create :metric, edition: edition1, date: 15.days.ago, useful_yes: 1, useful_no: 0 # satisfaction = 1.0
+        create :metric, edition: edition2, date: 15.days.ago, useful_yes: 0, useful_no: 1 # satisfaction = 0.0
+        create :metric, edition: edition3, date: 15.days.ago, useful_yes: 0, useful_no: 0 # satisfaction = NULL
+        recalculate_aggregations!
+      end
+
+      it 'orders NULL last when in ascending direction' do
+        response = described_class.call(filter: filter.merge(sort_attribute: 'satisfaction', sort_direction: 'asc'))
+
+        titles = response.fetch(:results).map { |result| result.fetch(:title) }
+        expect(titles).to eq(%w(second first null))
+      end
+
+      it 'orders NULL last when in descending direction' do
+        response = described_class.call(filter: filter.merge(sort_attribute: 'satisfaction', sort_direction: 'desc'))
+
+        titles = response.fetch(:results).map { |result| result.fetch(:title) }
+        expect(titles).to eq(%w(first second null))
+      end
+    end
+
     context 'when values do not repeat' do
       before do
         edition1 = create :edition, title: 'last', organisation_id: primary_org_id

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Finders::Content do
 
     response = described_class.call(filter: filter)
     expect(response[:results]).to contain_exactly(
-      hash_including(upviews: 35, searches: 11, satisfaction: 0.5652173913043478, satisfaction_score_responses: 23),
-      hash_including(upviews: 25, searches: 21, satisfaction: 0.3939393939393939, satisfaction_score_responses: 33),
+      hash_including(upviews: 35, searches: 11, satisfaction: 0.565217391304348),
+      hash_including(upviews: 25, searches: 21, satisfaction: 0.393939393939394),
     )
   end
 
@@ -92,8 +92,8 @@ RSpec.describe Finders::Content do
       response = described_class.call(filter: filter.merge(date_range: 'last-month'))
 
       expect(response[:results]).to contain_exactly(
-        hash_including(upviews: 20, searches: 1, satisfaction: 0.8, satisfaction_score_responses: 5),
-        hash_including(upviews: 10, searches: 11, satisfaction: 0.8, satisfaction_score_responses: 5),
+        hash_including(upviews: 20, searches: 1, satisfaction: 0.8),
+        hash_including(upviews: 10, searches: 11, satisfaction: 0.8),
       )
     end
 
@@ -109,8 +109,8 @@ RSpec.describe Finders::Content do
       response = described_class.call(filter: filter.merge(date_range: 'past-3-months'))
 
       expect(response[:results]).to contain_exactly(
-        hash_including(upviews: 35, searches: 11, satisfaction: 0.5, satisfaction_score_responses: 10),
-        hash_including(upviews: 25, searches: 21, satisfaction: 0.5, satisfaction_score_responses: 10),
+        hash_including(upviews: 35, searches: 11, satisfaction: 0.5),
+        hash_including(upviews: 25, searches: 21, satisfaction: 0.5),
       )
     end
 
@@ -126,8 +126,8 @@ RSpec.describe Finders::Content do
       response = described_class.call(filter: filter.merge(date_range: 'past-6-months'))
 
       expect(response[:results]).to contain_exactly(
-        hash_including(upviews: 35, searches: 11, satisfaction: 0.5, satisfaction_score_responses: 10),
-        hash_including(upviews: 25, searches: 21, satisfaction: 0.5, satisfaction_score_responses: 10),
+        hash_including(upviews: 35, searches: 11, satisfaction: 0.5),
+        hash_including(upviews: 25, searches: 21, satisfaction: 0.5),
       )
     end
 
@@ -143,8 +143,8 @@ RSpec.describe Finders::Content do
       response = described_class.call(filter: filter.merge(date_range: 'past-year'))
 
       expect(response[:results]).to contain_exactly(
-        hash_including(upviews: 35, searches: 11, satisfaction: 0.5, satisfaction_score_responses: 10),
-        hash_including(upviews: 25, searches: 21, satisfaction: 0.5, satisfaction_score_responses: 10),
+        hash_including(upviews: 35, searches: 11, satisfaction: 0.5),
+        hash_including(upviews: 25, searches: 21, satisfaction: 0.5),
       )
     end
   end
@@ -317,7 +317,6 @@ RSpec.describe Finders::Content do
       results = described_class.call(filter: filter)
       expect(results[:results].first).to include(
         satisfaction: nil,
-        satisfaction_score_responses: 0
       )
     end
   end

--- a/spec/models/aggregations/search_last_month_spec.rb
+++ b/spec/models/aggregations/search_last_month_spec.rb
@@ -4,24 +4,26 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
   subject { described_class }
 
   it_behaves_like 'a materialized view', described_class.table_name
+  include_examples 'calculates satisfaction', Date.today.last_month.end_of_month
 
   let(:from) { Date.today.last_month.beginning_of_month }
   let(:to) { Date.today.last_month.end_of_month }
 
   it 'aggregates metrics for the last month' do
     edition1 = create :edition, base_path: '/path1', date: '2018-01-10'
-    create :metric, edition: edition1, date: from, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
-    create :metric, edition: edition1, date: to, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
-    create :metric, edition: edition1, date: (from + 15.days), upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
+    create :metric, edition: edition1, date: from, upviews: 5, useful_yes: 1, useful_no: 1, searches: 8
+    create :metric, edition: edition1, date: to, upviews: 10, useful_yes: 73, useful_no: 23, searches: 9
+    create :metric, edition: edition1, date: (from + 15.days), upviews: 15, useful_yes: 1, useful_no: 1, searches: 10
 
     recalculate_aggregations!
 
     expect(subject.count).to eq(1)
     expect(subject.first).to have_attributes(
       upviews: 30,
-      useful_yes: 21,
-      useful_no: 24,
+      useful_yes: 75,
+      useful_no: 25,
       searches: 27,
+      satisfaction: 0.75
     )
   end
 

--- a/spec/models/aggregations/search_last_six_months_spec.rb
+++ b/spec/models/aggregations/search_last_six_months_spec.rb
@@ -4,17 +4,24 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
   subject { described_class }
 
   it_behaves_like 'a materialized view', described_class.table_name
+  include_examples 'calculates satisfaction', Date.yesterday
 
   it 'aggregates metrics for the last six months' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
-    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
-    create :metric, edition: edition1, date: 3.months.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 1, useful_no: 1, searches: 8
+    create :metric, edition: edition1, date: 3.months.ago, upviews: 10, useful_yes: 74, useful_no: 24, searches: 9
     create :metric, edition: edition1, date: 7.months.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
     recalculate_aggregations!
 
     expect(subject.count).to eq(1)
-    expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
+    expect(subject.first).to have_attributes(
+      upviews: 15,
+      useful_yes: 75,
+      useful_no: 25,
+      satisfaction: 0.75,
+      searches: 17
+    )
   end
 
   it 'aggregates by warehouse_item_id' do

--- a/spec/models/aggregations/search_last_thirty_days_spec.rb
+++ b/spec/models/aggregations/search_last_thirty_days_spec.rb
@@ -4,18 +4,19 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
   subject { described_class }
 
   it_behaves_like 'a materialized view', described_class.table_name
+  include_examples 'calculates satisfaction'
 
   it 'aggregates metrics for the last 30 days' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
     create :metric, edition: edition1, date: Date.today, upviews: 1, useful_yes: 1, useful_no: 1, searches: 1
-    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
-    create :metric, edition: edition1, date: 15.days.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 1, useful_no: 1, searches: 8
+    create :metric, edition: edition1, date: 15.days.ago, upviews: 10, useful_yes: 74, useful_no: 24, searches: 9
     create :metric, edition: edition1, date: 31.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
     recalculate_aggregations!
 
     expect(subject.count).to eq(1)
-    expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
+    expect(subject.first).to have_attributes(upviews: 15, useful_yes: 75, useful_no: 25, searches: 17, satisfaction: 0.75)
   end
 
   it 'aggregates by warehouse_item_id' do

--- a/spec/models/aggregations/search_last_thirty_days_spec.rb
+++ b/spec/models/aggregations/search_last_thirty_days_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
   subject { described_class }
 
   it_behaves_like 'a materialized view', described_class.table_name
-  include_examples 'calculates satisfaction'
+  include_examples 'calculates satisfaction', Date.yesterday
 
   it 'aggregates metrics for the last 30 days' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago

--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -4,17 +4,24 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
   subject { described_class }
 
   it_behaves_like 'a materialized view', described_class.table_name
+  include_examples 'calculates satisfaction', Date.yesterday
 
   it 'aggregates metrics for the last three months' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
-    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
-    create :metric, edition: edition1, date: 2.months.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 1, useful_no: 1, searches: 8
+    create :metric, edition: edition1, date: 2.months.ago, upviews: 10, useful_yes: 74, useful_no: 24, searches: 9
     create :metric, edition: edition1, date: 4.months.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
     recalculate_aggregations!
 
     expect(subject.count).to eq(1)
-    expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
+    expect(subject.first).to have_attributes(
+      upviews: 15,
+      useful_yes: 75,
+      useful_no: 25,
+      satisfaction: 0.75,
+      searches: 17
+    )
   end
 
   it 'aggregates by warehouse_item_id' do

--- a/spec/models/aggregations/search_last_twelve_months_spec.rb
+++ b/spec/models/aggregations/search_last_twelve_months_spec.rb
@@ -4,17 +4,24 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
   subject { described_class }
 
   it_behaves_like 'a materialized view', described_class.table_name
+  include_examples 'calculates satisfaction', Date.yesterday
 
   it 'aggregates metrics for the last twelve months' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
-    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 6, useful_no: 7, searches: 8
-    create :metric, edition: edition1, date: 6.months.ago, upviews: 10, useful_yes: 7, useful_no: 8, searches: 9
+    create :metric, edition: edition1, date: Date.yesterday, upviews: 5, useful_yes: 1, useful_no: 1, searches: 8
+    create :metric, edition: edition1, date: 6.months.ago, upviews: 10, useful_yes: 74, useful_no: 24, searches: 9
     create :metric, edition: edition1, date: 13.months.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
     recalculate_aggregations!
 
     expect(subject.count).to eq(1)
-    expect(subject.first).to have_attributes(upviews: 15, useful_yes: 13, useful_no: 15, searches: 17)
+    expect(subject.first).to have_attributes(
+      upviews: 15,
+      useful_yes: 75,
+      useful_no: 25,
+      satisfaction: 0.75,
+      searches: 17
+    )
   end
 
   it 'aggregates by warehouse_item_id' do

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -276,32 +276,42 @@ RSpec.describe '/content' do
 
   describe 'Sort by' do
     before do
-      edition1 = create :edition, date: 1.month.ago, title: 'Edition A'
-      create :metric, date: 15.days.ago, edition: edition1, upviews: 100, useful_yes: 100, useful_no: 100, searches: 1
+      edition1 = create :edition, date: 1.month.ago, title: 'A', document_type: 'news_story'
+      create :metric, date: 15.days.ago, edition: edition1, upviews: 10, useful_yes: 5, useful_no: 10, searches: 10
 
-      edition2 = create :edition, date: 1.month.ago, title: 'Edition B'
-      create :metric, date: 10.days.ago, edition: edition2, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
+      edition2 = create :edition, date: 1.month.ago, title: 'B', document_type: 'guide'
+      create :metric, date: 10.days.ago, edition: edition2, upviews: 100, useful_yes: 10, useful_no: 5, searches: 1
 
-      edition3 = create :edition, date: 1.month.ago, title: 'Edition C'
-      create :metric, date: 10.days.ago, edition: edition3, upviews: 1, useful_yes: 1, useful_no: 1, searches: 100
+      edition3 = create :edition, date: 1.month.ago, title: 'C', document_type: 'homepage'
+      create :metric, date: 10.days.ago, edition: edition3, upviews: 1, useful_yes: 10, useful_no: 10, searches: 100
 
       recalculate_aggregations!
     end
 
-    it 'sorts results by daily metric attribute ascending' do
-      get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: 'searches:asc' }
+    sort_results = {
+      'title': %w[A B C],
+      'document_type': %w[B C A],
+      'upviews': %w[C A B],
+      'satisfaction': %w[A C B],
+      'searches': %w[B A C]
+    }
 
-      response_body = JSON.parse(response.body).deep_symbolize_keys
-      content_item_titles = response_body[:results].map { |i| i[:title] }
-      expect(content_item_titles).to eq(['Edition A', 'Edition B', 'Edition C'])
-    end
+    sort_results.each do |sort_key, expected_values|
+      it "sorts results by #{sort_key} attribute ascending" do
+        get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: "#{sort_key}:asc" }
 
-    it 'sorts results by descending' do
-      get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: 'searches:desc' }
+        response_body = JSON.parse(response.body).deep_symbolize_keys
+        content_item_titles = response_body[:results].map { |i| i[:title] }
+        expect(content_item_titles).to eq(expected_values)
+      end
 
-      response_body = JSON.parse(response.body).deep_symbolize_keys
-      content_item_titles = response_body[:results].map { |i| i[:title] }
-      expect(content_item_titles).to eq(['Edition C', 'Edition B', 'Edition A'])
+      it "sorts results by #{sort_key} attribute descending" do
+        get '/content', params: { date_range: 'past-30-days', organisation_id: 'all', sort: "#{sort_key}:desc" }
+
+        response_body = JSON.parse(response.body).deep_symbolize_keys
+        content_item_titles = response_body[:results].map { |i| i[:title] }
+        expect(content_item_titles).to eq(expected_values.reverse)
+      end
     end
   end
 

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe '/content' do
           useful_no: 1,
           useful_yes: 1,
           satisfaction: 0.5,
-          satisfaction_score_responses: 2,
           searches: 1,
           pdf_count: 10,
           word_count: 300,

--- a/spec/support/shared/shared_aggregation_view.rb
+++ b/spec/support/shared/shared_aggregation_view.rb
@@ -1,16 +1,16 @@
-RSpec.shared_examples 'calculates satisfaction' do
+RSpec.shared_examples 'calculates satisfaction' do |date|
   it 'returns score with responses' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
-    create :metric, edition: edition1, date: Date.yesterday, useful_yes: 1, useful_no: 1
+    create :metric, edition: edition1, date: date, useful_yes: 1, useful_no: 1
 
     recalculate_aggregations!
 
-    expect(subject.first).to have_attributes( satisfaction: 0.5)
+    expect(subject.first).to have_attributes(satisfaction: 0.5)
   end
 
   it 'returns nil with no responses' do
     edition1 = create :edition, base_path: '/path1', date: 2.months.ago
-    create :metric, edition: edition1, date: Date.yesterday, useful_yes: 0, useful_no: 0
+    create :metric, edition: edition1, date: date, useful_yes: 0, useful_no: 0
 
     recalculate_aggregations!
 

--- a/spec/support/shared/shared_aggregation_view.rb
+++ b/spec/support/shared/shared_aggregation_view.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'calculates satisfaction' do
+  it 'returns score with responses' do
+    edition1 = create :edition, base_path: '/path1', date: 2.months.ago
+    create :metric, edition: edition1, date: Date.yesterday, useful_yes: 1, useful_no: 1
+
+    recalculate_aggregations!
+
+    expect(subject.first).to have_attributes( satisfaction: 0.5)
+  end
+
+  it 'returns nil with no responses' do
+    edition1 = create :edition, base_path: '/path1', date: 2.months.ago
+    create :metric, edition: edition1, date: Date.yesterday, useful_yes: 0, useful_no: 0
+
+    recalculate_aggregations!
+
+    expect(subject.first).to have_attributes(satisfaction: nil)
+  end
+end


### PR DESCRIPTION
This PR adds the following changes:
- Adds satisfaction column to aggregation views, where satisfaction is calculated within Postgres. For rows with no survey responses, the satisfaction is NULL.
- Removes satisfaction_score_responses from content response as no longer used
- Adds ordering constraint whereby NULLs are always ranked last regardless of direction.

These changes are needed to support sorting by satisfaction score, which previously threw an error. Coercing NULLs to always be last, helps users see valuable results without having to request subsequent pages.

Adding the calculation for satisfaction score for each aggregation view is not ideal - future work should be done to remove this repeated calculation.