### PR TITLE
Fix the Healthchecks::SearchAggregations test to be more consistent

### DIFF
--- a/spec/domain/healthchecks/search_aggregations_spec.rb
+++ b/spec/domain/healthchecks/search_aggregations_spec.rb
@@ -9,14 +9,12 @@ RSpec.describe Healthchecks::SearchAggregations do
   describe 'status' do
     let!(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
     let!(:edition) { create :edition, organisation_id: primary_org_id }
-    let!(:metric1) { create :metric, edition: edition, date: 15.days.ago }
-    let!(:metric2) { create :metric, edition: edition, date: 10.days.ago }
-
-    let(:from) { Date.today.last_month.beginning_of_month }
-    let(:to) { Date.today.last_month.end_of_month }
 
     context 'When there are search views for the last thirty days' do
       before do
+        create :metric, edition: edition, date: Date.today.last_month.beginning_of_month
+        create :metric, edition: edition, date: Date.today.last_month.end_of_month
+
         recalculate_aggregations!
       end
 
@@ -25,6 +23,10 @@ RSpec.describe Healthchecks::SearchAggregations do
     end
 
     context 'There are no search views for the last month' do
+      before do
+        recalculate_aggregations!
+      end
+
       its(:status) { is_expected.to eq(:critical) }
       its(:message) { is_expected.to eq('ETL :: no Last month searches updated from yesterday') }
     end


### PR DESCRIPTION
Previously, it worked for the first half of the month, as the metric
created 15.days.ago was in the previous month. However, this didn't
work in the later half of the month.

Switch to placing the created metrics always in the last month, so
that the test passes throughout the month.

Also call recalculate_aggregations! in the second context block, as
I'm not sure this happens automatically, and it might be necessary.