### PR TITLE
Fix to prevent failing tests on beginning of month

### DIFF
--- a/spec/models/aggregations/search_last_six_months_spec.rb
+++ b/spec/models/aggregations/search_last_six_months_spec.rb
@@ -52,9 +52,10 @@ RSpec.describe Aggregations::SearchLastSixMonths, type: :model do
 
 
   it 'does not include metrics older than 6 months ago' do
+    six_months_ago = Date.yesterday - 6.months
     edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-    create :metric, edition: edition1, date: 6.months.ago, upviews: 10
-    create :metric, edition: edition1, date: 6.months.ago - 1.day, upviews: 100
+    create :metric, edition: edition1, date: six_months_ago + 1.day, upviews: 10
+    create :metric, edition: edition1, date: six_months_ago, upviews: 100
 
     recalculate_aggregations!
 

--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -51,9 +51,10 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
   end
 
   it 'does not include metrics older than 3 months ago' do
+    three_months_ago = Date.yesterday - 3.months
     edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-    create :metric, edition: edition1, date: 3.months.ago, upviews: 10
-    create :metric, edition: edition1, date: 3.months.ago - 1.day, upviews: 100
+    create :metric, edition: edition1, date: three_months_ago + 1.day, upviews: 10
+    create :metric, edition: edition1, date: three_months_ago, upviews: 100
 
     recalculate_aggregations!
 

--- a/spec/models/aggregations/search_last_twelve_months_spec.rb
+++ b/spec/models/aggregations/search_last_twelve_months_spec.rb
@@ -51,9 +51,10 @@ RSpec.describe Aggregations::SearchLastTwelveMonths, type: :model do
   end
 
   it 'does not include metrics older than 12 months ago' do
+    tweleve_months_ago = Date.yesterday - 12.months
     edition1 = create :edition, warehouse_item_id: 'warehouse_item_id1', date: 1.months.ago
-    create :metric, edition: edition1, date: 12.months.ago, upviews: 10
-    create :metric, edition: edition1, date: 12.months.ago - 1.day, upviews: 100
+    create :metric, edition: edition1, date: tweleve_months_ago + 1.day, upviews: 10
+    create :metric, edition: edition1, date: tweleve_months_ago, upviews: 100
 
     recalculate_aggregations!
 


### PR DESCRIPTION
We have failing test when the current day is beginning of the month and the previous month only had 30 days. This is due to the tests calculating `x` months ago from today instead of yesterday, like the
Postgres aggregation views.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
