### PR TITLE
Add new content schemas: facet, facet_group, facet_value

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -8,6 +8,9 @@ class Etl::Edition::Content::Parsers::NoContent
       coming_soon
       completed_transaction
       external_content
+      facet
+      facet_group
+      facet_value
       generic
       homepage
       knowledge_alpha

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Etl::Edition::Content::Parser do
       coming_soon
       completed_transaction
       external_content
+      facet
+      facet_group
+      facet_value
       generic
       homepage
       knowledge_alpha

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -15,4 +15,84 @@ RSpec.describe 'Process all schemas' do
       end
     end
   end
+
+  it 'knows how to parse all GOV.UK schemas' do
+    expect(known_schemas).to match_array(GovukSchemas::Schema.schema_names)
+  end
+
+private
+
+  def known_schemas
+    %w[
+      answer
+      calendar
+      case_study
+      coming_soon
+      completed_transaction
+      consultation
+      contact
+      corporate_information_page
+      detailed_guide
+      document_collection
+      email_alert_signup
+      external_content
+      facet
+      facet_group
+      facet_value
+      fatality_notice
+      finder
+      finder_email_signup
+      generic
+      generic_with_external_related_links
+      gone
+      guide
+      help_page
+      hmrc_manual
+      hmrc_manual_section
+      homepage
+      html_publication
+      knowledge_alpha
+      licence
+      local_transaction
+      mainstream_browse_page
+      manual
+      manual_section
+      need
+      news_article
+      organisation
+      organisations_homepage
+      person
+      place
+      placeholder
+      publication
+      redirect
+      role
+      role_appointment
+      service_manual_guide
+      service_manual_homepage
+      service_manual_service_standard
+      service_manual_service_toolkit
+      service_manual_topic
+      service_sign_in
+      simple_smart_answer
+      special_route
+      specialist_document
+      speech
+      statistical_data_set
+      statistics_announcement
+      step_by_step_nav
+      take_part
+      taxon
+      topic
+      topical_event_about_page
+      transaction
+      travel_advice
+      travel_advice_index
+      unpublishing
+      vanish
+      working_group
+      world_location
+      world_location_news_article
+    ]
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/uzEzp9XA/1239-detect-when-a-new-schema-is-added-and-make-cpm-build-to-fail) 

All the schemas are provided by the GEM [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/). 
If a schema is added (or removed) we need to update our code accordingly.

This PR will:

1. Add handlers to missing schemas: `facet`, `facet_group` and `facet_value`
2. Add a test to ensure that this does not happen again.