### PR TITLE
Add missing attributes to transform_path helper

### DIFF
--- a/app/domain/etl/ga/concerns/transform_path.rb
+++ b/app/domain/etl/ga/concerns/transform_path.rb
@@ -22,6 +22,11 @@ private
     if duplicate_event
       attributes[:pviews] = event.pviews + duplicate_event.pviews
       attributes[:upviews] = event.upviews + duplicate_event.upviews
+      attributes[:useful_no] = event.useful_no + duplicate_event.useful_no
+      attributes[:useful_yes] = event.useful_yes + duplicate_event.useful_yes
+      attributes[:searches] = event.searches + duplicate_event.searches
+      attributes[:entrances] = event.entrances + duplicate_event.entrances
+      attributes[:exits] = event.exits + duplicate_event.exits
 
       duplicate_event.destroy
     end

--- a/app/domain/etl/ga/concerns/transform_path.rb
+++ b/app/domain/etl/ga/concerns/transform_path.rb
@@ -20,13 +20,10 @@ private
     attributes = { page_path: sanitised_page_path }
 
     if duplicate_event
-      attributes[:pviews] = event.pviews + duplicate_event.pviews
-      attributes[:upviews] = event.upviews + duplicate_event.upviews
-      attributes[:useful_no] = event.useful_no + duplicate_event.useful_no
-      attributes[:useful_yes] = event.useful_yes + duplicate_event.useful_yes
-      attributes[:searches] = event.searches + duplicate_event.searches
-      attributes[:entrances] = event.entrances + duplicate_event.entrances
-      attributes[:exits] = event.exits + duplicate_event.exits
+      metric_names = Metric.ga_metrics.map(&:name)
+      metric_names.each do |metric|
+        attributes[metric.to_sym] = event.send(metric) + duplicate_event.send(metric)
+      end
 
       duplicate_event.destroy
     end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -23,6 +23,11 @@ class Metric
     source['daily'].map { |attributes| Metric.new(attributes) }
   end
 
+  def self.ga_metrics
+    ga_source = source['daily'].select { |value| value['source'] == 'Google Analytics' }
+    ga_source.map { |attributes| Metric.new(attributes) }
+  end
+
   def self.source
     @source ||= YAML.load_file(Rails.root.join('config', 'metrics.yml'))
   end

--- a/spec/domain/etl/ga/concerns/transform_path_spec.rb
+++ b/spec/domain/etl/ga/concerns/transform_path_spec.rb
@@ -51,15 +51,8 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
     end
 
     it 'returns the correct number of metrics' do
-      event_attributes = event2.attribute_names
-        .reject { |name| name == 'id' }
-        .reject { |name| name == 'bounces' }
-        .reject { |name| name == 'date' }
-        .reject { |name| name == 'page_path' }
-        .reject { |name| name == 'updated_at' }
-        .reject { |name| name == 'created_at' }
-        .reject { |name| name == 'process_name' }
-        .reject { |name| name == 'page_time' }
+      names_to_exclude = %w(id bounces date page_path updated_at created_at process_name page_time)
+      event_attributes = event2.attribute_names.reject { |name| names_to_exclude.include?(name) }
 
       subject.format_events_with_invalid_prefix
 

--- a/spec/domain/etl/ga/concerns/transform_path_spec.rb
+++ b/spec/domain/etl/ga/concerns/transform_path_spec.rb
@@ -18,10 +18,38 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
   context 'when an event exists with the same page_path after formatting' do
     subject { Dummy.new }
 
-    let!(:event2) { create(:ga_event, :with_views, page_path: "/https://www.gov.uk/topics", upviews: 1, pviews: 1) }
+    let!(:event2) do
+      create(
+        :ga_event,
+        :with_views,
+        page_path: "/https://www.gov.uk/topics",
+        upviews: 1,
+        pviews: 1,
+        useful_no: 1,
+        useful_yes: 1,
+        searches: 1,
+        entrances: 1,
+        exits: 1
+      )
+    end
 
     before(:each) do
-      create(:ga_event, :with_views, page_path: "/topics", upviews: 100, pviews: 200)
+      create(:ga_event,
+        :with_views,
+        page_path: "/topics",
+        upviews: 100,
+        pviews: 200,
+        useful_no: 300,
+        useful_yes: 400,
+        searches: 500,
+        entrances: 600,
+        exits: 700)
+    end
+
+    it 'updates events with their combined upviews' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.upviews).to eq 101
     end
 
     it 'updates events with their combined pviews' do
@@ -30,10 +58,34 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
       expect(event2.reload.pviews).to eq 201
     end
 
-    it 'updates events with their combined upviews' do
+    it 'updates events with their combines useful_no' do
       subject.format_events_with_invalid_prefix
 
-      expect(event2.reload.upviews).to eq 101
+      expect(event2.reload.useful_no).to eq 301
+    end
+
+    it 'updates events with their combines useful_yes' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.useful_yes).to eq 401
+    end
+
+    it 'updates events with their combines searches' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.searches).to eq 501
+    end
+
+    it 'updates events with their combines entrances' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.entrances).to eq 601
+    end
+
+    it 'updates events with their combines exits' do
+      subject.format_events_with_invalid_prefix
+
+      expect(event2.reload.exits).to eq 701
     end
 
     it 'deletes the duplicated event' do


### PR DESCRIPTION
We were not consolidating metrics from Google Analytics such as searches
when addressing duplicate paths from GA reports. This resulted in odd
numbers in our data.