### PR TITLE
Add --parallel to rubocop when run through `rake lint`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Rails.application.load_tasks
 
 namespace :lint do
   task :ruby do
-    sh "bundle exec rubocop app config lib spec"
+    sh "bundle exec rubocop --parallel app config lib spec"
   end
 end
 


### PR DESCRIPTION
# Description

Add --parallel to rubocop when run through `rake lint`, as this makes it run faster on multi-core machines.

---
# Review Checklist
* ~~Changes in scope.~~
* ~~Added/updated unit tests.~~
* ~~Added/updated feature tests.~~
* ~~Added/updated relevant documentation.~~
* ~~Added to Trello card.~~
