### PR TITLE
Remove the production environment database connection configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,6 +15,4 @@ test:
 
 production:
   <<: *default
-  database: content_performance_manager_production
-  username: content_performance_manager
-  password: <%= ENV['CONTENT-PERFORMANCE-MANAGER_DATABASE_PASSWORD'] %>
+  # Set using the DATABASE_URL environment variable


### PR DESCRIPTION
This is also specified in govuk-puppet, and it's more consistent to
use the details specified in the DATABASE_URL environment variable.

The CONTENT-PERFORMANCE-MANAGER_DATABASE_PASSWORD environment variable
is unset, at least in Carrenza Staging.