### PR TITLE
Include the Sidekiq retry set size in the healthcheck

### DIFF
--- a/app/domain/healthchecks/sidekiq_retry_size.rb
+++ b/app/domain/healthchecks/sidekiq_retry_size.rb
@@ -1,0 +1,11 @@
+module Healthchecks
+  class SidekiqRetrySize < GovukHealthcheck::SidekiqRetrySizeCheck
+    def critical_threshold
+      100
+    end
+
+    def warning_threshold
+      1
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     Healthchecks::MonthlyAggregations,
     Healthchecks::DailyMetricsCheck,
     Healthchecks::DatabaseConnection,
+    Healthchecks::SidekiqRetrySize,
     Healthchecks::EtlGoogleAnalytics.build(:pviews),
     Healthchecks::EtlGoogleAnalytics.build(:upviews),
     Healthchecks::EtlGoogleAnalytics.build(:searches),


### PR DESCRIPTION
It's a good idea to keep an eye on this. I've set the warning
threshold very low as currently the application is running with an
empty retry set (which is great!).

---
# Review Checklist
* [x] Changes in scope.
* ~~Added/updated unit tests.~~
* ~~Added/updated feature tests.~~
* ~~Added/updated relevant documentation.~~
* [x] Added to Trello card.
