### PR TITLE
Remove propagation of warehouse_item_id between editions

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -35,15 +35,8 @@ class Dimensions::Edition < ApplicationRecord
   end
 
   def promote!(old_edition)
-    if old_edition
-      old_edition.deprecate!
-      assign_attributes warehouse_item_id: old_edition.warehouse_item_id
-    end
+    old_edition.update!(live: false) if old_edition
     update!(live: true) unless unpublished?
-  end
-
-  def deprecate!
-    update!(live: false)
   end
 
   def unpublished?

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -23,6 +23,9 @@ FactoryBot.define do
 
     to_create do |new_edition, evaluator|
       if evaluator.replaces
+        new_edition.content_id = evaluator.replaces.content_id
+        new_edition.locale = evaluator.replaces.locale
+        new_edition.warehouse_item_id = evaluator.replaces.warehouse_item_id
         new_edition.promote! evaluator.replaces
       else
         new_edition.save!

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -109,10 +109,6 @@ RSpec.describe Dimensions::Edition, type: :model do
       it 'sets the live attribute to false for the old version' do
         expect(old_edition.live).to be false
       end
-
-      it 'copies the warehouse_item_id from the old edition' do
-        expect(edition.reload.warehouse_item_id).to eq(warehouse_item_id)
-      end
     end
 
     context 'for unpublished edition' do
@@ -130,10 +126,6 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       it 'sets the live attribute to false for the old version' do
         expect(old_edition.live).to be false
-      end
-
-      it 'copies the warehouse_item_id from the old edition' do
-        expect(edition.warehouse_item_id).to eq(warehouse_item_id)
       end
     end
   end


### PR DESCRIPTION
Previously we copied the warehouse item id from an old edition to the new edition when "promoting" an new edition. This is un-needed as warehouse item id should always represent the combination of
the content id and locale for the current edition.

---
#### Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.

