### PR TITLE
Add type casts to aggregation views

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -115,16 +115,16 @@ private
       title: array[:title],
       organisation_id: array[:organisation_id],
       document_type: array[:document_type],
-      upviews: array[:upviews].to_i,
-      pviews: array[:pviews].to_i,
-      useful_yes: array[:useful_yes].to_i,
-      useful_no: array[:useful_no].to_i,
-      feedex: array[:feedex].to_i,
+      upviews: array[:upviews],
+      pviews: array[:pviews],
+      useful_yes: array[:useful_yes],
+      useful_no: array[:useful_no],
+      feedex: array[:feedex],
       satisfaction: array[:satisfaction],
-      searches: array[:searches].to_i,
-      pdf_count: array[:pdf_count].to_i,
-      words: array[:words].to_i,
-      reading_time: array[:reading_time].to_i
+      searches: array[:searches],
+      pdf_count: array[:pdf_count],
+      words: array[:words],
+      reading_time: array[:reading_time],
     }
   end
 end

--- a/db/migrate/20190311163406_update_aggregations_search_last_twelve_months_to_version_7.rb
+++ b/db/migrate/20190311163406_update_aggregations_search_last_twelve_months_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastTwelveMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_twelve_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190311164157_update_aggregations_search_last_six_months_to_version_7.rb
+++ b/db/migrate/20190311164157_update_aggregations_search_last_six_months_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastSixMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_six_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190311164340_update_aggregations_search_last_three_months_to_version_7.rb
+++ b/db/migrate/20190311164340_update_aggregations_search_last_three_months_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastThreeMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_three_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/migrate/20190311164541_update_aggregations_search_last_months_to_version_5.rb
+++ b/db/migrate/20190311164541_update_aggregations_search_last_months_to_version_5.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastMonthsToVersion5 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_months,
+      version: 5,
+      revert_to_version: 4,
+      materialized: true
+  end
+end

--- a/db/migrate/20190311164701_update_aggregations_search_last_thirty_days_to_version_7.rb
+++ b/db/migrate/20190311164701_update_aggregations_search_last_thirty_days_to_version_7.rb
@@ -1,0 +1,8 @@
+class UpdateAggregationsSearchLastThirtyDaysToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :aggregations_search_last_thirty_days,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_04_151614) do
+ActiveRecord::Schema.define(version: 2019_03_11_164701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,111 +209,23 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
   add_foreign_key "facts_metrics", "dimensions_dates", primary_key: "date"
   add_foreign_key "facts_metrics", "dimensions_editions"
 
-  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
+  create_view "aggregations_search_last_twelve_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
       dimensions_editions.title,
       dimensions_editions.document_type,
       dimensions_editions.base_path,
       dimensions_editions.organisation_id,
       dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
-              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(facts_metrics.upviews) AS upviews,
-              sum(facts_metrics.pviews) AS pviews,
-              sum(facts_metrics.useful_yes) AS useful_yes,
-              sum(facts_metrics.useful_no) AS useful_no,
-              sum(facts_metrics.feedex) AS feedex,
-              sum(facts_metrics.searches) AS searches
-             FROM ((facts_metrics
-               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
-               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
-            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
-  SQL
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
-  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
-  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
-  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
-  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
-  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
-
-  create_view "aggregations_search_last_months", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
-          CASE
-              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
-              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
-          END AS satisfaction,
-      aggregations.searches,
-      facts_editions.words,
-      facts_editions.pdf_count,
-      facts_editions.reading_time
-     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
-              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
-              sum(aggregations_monthly_metrics.upviews) AS upviews,
-              sum(aggregations_monthly_metrics.pviews) AS pviews,
-              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
-              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
-              sum(aggregations_monthly_metrics.feedex) AS feedex,
-              sum(aggregations_monthly_metrics.searches) AS searches
-             FROM ((aggregations_monthly_metrics
-               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
-               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
-            WHERE ((dimensions_months.id)::text = to_char((now() - '1 mon'::interval), 'YYYY-MM'::text))
-            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
-       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
-       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
-    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
-  SQL
-  add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_month_gin_title", using: :gin
-  add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin
-  add_index "aggregations_search_last_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_month_document_type"
-  add_index "aggregations_search_last_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_month_organisation_id"
-  add_index "aggregations_search_last_months", ["upviews", "warehouse_item_id"], name: "search_last_month_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
-  add_index "aggregations_search_last_months", ["warehouse_item_id"], name: "aggregations_search_last_months_pk", unique: true
-
-  create_view "aggregations_search_last_three_months", materialized: true, sql_definition: <<-SQL
-      SELECT dimensions_editions.warehouse_item_id,
-      dimensions_editions.title,
-      dimensions_editions.document_type,
-      dimensions_editions.base_path,
-      dimensions_editions.organisation_id,
-      dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
+      (aggregations.upviews)::bigint AS upviews,
+      (aggregations.pviews)::bigint AS pviews,
+      (aggregations.feedex)::bigint AS feedex,
+      (aggregations.useful_yes)::bigint AS useful_yes,
+      (aggregations.useful_no)::bigint AS useful_no,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
           END AS satisfaction,
-      aggregations.searches,
+      (aggregations.searches)::bigint AS searches,
       facts_editions.words,
       facts_editions.pdf_count,
       facts_editions.reading_time
@@ -336,7 +248,7 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
                      FROM ((aggregations_monthly_metrics
                        JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
                        JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
-                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM'::text))
+                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM'::text))
                     GROUP BY dimensions_editions_1.warehouse_item_id
                   UNION
                    SELECT dimensions_editions_1.warehouse_item_id,
@@ -350,19 +262,19 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
                      FROM ((facts_metrics
                        JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                        JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM-01'::text))::date))
+                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM-01'::text))::date))
                     GROUP BY dimensions_editions_1.warehouse_item_id) agg
             GROUP BY agg.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
     WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
   SQL
-  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_three_months_gin_title", using: :gin
-  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
-  add_index "aggregations_search_last_three_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_three_months_document_type"
-  add_index "aggregations_search_last_three_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
-  add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
-  add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
+  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_twelve_months_gin_title", using: :gin
+  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
+  add_index "aggregations_search_last_twelve_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_document_type"
+  add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
+  add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
+  add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
 
   create_view "aggregations_search_last_six_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
@@ -371,16 +283,16 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
       dimensions_editions.base_path,
       dimensions_editions.organisation_id,
       dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
+      (aggregations.upviews)::bigint AS upviews,
+      (aggregations.pviews)::bigint AS pviews,
+      (aggregations.feedex)::bigint AS feedex,
+      (aggregations.useful_yes)::bigint AS useful_yes,
+      (aggregations.useful_no)::bigint AS useful_no,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
           END AS satisfaction,
-      aggregations.searches,
+      (aggregations.searches)::bigint AS searches,
       facts_editions.words,
       facts_editions.pdf_count,
       facts_editions.reading_time
@@ -431,23 +343,23 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
   add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_six_months", ["warehouse_item_id"], name: "aggregations_search_last_six_months_pk", unique: true
 
-  create_view "aggregations_search_last_twelve_months", materialized: true, sql_definition: <<-SQL
+  create_view "aggregations_search_last_three_months", materialized: true, sql_definition: <<-SQL
       SELECT dimensions_editions.warehouse_item_id,
       dimensions_editions.title,
       dimensions_editions.document_type,
       dimensions_editions.base_path,
       dimensions_editions.organisation_id,
       dimensions_editions.id AS dimensions_edition_id,
-      aggregations.upviews,
-      aggregations.pviews,
-      aggregations.feedex,
-      aggregations.useful_yes,
-      aggregations.useful_no,
+      (aggregations.upviews)::bigint AS upviews,
+      (aggregations.pviews)::bigint AS pviews,
+      (aggregations.feedex)::bigint AS feedex,
+      (aggregations.useful_yes)::bigint AS useful_yes,
+      (aggregations.useful_no)::bigint AS useful_no,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
           END AS satisfaction,
-      aggregations.searches,
+      (aggregations.searches)::bigint AS searches,
       facts_editions.words,
       facts_editions.pdf_count,
       facts_editions.reading_time
@@ -470,7 +382,7 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
                      FROM ((aggregations_monthly_metrics
                        JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
                        JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
-                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM'::text))
+                    WHERE ((dimensions_months.id)::text >= to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM'::text))
                     GROUP BY dimensions_editions_1.warehouse_item_id
                   UNION
                    SELECT dimensions_editions_1.warehouse_item_id,
@@ -484,18 +396,106 @@ ActiveRecord::Schema.define(version: 2019_03_04_151614) do
                      FROM ((facts_metrics
                        JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
                        JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
-                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '1 year'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '11 mons'::interval), 'YYYY-MM-01'::text))::date))
+                    WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '3 mons'::interval)) AND (facts_metrics.dimensions_date_id < (to_char((('yesterday'::text)::date - '2 mons'::interval), 'YYYY-MM-01'::text))::date))
                     GROUP BY dimensions_editions_1.warehouse_item_id) agg
             GROUP BY agg.warehouse_item_id) aggregations
        JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
        JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
     WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
   SQL
-  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_twelve_months_gin_title", using: :gin
-  add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
-  add_index "aggregations_search_last_twelve_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_document_type"
-  add_index "aggregations_search_last_twelve_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
-  add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
-  add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
+  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_three_months_gin_title", using: :gin
+  add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
+  add_index "aggregations_search_last_three_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_three_months_document_type"
+  add_index "aggregations_search_last_three_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
+  add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
+  add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
+
+  create_view "aggregations_search_last_months", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
+              max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(aggregations_monthly_metrics.upviews) AS upviews,
+              sum(aggregations_monthly_metrics.pviews) AS pviews,
+              sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+              sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+              sum(aggregations_monthly_metrics.feedex) AS feedex,
+              sum(aggregations_monthly_metrics.searches) AS searches
+             FROM ((aggregations_monthly_metrics
+               JOIN dimensions_months ON (((dimensions_months.id)::text = (aggregations_monthly_metrics.dimensions_month_id)::text)))
+               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = aggregations_monthly_metrics.dimensions_edition_id)))
+            WHERE ((dimensions_months.id)::text = to_char((now() - '1 mon'::interval), 'YYYY-MM'::text))
+            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_month_gin_title", using: :gin
+  add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin
+  add_index "aggregations_search_last_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_month_document_type"
+  add_index "aggregations_search_last_months", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_month_organisation_id"
+  add_index "aggregations_search_last_months", ["upviews", "warehouse_item_id"], name: "search_last_month_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
+  add_index "aggregations_search_last_months", ["warehouse_item_id"], name: "aggregations_search_last_months_pk", unique: true
+
+  create_view "aggregations_search_last_thirty_days", materialized: true, sql_definition: <<-SQL
+      SELECT dimensions_editions.warehouse_item_id,
+      dimensions_editions.title,
+      dimensions_editions.document_type,
+      dimensions_editions.base_path,
+      dimensions_editions.organisation_id,
+      dimensions_editions.id AS dimensions_edition_id,
+      aggregations.upviews,
+      aggregations.pviews,
+      aggregations.feedex,
+      aggregations.useful_yes,
+      aggregations.useful_no,
+          CASE
+              WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
+              ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
+          END AS satisfaction,
+      aggregations.searches,
+      facts_editions.words,
+      facts_editions.pdf_count,
+      facts_editions.reading_time
+     FROM ((( SELECT dimensions_editions_1.warehouse_item_id,
+              max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+              sum(facts_metrics.upviews) AS upviews,
+              sum(facts_metrics.pviews) AS pviews,
+              sum(facts_metrics.useful_yes) AS useful_yes,
+              sum(facts_metrics.useful_no) AS useful_no,
+              sum(facts_metrics.feedex) AS feedex,
+              sum(facts_metrics.searches) AS searches
+             FROM ((facts_metrics
+               JOIN dimensions_dates ON ((dimensions_dates.date = facts_metrics.dimensions_date_id)))
+               JOIN dimensions_editions dimensions_editions_1 ON ((dimensions_editions_1.id = facts_metrics.dimensions_edition_id)))
+            WHERE ((facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day)) AND (facts_metrics.dimensions_date_id < ('now'::text)::date))
+            GROUP BY dimensions_editions_1.warehouse_item_id) aggregations
+       JOIN dimensions_editions ON ((aggregations.dimensions_edition_id = dimensions_editions.id)))
+       JOIN facts_editions ON ((dimensions_editions.id = facts_editions.dimensions_edition_id)))
+    WHERE ((dimensions_editions.document_type)::text <> ALL ((ARRAY['gone'::character varying, 'vanish'::character varying, 'need'::character varying, 'unpublishing'::character varying, 'redirect'::character varying])::text[]));
+  SQL
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
+  add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
+  add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
+  add_index "aggregations_search_last_thirty_days", ["organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
+  add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
+  add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
 end

--- a/db/views/aggregations_search_last_months_v05.sql
+++ b/db/views/aggregations_search_last_months_v05.sql
@@ -1,0 +1,38 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.pviews) AS pviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.feedex) AS feedex,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id = to_char(NOW() - interval '1 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_six_months_v07.sql
+++ b/db/views/aggregations_search_last_six_months_v07.sql
@@ -1,0 +1,66 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '5 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '6 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '5 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_thirty_days_v07.sql
+++ b/db/views/aggregations_search_last_thirty_days_v07.sql
@@ -1,0 +1,40 @@
+SELECT
+  dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.pviews) AS pviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.feedex) AS feedex,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+     WHERE (facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day))
+       AND (facts_metrics.dimensions_date_id < ('now'::text)::date)
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_three_months_v07.sql
+++ b/db/views/aggregations_search_last_three_months_v07.sql
@@ -1,0 +1,66 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '3 month')
+             AND facts_metrics.dimensions_date_id < to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_twelve_months_v07.sql
+++ b/db/views/aggregations_search_last_twelve_months_v07.sql
@@ -1,0 +1,67 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.organisation_id as organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT  warehouse_item_id,
+    max(agg.dimensions_edition_id) AS dimensions_edition_id,
+    sum(agg.upviews) AS upviews,
+    sum(agg.pviews) AS pviews,
+    sum(agg.useful_yes) AS useful_yes,
+    sum(agg.useful_no) AS useful_no,
+    sum(agg.feedex) AS feedex,
+    sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '11 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '12 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '11 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')
+


### PR DESCRIPTION
This adds integer type casts to the aggregations views as there is no way to specify column types for materialised view. We currently cast the type in the Content finder. Moving the type cast to Postgres, removes complexity from the finder and helps support batch querying need for CSV requests.