### PR TITLE
Enable null values for satisfaction score

### DIFF
--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -45,7 +45,7 @@ private
       UPDATE facts_metrics
       SET useful_no = s.useful_no,
           useful_yes = s.useful_yes,
-          satisfaction= s.useful_yes / (s.useful_yes + s.useful_no::float)
+          satisfaction= s.useful_yes / NULLIF((s.useful_yes + s.useful_no::float),0)
       FROM (
         SELECT useful_no,
                useful_yes,

--- a/db/migrate/20190304151614_remove_default_satisfaction.rb
+++ b/db/migrate/20190304151614_remove_default_satisfaction.rb
@@ -1,0 +1,17 @@
+class RemoveDefaultSatisfaction < ActiveRecord::Migration[5.2]
+  def up
+    change_column :facts_metrics, :satisfaction, :float, null: true
+    change_column_default :facts_metrics, :satisfaction, nil
+
+    change_column :aggregations_monthly_metrics, :satisfaction, :float, null: true
+    change_column_default :aggregations_monthly_metrics, :satisfaction, nil
+  end
+
+  def down
+    change_column :facts_metrics, :satisfaction, :float, null: false
+    change_column_default :facts_metrics, :satisfaction, 0.0
+
+    change_column :aggregations_monthly_metrics, :satisfaction, :float, null: false
+    change_column_default :aggregations_monthly_metrics, :satisfaction, 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_25_113933) do
+ActiveRecord::Schema.define(version: 2019_03_04_151614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2019_02_25_113933) do
     t.integer "entrances"
     t.integer "bounces"
     t.integer "page_time"
-    t.float "satisfaction", default: 0.0, null: false
+    t.float "satisfaction"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_aggregations_monthly_metrics_on_created_at"
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 2019_02_25_113933) do
     t.integer "entrances", default: 0, null: false
     t.integer "bounces", default: 0, null: false
     t.integer "page_time", default: 0, null: false
-    t.float "satisfaction", default: 0.0, null: false
+    t.float "satisfaction"
     t.index ["dimensions_date_id", "dimensions_edition_id"], name: "metrics_edition_id_date_id", unique: true
     t.index ["dimensions_date_id", "feedex"], name: "index_facts_metrics_on_dimensions_date_id_and_feedex"
     t.index ["dimensions_date_id", "pviews"], name: "index_facts_metrics_on_dimensions_date_id_and_pviews"

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,15 @@
+namespace :data_migrations do
+  desc 'Sets all metrics with no useful yes/no responses to have null for satisfaction'
+  task satisfaction_defaults_to_null: :environment do
+    puts "Setting default satisfaction to nil for pages with no responses"
+
+    zero_responses = Facts::Metric.where('useful_yes = 0').where('useful_no = 0')
+
+    zero_responses.in_batches.each_with_index do |metrics, batch_index|
+      puts "Updating #{batch_index} records"
+      metrics.update_all(satisfaction: nil)
+    end
+
+    puts "END"
+  end
+end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -3,12 +3,10 @@ namespace :data_migrations do
   task satisfaction_defaults_to_null: :environment do
     puts "Setting default satisfaction to nil for pages with no responses"
 
-    zero_responses = Facts::Metric.where('useful_yes = 0').where('useful_no = 0')
-
-    zero_responses.in_batches.each_with_index do |metrics, batch_index|
-      puts "Updating #{batch_index} records"
-      metrics.update_all(satisfaction: nil)
-    end
+    Facts::Metric
+      .where('useful_yes = 0')
+      .where('useful_no = 0')
+      .update_all(satisfaction: nil)
 
     puts "END"
   end

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
 
       expect(fact.reload.satisfaction).to be_within(0.1).of(0.0)
     end
+
+    it 'set `satisfaction = nil` with `useful_yes:0` and `no: 0`' do
+      allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_yield(ga_response(useful_yes: 0, useful_no: 0))
+      described_class.process(date: date)
+
+      expect(fact.reload.satisfaction).to be_nil
+    end
   end
 
   it_behaves_like 'traps and logs errors in process', Etl::GA::UserFeedbackService, :find_in_batches


### PR DESCRIPTION
Null values are a valid representation of satisfaction scores, as it
denotes that we did not get any responses for the yes/no survey. This
also fixes the representation of data in the graphs, which until now
have been misleading - setting 0 as a satisfacion score (the default
value) for periods even before the rollout of the yes/no survey is
misleading.

## After
The code changes and running the rake task results in the Content Data Admin's graphs handling null values as blanks on the graph, instead of defaulting to zeros:

![screenshot at mar 08 9-54-21 am](https://user-images.githubusercontent.com/424772/54021575-5ccff100-4188-11e9-8641-ae820648597a.png)
