### PR TITLE
Removed unused gems: capybara, phantomjs, sass-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'pg'
 gem 'rack-proxy'
 gem 'rails', '~> 5.2'
 gem 'ruby-progressbar'
-gem 'sass-rails'
 gem 'scenic'
 gem 'uuid'
 
@@ -37,14 +36,12 @@ end
 
 group :development, :test do
   gem 'byebug'
-  gem 'capybara'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'govuk-lint', '3.11.0'
   gem 'govuk_schemas', '3.2.0'
   gem 'guard-rspec', require: false
   gem 'listen'
-  gem 'phantomjs'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem "rack", ">= 2.0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,14 +73,6 @@ GEM
     bunny (2.11.0)
       amq-protocol (~> 2.3.0)
     byebug (11.0.0)
-    capybara (3.13.2)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
-      xpath (~> 3.2)
     case_transform (0.2)
       activesupport
     coderay (1.1.2)
@@ -279,7 +271,6 @@ GEM
     parser (2.6.0.0)
       ast (~> 2.4.0)
     pg (1.1.4)
-    phantomjs (2.1.1.0)
     plek (2.1.1)
     powerpack (0.1.2)
     pry (0.12.2)
@@ -337,7 +328,6 @@ GEM
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    regexp_parser (1.3.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -392,12 +382,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     scenic (1.5.1)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -448,7 +432,6 @@ GEM
     systemu (2.6.5)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.8)
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -478,8 +461,6 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -491,7 +472,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   byebug
-  capybara
   database_cleaner
   factory_bot_rails
   gds-api-adapters (~> 57.4.1)
@@ -511,7 +491,6 @@ DEPENDENCIES
   nokogiri (~> 1.10)
   odyssey
   pg
-  phantomjs
   plek
   pry-byebug
   pry-rails
@@ -522,7 +501,6 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   ruby-progressbar
-  sass-rails
   scenic
   shoulda-matchers
   simplecov


### PR DESCRIPTION
**Removed unused gems: capybara, phantomjs, sass-rails**

Remove UI dependent gems

We no longer have any UI code in Content Performance manager, 
so we can safely remove:

1. Capybara
2. PhantomJS
3. Saas-Rails