### PR TITLE
Use GOVUK_APP_NAME for the RabbitMQ queues

### DIFF
--- a/lib/tasks/publishing_api_consumer.rake
+++ b/lib/tasks/publishing_api_consumer.rake
@@ -1,11 +1,17 @@
 require_relative '../../app/domain/streams/consumer'
 
+# This is just useful when changing Content Performance Manager to the
+# Content Data API, and can be removed afterwards
+def app_name
+  ENV.fetch('GOVUK_APP_NAME', 'content-performance-manager')
+end
+
 namespace :publishing_api do
   desc "Run worker to publishing API from rabbitmq"
   task consumer: :environment do
     begin
       GovukMessageQueueConsumer::Consumer.new(
-        queue_name: "content_performance_manager",
+        queue_name: app_name.underscore,
         processor: Streams::Consumer.new,
       ).run
     rescue SignalException
@@ -17,7 +23,7 @@ namespace :publishing_api do
   task bulk_import_consumer: :environment do
     begin
       GovukMessageQueueConsumer::Consumer.new(
-        queue_name: "content_performance_manager_govuk_importer",
+        queue_name: "#{app_name.underscore}_govuk_importer",
         processor: Streams::Consumer.new,
       ).run
     rescue SignalException


### PR DESCRIPTION
This means that when running as the Content Data API, the queues will
be correct.