### PR TITLE
Add migration to change the upviews and warehouse_item_id indexes

### DIFF
--- a/db/migrate/20190220161718_change_upviews_and_warehouse_item_id_indexes.rb
+++ b/db/migrate/20190220161718_change_upviews_and_warehouse_item_id_indexes.rb
@@ -1,0 +1,18 @@
+class ChangeUpviewsAndWarehouseItemIdIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :aggregations_search_last_twelve_months, name: :search_last_twelve_months_upviews
+    remove_index :aggregations_search_last_six_months, name: :search_last_six_months_upviews
+    remove_index :aggregations_search_last_three_months, name: :search_last_three_months_upviews
+    remove_index :aggregations_search_last_months, name: :search_last_month_upviews
+    remove_index :aggregations_search_last_thirty_days, name: :search_last_thirty_days_upviews
+
+    fields = %i[upviews warehouse_item_id]
+    order = { upviews: 'DESC NULLS LAST', warehouse_item_id: :desc }
+
+    add_index :aggregations_search_last_twelve_months, fields, order: order, name: :search_last_twelve_months_upviews
+    add_index :aggregations_search_last_six_months, fields, order: order, name: :search_last_six_months_upviews
+    add_index :aggregations_search_last_three_months, fields, order: order, name: :search_last_three_months_upviews
+    add_index :aggregations_search_last_months, fields, order: order, name: :search_last_month_upviews
+    add_index :aggregations_search_last_thirty_days, fields, order: order, name: :search_last_thirty_days_upviews
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_124214) do
+ActiveRecord::Schema.define(version: 2019_02_20_161718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -249,7 +249,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_124214) do
   add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
   add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
   add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
-  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews"
+  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
   create_view "aggregations_search_last_months", materialized: true, sql_definition: <<-SQL
@@ -293,7 +293,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_124214) do
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin
   add_index "aggregations_search_last_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_month_document_type"
   add_index "aggregations_search_last_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_month_organisation_id"
-  add_index "aggregations_search_last_months", ["upviews", "warehouse_item_id"], name: "search_last_month_upviews"
+  add_index "aggregations_search_last_months", ["upviews", "warehouse_item_id"], name: "search_last_month_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_months", ["warehouse_item_id"], name: "aggregations_search_last_months_pk", unique: true
 
   create_view "aggregations_search_last_three_months", materialized: true, sql_definition: <<-SQL
@@ -360,7 +360,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_124214) do
   add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
   add_index "aggregations_search_last_three_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_three_months_document_type"
   add_index "aggregations_search_last_three_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
-  add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews"
+  add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
 
   create_view "aggregations_search_last_six_months", materialized: true, sql_definition: <<-SQL
@@ -427,7 +427,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_124214) do
   add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_six_months_gin_base_path", using: :gin
   add_index "aggregations_search_last_six_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_six_months_document_type"
   add_index "aggregations_search_last_six_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_six_months_organisation_id"
-  add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews"
+  add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_six_months", ["warehouse_item_id"], name: "aggregations_search_last_six_months_pk", unique: true
 
   create_view "aggregations_search_last_twelve_months", materialized: true, sql_definition: <<-SQL
@@ -494,7 +494,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_124214) do
   add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
   add_index "aggregations_search_last_twelve_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_document_type"
   add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
-  add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews"
+  add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
 
 end


### PR DESCRIPTION
For the content page, including the CSV download, the ordering for the
queries uses DESC NULLS LAST for upviews, and DESC for
warehouse_item_id. This migration changes the btree index on upviews
and warehouse_item_id to match, so that these indexes can be used for
the content endpoint query.