### PR TITLE
Chomp off long page_paths from GA reports

### DIFF
--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -1,4 +1,6 @@
 class Etl::GA::ViewsAndNavigationService
+  PAGE_PATH_LENGTH_LIMIT = 1500
+
   def self.find_in_batches(*args, &block)
     new.find_in_batches(*args, &block)
   end
@@ -22,6 +24,8 @@ private
 
   def append_data_labels(values)
     page_path, pviews, upviews, entrances, exits, bounces, page_time = *values
+
+    page_path = page_path.slice(PAGE_PATH_LENGTH_LIMIT) if page_path.length > PAGE_PATH_LENGTH_LIMIT
 
     {
       'page_path' => page_path,


### PR DESCRIPTION
During the ETL process, page_paths that have very long query params
(suspicious looking query stuffing) will cause the import to fail as the
index can't store a string value so long. This pragmatic fix will allow
the ETL to complete, as we do not treat URLs with query params as
separate instances of page visits as Google Analytics does so we can
mitigate against this problem.