### PR TITLE
[Do not merge] Decode characters base paths

### DIFF
--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -51,9 +51,9 @@ module Streams
       part_sub_path = sub_path_for_part(part, index)
 
       if part_sub_path
-        "#{base_path}/#{part_sub_path}"
+        CGI::unescape "#{base_path}/#{part_sub_path}"
       else
-        base_path
+        CGI::unescape base_path
       end
     end
 

--- a/app/domain/streams/messages/single_item_message.rb
+++ b/app/domain/streams/messages/single_item_message.rb
@@ -26,7 +26,7 @@ module Streams
   private
 
     def base_path
-      @payload.fetch('base_path')
+      CGI::unescape @payload.fetch('base_path')
     end
 
     def title

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -99,5 +99,19 @@ RSpec.describe Streams::Messages::MultipartMessage do
         ])
       end
     end
+
+    context 'when unescaped characters in base_path' do
+      let(:messages) do
+        message = build(:message, :with_parts, base_path: '/gov.uk')
+        message.payload['details']['parts'][1]['slug'] = '%E0%B8%81%E0%B8%B2%E0%B8%A3%E0%B8%A2'
+
+        subject.new(message.payload, "routing_key")
+      end
+
+      it 'decodes the characters' do
+        expect(messages.edition_attributes[0]).to include(base_path: '/gov.uk')
+        expect(messages.edition_attributes[1]).to include(base_path: '/gov.uk/การย')
+      end
+    end
   end
 end

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 RSpec.describe Streams::Messages::SingleItemMessage do
   include PublishingEventProcessingSpecHelper
 
@@ -30,6 +32,19 @@ RSpec.describe Streams::Messages::SingleItemMessage do
           acronym: nil
         )
       )
+    end
+  end
+
+  context 'when unescaped characters in the base_path' do
+    let(:message) do
+      message = build :message
+      message.payload['base_path'] = '/gov.uk/%E0%B8%81%E0%B8%B2%E0%B8%A3%E0%B8%A2'
+
+      subject.new(message.payload, "routing_key")
+    end
+
+    it 'decodes the characters' do
+      expect(message.edition_attributes).to include(base_path: '/gov.uk/การย')
     end
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/EHrM18LF/1198-2-bug-some-foreign-language-slugs-stretch-the-page-title-column-width-in-the-table)

Some URLs have the following format:

/government/publications/apply-for-a-uk-visa-in-thailand/%E0%B8%81%E0%B8%B2%E0%B8%A3%E0%B8%A2%E0%B8%B7%E0%B9%88%E0%B8%99%E0%B8%84%E0%B8%B3%E0%B8%A3%E0%B9%89%E0%B8%AD%E0%B8%87%E0%B8%82%E0%B8%AD%E0%B8%A7%E0%B8%B5%E0%B8%8B%E0%B9%88%E0%B8%B2%E0%B8%AA%E0%B8%AB%E0%B8%A3%E0%B8%B2%E0%B8%8A%E0%B8%AD%E0%B8%B2%E0%B8%93%E0%B8%B2%E0%B8%88%E0%B8%B1%E0%B8%81%E0%B8%A3

This seems to be related with unescaped characters.