### PR TITLE
Fix rake tasks to repopulate feedex

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -45,12 +45,23 @@ namespace :etl do
   end
 
   desc 'Run Etl::GA::UserFeedbackProcessor for range of dates'
+  task :repopulate_useful, %i[from to] => [:environment] do |_t, args|
+    from = args[:from].to_date
+    to = args[:to].to_date
+    (from..to).each do |date|
+      console_log "repopulating useful scores for #{date}"
+      Etl::GA::UserFeedbackProcessor.process(date: date)
+      console_log "finished repopulating useful scores for #{date}"
+    end
+  end
+
+  desc 'Run Etl::Feedex::Processor for range of dates'
   task :repopulate_feedex, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date
     to = args[:to].to_date
     (from..to).each do |date|
       console_log "repopulating feedex for #{date}"
-      Etl::GA::UserFeedbackProcessor.process(date: date)
+      Etl::Feedex::Processor.process(date: date)
       console_log "finished repopulating feedex for #{date}"
     end
   end

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -54,9 +54,21 @@ RSpec.describe 'etl.rake', type: task do
     end
   end
 
-  describe 'rake etl:repopulate_feedex' do
+  describe 'rake etl:repopulate_useful' do
     it 'calls Etl::GA::UserFeedbackProcessor.process with each date' do
       processor = class_double(Etl::GA::UserFeedbackProcessor, process: true).as_stubbed_const
+
+      Rake::Task['etl:repopulate_useful'].invoke('2018-11-01', '2018-11-03')
+
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
+    end
+  end
+
+  describe 'rake etl:repopulate_feedex' do
+    it 'calls Etl::Feedex::Processor.process with each date' do
+      processor = class_double(Etl::Feedex::Processor, process: true).as_stubbed_const
 
       Rake::Task['etl:repopulate_feedex'].invoke('2018-11-01', '2018-11-03')
 


### PR DESCRIPTION
The rake task to repopulate feedex incorrectly ran the GA feedback processor. This adds a new rake task repopulate_useful to run GA feedback processor and reconfigures repopulate_feedex to run the Feedex processor.