### PR TITLE
Add Postgres calculate satisfaction function

### DIFF
--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -65,7 +65,7 @@ private
         sum(entrances),
         sum(searches),
         sum(feedex),
-        sum(satisfaction),
+        calculate_satisfaction(sum(useful_yes), sum(useful_no)),
         sum(useful_yes),
         sum(useful_no),
         sum(exits),

--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -45,7 +45,7 @@ private
       UPDATE facts_metrics
       SET useful_no = s.useful_no,
           useful_yes = s.useful_yes,
-          satisfaction= s.useful_yes / (s.useful_yes + s.useful_no::float)
+          satisfaction = calculate_satisfaction(s.useful_yes, s.useful_no)
       FROM (
         SELECT useful_no,
                useful_yes,

--- a/db/migrate/20190227105543_add_satisfaction_function.rb
+++ b/db/migrate/20190227105543_add_satisfaction_function.rb
@@ -1,0 +1,26 @@
+class AddSatisfactionFunction < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION calculate_satisfaction (useful_yes NUMERIC, useful_no NUMERIC)
+      RETURNS float AS $$
+        BEGIN
+          CASE
+            WHEN useful_yes + useful_no = 0 THEN RETURN NULL;
+            ELSE RETURN useful_yes / (useful_yes + useful_no)::float;
+          END CASE;
+        END;
+      $$
+      LANGUAGE 'plpgsql'
+      IMMUTABLE
+      LEAKPROOF
+      PARALLEL SAFE
+      RETURNS NULL ON NULL INPUT;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP FUNCTION IF EXISTS calculate_satisfaction(useful_yes NUMERIC, useful_no NUMERIC);
+    SQL
+  end
+end

--- a/db/migrate/20190227143637_update_aggregations_search_last_thirty_days_to_version_7.rb
+++ b/db/migrate/20190227143637_update_aggregations_search_last_thirty_days_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastThirtyDaysToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_thirty_days,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190227152916_update_aggregations_search_last_months_to_version_5.rb
+++ b/db/migrate/20190227152916_update_aggregations_search_last_months_to_version_5.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastMonthsToVersion5 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_months,
+      version: 5,
+      revert_to_version: 4,
+      materialized: true
+  end
+end

--- a/db/migrate/20190227155747_update_aggregations_search_last_three_months_to_version_7.rb
+++ b/db/migrate/20190227155747_update_aggregations_search_last_three_months_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastThreeMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_three_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190227160112_update_aggregations_search_last_six_months_to_version_7.rb
+++ b/db/migrate/20190227160112_update_aggregations_search_last_six_months_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastSixMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_six_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190227160625_update_aggregations_search_last_twelve_months_to_version_7.rb
+++ b/db/migrate/20190227160625_update_aggregations_search_last_twelve_months_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastTwelveMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_twelve_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190227162354_remove_default_and_null_constraint_from_monthly_aggregations.rb
+++ b/db/migrate/20190227162354_remove_default_and_null_constraint_from_monthly_aggregations.rb
@@ -1,0 +1,6 @@
+class RemoveDefaultAndNullConstraintFromMonthlyAggregations < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :aggregations_monthly_metrics, :satisfaction, nil
+    change_column_null :aggregations_monthly_metrics, :satisfaction, true
+  end
+end

--- a/db/migrate/20190228110930_remove_default_and_null_constraint_from_facts_metrics.rb
+++ b/db/migrate/20190228110930_remove_default_and_null_constraint_from_facts_metrics.rb
@@ -1,0 +1,6 @@
+class RemoveDefaultAndNullConstraintFromFactsMetrics < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :facts_metrics, :satisfaction, nil
+    change_column_null :facts_metrics, :satisfaction, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_105543) do
+ActiveRecord::Schema.define(version: 2019_02_27_160625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,47 @@ ActiveRecord::Schema.define(version: 2019_02_27_105543) do
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
 
+  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+      calculate_satisfaction((aggregations.useful_yes)::numeric, (aggregations.useful_no)::numeric) AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.pviews) AS pviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.feedex) AS feedex,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
+            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
+  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
+  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
+  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
+  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
+
   create_view "aggregations_search_last_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
       dimensions_editions.title,
@@ -221,10 +262,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_105543) do
       aggregations.feedex,
       aggregations.useful_yes,
       aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
+      calculate_satisfaction((aggregations.useful_yes)::numeric, (aggregations.useful_no)::numeric) AS satisfaction,
       aggregations.searches,
       facts_editions.words,
       facts_editions.pdf_count,
@@ -265,10 +303,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_105543) do
       aggregations.feedex,
       aggregations.useful_yes,
       aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
+      calculate_satisfaction(aggregations.useful_yes, aggregations.useful_no) AS satisfaction,
       aggregations.searches,
       facts_editions.words,
       facts_editions.pdf_count,
@@ -332,10 +367,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_105543) do
       aggregations.feedex,
       aggregations.useful_yes,
       aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
+      calculate_satisfaction(aggregations.useful_yes, aggregations.useful_no) AS satisfaction,
       aggregations.searches,
       facts_editions.words,
       facts_editions.pdf_count,
@@ -399,10 +431,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_105543) do
       aggregations.feedex,
       aggregations.useful_yes,
       aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
+      calculate_satisfaction(aggregations.useful_yes, aggregations.useful_no) AS satisfaction,
       aggregations.searches,
       facts_editions.words,
       facts_editions.pdf_count,
@@ -453,49 +482,5 @@ ActiveRecord::Schema.define(version: 2019_02_27_105543) do
   add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
   add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
-
-  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.pviews) AS pviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.feedex) AS feedex,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
-            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
-  SQL
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
-  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
-  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
-  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
-  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_25_113933) do
+ActiveRecord::Schema.define(version: 2019_02_27_105543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,50 +208,6 @@ ActiveRecord::Schema.define(version: 2019_02_25_113933) do
   add_foreign_key "facts_editions", "dimensions_editions"
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
-
-  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.pviews) AS pviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.feedex) AS feedex,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
-            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
-  SQL
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
-  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
-  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
-  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
-  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
   create_view "aggregations_search_last_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
@@ -497,5 +453,49 @@ ActiveRecord::Schema.define(version: 2019_02_25_113933) do
   add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
   add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
+
+  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.pviews) AS pviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.feedex) AS feedex,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
+            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
+  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
+  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
+  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
+  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_160625) do
+ActiveRecord::Schema.define(version: 2019_02_27_162354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_160625) do
     t.integer "entrances"
     t.integer "bounces"
     t.integer "page_time"
-    t.float "satisfaction", default: 0.0, null: false
+    t.float "satisfaction"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_aggregations_monthly_metrics_on_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_162354) do
+ActiveRecord::Schema.define(version: 2019_02_28_110930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_162354) do
     t.integer "entrances", default: 0, null: false
     t.integer "bounces", default: 0, null: false
     t.integer "page_time", default: 0, null: false
-    t.float "satisfaction", default: 0.0, null: false
+    t.float "satisfaction"
     t.index ["dimensions_date_id", "dimensions_edition_id"], name: "metrics_edition_id_date_id", unique: true
     t.index ["dimensions_date_id", "feedex"], name: "index_facts_metrics_on_dimensions_date_id_and_feedex"
     t.index ["dimensions_date_id", "pviews"], name: "index_facts_metrics_on_dimensions_date_id_and_pviews"

--- a/db/views/aggregations_search_last_months_v05.sql
+++ b/db/views/aggregations_search_last_months_v05.sql
@@ -1,0 +1,35 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  calculate_satisfaction(useful_yes, useful_no) as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.pviews) AS pviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.feedex) AS feedex,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id = to_char(NOW() - interval '1 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_six_months_v07.sql
+++ b/db/views/aggregations_search_last_six_months_v07.sql
@@ -1,0 +1,63 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  calculate_satisfaction(useful_yes, useful_no) as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '5 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '6 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '5 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_thirty_days_v07.sql
+++ b/db/views/aggregations_search_last_thirty_days_v07.sql
@@ -1,0 +1,37 @@
+SELECT
+  dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  calculate_satisfaction(useful_yes, useful_no) as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.pviews) AS pviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.feedex) AS feedex,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+     WHERE (facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day))
+       AND (facts_metrics.dimensions_date_id < ('now'::text)::date)
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_three_months_v07.sql
+++ b/db/views/aggregations_search_last_three_months_v07.sql
@@ -1,0 +1,63 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  calculate_satisfaction(useful_yes, useful_no) as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '3 month')
+             AND facts_metrics.dimensions_date_id < to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_twelve_months_v07.sql
+++ b/db/views/aggregations_search_last_twelve_months_v07.sql
@@ -1,0 +1,64 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews as upviews,
+  aggregations.pviews as pviews,
+  aggregations.feedex as feedex,
+  aggregations.useful_yes as useful_yes,
+  aggregations.useful_no as useful_no,
+  calculate_satisfaction(useful_yes, useful_no) as satisfaction,
+  aggregations.searches as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT  warehouse_item_id,
+    max(agg.dimensions_edition_id) AS dimensions_edition_id,
+    sum(agg.upviews) AS upviews,
+    sum(agg.pviews) AS pviews,
+    sum(agg.useful_yes) AS useful_yes,
+    sum(agg.useful_no) AS useful_no,
+    sum(agg.feedex) AS feedex,
+    sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '11 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '12 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '11 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')
+

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe Etl::Aggregations::Monthly do
     )
   end
 
-  Metric.daily_metrics.map(&:name).each do |metric_name|
+  sum_metrics = Metric.daily_metrics.map(&:name)
+  sum_metrics.delete('satisfaction')
+  sum_metrics.each do |metric_name|
     it "Calculates aggregations for metric: `#{metric_name}`" do
       create :metric, edition: edition1, date: '2018-02-21', metric_name => 10
       create :metric, edition: edition1, date: '2018-02-22', metric_name => 20
@@ -74,6 +76,15 @@ RSpec.describe Etl::Aggregations::Monthly do
 
       expect(Aggregations::MonthlyMetric.first).to have_attributes(metric_name => 30)
     end
+  end
+
+  it "Calculates aggregations for metric: satisfaction" do
+    create :metric, edition: edition1, date: '2018-02-21', useful_yes: 5, useful_no: 5, satisfaction: 0.5
+    create :metric, edition: edition1, date: '2018-02-22', useful_yes: 1, useful_no: 0, satisfaction: 1.0
+
+    subject.process(date: date)
+
+    expect(Aggregations::MonthlyMetric.first).to have_attributes(satisfaction: 0.545454545454545)
   end
 
   describe 'it can run multiple times for any month' do

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
       expect(fact.reload.satisfaction).to be_within(0.1).of(1.0)
     end
 
-    it 'sets `satisfaction = 0.0` with `useful_yes:0` and `no: 1`' do
+    it 'sets `satisfaction = 0.0` with `useful_yes: 0` and `no: 1`' do
       allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_yield(ga_response(useful_yes: 0, useful_no: 1))
       described_class.process(date: date)
 


### PR DESCRIPTION
This PR addresses the issue of having multiple statements that calculate satisfaction score within the codebase. The following has been changed:
- Adds migrations to add Postgres function for calculating satisfaction score. Currently all calculations happen within Postgres and this will reduce repetition of the same logic. 
- Remove default and nulls constraint to satisfaction columns in facts_metrics and monthly_aggregation tables. If we are unable to calculate the score, due to insufficient data (e.g. 0 useful yes and 0 useful_no) we should not default the satisfaction score to 0.0. We should use NULL to represent this unknown.
- Updates SQL queries that calculated satisfaction score to use the Postgres function. 