### PR TITLE
Support 'all' as a document_type for the content endpoint

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -59,7 +59,11 @@ private
   def find_by_document_type(scope)
     document_type = @filter.fetch(:document_type)
 
-    scope.where('document_type = ?', document_type)
+    if document_type == ALL
+      scope
+    else
+      scope.where('document_type = ?', document_type)
+    end
   end
 
   def find_by_organisation(scope)

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -149,6 +149,16 @@ RSpec.describe Finders::Content do
     end
   end
 
+  describe 'Filter by all document types' do
+    it 'doesnt include document_type in the query' do
+      scope = described_class
+                .new(filter.merge(document_type: 'all'))
+                .send(:apply_filter)
+
+      expect(scope.to_sql).not_to include('document_type')
+    end
+  end
+
   describe 'Filter by all organisations' do
     let(:edition1) { create :edition, date: 15.days.ago }
     let(:edition2) { create :edition, date: 15.days.ago, organisation_id: nil }


### PR DESCRIPTION
This adds similar support for document_type, which currently exists
for organisation_id.

This will indirectly fix some problems with the CSV exporting from the
Content Data Admin, as it's currently sending 'all' as the
document_type, just when attempting to download CSV files.