### PR TITLE
Fix interation of monthly re-aggregation rake task

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -8,10 +8,14 @@ namespace :etl do
   task :repopulate_aggregations_month, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date
     to = args[:to].to_date
-    (from..to).each do |date|
-      console_log "repopulating Monthly Aggregation for #{date}"
+    months = (from..to).map { |d| [d.year, d.month] }.uniq
+
+    months.each do |month|
+      date = Date.new(*month, 1)
+      string_date = date.strftime('%Y-%m')
+      console_log "repopulating Monthly Aggregation for #{string_date}"
       Etl::Aggregations::Monthly.process(date: date)
-      console_log "finished repopulating Monthly Aggregation for #{date}"
+      console_log "finished repopulating Monthly Aggregation for #{string_date}"
     end
   end
 

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe 'etl.rake', type: task do
     it 'calls Etl::Aggregations::Monthly with each date' do
       processor = class_double(Etl::Aggregations::Monthly, process: true).as_stubbed_const
 
-      Rake::Task['etl:repopulate_aggregations_month'].invoke('2018-11-01', '2018-11-03')
+      Rake::Task['etl:repopulate_aggregations_month'].invoke('2018-11-01', '2019-01-03')
 
       expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 1))
-      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 2))
-      expect(processor).to have_received(:process).with(date: Date.new(2018, 11, 3))
+      expect(processor).to have_received(:process).with(date: Date.new(2018, 12, 1))
+      expect(processor).to have_received(:process).with(date: Date.new(2019, 1, 1))
     end
   end
 


### PR DESCRIPTION
The rake task accepts a date range in which to update the monthly aggregation. Previously it iterated through the date range by day which causes a pointless re-calculation of the same month.

Updated the task to iterate the date range per month.

---
# Review Checklist
* [x] Changes in scope.

