### PR TITLE
Support `local_env.yml` in test mode

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,13 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :inline
+
+  config.before_configuration do
+    env_file = File.join(Rails.root, 'config', 'local_env.yml')
+    if File.exist?(env_file)
+      YAML.safe_load(File.open(env_file)).each do |key, value|
+        ENV[key.to_s] = value
+      end
+    end
+  end
 end


### PR DESCRIPTION
To make local (mac) development easier when running tests.

This was already enabled in development, This makes it possible
to run specs from something like emacs by setting the environment
variables locally.

The file is already gitignored so we can all have different ones depending
on individual setup.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
