### PR TITLE
Improve ETL process error reporting

### DIFF
--- a/app/domain/etl/feedex/processor.rb
+++ b/app/domain/etl/feedex/processor.rb
@@ -27,11 +27,6 @@ private
       Events::Feedex.import(events, batch_size: BATCH_SIZE)
       batch += 1
     end
-  rescue GdsApi::TimedOutException,
-         GdsApi::HTTPNotFound,
-         GdsApi::EndpointNotFound,
-         GdsApi::InvalidUrl => e
-    GovukError.notify(e)
   end
 
   def load_metrics

--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -1,7 +1,9 @@
+require_dependency 'concerns/trace_and_recoverable'
+
 module Etl
   module Master
     class MetricsProcessor
-      include Concerns::Traceable
+      include Concerns::TraceAndRecoverable
 
       def self.process(*args)
         new(*args).process
@@ -12,7 +14,7 @@ module Etl
       end
 
       def process
-        time(process: :metrics) do
+        time_and_trap(process: :metrics) do
           create_metrics
         end
       end
@@ -36,8 +38,6 @@ module Etl
           end
           Facts::Metric.import(values, validate: false)
         end
-      rescue StandardError => e
-        GovukError.notify(e)
       end
     end
   end

--- a/app/models/concerns/trace_and_recoverable.rb
+++ b/app/models/concerns/trace_and_recoverable.rb
@@ -10,8 +10,12 @@ module Concerns::TraceAndRecoverable
 
       begin
         time(process: process, &block)
+
+        true
       rescue StandardError => e
         GovukError.notify(e)
+
+        false
       end
     end
 
@@ -20,8 +24,12 @@ module Concerns::TraceAndRecoverable
 
       begin
         yield
+
+        true
       rescue StandardError => e
         GovukError.notify(e)
+
+        false
       end
     end
   end

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -1,7 +1,9 @@
 namespace :etl do
   desc 'Run ETL master process'
   task master: :environment do
-    Etl::Master::MasterProcessor.process
+    unless Etl::Master::MasterProcessor.process
+      abort('Etl::Master::MasterProcessor failed')
+    end
   end
 
   desc 'Run Etl::Aggregations::Monthly for range of dates'
@@ -28,7 +30,9 @@ namespace :etl do
     to = args[:to].to_date
     (from..to).each do |date|
       console_log "repopulating GA pviews for #{date}"
-      Etl::GA::ViewsAndNavigationProcessor.process(date: date)
+      unless Etl::GA::ViewsAndNavigationProcessor.process(date: date)
+        abort('Etl::GA::ViewsAndNavigationProcessor failed')
+      end
       console_log "finished repopulating GA pviews for #{date}"
     end
   end
@@ -39,7 +43,9 @@ namespace :etl do
     to = args[:to].to_date
     (from..to).each do |date|
       console_log "repopulating searches for #{date}"
-      Etl::GA::InternalSearchProcessor.process(date: date)
+      unless Etl::GA::InternalSearchProcessor.process(date: date)
+        abort('Etl::GA::InternalSearchProcessor failed')
+      end
       console_log "finished repopulating searches for #{date}"
     end
   end
@@ -50,7 +56,9 @@ namespace :etl do
     to = args[:to].to_date
     (from..to).each do |date|
       console_log "repopulating useful scores for #{date}"
-      Etl::GA::UserFeedbackProcessor.process(date: date)
+      unless Etl::GA::UserFeedbackProcessor.process(date: date)
+        abort('Etl::GA::UserFeedbackProcessor failed')
+      end
       console_log "finished repopulating useful scores for #{date}"
     end
   end
@@ -61,7 +69,9 @@ namespace :etl do
     to = args[:to].to_date
     (from..to).each do |date|
       console_log "repopulating feedex for #{date}"
-      Etl::Feedex::Processor.process(date: date)
+      unless Etl::Feedex::Processor.process(date: date)
+        abort('Etl::Feedex::Processor failed')
+      end
       console_log "finished repopulating feedex for #{date}"
     end
   end
@@ -76,7 +86,9 @@ namespace :etl do
         console_log "Deleting existing metrics for #{date}"
         Facts::Metric.where(dimensions_date_id: date).delete_all
         console_log "Running Etl::Master process for #{date}"
-        Etl::Master::MasterProcessor.process(date: date)
+        unless Etl::Master::MasterProcessor.process(date: date)
+          abort('Etl::Master::MasterProcessor failed')
+        end
         console_log "finished running Etl::Master for #{date}"
       end
     end

--- a/spec/domain/etl/master/master_processor_spec.rb
+++ b/spec/domain/etl/master/master_processor_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Etl::Master::MasterProcessor do
   end
 
   before do
-    allow(Etl::GA::ViewsAndNavigationProcessor).to receive(:process)
-    allow(Etl::GA::UserFeedbackProcessor).to receive(:process)
-    allow(Etl::GA::InternalSearchProcessor).to receive(:process)
-    allow(Etl::Feedex::Processor).to receive(:process)
-    allow(Etl::Master::MetricsProcessor).to receive(:process)
-    allow(Monitor::Etl).to receive(:run)
+    allow(Etl::GA::ViewsAndNavigationProcessor).to receive(:process).and_return(true)
+    allow(Etl::GA::UserFeedbackProcessor).to receive(:process).and_return(true)
+    allow(Etl::GA::InternalSearchProcessor).to receive(:process).and_return(true)
+    allow(Etl::Feedex::Processor).to receive(:process).and_return(true)
+    allow(Etl::Master::MetricsProcessor).to receive(:process).and_return(true)
+    allow(Monitor::Etl).to receive(:run).and_return(true)
 
     allow(Etl::Aggregations::Monthly).to receive(:process)
     allow(Etl::Aggregations::Search).to receive(:process)
@@ -54,6 +54,12 @@ RSpec.describe Etl::Master::MasterProcessor do
     expect(Etl::Feedex::Processor).to receive(:process).with(date: Date.new(2018, 2, 19))
 
     subject.process
+  end
+
+  it 'handles processor failures' do
+    allow(Etl::GA::ViewsAndNavigationProcessor).to receive(:process).and_return(false)
+
+    expect(subject.process).to be false
   end
 
   describe 'Aggregations' do
@@ -110,6 +116,12 @@ RSpec.describe Etl::Master::MasterProcessor do
         expect(Monitor::Aggregations).to receive(:run)
 
         subject.process
+      end
+
+      it 'handles failures' do
+        allow(Monitor::Aggregations).to receive(:run).and_return(false)
+
+        expect(subject.process).to be false
       end
     end
 

--- a/spec/domain/etl/master/metrics_spec.rb
+++ b/spec/domain/etl/master/metrics_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Etl::Master::MetricsProcessor do
     create :edition, live: true
     item = create(:edition, live: true, content_id: 'cid1')
 
-    subject.process
+    expect(subject.process).to be true
 
     expect(Facts::Metric.count).to eq(2)
     expect(Facts::Metric.find_by(dimensions_edition: item)).to have_attributes(
@@ -20,8 +20,14 @@ RSpec.describe Etl::Master::MetricsProcessor do
     create(:edition, live: true, content_id: 'cid1')
     create(:edition, live: false, content_id: 'cid1')
 
-    subject.process
+    expect(subject.process).to be true
 
     expect(Facts::Metric.count).to eq(1)
+  end
+
+  it 'reports failure' do
+    allow(subject).to receive(:create_metrics).and_raise
+
+    expect(subject.process).to be false
   end
 end

--- a/spec/support/shared/shared_traps_and_logs.rb
+++ b/spec/support/shared/shared_traps_and_logs.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'traps and logs errors in process' do |object, method|
   end
 
   it 'traps and logs the error to Sentry' do
-    expect { subject.process(date: date) }.not_to raise_error
+    expect(subject.process(date: date)).to be false
     expect(GovukError).to have_received(:notify).with(error)
   end
 end
@@ -19,7 +19,7 @@ RSpec.shared_examples 'traps and logs errors in run' do |object, method|
   end
 
   it 'traps and logs the error to Sentry' do
-    expect { subject.run }.not_to raise_error
+    expect(subject.run).to be false
     expect(GovukError).to have_received(:notify).with(error)
   end
 end


### PR DESCRIPTION
# Description

Propagate failures up through the ETL process, so that the Rake tasks exits at the end with code 1 when any part of the process has failed. This means that the Jenkins job will show an appropriate status, and the Icinga passive alert will show the correct status.

---
# Review Checklist
* ~~Changes in scope.~~
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* ~~Added/updated relevant documentation.~~
* ~~Added to Trello card.~~
