### PR TITLE
Fix monthly aggrgation healthcheck using timestamp

### DIFF
--- a/app/domain/healthchecks/monthly_aggregations.rb
+++ b/app/domain/healthchecks/monthly_aggregations.rb
@@ -17,7 +17,7 @@ module Healthchecks
   private
 
     def aggregations
-      @aggregations ||= Aggregations::MonthlyMetric.where(created_at: Date.today).count
+      @aggregations ||= Aggregations::MonthlyMetric.where('created_at > ?', Date.today).count
     end
   end
 end

--- a/spec/domain/healthchecks/monthly_aggregations_spec.rb
+++ b/spec/domain/healthchecks/monthly_aggregations_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Healthchecks::MonthlyAggregations do
   include_examples 'Healthcheck enabled/disabled within time range'
 
   around do |example|
-    Timecop.freeze(Date.new(2019, 2, 22)) { example.run }
+    Timecop.freeze(Time.zone.local(2019, 2, 22, 14, 0)) { example.run }
   end
 
   its(:name) { is_expected.to eq(:aggregations) }


### PR DESCRIPTION
The changes the healthcheck to count rows where the date is any timestamp during the current day. Previously it was failing because it was checking for rows with a date stamp equal to current day, ignoring the time element. i.e. `2019-2-22` doesn't equal `2019-2-22 07:30:14`