### PR TITLE
Update Search Aggregation models to inherit from MaterializedView

### DIFF
--- a/app/models/aggregations/materialized_view.rb
+++ b/app/models/aggregations/materialized_view.rb
@@ -1,6 +1,8 @@
 class Aggregations::MaterializedView < ActiveRecord::Base
   self.abstract_class = true
 
+  self.primary_key = 'warehouse_item_id'
+
   def self.prepare
     increase_work_mem_for_current_transaction
   end

--- a/app/models/aggregations/materialized_view.rb
+++ b/app/models/aggregations/materialized_view.rb
@@ -1,4 +1,6 @@
-class Aggregations::MaterializedView
+class Aggregations::MaterializedView < ActiveRecord::Base
+  self.abstract_class = true
+
   def self.prepare
     increase_work_mem_for_current_transaction
   end
@@ -12,5 +14,10 @@ class Aggregations::MaterializedView
   # This should never be enabled globally.
   def self.increase_work_mem_for_current_transaction
     ActiveRecord::Base.connection.execute("set local work_mem = '500MB'")
+  end
+
+  def self.refresh
+    prepare
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/app/models/aggregations/search_last_month.rb
+++ b/app/models/aggregations/search_last_month.rb
@@ -1,6 +1,2 @@
-class Aggregations::SearchLastMonth < ApplicationRecord
-  def self.refresh
-    Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
-  end
+class Aggregations::SearchLastMonth < Aggregations::MaterializedView
 end

--- a/app/models/aggregations/search_last_six_months.rb
+++ b/app/models/aggregations/search_last_six_months.rb
@@ -1,6 +1,2 @@
-class Aggregations::SearchLastSixMonths < ApplicationRecord
-  def self.refresh
-    Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
-  end
+class Aggregations::SearchLastSixMonths < Aggregations::MaterializedView
 end

--- a/app/models/aggregations/search_last_thirty_days.rb
+++ b/app/models/aggregations/search_last_thirty_days.rb
@@ -1,6 +1,2 @@
-class Aggregations::SearchLastThirtyDays < ApplicationRecord
-  def self.refresh
-    Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
-  end
+class Aggregations::SearchLastThirtyDays < Aggregations::MaterializedView
 end

--- a/app/models/aggregations/search_last_three_months.rb
+++ b/app/models/aggregations/search_last_three_months.rb
@@ -1,6 +1,2 @@
-class Aggregations::SearchLastThreeMonths < ApplicationRecord
-  def self.refresh
-    Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
-  end
+class Aggregations::SearchLastThreeMonths < Aggregations::MaterializedView
 end

--- a/app/models/aggregations/search_last_twelve_months.rb
+++ b/app/models/aggregations/search_last_twelve_months.rb
@@ -1,6 +1,2 @@
-class Aggregations::SearchLastTwelveMonths < ApplicationRecord
-  def self.refresh
-    Aggregations::MaterializedView.prepare
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
-  end
+class Aggregations::SearchLastTwelveMonths < Aggregations::MaterializedView
 end


### PR DESCRIPTION
This PR aims to simplify the logic for the search aggregations models and adds the ability for batch requests within Rails.

The following classes are now subclasses for `MaterializedViews`:
- `SearchLastThirtyDaysMonths`
- `SearchLastMonth`
- `SearchLastThreeMonths`
- `SearchLastSixMonths`
- `SearchLastTwelveMonths`

This allows use to push repeated logic into the parent class.

Also added a the primary_key attribute to the parent class required by Rails to perform batch requests.