### PR TITLE
Redefine `latest` to `live` for editions

### DIFF
--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -25,7 +25,7 @@ module Etl
         log process: :metrics, message: 'about to get the Dimensions::Date'
         dimensions_date = Dimensions::Date.find_or_create(date)
         log process: :metrics, message: 'got the Dimensions::Date'
-        Dimensions::Edition.latest.find_in_batches(batch_size: 50000)
+        Dimensions::Edition.live.find_in_batches(batch_size: 50000)
           .with_index do |batch, index|
           log process: :metrics, message: "processing #{batch.length} items in batch #{index}"
           values = batch.pluck(:id).map do |value|

--- a/app/domain/finders/all_document_types.rb
+++ b/app/domain/finders/all_document_types.rb
@@ -16,9 +16,9 @@ private
   def query
     <<-SQL
       WITH RECURSIVE temp AS (
-        (SELECT document_type FROM dimensions_editions WHERE latest ORDER BY document_type LIMIT 1)
+        (SELECT document_type FROM dimensions_editions WHERE live ORDER BY document_type LIMIT 1)
           UNION ALL
-         SELECT (SELECT document_type FROM dimensions_editions WHERE document_type > temp.document_type AND latest ORDER BY document_type LIMIT 1)
+         SELECT (SELECT document_type FROM dimensions_editions WHERE document_type > temp.document_type AND live ORDER BY document_type LIMIT 1)
          FROM temp
          WHERE temp.document_type IS NOT NULL
       )

--- a/app/domain/finders/all_organisations.rb
+++ b/app/domain/finders/all_organisations.rb
@@ -19,7 +19,7 @@ private
   end
 
   def find_all(locale)
-    Dimensions::Edition.latest
+    Dimensions::Edition.live
       .select(:content_id, :title, :locale, :acronym)
       .where(document_type: 'organisation', locale: locale)
       .order(:title)

--- a/app/domain/finders/edition_metrics.rb
+++ b/app/domain/finders/edition_metrics.rb
@@ -2,7 +2,7 @@ class Finders::EditionMetrics
   def self.run(base_path, metric_names = nil)
     metric_names ||= Metric.edition_metrics.map(&:name)
 
-    item = Dimensions::Edition.find_by(base_path: base_path, latest: true)
+    item = Dimensions::Edition.find_by(base_path: base_path, live: true)
     edition = item.facts_edition
     metric_names.map do |metric_name|
       { name: metric_name, value: edition.attributes[metric_name] }

--- a/app/domain/finders/metadata.rb
+++ b/app/domain/finders/metadata.rb
@@ -1,6 +1,6 @@
 class Finders::Metadata
   def self.run(base_path)
-    latest_item = Dimensions::Edition.latest_by_base_path(base_path).first
-    latest_item.nil? ? nil : latest_item.metadata
+    live_item = Dimensions::Edition.live_by_base_path(base_path).first
+    live_item.nil? ? nil : live_item.metadata
   end
 end

--- a/app/domain/monitor/dimensions.rb
+++ b/app/domain/monitor/dimensions.rb
@@ -7,17 +7,17 @@ class Monitor::Dimensions
   def run
     trap do
       statsd_for_all_base_paths!
-      statsd_for_latest_base_paths!
+      statsd_for_live_base_paths!
       statsd_for_all_content_items!
-      statsd_for_latest_content_items!
+      statsd_for_live_content_items!
     end
   end
 
 private
 
-  def statsd_for_latest_base_paths!
-    path = path_for('latest_base_paths')
-    count = Dimensions::Edition.latest.count
+  def statsd_for_live_base_paths!
+    path = path_for('live_base_paths')
+    count = Dimensions::Edition.live.count
 
     GovukStatsd.count(path, count)
   end
@@ -29,9 +29,9 @@ private
     GovukStatsd.count(path, count)
   end
 
-  def statsd_for_latest_content_items!
-    path = path_for('latest_content_items')
-    count = Dimensions::Edition.latest.count('distinct content_id')
+  def statsd_for_live_content_items!
+    path = path_for('live_content_items')
+    count = Dimensions::Edition.live.count('distinct content_id')
 
     GovukStatsd.count(path, count)
   end

--- a/app/domain/streams/grow_dimension.rb
+++ b/app/domain/streams/grow_dimension.rb
@@ -37,6 +37,6 @@ private
   end
 
   def excluded_from_comparison?(key, _value)
-    %i[publishing_api_payload_version public_updated_at id update_at created_at latest warehouse_item_id publishing_api_event_id].include? key
+    %i[publishing_api_payload_version public_updated_at id update_at created_at live warehouse_item_id publishing_api_event_id].include? key
   end
 end

--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -18,10 +18,10 @@ class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
 private
 
   def find_old_edition(hash)
-    { attrs: hash, old_edition: Dimensions::Edition.latest_by_base_path(hash[:base_path]).first }
+    { attrs: hash, old_edition: Dimensions::Edition.live_by_base_path(hash[:base_path]).first }
   end
 
   def deprecate_redundant_paths(current_base_paths)
-    Dimensions::Edition.outdated_subpages(content_id, locale, current_base_paths).update(latest: false)
+    Dimensions::Edition.outdated_subpages(content_id, locale, current_base_paths).update(live: false)
   end
 end

--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -18,7 +18,8 @@ class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
 private
 
   def find_old_edition(hash)
-    { attrs: hash, old_edition: Dimensions::Edition.live_by_base_path(hash[:base_path]).first }
+    old_edition = Dimensions::Edition.find_latest(hash[:warehouse_item_id])
+    { attrs: hash, old_edition: old_edition }
   end
 
   def deprecate_redundant_paths(current_base_paths)

--- a/app/domain/streams/handlers/single_item_handler.rb
+++ b/app/domain/streams/handlers/single_item_handler.rb
@@ -15,14 +15,14 @@ class Streams::Handlers::SingleItemHandler < Streams::Handlers::BaseHandler
   attr_reader :attrs, :old_edition
 
   def process
-    update_editions [attrs: attrs, old_edition: find_old_edition(attrs[:content_id], attrs[:locale])]
+    update_editions [attrs: attrs, old_edition: find_old_edition(attrs[:warehouse_item_id], attrs[:locale])]
   end
 
 private
 
-  def find_old_edition(content_id, locale)
+  def find_old_edition(warehouse_item_id, locale)
     raise MissingLocaleError unless locale
 
-    Dimensions::Edition.find_by(content_id: content_id, locale: locale, live: true)
+    Dimensions::Edition.find_latest(warehouse_item_id)
   end
 end

--- a/app/domain/streams/handlers/single_item_handler.rb
+++ b/app/domain/streams/handlers/single_item_handler.rb
@@ -23,6 +23,6 @@ private
   def find_old_edition(content_id, locale)
     raise MissingLocaleError unless locale
 
-    Dimensions::Edition.find_by(content_id: content_id, locale: locale, latest: true)
+    Dimensions::Edition.find_by(content_id: content_id, locale: locale, live: true)
   end
 end

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -26,7 +26,7 @@ class Streams::Messages::BaseMessage
       rendering_app: @payload.fetch('rendering_app', nil),
       analytics_identifier: @payload.fetch('analytics_identifier', nil),
       update_type: @payload.fetch('update_type', nil),
-      latest: false,
+      live: false,
       warehouse_item_id: warehouse_item_id,
       withdrawn: withdrawn_notice?,
       historical: historically_political?,

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -11,14 +11,9 @@ class Dimensions::Edition < ApplicationRecord
   validates :warehouse_item_id, presence: true
 
   scope :by_base_path, ->(base_path) { where('base_path like (?)', base_path) }
-  scope :by_content_id, ->(content_id) { where(content_id: content_id) }
-  scope :by_organisation_id, ->(organisation_id) { where(organisation_id: organisation_id) }
-  scope :by_document_type, ->(document_type) { where('document_type like (?)', document_type) }
-  scope :by_locale, ->(locale) { where(locale: locale) }
   scope :live, -> { where(live: true) }
   scope :live_by_content_id, ->(content_id, locale) { where(content_id: content_id, locale: locale, live: true) }
   scope :live_by_base_path, ->(base_paths) { where(base_path: base_paths, live: true) }
-  scope :existing_live_editions, ->(content_id, locale, base_paths) { live_by_content_id(content_id, locale).or(live_by_base_path(base_paths)) }
   scope :outdated_subpages, ->(content_id, locale, exclude_paths) do
     live_by_content_id(content_id, locale)
       .where.not(base_path: exclude_paths)

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -15,12 +15,12 @@ class Dimensions::Edition < ApplicationRecord
   scope :by_organisation_id, ->(organisation_id) { where(organisation_id: organisation_id) }
   scope :by_document_type, ->(document_type) { where('document_type like (?)', document_type) }
   scope :by_locale, ->(locale) { where(locale: locale) }
-  scope :latest, -> { where(latest: true) }
-  scope :latest_by_content_id, ->(content_id, locale) { where(content_id: content_id, locale: locale, latest: true) }
-  scope :latest_by_base_path, ->(base_paths) { where(base_path: base_paths, latest: true) }
-  scope :existing_latest_editions, ->(content_id, locale, base_paths) { latest_by_content_id(content_id, locale).or(latest_by_base_path(base_paths)) }
+  scope :live, -> { where(live: true) }
+  scope :live_by_content_id, ->(content_id, locale) { where(content_id: content_id, locale: locale, live: true) }
+  scope :live_by_base_path, ->(base_paths) { where(base_path: base_paths, live: true) }
+  scope :existing_live_editions, ->(content_id, locale, base_paths) { live_by_content_id(content_id, locale).or(live_by_base_path(base_paths)) }
   scope :outdated_subpages, ->(content_id, locale, exclude_paths) do
-    latest_by_content_id(content_id, locale)
+    live_by_content_id(content_id, locale)
       .where.not(base_path: exclude_paths)
   end
 
@@ -29,11 +29,11 @@ class Dimensions::Edition < ApplicationRecord
       old_edition.deprecate!
       assign_attributes warehouse_item_id: old_edition.warehouse_item_id
     end
-    update!(latest: true)
+    update!(live: true)
   end
 
   def deprecate!
-    update!(latest: false)
+    update!(live: false)
   end
 
   def change_from?(attributes)

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -39,11 +39,15 @@ class Dimensions::Edition < ApplicationRecord
       old_edition.deprecate!
       assign_attributes warehouse_item_id: old_edition.warehouse_item_id
     end
-    update!(live: true)
+    update!(live: true) unless unpublished?
   end
 
   def deprecate!
     update!(live: false)
+  end
+
+  def unpublished?
+    %w(gone vanish).include?(document_type)
   end
 
   def change_from?(attributes)

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -47,7 +47,7 @@ class Dimensions::Edition < ApplicationRecord
   end
 
   def unpublished?
-    %w(gone vanish).include?(document_type)
+    %w(gone vanish redirect).include?(document_type)
   end
 
   def change_from?(attributes)

--- a/db/migrate/20190402143148_rename_latest_column_to_live.rb
+++ b/db/migrate/20190402143148_rename_latest_column_to_live.rb
@@ -1,0 +1,9 @@
+class RenameLatestColumnToLive < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :dimensions_editions, :latest, :live
+  end
+
+  def down
+    rename_column :dimensions_editions, :live, :latest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_12_141439) do
+ActiveRecord::Schema.define(version: 2019_04_02_143148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "latest"
+    t.boolean "live"
     t.string "document_type", null: false
     t.datetime "first_published_at"
     t.datetime "public_updated_at"
@@ -89,17 +89,17 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
     t.bigint "publishing_api_event_id"
     t.string "acronym"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
-    t.index ["content_id", "latest"], name: "index_dimensions_editions_on_content_id_and_latest"
+    t.index ["content_id", "live"], name: "index_dimensions_editions_on_content_id_and_live"
     t.index ["document_type"], name: "index_dimensions_editions_on_document_type"
-    t.index ["latest", "base_path"], name: "index_dimensions_editions_on_latest_and_base_path", unique: true, where: "(latest = true)"
-    t.index ["latest", "document_type"], name: "index_dimensions_editions_on_latest_and_document_type"
-    t.index ["latest", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
-    t.index ["latest", "warehouse_item_id"], name: "index_dimensions_editions_on_latest_and_warehouse_item_id", unique: true, where: "(latest = true)"
-    t.index ["latest"], name: "index_dimensions_editions_on_latest"
+    t.index ["live", "base_path"], name: "index_dimensions_editions_on_live_and_base_path", unique: true, where: "(live = true)"
+    t.index ["live", "document_type"], name: "index_dimensions_editions_on_live_and_document_type"
+    t.index ["live", "organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
+    t.index ["live", "warehouse_item_id"], name: "index_dimensions_editions_on_live_and_warehouse_item_id", unique: true, where: "(live = true)"
+    t.index ["live"], name: "index_dimensions_editions_on_live"
     t.index ["organisation_id"], name: "index_dimensions_editions_organisation_id"
     t.index ["publishing_api_event_id"], name: "index_dimensions_editions_on_publishing_api_event_id"
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"
-    t.index ["warehouse_item_id", "latest"], name: "index_dimensions_editions_warehouse_item_id_latest"
+    t.index ["warehouse_item_id", "live"], name: "index_dimensions_editions_warehouse_item_id_latest"
     t.index ["warehouse_item_id"], name: "index_dimensions_editions_warehouse_item_id"
   end
 
@@ -221,7 +221,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
       aggregations.feedex,
       aggregations.useful_yes,
       aggregations.useful_no,
-      ('now'::text)::date AS updated_at,
+      CURRENT_DATE AS updated_at,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
       aggregations.feedex,
       aggregations.useful_yes,
       aggregations.useful_no,
-      ('now'::text)::date AS updated_at,
+      CURRENT_DATE AS updated_at,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = 0) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
@@ -311,7 +311,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
       (aggregations.feedex)::bigint AS feedex,
       (aggregations.useful_yes)::bigint AS useful_yes,
       (aggregations.useful_no)::bigint AS useful_no,
-      ('now'::text)::date AS updated_at,
+      CURRENT_DATE AS updated_at,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
@@ -379,7 +379,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
       (aggregations.feedex)::bigint AS feedex,
       (aggregations.useful_yes)::bigint AS useful_yes,
       (aggregations.useful_no)::bigint AS useful_no,
-      ('now'::text)::date AS updated_at,
+      CURRENT_DATE AS updated_at,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)
@@ -447,7 +447,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_141439) do
       (aggregations.feedex)::bigint AS feedex,
       (aggregations.useful_yes)::bigint AS useful_yes,
       (aggregations.useful_no)::bigint AS useful_no,
-      ('now'::text)::date AS updated_at,
+      CURRENT_DATE AS updated_at,
           CASE
               WHEN ((aggregations.useful_yes + aggregations.useful_no) = (0)::numeric) THEN NULL::double precision
               ELSE ((aggregations.useful_yes)::double precision / ((aggregations.useful_yes + aggregations.useful_no))::double precision)

--- a/lib/tasks/editions.rake
+++ b/lib/tasks/editions.rake
@@ -18,7 +18,7 @@ namespace :editions do
 
   desc "Update live attribute for unpublished editions"
   task unset_live_for_unpublished_editions: :environment do
-    live_unpublished_editions = Dimensions::Edition.live.where(document_type: %w(gone vanish))
+    live_unpublished_editions = Dimensions::Edition.live.where(document_type: %w(gone vanish redirect))
     puts "Updating live #{live_unpublished_editions.count} editions"
 
     live_unpublished_editions.update_all(live: false)

--- a/lib/tasks/editions.rake
+++ b/lib/tasks/editions.rake
@@ -15,4 +15,14 @@ namespace :editions do
 
     puts "Done!"
   end
+
+  desc "Update live attribute for unpublished editions"
+  task unset_live_for_unpublished_editions: :environment do
+    live_unpublished_editions = Dimensions::Edition.live.where(document_type: %w(gone vanish))
+    puts "Updating live #{live_unpublished_editions.count} editions"
+
+    live_unpublished_editions.update_all(live: false)
+
+    puts "Done!"
+  end
 end

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Etl::Aggregations::Monthly do
 
   let(:date) { Date.new(2018, 2, 20) }
 
-  let(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
-  let(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
+  let(:edition1) { create :edition, base_path: '/path1', live: true, date: '2018-02-20' }
+  let(:edition2) { create :edition, base_path: '/path2', live: true, date: '2018-02-20' }
 
   it 'calculates monthly aggregations for a given date' do
     create :metric, edition: edition1, date: '2018-02-20', pviews: 20, upviews: 10

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -4,8 +4,8 @@ require 'traceable'
 RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
   subject { described_class }
 
-  let!(:edition1) { create :edition, base_path: '/path1', latest: true, date: '2018-02-20' }
-  let!(:edition2) { create :edition, base_path: '/path2', latest: true, date: '2018-02-20' }
+  let!(:edition1) { create :edition, base_path: '/path1', live: true, date: '2018-02-20' }
+  let!(:edition2) { create :edition, base_path: '/path2', live: true, date: '2018-02-20' }
 
   let(:date) { Date.new(2018, 2, 20) }
 

--- a/spec/domain/etl/master/metrics_spec.rb
+++ b/spec/domain/etl/master/metrics_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Etl::Master::MetricsProcessor do
   subject { described_class.new(date: date) }
 
   it 'creates a Metrics fact per content item' do
-    create :edition, latest: true
-    item = create(:edition, latest: true, content_id: 'cid1')
+    create :edition, live: true
+    item = create(:edition, live: true, content_id: 'cid1')
 
     subject.process
 
@@ -16,9 +16,9 @@ RSpec.describe Etl::Master::MetricsProcessor do
     )
   end
 
-  it 'only create a Metrics Fact entry for Content Items with latest = `true`' do
-    create(:edition, latest: true, content_id: 'cid1')
-    create(:edition, latest: false, content_id: 'cid1')
+  it 'only create a Metrics Fact entry for Content Items with live = `true`' do
+    create(:edition, live: true, content_id: 'cid1')
+    create(:edition, live: false, content_id: 'cid1')
 
     subject.process
 

--- a/spec/domain/finders/all_document_types_spec.rb
+++ b/spec/domain/finders/all_document_types_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Finders::AllDocumentTypes do
       expect(subject.run).to be_sorted_by(&:name)
     end
 
-    it 'returns only document types of latest editions' do
+    it 'returns only document types of live editions' do
       create(:edition, document_type: 'news_story')
-      create(:edition, document_type: 'guidance', latest: false)
+      create(:edition, document_type: 'guidance', live: false)
 
       expect(subject.run).to match_array([
         have_attributes(id: 'news_story'),

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -206,11 +206,11 @@ RSpec.describe Finders::Content do
         create :metric, edition: edition, date: 15.days.ago, upviews: (100 - n)
       end
 
-      # not latest edition - should not affect total results
+      # not live edition - should not affect total results
       old_edition = create :edition,
         base_path: '/path/0',
         organisation_id: primary_org_id,
-        latest: false,
+        live: false,
         warehouse_item_id: 'item-0'
       create :metric, edition: old_edition, date: 15.days.ago
 

--- a/spec/domain/finders/edition_metrics_spec.rb
+++ b/spec/domain/finders/edition_metrics_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Finders::EditionMetrics do
       }])
     end
 
-    it "returns editions metrics for latest edition" do
+    it "returns editions metrics for live edition" do
       create :edition,
         replaces: edition,
         base_path: '/base_path',

--- a/spec/domain/finders/find_metadata_spec.rb
+++ b/spec/domain/finders/find_metadata_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Finders::Metadata do
 
   before do
     create :edition,
-      latest: true,
+      live: true,
       title: 'the title',
       base_path: base_path,
       content_id: 'content_id - 1',
@@ -16,7 +16,7 @@ RSpec.describe Finders::Metadata do
       historical: false
 
     create :edition,
-      latest: false,
+      live: false,
       title: 'the old title',
       base_path: base_path,
       document_type: 'guide',
@@ -28,7 +28,7 @@ RSpec.describe Finders::Metadata do
       historical: false
   end
 
-  it "returns metadata for latest edition" do
+  it "returns metadata for live edition" do
     metadata = described_class.run('/base_path')
 
     expect(metadata).to eq(

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Monitor::Dimensions do
   it 'sends StatsD counter of content_items' do
     expect(GovukStatsd).to receive(:count).with("monitor.dimensions.content_items", 1)
 
-    create :edition, content_id: 'id1', base_path: '/foo'
-    create :edition, content_id: 'id1', base_path: '/bar'
+    edition1 = create :edition, content_id: 'id1', base_path: '/foo'
+    create :edition, content_id: 'id1', base_path: '/bar', replaces: edition1
 
     subject.run
   end
@@ -36,9 +36,9 @@ RSpec.describe Monitor::Dimensions do
   it 'sends StatsD counter of `live` content_items' do
     expect(GovukStatsd).to receive(:count).with("monitor.dimensions.live_content_items", 1)
 
-    create :edition, content_id: 'id1', base_path: '/foo', live: true
-    create :edition, content_id: 'id1', base_path: '/bar', live: true
-    create :edition, content_id: 'id1', base_path: '/other', live: false
+    edition1 = create :edition, content_id: 'id1', base_path: '/foo'
+    create :edition, content_id: 'id1', base_path: '/bar', replaces: edition1
+    create :edition, content_id: 'id2', base_path: '/other', live: false
     subject.run
   end
 

--- a/spec/domain/monitor/dimensions_spec.rb
+++ b/spec/domain/monitor/dimensions_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Monitor::Dimensions do
     subject.run
   end
 
-  it 'sends StatsD counter of `latest` base_paths' do
-    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_base_paths", 1)
+  it 'sends StatsD counter of `live` base_paths' do
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.live_base_paths", 1)
 
-    create :edition, base_path: '/foo', latest: true
-    create :edition, base_path: '/bar', latest: false
+    create :edition, base_path: '/foo', live: true
+    create :edition, base_path: '/bar', live: false
 
     subject.run
   end
@@ -33,14 +33,14 @@ RSpec.describe Monitor::Dimensions do
     subject.run
   end
 
-  it 'sends StatsD counter of `latest` content_items' do
-    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.latest_content_items", 1)
+  it 'sends StatsD counter of `live` content_items' do
+    expect(GovukStatsd).to receive(:count).with("monitor.dimensions.live_content_items", 1)
 
-    create :edition, content_id: 'id1', base_path: '/foo', latest: true
-    create :edition, content_id: 'id1', base_path: '/bar', latest: true
-    create :edition, content_id: 'id1', base_path: '/other', latest: false
+    create :edition, content_id: 'id1', base_path: '/foo', live: true
+    create :edition, content_id: 'id1', base_path: '/bar', live: true
+    create :edition, content_id: 'id1', base_path: '/other', live: false
     subject.run
   end
 
-  it_behaves_like 'traps and logs errors in run', Dimensions::Edition, :latest
+  it_behaves_like 'traps and logs errors in run', Dimensions::Edition, :live
 end

--- a/spec/domain/streams/grow_dimension_spec.rb
+++ b/spec/domain/streams/grow_dimension_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Streams::GrowDimension do
 
     context 'when attributes we ignore have changed' do
       let(:attributes_that_should_not_grow_dimension) do
-        %i[publishing_api_payload_version public_updated_at id update_at created_at latest]
+        %i[publishing_api_payload_version public_updated_at id update_at created_at live]
       end
 
       it 'returns false' do

--- a/spec/domain/streams/handlers/single_item_handler_spec.rb
+++ b/spec/domain/streams/handlers/single_item_handler_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Streams::Handlers::SingleItemHandler do
     let(:attrs) do
       old_edition
         .attributes
-        .slice('content_id', 'base_path', 'locale')
+        .slice('content_id', 'base_path', 'locale', 'warehouse_item_id')
         .symbolize_keys
     end
 

--- a/spec/domain/streams/handlers/single_item_handler_spec.rb
+++ b/spec/domain/streams/handlers/single_item_handler_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Streams::Handlers::SingleItemHandler do
       content_id: content_id,
       base_path: base_path,
       locale: 'en',
-      latest: true
+      live: true
     )
   end
 

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :edition, class: Dimensions::Edition do
-    latest { true }
+    live { true }
     locale { 'en' }
     sequence(:content_id) { SecureRandom.uuid }
     sequence(:title) { |i| "title - #{i}" }

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     sequence(:publishing_api_payload_version)
     schema_name { 'detailed_guide' }
     document_type { 'detailed_guide' }
-    warehouse_item_id { "#{content_id}:#{locale}:#{base_path}" }
+    warehouse_item_id { "#{content_id}:#{locale}" }
     organisation_id { '17d84dc6-e5b5-4065-a8b5-8783bd934938' }
     withdrawn { false }
     historical { false }
@@ -33,6 +33,10 @@ FactoryBot.define do
         dimensions_edition: new_edition,
         )
       new_edition
+    end
+
+    trait :multipart do
+      warehouse_item_id { "#{content_id}:#{locale}:#{base_path}" }
     end
   end
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -169,7 +169,7 @@ FactoryBot.define do
           }
         ],
         'content_id' => content_id,
-        'payload_version' => 1
+        'payload_version' => payload_version
       }
     end
   end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -173,4 +173,28 @@ FactoryBot.define do
       }
     end
   end
+
+  factory :redirect_message, parent: :message do
+    payload do
+      {
+        'document_type' => 'redirect',
+        'schema_name' => 'redirect',
+        'base_path' => base_path,
+        'locale' => locale,
+        'publishing_app' => 'whitehall',
+        'details' => {
+          'explanation' => '',
+          'alternative_path' => ''
+        },
+        'routes' => [
+          {
+            'path' => content_id,
+            'type' => 'exact'
+          }
+        ],
+        'content_id' => content_id,
+        'payload_version' => payload_version
+      }
+    end
+  end
 end

--- a/spec/integration/item/import_edition_metrics_spec.rb
+++ b/spec/integration/item/import_edition_metrics_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Import edition metrics' do
     }
   end
 
-  def find_latest_edition(base_path)
-    Dimensions::Edition.latest_by_base_path([base_path]).first.facts_edition
+  def find_live_edition(base_path)
+    Dimensions::Edition.live_by_base_path([base_path]).first.facts_edition
   end
 end

--- a/spec/integration/streams/multiple/grow_dimension_spec.rb
+++ b/spec/integration/streams/multiple/grow_dimension_spec.rb
@@ -130,23 +130,6 @@ RSpec.describe "Process sub-pages for multipart content types" do
     expect(Dimensions::Edition.live.count).to eq(4)
   end
 
-  context "when base paths in the message already belong to items with a different content id" do
-    it "deprecates the clashing items" do
-      message = build(:message, :with_parts)
-      message.payload["content_id"] = "df9b33a8-73ae-4504-91a1-4a397cf1f3c5"
-      message.payload["base_path"] = "/some-url"
-      subject.process(message)
-
-      another_message = build(:message, :with_parts)
-      another_message.payload["content_id"] = "db3df7bc-4315-496a-b3b7-4f0e705a2c1f"
-      another_message.payload["base_path"] = "/some-url"
-      subject.process(another_message)
-
-      expect(Dimensions::Edition.count).to eq(8)
-      expect(Dimensions::Edition.live.count).to eq(4)
-    end
-  end
-
   context "when multi part content types have different first parts" do
     multipart_types = Etl::Edition::Content::Parsers::Parts.new.schemas
 

--- a/spec/integration/streams/multiple/grow_dimension_spec.rb
+++ b/spec/integration/streams/multiple/grow_dimension_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Edition.count).to eq(5)
-    expect(Dimensions::Edition.latest.count).to eq(4)
+    expect(Dimensions::Edition.live.count).to eq(4)
   end
 
-  it "increases the number of latest items when a subpage is added" do
+  it "increases the number of live items when a subpage is added" do
     message = build(:message, :with_parts)
     subject.process(message)
 
@@ -101,10 +101,10 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Edition.count).to eq(5)
-    expect(Dimensions::Edition.latest.count).to eq(5)
+    expect(Dimensions::Edition.live.count).to eq(5)
   end
 
-  it "decreases the number of latest items when a subpage is removed" do
+  it "decreases the number of live items when a subpage is removed" do
     message = build(:message, :with_parts)
     subject.process(message)
 
@@ -114,7 +114,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Edition.count).to eq(4)
-    expect(Dimensions::Edition.latest.count).to eq(3)
+    expect(Dimensions::Edition.live.count).to eq(3)
   end
 
   it "still grows the dimension if parts are renamed" do
@@ -127,7 +127,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     subject.process(message)
 
     expect(Dimensions::Edition.count).to eq(5)
-    expect(Dimensions::Edition.latest.count).to eq(4)
+    expect(Dimensions::Edition.live.count).to eq(4)
   end
 
   context "when base paths in the message already belong to items with a different content id" do
@@ -143,7 +143,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
       subject.process(another_message)
 
       expect(Dimensions::Edition.count).to eq(8)
-      expect(Dimensions::Edition.latest.count).to eq(4)
+      expect(Dimensions::Edition.live.count).to eq(4)
     end
   end
 
@@ -157,8 +157,8 @@ RSpec.describe "Process sub-pages for multipart content types" do
           message.payload["base_path"] = "/#{type}-url"
           subject.process(message)
 
-          edition = Dimensions::Edition.where(base_path: "/#{type}-url", latest: true).first
-          part = Dimensions::Edition.where(base_path: "/#{type}-url/part2", latest: true).first
+          edition = Dimensions::Edition.where(base_path: "/#{type}-url", live: true).first
+          part = Dimensions::Edition.where(base_path: "/#{type}-url/part2", live: true).first
 
           expect(edition.base_path).to eq("/#{type}-url")
           expect(part.base_path).to eq("/#{type}-url/part2")
@@ -200,7 +200,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     it_behaves_like 'when unchanged'
 
     it "extracts the Summary" do
-      item = Dimensions::Edition.where(base_path: "/travel-advice", latest: true).first
+      item = Dimensions::Edition.where(base_path: "/travel-advice", live: true).first
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/travel-advice',
                                         content_id: '12123d8e-1a8b-42fd-ba93-c953ad20bc8a',
@@ -212,7 +212,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     end
 
     it 'extracts /travel-advice/part1' do
-      item = Dimensions::Edition.where(base_path: "/travel-advice/part1", latest: true).first
+      item = Dimensions::Edition.where(base_path: "/travel-advice/part1", live: true).first
 
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/travel-advice/part1',
@@ -225,7 +225,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     end
 
     it 'extracts /travel-advice/part2' do
-      item = Dimensions::Edition.where(base_path: "/travel-advice/part2", latest: true).first
+      item = Dimensions::Edition.where(base_path: "/travel-advice/part2", live: true).first
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/travel-advice/part2',
                                         content_id: '12123d8e-1a8b-42fd-ba93-c953ad20bc8a',
@@ -239,7 +239,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     it 'deprecates any other items' do
       query = Dimensions::Edition.where(base_path: "/travel-advice/part3")
       expect(query.count).to eq(1)
-      expect(query.first.latest).to eq(false)
+      expect(query.first.live).to eq(false)
     end
 
     it 'does not log any errors' do
@@ -274,7 +274,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
 
 
     it 'extracts part 1 on the base path' do
-      item = Dimensions::Edition.where(base_path: "/guide", latest: true).first
+      item = Dimensions::Edition.where(base_path: "/guide", live: true).first
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/guide',
                                         content_id: '12123d8e-1a8b-42fd-ba93-c953ad20bc8a',
@@ -286,7 +286,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     end
 
     it 'extracts part 2 under the base path' do
-      item = Dimensions::Edition.where(base_path: '/guide/part2', latest: true).first
+      item = Dimensions::Edition.where(base_path: '/guide/part2', live: true).first
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/guide/part2',
                                         content_id: '12123d8e-1a8b-42fd-ba93-c953ad20bc8a',
@@ -298,7 +298,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     end
 
     it 'extracts part 3 under the base path' do
-      item = Dimensions::Edition.where(base_path: '/guide/part3', latest: true).first
+      item = Dimensions::Edition.where(base_path: '/guide/part3', live: true).first
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/guide/part3',
                                         content_id: '12123d8e-1a8b-42fd-ba93-c953ad20bc8a',
@@ -310,7 +310,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     end
 
     it 'extracts part 4 under the base path' do
-      item = Dimensions::Edition.where(base_path: '/guide/part4', latest: true).first
+      item = Dimensions::Edition.where(base_path: '/guide/part4', live: true).first
       expect(item).to have_attributes(expected_edition_attributes(
                                         base_path: '/guide/part4',
                                         content_id: '12123d8e-1a8b-42fd-ba93-c953ad20bc8a',
@@ -324,7 +324,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
     it 'deprecates any other items' do
       query = Dimensions::Edition.where(base_path: "/guide/part5")
       expect(query.count).to eq(1)
-      expect(query.first.latest).to eq(false)
+      expect(query.first.live).to eq(false)
     end
 
     it 'does not log any errors' do

--- a/spec/integration/streams/single/grow_dimension_spec.rb
+++ b/spec/integration/streams/single/grow_dimension_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Streams::Consumer do
     }.to change(Dimensions::Edition, :count).by(1)
     expect(Dimensions::Edition.first).to have_attributes(
       publishing_api_payload_version: 2,
-      latest: true
+      live: true
     )
   end
 
@@ -63,8 +63,8 @@ RSpec.describe Streams::Consumer do
         subject.process(message2)
       }.to change(Dimensions::Edition, :count).by(2)
 
-      expect(Dimensions::Edition.find_by(publishing_api_payload_version: 2)).to have_attributes(latest: false)
-      expect(Dimensions::Edition.find_by(publishing_api_payload_version: 4)).to have_attributes(latest: true)
+      expect(Dimensions::Edition.find_by(publishing_api_payload_version: 2)).to have_attributes(live: false)
+      expect(Dimensions::Edition.find_by(publishing_api_payload_version: 4)).to have_attributes(live: true)
     end
 
     it 'grows the dimension' do
@@ -82,8 +82,8 @@ RSpec.describe Streams::Consumer do
       message = build :message, base_path: '/base-path', attributes: message_attributes
       message.payload['details']['body'] = '<p>some content</p>'
       subject.process(message)
-      latest_edition = Dimensions::Edition.latest.find_by(base_path: '/base-path')
-      expect(latest_edition).to have_attributes(expected_edition_attributes(content_id: message.payload['content_id']))
+      live_edition = Dimensions::Edition.live.find_by(base_path: '/base-path')
+      expect(live_edition).to have_attributes(expected_edition_attributes(content_id: message.payload['content_id']))
     end
 
     it 'assigns the same warehouse_item_id to the new edition' do
@@ -117,7 +117,7 @@ RSpec.describe Streams::Consumer do
 
       subject.process(message)
 
-      new_edition = Dimensions::Edition.latest.find_by(content_id: content_id)
+      new_edition = Dimensions::Edition.live.find_by(content_id: content_id)
       expect(new_edition).to have_attributes(warehouse_item_id: warehouse_item_id, base_path: new_base_path)
     end
   end
@@ -128,8 +128,8 @@ RSpec.describe Streams::Consumer do
       message.payload['details']['acronym'] = 'HMRC'
       subject.process(message)
 
-      latest_edition = Dimensions::Edition.latest.find_by(base_path: '/base-path')
-      expect(latest_edition).to have_attributes(acronym: 'HMRC')
+      live_edition = Dimensions::Edition.live.find_by(base_path: '/base-path')
+      expect(live_edition).to have_attributes(acronym: 'HMRC')
     end
   end
 

--- a/spec/integration/streams/single/publishing_editions_spec.rb
+++ b/spec/integration/streams/single/publishing_editions_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe 'PublishingAPI message queue' do
   end
 
 
-  xit 'publishes redirect edition for content item' do
+  it 'publishes redirect edition for content item' do
     expect(GovukStatsd).to receive(:increment)
      .with('monitor.messages.major').twice
 
@@ -188,15 +188,15 @@ RSpec.describe 'PublishingAPI message queue' do
 
     content_id = message.payload['content_id']
 
-    gone_message = build :gone_message, content_id: content_id
-    subject.process(gone_message)
+    redirect_message = build :redirect_message, content_id: content_id
+    subject.process(redirect_message)
 
     expect(Dimensions::Edition.all).to contain_exactly(
       have_attributes(
         warehouse_item_id: "#{content_id}:en",
         base_path: '/base-path',
         live: false,
-        schema_name: 'gone'
+        schema_name: 'redirect'
       ),
       have_attributes(
         warehouse_item_id: "#{content_id}:en",
@@ -205,9 +205,9 @@ RSpec.describe 'PublishingAPI message queue' do
       )
     )
 
-    expect_messages_to_have_publishing_api_events([message, gone_message])
+    expect_messages_to_have_publishing_api_events([message, redirect_message])
     expect(message).to be_acked
-    expect(gone_message).to be_acked
+    expect(redirect_message).to be_acked
   end
 
   it 'publishes edition with new base_path for content item' do

--- a/spec/integration/streams/single/publishing_editions_spec.rb
+++ b/spec/integration/streams/single/publishing_editions_spec.rb
@@ -1,0 +1,285 @@
+require 'govuk_message_queue_consumer/test_helpers'
+
+def expect_messages_to_have_publishing_api_events(messages)
+  expected_messages = messages.map do |message|
+    have_attributes(
+      routing_key: message.delivery_info['routing_key'],
+      payload: message.payload
+    )
+  end
+  expect(Events::PublishingApi.all).to contain_exactly(*expected_messages)
+end
+
+RSpec.describe 'PublishingAPI message queue' do
+  include PublishingEventProcessingSpecHelper
+
+  let(:subject) { Streams::Consumer.new }
+
+  it 'publishes new edition for new content item' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major')
+
+    message = build :message
+    subject.process(message)
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{message.payload['content_id']}:en",
+        base_path: "/base-path",
+        live: true
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message])
+    expect(message).to be_acked
+  end
+
+  it 'publishes multiple editions for a content item' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major').twice
+
+    message1 = build :message
+    subject.process(message1)
+
+    content_id = message1.payload['content_id']
+
+    message2 = build :message, content_id: content_id
+    subject.process(message2)
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: false
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: true
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message1, message2])
+    expect(message1).to be_acked
+    expect(message2).to be_acked
+  end
+
+  it 'republishes same edition for content item' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major').twice
+
+    message = build :message
+    subject.process(message)
+    subject.process(message)
+
+    content_id = message.payload['content_id']
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: true
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message])
+    expect(message).to be_acked
+  end
+
+  it 'sends an old publishing message' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major').twice
+
+    message = build :message, attributes: { 'payload_version' => 2 }
+    subject.process(message)
+
+    content_id = message.payload['content_id']
+
+    old_message = build :message, content_id: content_id, attributes: { 'payload_version' => 1 }
+    subject.process(old_message)
+
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: true
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message])
+    expect(message).to be_acked
+    expect(old_message).to be_acked
+  end
+
+  it 'unpublishes edition for content item' do
+    expect(GovukStatsd).to receive(:increment)
+     .with('monitor.messages.major').twice
+
+    message = build :message
+    subject.process(message)
+
+    content_id = message.payload['content_id']
+
+    gone_message = build :gone_message, content_id: content_id
+    subject.process(gone_message)
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: '/base-path',
+        live: true,
+        schema_name: 'gone'
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: '/base-path',
+        live: false,
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message, gone_message])
+    expect(message).to be_acked
+    expect(gone_message).to be_acked
+  end
+
+  it 'twice unpublishes edition for content item' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major').exactly(3).times
+
+    message = build :message
+    subject.process(message)
+
+    content_id = message.payload['content_id']
+
+    gone_message1 = build :gone_message, content_id: content_id
+    subject.process(gone_message1)
+
+    gone_message2 = build :gone_message, content_id: content_id
+    subject.process(gone_message2)
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: '/base-path',
+        live: true,
+        schema_name: 'gone'
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: '/base-path',
+        live: false,
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message, gone_message1])
+    expect(message).to be_acked
+    expect(gone_message1).to be_acked
+    expect(gone_message2).to be_acked
+  end
+
+
+  xit 'publishes redirect edition for content item' do
+    expect(GovukStatsd).to receive(:increment)
+     .with('monitor.messages.major').twice
+
+    message = build :message
+    subject.process(message)
+
+    content_id = message.payload['content_id']
+
+    gone_message = build :gone_message, content_id: content_id
+    subject.process(gone_message)
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: '/base-path',
+        live: true,
+        schema_name: 'gone'
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: '/base-path',
+        live: false,
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message, gone_message])
+    expect(message).to be_acked
+    expect(gone_message).to be_acked
+  end
+
+  it 'publishes edition with new base_path for content item' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major').twice
+
+    message1 = build :message
+    subject.process(message1)
+
+    content_id = message1.payload['content_id']
+
+    message2 = build :message, content_id: content_id, base_path: '/base-path-2'
+    subject.process(message2)
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: false
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path-2",
+        live: true
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message1, message2])
+    expect(message1).to be_acked
+    expect(message2).to be_acked
+  end
+
+  it 'publishes new content item using base path of previously unpublished content item' do
+    expect(GovukStatsd).to receive(:increment)
+      .with('monitor.messages.major').exactly(3).times
+
+    message1 = build :message
+    subject.process(message1)
+
+    content_id = message1.payload['content_id']
+
+    gone_message = build :gone_message, content_id: content_id
+    subject.process(gone_message)
+
+    message2 = build :message
+    subject.process(message2)
+
+    content_id2 = message2.payload['content_id']
+
+    expect(Dimensions::Edition.all).to contain_exactly(
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: false
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id}:en",
+        base_path: "/base-path",
+        live: false,
+        schema_name: 'gone'
+      ),
+      have_attributes(
+        warehouse_item_id: "#{content_id2}:en",
+        base_path: "/base-path",
+        live: true
+      )
+    )
+
+    expect_messages_to_have_publishing_api_events([message1, gone_message, message2])
+    expect(message1).to be_acked
+    expect(gone_message).to be_acked
+    expect(message2).to be_acked
+  end
+end
+

--- a/spec/integration/streams/single/publishing_editions_spec.rb
+++ b/spec/integration/streams/single/publishing_editions_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'PublishingAPI message queue' do
       have_attributes(
         warehouse_item_id: "#{content_id}:en",
         base_path: '/base-path',
-        live: true,
+        live: false,
         schema_name: 'gone'
       ),
       have_attributes(
@@ -162,7 +162,7 @@ RSpec.describe 'PublishingAPI message queue' do
       have_attributes(
         warehouse_item_id: "#{content_id}:en",
         base_path: '/base-path',
-        live: true,
+        live: false,
         schema_name: 'gone'
       ),
       have_attributes(
@@ -195,7 +195,7 @@ RSpec.describe 'PublishingAPI message queue' do
       have_attributes(
         warehouse_item_id: "#{content_id}:en",
         base_path: '/base-path',
-        live: true,
+        live: false,
         schema_name: 'gone'
       ),
       have_attributes(
@@ -282,4 +282,3 @@ RSpec.describe 'PublishingAPI message queue' do
     expect(message2).to be_acked
   end
 end
-

--- a/spec/models/aggregations/search_aggregations_spec.rb
+++ b/spec/models/aggregations/search_aggregations_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Aggregations::SearchLastMonth, type: :model do
     end
   end
 
-  it 'is linked to the latest dimension edition' do
+  it 'is linked to the live dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 

--- a/spec/models/aggregations/search_last_six_months_spec.rb
+++ b/spec/models/aggregations/search_last_six_months_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  it 'references the latest dimension edition' do
+  it 'references the live dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 

--- a/spec/models/aggregations/search_last_thirty_days_spec.rb
+++ b/spec/models/aggregations/search_last_thirty_days_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Aggregations::SearchLastThirtyDays, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  it 'references the latest dimension edition' do
+  it 'references the live dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 

--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  it 'references the latest dimension edition' do
+  it 'references the live dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 

--- a/spec/models/aggregations/search_last_twelve_months_spec.rb
+++ b/spec/models/aggregations/search_last_twelve_months_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
     expect(subject.pluck(:dimensions_edition_id)).to match_array([edition1.id, edition2.id])
   end
 
-  it 'references the latest dimension edition' do
+  it 'references the live dimension edition' do
     edition1 = create :edition
     edition2 = create :edition, replaces: edition1
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -18,30 +18,6 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(results).to match_array([edition1])
     end
 
-    it '.by_content_id' do
-      edition1 = create(:edition, content_id: 'id1')
-      create(:edition, content_id: 'id2')
-
-      results = subject.by_content_id('id1')
-      expect(results).to match_array([edition1])
-    end
-
-    it '.by_organisation_id' do
-      edition1 = create(:edition, organisation_id: 'org-1')
-      create(:edition, organisation_id: 'org-2')
-
-      results = subject.by_organisation_id('org-1')
-      expect(results).to match_array([edition1])
-    end
-
-    it '.by_locale' do
-      edition1 = create(:edition, locale: 'fr')
-      create(:edition, locale: 'de')
-
-      results = subject.by_locale('fr')
-      expect(results).to match_array(edition1)
-    end
-
     describe '.outdated_subpages' do
       let(:content_id) { 'd5348817-0c34-4942-9111-2331e12cb1c5' }
       let(:locale) { 'fr' }
@@ -55,97 +31,11 @@ RSpec.describe Dimensions::Edition, type: :model do
       end
     end
 
-    it '.by_document_type' do
-      edition1 = create(:edition, document_type: 'guide')
-      create(:edition, document_type: 'local_transaction')
-
-      results = subject.by_document_type('guide')
-      expect(results).to match_array([edition1])
-    end
-
     it '.live' do
       edition1 = create :edition, live: true
       create :edition, live: false
 
       expect(subject.live).to match_array([edition1])
-    end
-
-    describe '.existing_live_editions' do
-      let(:content_id_1) { 'd5348817-0c34-4942-9111-2331e12cb1c5' }
-      let(:content_id_2) { 'aaaaaaaa-0c34-4942-9111-2331e12cb1c5' }
-      let(:base_path_1_1) { '/foo/part1' }
-      let(:base_path_1_2) { '/foo/part2' }
-      let(:base_path_2) { '/bar' }
-
-      let!(:edition_1_1) do
-        create(
-          :edition,
-          document_type: 'guide',
-          base_path: base_path_1_1,
-          content_id: content_id_1
-        )
-      end
-
-      let!(:edition_1_2) do
-        create(
-          :edition,
-          document_type: 'guide',
-          base_path: base_path_1_2,
-          content_id: content_id_1
-        )
-      end
-
-      let!(:edition_2) do
-        create(
-          :edition,
-          document_type: 'guide',
-          base_path: '/bar',
-          content_id: content_id_2
-        )
-      end
-
-      it "includes editions with the same content id as the new thing, even if the base path has changed" do
-        new_paths = ['/baz']
-        existing = Dimensions::Edition.existing_live_editions(content_id_2, 'en', new_paths)
-        expect(existing).to eq([edition_2])
-      end
-
-      it "includes editions with a different content id that clash with a new base path" do
-        new_content_id = 'bbbbbbbb-0c34-4942-9111-2331e12cb1c5'
-        new_paths = ['/bar']
-        existing = Dimensions::Edition.existing_live_editions(new_content_id, 'en', new_paths)
-
-        expect(existing).to eq([edition_2])
-      end
-
-      it "excludes editions with a different locale" do
-        translation = create(
-          :edition,
-          document_type: 'guide',
-          base_path: '/bar.fr',
-          content_id: content_id_2,
-          locale: 'fr'
-        )
-
-        existing = Dimensions::Edition.existing_live_editions(content_id_2, 'en', [base_path_2])
-
-        expect(existing).to include(edition_2)
-        expect(existing).not_to include(translation)
-      end
-
-      context "when the new document has one part the same and one part different" do
-        let(:new_paths) { [base_path_1_1, '/foo/new-part'] }
-        let(:existing) { Dimensions::Edition.existing_live_editions(content_id_1, 'en', new_paths) }
-
-        it 'includes all parts that currently map to the content id' do
-          expect(existing).to include(edition_1_1)
-          expect(existing).to include(edition_1_2)
-        end
-
-        it "doesn't include editions with completely different content id and base path" do
-          expect(existing).not_to include(edition_2)
-        end
-      end
     end
   end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -63,14 +63,14 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(results).to match_array([edition1])
     end
 
-    it '.latest' do
-      edition1 = create :edition, latest: true
-      create :edition, latest: false
+    it '.live' do
+      edition1 = create :edition, live: true
+      create :edition, live: false
 
-      expect(subject.latest).to match_array([edition1])
+      expect(subject.live).to match_array([edition1])
     end
 
-    describe '.existing_latest_editions' do
+    describe '.existing_live_editions' do
       let(:content_id_1) { 'd5348817-0c34-4942-9111-2331e12cb1c5' }
       let(:content_id_2) { 'aaaaaaaa-0c34-4942-9111-2331e12cb1c5' }
       let(:base_path_1_1) { '/foo/part1' }
@@ -106,14 +106,14 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       it "includes editions with the same content id as the new thing, even if the base path has changed" do
         new_paths = ['/baz']
-        existing = Dimensions::Edition.existing_latest_editions(content_id_2, 'en', new_paths)
+        existing = Dimensions::Edition.existing_live_editions(content_id_2, 'en', new_paths)
         expect(existing).to eq([edition_2])
       end
 
       it "includes editions with a different content id that clash with a new base path" do
         new_content_id = 'bbbbbbbb-0c34-4942-9111-2331e12cb1c5'
         new_paths = ['/bar']
-        existing = Dimensions::Edition.existing_latest_editions(new_content_id, 'en', new_paths)
+        existing = Dimensions::Edition.existing_live_editions(new_content_id, 'en', new_paths)
 
         expect(existing).to eq([edition_2])
       end
@@ -127,7 +127,7 @@ RSpec.describe Dimensions::Edition, type: :model do
           locale: 'fr'
         )
 
-        existing = Dimensions::Edition.existing_latest_editions(content_id_2, 'en', [base_path_2])
+        existing = Dimensions::Edition.existing_live_editions(content_id_2, 'en', [base_path_2])
 
         expect(existing).to include(edition_2)
         expect(existing).not_to include(translation)
@@ -135,7 +135,7 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       context "when the new document has one part the same and one part different" do
         let(:new_paths) { [base_path_1_1, '/foo/new-part'] }
-        let(:existing) { Dimensions::Edition.existing_latest_editions(content_id_1, 'en', new_paths) }
+        let(:existing) { Dimensions::Edition.existing_live_editions(content_id_1, 'en', new_paths) }
 
         it 'includes all parts that currently map to the content id' do
           expect(existing).to include(edition_1_1)
@@ -150,7 +150,7 @@ RSpec.describe Dimensions::Edition, type: :model do
   end
 
   describe '#promote!' do
-    let(:edition) { build :edition, latest: false }
+    let(:edition) { build :edition, live: false }
     let(:warehouse_item_id) { 'warehouse-item-id' }
     let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
 
@@ -158,12 +158,12 @@ RSpec.describe Dimensions::Edition, type: :model do
       edition.promote!(old_edition)
     end
 
-    it 'set the latest attribute to true' do
-      expect(edition.latest).to be true
+    it 'set the live attribute to true' do
+      expect(edition.live).to be true
     end
 
-    it 'sets the latest attribute to false for the old version' do
-      expect(old_edition.latest).to be false
+    it 'sets the live attribute to false for the old version' do
+      expect(old_edition.live).to be false
     end
 
     it 'copies the warehouse_item_id from the old edition' do
@@ -225,31 +225,31 @@ RSpec.describe Dimensions::Edition, type: :model do
     end
   end
 
-  describe 'Unique constraint on `warehouse_item_id` and `latest`' do
-    it 'prevent duplicating `warehouse_item_id` for latest items' do
-      create :edition, warehouse_item_id: 'value', latest: true
+  describe 'Unique constraint on `warehouse_item_id` and `live`' do
+    it 'prevent duplicating `warehouse_item_id` for live items' do
+      create :edition, warehouse_item_id: 'value', live: true
 
-      expect(-> { create :edition, warehouse_item_id: 'value', latest: true }).to raise_error(ActiveRecord::RecordNotUnique)
+      expect(-> { create :edition, warehouse_item_id: 'value', live: true }).to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'does not prevent duplicating `warehouse_item_id` for old items' do
-      create :edition, warehouse_item_id: 'value', latest: true
+      create :edition, warehouse_item_id: 'value', live: true
 
-      expect(-> { create :edition, warehouse_item_id: 'value', latest: false }).to_not raise_error
+      expect(-> { create :edition, warehouse_item_id: 'value', live: false }).to_not raise_error
     end
   end
 
-  describe 'Unique constraint on `base_path` and `latest`' do
-    it 'prevent duplicating `base_path` for latest items' do
-      create :edition, base_path: 'value', latest: true
+  describe 'Unique constraint on `base_path` and `live`' do
+    it 'prevent duplicating `base_path` for live items' do
+      create :edition, base_path: 'value', live: true
 
-      expect(-> { create :edition, base_path: 'value', latest: true }).to raise_error(ActiveRecord::RecordNotUnique)
+      expect(-> { create :edition, base_path: 'value', live: true }).to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'does not prevent duplicating `base_path` for old items' do
-      create :edition, base_path: 'value', latest: true
+      create :edition, base_path: 'value', live: true
 
-      expect(-> { create :edition, base_path: 'value', latest: false }).to_not raise_error
+      expect(-> { create :edition, base_path: 'value', live: false }).to_not raise_error
     end
   end
 end

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -93,24 +93,48 @@ RSpec.describe Dimensions::Edition, type: :model do
   end
 
   describe '#promote!' do
-    let(:edition) { build :edition, live: false }
-    let(:warehouse_item_id) { 'warehouse-item-id' }
-    let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
+    context 'for published edition' do
+      let(:edition) { build :edition, live: false }
+      let(:warehouse_item_id) { 'warehouse-item-id' }
+      let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
 
-    before do
-      edition.promote!(old_edition)
+      before do
+        edition.promote!(old_edition)
+      end
+
+      it 'set the live attribute to true' do
+        expect(edition.live).to be true
+      end
+
+      it 'sets the live attribute to false for the old version' do
+        expect(old_edition.live).to be false
+      end
+
+      it 'copies the warehouse_item_id from the old edition' do
+        expect(edition.reload.warehouse_item_id).to eq(warehouse_item_id)
+      end
     end
 
-    it 'set the live attribute to true' do
-      expect(edition.live).to be true
-    end
+    context 'for unpublished edition' do
+      let(:edition) { build :edition, live: false, document_type: 'gone' }
+      let(:warehouse_item_id) { 'warehouse-item-id' }
+      let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
 
-    it 'sets the live attribute to false for the old version' do
-      expect(old_edition.live).to be false
-    end
+      before do
+        edition.promote!(old_edition)
+      end
 
-    it 'copies the warehouse_item_id from the old edition' do
-      expect(edition.reload.warehouse_item_id).to eq(warehouse_item_id)
+      it 'set the live attribute to true' do
+        expect(edition.live).to be false
+      end
+
+      it 'sets the live attribute to false for the old version' do
+        expect(old_edition.live).to be false
+      end
+
+      it 'copies the warehouse_item_id from the old edition' do
+        expect(edition.warehouse_item_id).to eq(warehouse_item_id)
+      end
     end
   end
 

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe '/single_page', type: :request do
   let!(:base_path) { '/base_path' }
   let!(:item) do
     create :edition,
-      latest: true,
+      live: true,
       title: 'the title',
       base_path: base_path,
       content_id: 'the-content-id',

--- a/spec/support/publishing_event_processing_spec_helper.rb
+++ b/spec/support/publishing_event_processing_spec_helper.rb
@@ -27,7 +27,7 @@ module PublishingEventProcessingSpecHelper
       first_published_at: Time.zone.parse('2018-04-19T12:00:40+01:00'),
       public_updated_at: Time.zone.parse('2018-04-20T12:00:40+01:00'),
       schema_name: 'detailed_guide',
-      latest: true,
+      live: true,
       document_text: 'some content',
       phase: 'live',
       organisation_id: org_content_id,
@@ -47,7 +47,7 @@ module PublishingEventProcessingSpecHelper
       first_published_at: "2018-04-19T12:00:40+01:00",
       withdrawn: false,
       historical: false,
-      latest: false
+      live: false
     ).merge(overrides)
   end
 


### PR DESCRIPTION
This PR is to fix the logic around how we process messages from the PublishingAPI. We have bug whereby content items that are unpublished ('gone' or 'vanish') prevent new content items published with the same base path from being processed.

For example:
- Content item `A` published for base path `/a`
- Content item `A` unpublished for base path `/a` - so edition: `latest: true` and `gone` 
- Content item `B` published for base path `/a` - **this fails to add new edition**

Editions for new content item `B` fail to be added due to the unique `base_path` and `latest` constraint for dimension editions. This is because the base path `/a`  is being used by the unpublished edition from the old content item `A`. Our logic doesn't "demote" the old edition to `latest: false` as it is from a different content item.

This PR aims to redefine `latest`. The attribute previously represented the most current edition of a content item. However, this means the unique constraint of `base_path` and `latest` is incorrect. To fix this `latest` should represent the editions which are currently "live" i.e. using a base_path on GOV.UK. This means `gone` and `vanish` editions are not "live" and allows new content items to use the base path. 

Changes include:
- Renaming the edition attribute `latest` to `live`
- Preventing the promotion of unpublished editions to `live`
- Fix finding previous editions of a content item when processing messages from PublishingAPI
- Add rake task to update existing unpublished editions