### PR TITLE
Add missing `requires` for ETL rake tasks

### DIFF
--- a/app/domain/etl/ga/internal_search_processor.rb
+++ b/app/domain/etl/ga/internal_search_processor.rb
@@ -1,3 +1,4 @@
+require_dependency 'concerns/trace_and_recoverable'
 class Etl::GA::InternalSearchProcessor
   include Concerns::TraceAndRecoverable
   include Etl::GA::Concerns::TransformPath

--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -1,3 +1,4 @@
+require_dependency 'concerns/trace_and_recoverable'
 class Etl::GA::UserFeedbackProcessor
   include Concerns::TraceAndRecoverable
   include Etl::GA::Concerns::TransformPath


### PR DESCRIPTION
The etl:repopulate_feedex and the etl:repopulate_searches rake task are missing trace_and_recoverable dependency. This adds in the require.